### PR TITLE
fix: terminal output counts carried-forward comments as new

### DIFF
--- a/server.go
+++ b/server.go
@@ -290,6 +290,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	s.session.WriteFiles()
 
 	totalComments := s.session.TotalCommentCount()
+	newComments := s.session.NewCommentCount()
 	critJSON := s.session.critJSONPath()
 	prompt := ""
 	if totalComments > 0 {
@@ -309,7 +310,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 
 	if s.status != nil {
 		round := s.session.GetReviewRound()
-		s.status.RoundFinished(round, totalComments, totalComments > 0)
+		s.status.RoundFinished(round, newComments, totalComments > 0)
 		if totalComments > 0 {
 			s.status.WaitingForAgent()
 		}

--- a/session.go
+++ b/session.go
@@ -455,6 +455,21 @@ func (s *Session) TotalCommentCount() int {
 	return total
 }
 
+// NewCommentCount returns the number of new (non-carried-forward) comments across all files.
+func (s *Session) NewCommentCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	total := 0
+	for _, f := range s.Files {
+		for _, c := range f.Comments {
+			if !c.CarriedForward {
+				total++
+			}
+		}
+	}
+	return total
+}
+
 func (s *Session) fileByPathLocked(path string) *FileEntry {
 	for _, f := range s.Files {
 		if f.Path == path {

--- a/session_test.go
+++ b/session_test.go
@@ -161,6 +161,49 @@ func TestSession_TotalCommentCount(t *testing.T) {
 	}
 }
 
+func TestSession_NewCommentCount(t *testing.T) {
+	s := newTestSession(t)
+	s.AddComment("plan.md", 1, 1, "", "new one")
+	s.AddComment("plan.md", 2, 2, "", "new two")
+
+	// Simulate carried-forward comments (as happens after round complete)
+	s.mu.Lock()
+	f := s.fileByPathLocked("main.go")
+	f.Comments = append(f.Comments, Comment{
+		ID:             "c1",
+		StartLine:      1,
+		EndLine:        1,
+		Body:           "carried",
+		CarriedForward: true,
+	})
+	s.mu.Unlock()
+
+	if got := s.TotalCommentCount(); got != 3 {
+		t.Errorf("TotalCommentCount = %d, want 3", got)
+	}
+	if got := s.NewCommentCount(); got != 2 {
+		t.Errorf("NewCommentCount = %d, want 2", got)
+	}
+}
+
+func TestSession_NewCommentCount_AllCarriedForward(t *testing.T) {
+	s := newTestSession(t)
+	s.mu.Lock()
+	f := s.fileByPathLocked("plan.md")
+	f.Comments = []Comment{
+		{ID: "c1", StartLine: 1, EndLine: 1, Body: "resolved", CarriedForward: true, Resolved: true},
+		{ID: "c2", StartLine: 2, EndLine: 2, Body: "open", CarriedForward: true},
+	}
+	s.mu.Unlock()
+
+	if got := s.TotalCommentCount(); got != 2 {
+		t.Errorf("TotalCommentCount = %d, want 2", got)
+	}
+	if got := s.NewCommentCount(); got != 0 {
+		t.Errorf("NewCommentCount = %d, want 0", got)
+	}
+}
+
 func TestSession_WriteFiles(t *testing.T) {
 	s := newTestSession(t)
 	s.AddComment("plan.md", 1, 1, "", "fix")


### PR DESCRIPTION
## Summary

The terminal status line (e.g. `→ Round 2: 10 comments added`) was inflated because `TotalCommentCount()` included carried-forward comments from previous rounds (both resolved and unresolved). After round 1 with 6 comments, round 2 would report `6 carried + 4 new = 10 comments added` instead of just `4`.

## Changes

- Add `NewCommentCount()` to `session.go` — counts only comments where `CarriedForward == false`
- Use `NewCommentCount()` for the terminal "N comments added" message in `handleFinish`
- Keep `TotalCommentCount()` for the prompt condition (agent still needs to know about all unresolved comments)
- Add two tests: mixed new + carried-forward, and all carried-forward

## Test plan

- [x] `go test ./...` passes
- [x] Manual: run multi-round review, verify terminal output shows only new comment counts per round