### PR TITLE
fix: hide share button in git mode

### DIFF
--- a/e2e/tests/share.filemode.spec.ts
+++ b/e2e/tests/share.filemode.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function loadPage(page: Page) {
+  await page.goto('/');
+  await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
+}
+
+// ============================================================
+// Share Feature — File Mode (share button visible)
+// ============================================================
+test.describe('Share — File Mode', () => {
+  test('share button is visible in file mode', async ({ page }) => {
+    await loadPage(page);
+
+    const shareBtn = page.locator('#shareBtn');
+    await expect(shareBtn).toBeVisible();
+    await expect(shareBtn).toHaveText('Share');
+  });
+
+  test('share button is enabled and clickable', async ({ page }) => {
+    await loadPage(page);
+
+    const shareBtn = page.locator('#shareBtn');
+    await expect(shareBtn).toBeEnabled();
+  });
+
+  test('no share-related toasts are shown on initial load', async ({ page }) => {
+    await loadPage(page);
+
+    const shareToast = page.locator('#toast-share');
+    await expect(shareToast).toHaveCount(0);
+  });
+});

--- a/e2e/tests/share.spec.ts
+++ b/e2e/tests/share.spec.ts
@@ -6,18 +6,17 @@ async function loadPage(page: Page) {
 }
 
 // ============================================================
-// Share Feature — Git Mode (default share URL: crit.live)
+// Share Feature — Git Mode (share button hidden)
 // ============================================================
-test.describe('Share — Default Configuration', () => {
-  test('share button is visible by default', async ({ page }) => {
+test.describe('Share — Git Mode', () => {
+  test('share button is hidden in git mode', async ({ page }) => {
     await loadPage(page);
 
     const shareBtn = page.locator('#shareBtn');
-    await expect(shareBtn).toBeVisible();
-    await expect(shareBtn).toHaveText('Share');
+    await expect(shareBtn).toBeHidden();
   });
 
-  test('config API returns default share_url', async ({ request }) => {
+  test('config API still returns share_url', async ({ request }) => {
     const res = await request.get('/api/config');
     const config = await res.json();
     expect(config.share_url).toBeTruthy();
@@ -33,19 +32,5 @@ test.describe('Share — Default Configuration', () => {
     const res = await request.get('/api/config');
     const config = await res.json();
     expect(config.delete_token).toBe('');
-  });
-
-  test('no share-related toasts are shown on initial load', async ({ page }) => {
-    await loadPage(page);
-
-    const shareToast = page.locator('#toast-share');
-    await expect(shareToast).toHaveCount(0);
-  });
-
-  test('share button is enabled and clickable', async ({ page }) => {
-    await loadPage(page);
-
-    const shareBtn = page.locator('#shareBtn');
-    await expect(shareBtn).toBeEnabled();
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -193,7 +193,7 @@
     hostedURL = configRes.hosted_url || '';
     deleteToken = configRes.delete_token || '';
 
-    if (shareURL) document.getElementById('shareBtn').style.display = '';
+    if (shareURL && session.mode !== 'git') document.getElementById('shareBtn').style.display = '';
     if (hostedURL) showSharedNotice(hostedURL);
 
     // Version check


### PR DESCRIPTION
## Summary

- Hide the Share button in git mode — sharing is only relevant for plan reviews using file mode
- Update git-mode E2E tests to assert the button is hidden
- Add file-mode share E2E tests to assert the button is visible

## Test plan

- [x] E2E: `share.spec.ts` — share button hidden in git mode, config API still returns share_url
- [x] E2E: `share.filemode.spec.ts` — share button visible and enabled in file mode
- [x] Go tests pass