### PR TITLE
fix: resolve empty diffs when cwd is not repo root

### DIFF
--- a/git.go
+++ b/git.go
@@ -186,20 +186,24 @@ func changedFilesBranch(baseRef string) ([]FileChange, error) {
 
 // FileDiffScoped returns parsed diff hunks for a file using a scope-appropriate git diff command.
 // Supported scopes: "branch", "staged", "unstaged". Any other value delegates to FileDiffUnified.
-func FileDiffScoped(path, scope, baseRef string) ([]DiffHunk, error) {
+// The dir parameter sets the working directory for git commands (use repo root for correct path resolution).
+func FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
 	var cmd *exec.Cmd
 	switch scope {
 	case "branch":
 		if baseRef == "" {
 			return nil, nil
 		}
-		cmd = exec.Command("git", "diff", baseRef+"..HEAD", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", baseRef+"..HEAD", "--", path)
 	case "staged":
-		cmd = exec.Command("git", "diff", "--cached", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--cached", "--", path)
 	case "unstaged":
-		cmd = exec.Command("git", "diff", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--", path)
 	default:
-		return FileDiffUnified(path, baseRef)
+		return fileDiffUnified(path, baseRef, dir)
+	}
+	if dir != "" {
+		cmd.Dir = dir
 	}
 
 	out, err := cmd.Output()
@@ -215,12 +219,22 @@ func FileDiffScoped(path, scope, baseRef string) ([]DiffHunk, error) {
 }
 
 func changedFilesOnDefault() ([]FileChange, error) {
+	return changedFilesOnDefaultInDir("")
+}
+
+func changedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
 	// Staged + unstaged changes vs HEAD
 	cmd := exec.Command("git", "diff", "HEAD", "--name-status")
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	out, err := cmd.Output()
 	if err != nil {
 		// If there's no HEAD (empty repo), try diff --cached + working tree
 		cmd = exec.Command("git", "diff", "--name-status")
+		if dir != "" {
+			cmd.Dir = dir
+		}
 		out, err = cmd.Output()
 		if err != nil {
 			return nil, fmt.Errorf("git diff failed: %w", err)
@@ -230,7 +244,7 @@ func changedFilesOnDefault() ([]FileChange, error) {
 	changes := parseNameStatus(string(out))
 
 	// Add untracked files
-	untracked, err := untrackedFiles()
+	untracked, err := untrackedFilesInDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +261,21 @@ func changedFilesOnFeature() ([]FileChange, error) {
 		return changedFilesOnDefault()
 	}
 
-	// All changes from merge base to working tree
-	cmd := exec.Command("git", "diff", mergeBase, "--name-status")
+	return changedFilesFromBase(mergeBase)
+}
+
+// changedFilesFromBase returns files changed between a base ref and the working tree, plus untracked files.
+func changedFilesFromBase(baseRef string) ([]FileChange, error) {
+	return changedFilesFromBaseInDir(baseRef, "")
+}
+
+// changedFilesFromBaseInDir is like changedFilesFromBase but runs git from the specified directory.
+func changedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error) {
+	// All changes from base ref to working tree
+	cmd := exec.Command("git", "diff", baseRef, "--name-status")
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("git diff failed: %w", err)
@@ -257,7 +284,7 @@ func changedFilesOnFeature() ([]FileChange, error) {
 	changes := parseNameStatus(string(out))
 
 	// Add untracked files
-	untracked, err := untrackedFiles()
+	untracked, err := untrackedFilesInDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +294,17 @@ func changedFilesOnFeature() ([]FileChange, error) {
 }
 
 func untrackedFiles() ([]FileChange, error) {
+	return untrackedFilesInDir("")
+}
+
+// untrackedFilesInDir returns untracked files, running from the specified directory.
+// git ls-files returns paths relative to cwd, so dir should be the repo root
+// to get repo-root-relative paths.
+func untrackedFilesInDir(dir string) ([]FileChange, error) {
 	cmd := exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("ls-files failed: %w", err)
@@ -330,11 +367,19 @@ func dedup(changes []FileChange) []FileChange {
 // FileDiffUnified returns the parsed diff hunks for a file against a base ref.
 // If baseRef is empty, diffs against HEAD.
 func FileDiffUnified(path, baseRef string) ([]DiffHunk, error) {
+	return fileDiffUnified(path, baseRef, "")
+}
+
+// fileDiffUnified is the internal implementation that accepts an optional working directory.
+func fileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
 	var cmd *exec.Cmd
 	if baseRef == "" {
-		cmd = exec.Command("git", "diff", "HEAD", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "HEAD", "--", path)
 	} else {
-		cmd = exec.Command("git", "diff", baseRef, "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", baseRef, "--", path)
+	}
+	if dir != "" {
+		cmd.Dir = dir
 	}
 	out, err := cmd.Output()
 	if err != nil {

--- a/git_test.go
+++ b/git_test.go
@@ -593,7 +593,7 @@ func TestFileDiffScoped_Branch(t *testing.T) {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "modify readme")
 
-	hunks, err := FileDiffScoped("README.md", "branch", baseRef)
+	hunks, err := FileDiffScoped("README.md", "branch", baseRef, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -612,7 +612,7 @@ func TestFileDiffScoped_Staged(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Staged content\n")
 	runGit(t, dir, "add", "README.md")
 
-	hunks, err := FileDiffScoped("README.md", "staged", "")
+	hunks, err := FileDiffScoped("README.md", "staged", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func TestFileDiffScoped_Unstaged(t *testing.T) {
 	// Modify without staging
 	writeFile(t, filepath.Join(dir, "README.md"), "# Unstaged content\n")
 
-	hunks, err := FileDiffScoped("README.md", "unstaged", "")
+	hunks, err := FileDiffScoped("README.md", "unstaged", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -649,7 +649,7 @@ func TestFileDiffScoped_Default(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Default scope\n")
 	runGit(t, dir, "add", "README.md")
 
-	hunks, err := FileDiffScoped("README.md", "", "HEAD")
+	hunks, err := FileDiffScoped("README.md", "", "HEAD", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,7 +664,7 @@ func TestFileDiffScoped_BranchEmptyBaseRef(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	hunks, err := FileDiffScoped("README.md", "branch", "")
+	hunks, err := FileDiffScoped("README.md", "branch", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,17 +694,17 @@ func TestFileDiffScoped_DifferentHunksPerScope(t *testing.T) {
 	// Make an unstaged change on top
 	writeFile(t, filepath.Join(dir, "README.md"), "# Branch change\n\nStaged line\nUnstaged line\n")
 
-	branchHunks, err := FileDiffScoped("README.md", "branch", baseRef)
+	branchHunks, err := FileDiffScoped("README.md", "branch", baseRef, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	stagedHunks, err := FileDiffScoped("README.md", "staged", "")
+	stagedHunks, err := FileDiffScoped("README.md", "staged", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	unstagedHunks, err := FileDiffScoped("README.md", "unstaged", "")
+	unstagedHunks, err := FileDiffScoped("README.md", "unstaged", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/session.go
+++ b/session.go
@@ -105,18 +105,27 @@ func NewSessionFromGit() (*Session, error) {
 		return nil, fmt.Errorf("not a git repository: %w", err)
 	}
 
-	changes, err := ChangedFiles()
+	// Compute baseRef FIRST so we use the same value for both file detection and diffs.
+	// Previously these were computed independently which could lead to inconsistencies.
+	branch := CurrentBranch()
+	baseRef := ""
+	if !IsOnDefaultBranch() {
+		baseRef, _ = MergeBase(DefaultBranch())
+	}
+
+	var changes []FileChange
+	if baseRef != "" {
+		// Feature branch with valid merge base: diff against it
+		changes, err = changedFilesFromBaseInDir(baseRef, root)
+	} else {
+		// Default branch or merge-base unavailable: diff against HEAD
+		changes, err = changedFilesOnDefaultInDir(root)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("detecting changes: %w", err)
 	}
 	if len(changes) == 0 {
 		return nil, fmt.Errorf("no changed files detected")
-	}
-
-	branch := CurrentBranch()
-	baseRef := ""
-	if !IsOnDefaultBranch() {
-		baseRef, _ = MergeBase(DefaultBranch())
 	}
 
 	s := &Session{
@@ -149,13 +158,16 @@ func NewSessionFromGit() (*Session, error) {
 			fe.FileHash = fileHash(data)
 		}
 
-		// Load diff hunks for all files in git mode
+		// Load diff hunks for all files in git mode.
+		// Run git diff from the repo root to ensure path consistency.
 		if fc.Status != "deleted" {
 			if fc.Status == "added" || fc.Status == "untracked" {
 				fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
 			} else {
-				hunks, err := FileDiffUnified(fc.Path, baseRef)
-				if err == nil {
+				hunks, err := fileDiffUnified(fc.Path, baseRef, root)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fc.Path, err)
+				} else {
 					fe.DiffHunks = hunks
 				}
 			}
@@ -266,8 +278,10 @@ func NewSessionFromFiles(paths []string) (*Session, error) {
 
 		// Load diff hunks in a git repo
 		if IsGitRepo() {
-			hunks, err := FileDiffUnified(relPath, baseRef)
-			if err == nil {
+			hunks, err := fileDiffUnified(relPath, baseRef, root)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", relPath, err)
+			} else {
 				fe.DiffHunks = hunks
 			}
 		}
@@ -741,6 +755,7 @@ func (s *Session) RefreshDiffs() {
 		})
 	}
 	baseRef := s.BaseRef
+	repoRoot := s.RepoRoot
 	s.mu.RUnlock()
 
 	// Compute diffs without holding any lock
@@ -754,8 +769,10 @@ func (s *Session) RefreshDiffs() {
 		if snap.status == "added" || snap.status == "untracked" {
 			hunks = FileDiffUnifiedNewFile(snap.content)
 		} else {
-			h, err := FileDiffUnified(snap.path, baseRef)
-			if err == nil {
+			h, err := fileDiffUnified(snap.path, baseRef, repoRoot)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", snap.path, err)
+			} else {
 				hunks = h
 			}
 		}
@@ -1413,7 +1430,7 @@ func (s *Session) GetSessionInfoScoped(scope string) SessionInfo {
 				hunks = FileDiffUnifiedNewFile(string(data))
 			}
 		} else {
-			h, err := FileDiffScoped(fc.Path, scope, baseRef)
+			h, err := FileDiffScoped(fc.Path, scope, baseRef, repoRoot)
 			if err == nil {
 				hunks = h
 			}
@@ -1444,7 +1461,7 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope string) (map[string]any,
 
 	s.mu.RLock()
 	f := s.fileByPathLocked(path)
-	var baseRef, status, content string
+	var baseRef, repoRoot, status, content string
 	if f != nil {
 		baseRef = s.BaseRef
 		status = f.Status
@@ -1452,13 +1469,14 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope string) (map[string]any,
 	} else {
 		baseRef = s.BaseRef
 	}
+	repoRoot = s.RepoRoot
 	s.mu.RUnlock()
 
 	var hunks []DiffHunk
 	if (status == "added" || status == "untracked") && scope == "unstaged" {
 		hunks = FileDiffUnifiedNewFile(content)
 	} else {
-		h, err := FileDiffScoped(path, scope, baseRef)
+		h, err := FileDiffScoped(path, scope, baseRef, repoRoot)
 		if err == nil {
 			hunks = h
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -551,5 +552,157 @@ func TestSession_PerFileCommentIDs(t *testing.T) {
 	}
 	if c2.ID != "c1" {
 		t.Errorf("main.go first comment ID = %q, want c1", c2.ID)
+	}
+}
+
+// TestNewSessionFromGit_SubdirectoryCwd verifies that diff hunks are correctly
+// populated when crit's working directory is a subdirectory of the git repo.
+//
+// This reproduces GitHub issue #24: `git diff --name-status` returns paths
+// relative to the repo root (e.g. "src/main.go"), but `git diff HEAD -- src/main.go`
+// interprets the pathspec relative to cwd. From src/, git looks for src/src/main.go
+// which doesn't exist, producing empty diff output. The fix sets cmd.Dir to the
+// repo root so pathspecs resolve correctly.
+func TestNewSessionFromGit_SubdirectoryCwd(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Reset DefaultBranch cache so it detects the test repo's branch
+	defaultBranchOnce = sync.Once{}
+
+	// Create a file in a subdirectory and commit it
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "add src/main.go")
+
+	// Make an unstaged modification (the kind that shows in git diff HEAD)
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n\nfunc main() {}\n")
+
+	// Change process cwd to the subdirectory — this is the key trigger.
+	// Claude Code or other tools may run crit from a subdirectory of the repo.
+	origDir, _ := os.Getwd()
+	os.Chdir(filepath.Join(dir, "src"))
+	defer os.Chdir(origDir)
+
+	session, err := NewSessionFromGit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the file and verify it has non-empty diff hunks
+	for _, f := range session.Files {
+		if strings.HasSuffix(f.Path, "main.go") {
+			if len(f.DiffHunks) == 0 {
+				t.Errorf("file %s has empty diff hunks — git diff pathspec likely failed to resolve from subdirectory cwd", f.Path)
+			}
+			return
+		}
+	}
+	t.Error("expected to find main.go in session files")
+}
+
+// TestNewSessionFromGit_SubdirectoryCwd_UntrackedFiles verifies that untracked files
+// are correctly detected with repo-root-relative paths when cwd is a subdirectory.
+// git ls-files returns paths relative to cwd, so without cmd.Dir set to the repo root,
+// untracked files would get cwd-relative paths that don't match the expected repo layout.
+func TestNewSessionFromGit_SubdirectoryCwd_UntrackedFiles(t *testing.T) {
+	dir := initTestRepo(t)
+
+	defaultBranchOnce = sync.Once{}
+
+	// Create a subdirectory with an untracked file
+	writeFile(t, filepath.Join(dir, "src", "new.go"), "package main\n\nfunc New() {}\n")
+
+	// Also make a tracked change so NewSessionFromGit doesn't fail with "no changed files"
+	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(filepath.Join(dir, "src"))
+	defer os.Chdir(origDir)
+
+	session, err := NewSessionFromGit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The untracked file should have a repo-root-relative path (src/new.go), not just "new.go"
+	for _, f := range session.Files {
+		if f.Path == "src/new.go" {
+			if len(f.DiffHunks) == 0 {
+				t.Error("expected diff hunks for untracked file src/new.go")
+			}
+			return
+		}
+	}
+
+	// Show what paths we got for debugging
+	var paths []string
+	for _, f := range session.Files {
+		paths = append(paths, f.Path)
+	}
+	t.Errorf("expected to find src/new.go in session files, got: %v", paths)
+}
+
+// TestParseUnifiedDiff_WithANSIColors verifies that ANSI color codes in git diff
+// output break ParseUnifiedDiff. This motivates the --no-color flag on git commands.
+func TestParseUnifiedDiff_WithANSIColors(t *testing.T) {
+	// Simulate git diff output with color.diff=always — ANSI codes wrap the @@ header and +/- lines
+	coloredDiff := "" +
+		"\033[1mdiff --git a/file.go b/file.go\033[m\n" +
+		"\033[1mindex abc..def 100644\033[m\n" +
+		"\033[1m--- a/file.go\033[m\n" +
+		"\033[1m+++ b/file.go\033[m\n" +
+		"\033[36m@@ -1,3 +1,3 @@\033[m\n" +
+		" line1\n" +
+		"\033[31m-old line\033[m\n" +
+		"\033[32m+new line\033[m\n" +
+		" line3\n"
+
+	hunks := ParseUnifiedDiff(coloredDiff)
+
+	// With ANSI codes wrapping the @@ header, the regex won't match and
+	// ParseUnifiedDiff returns no hunks — this is the bug that --no-color prevents.
+	if len(hunks) != 0 {
+		t.Skip("ANSI-colored @@ headers parsed successfully (unexpected) — --no-color is still good defense")
+	}
+
+	// Verify that clean (no-color) output parses correctly
+	cleanDiff := "" +
+		"diff --git a/file.go b/file.go\n" +
+		"index abc..def 100644\n" +
+		"--- a/file.go\n" +
+		"+++ b/file.go\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" line1\n" +
+		"-old line\n" +
+		"+new line\n" +
+		" line3\n"
+
+	hunks = ParseUnifiedDiff(cleanDiff)
+	if len(hunks) != 1 {
+		t.Errorf("clean diff: expected 1 hunk, got %d", len(hunks))
+	}
+}
+
+// TestFileDiffUnified_ColorConfigDoesNotBreakParsing verifies that even with
+// color.diff=always in gitconfig, the --no-color flag produces parseable output.
+func TestFileDiffUnified_ColorConfigDoesNotBreakParsing(t *testing.T) {
+	dir := initTestRepo(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// Set color.diff=always in the repo config (simulates a user's gitconfig)
+	runGit(t, dir, "config", "color.diff", "always")
+
+	// Modify a file to create a diff
+	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n\nNew content\n")
+
+	// fileDiffUnified uses --no-color, so it should parse correctly despite the config
+	hunks, err := fileDiffUnified("README.md", "HEAD", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hunks) == 0 {
+		t.Error("expected non-empty diff hunks even with color.diff=always configured")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #24 — when `crit` runs from a subdirectory of the git repo (e.g. when invoked by Claude Code), files are detected but all diffs show as "No changes".

**Root cause**: `git diff HEAD --name-status` returns repo-root-relative paths (e.g. `src/main.go`), but `git diff HEAD -- src/main.go` interprets the pathspec relative to cwd. From `src/`, git looks for `src/src/main.go` which doesn't exist → empty diff output → "No changes" in the UI.

Verified empirically:
```
$ cd /tmp/repo/src
$ git diff HEAD --name-status
M	src/main.go                    # ← repo-root-relative
$ git diff HEAD -- src/main.go     # ← empty! (looks for src/src/main.go)
$ git diff HEAD -- main.go         # ← works (cwd-relative)
```

## Changes

- **`cmd.Dir` on all git commands that use pathspecs** — `fileDiffUnified`, `FileDiffScoped`, `changedFilesOnDefaultInDir`, `changedFilesFromBaseInDir`, and `untrackedFilesInDir` all accept a `dir` parameter and set `cmd.Dir` to the repo root
- **`--no-color` on all parsed git diff commands** — prevents ANSI escape codes from breaking `ParseUnifiedDiff` when `color.diff=always` is configured in gitconfig
- **Single baseRef computation** — `NewSessionFromGit` now computes `baseRef` once upfront and uses it for both file detection and diff computation, eliminating a potential inconsistency
- **Error logging** — git diff failures are now logged to stderr instead of silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)