### PR TITLE
fix: unstaged scope showing full file instead of unstaged changes

### DIFF
--- a/git.go
+++ b/git.go
@@ -12,7 +12,7 @@ import (
 // FileChange represents a single file change detected by git.
 type FileChange struct {
 	Path   string // relative to repo root
-	Status string // "added", "modified", "deleted", "renamed"
+	Status string // "added", "modified", "deleted", "renamed", "untracked"
 }
 
 // DiffHunk represents a single hunk in a unified diff.
@@ -277,7 +277,7 @@ func untrackedFiles() ([]FileChange, error) {
 		if line == "" {
 			continue
 		}
-		changes = append(changes, FileChange{Path: line, Status: "added"})
+		changes = append(changes, FileChange{Path: line, Status: "untracked"})
 	}
 	return changes, nil
 }

--- a/git_test.go
+++ b/git_test.go
@@ -264,8 +264,8 @@ func TestChangedFiles_RealRepo(t *testing.T) {
 	if paths["README.md"] != "modified" {
 		t.Errorf("README.md status = %q, want modified", paths["README.md"])
 	}
-	if paths["new.go"] != "added" {
-		t.Errorf("new.go status = %q, want added", paths["new.go"])
+	if paths["new.go"] != "untracked" {
+		t.Errorf("new.go status = %q, want untracked", paths["new.go"])
 	}
 }
 
@@ -500,7 +500,7 @@ func TestChangedFilesUnstaged_IncludesUntracked(t *testing.T) {
 
 	found := false
 	for _, c := range unstaged {
-		if c.Path == "untracked.go" && c.Status == "added" {
+		if c.Path == "untracked.go" && c.Status == "untracked" {
 			found = true
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -1455,7 +1455,7 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope string) (map[string]any,
 	s.mu.RUnlock()
 
 	var hunks []DiffHunk
-	if (status == "added" || status == "untracked") && scope == "unstaged" {
+	if status == "untracked" && scope == "unstaged" {
 		hunks = FileDiffUnifiedNewFile(content)
 	} else {
 		h, err := FileDiffScoped(path, scope, baseRef)

--- a/session_test.go
+++ b/session_test.go
@@ -540,6 +540,60 @@ func TestSession_LoadCritJSON_OutputDir(t *testing.T) {
 	}
 }
 
+func TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope(t *testing.T) {
+	// Issue #25: When a file has status "added" (committed on branch, new relative
+	// to merge-base) and the user switches to "unstaged" scope, we should NOT show
+	// the entire file as a diff. Only truly untracked files should get that treatment.
+	s := newTestSession(t)
+	// Simulate a file that is "added" relative to merge-base (committed on branch)
+	s.Files[1].Status = "added"
+	s.Files[1].Content = "package main\n\nfunc main() {}\n"
+
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	hunks := result["hunks"].([]DiffHunk)
+
+	// With "added" status + "unstaged" scope, the bug would show the entire file
+	// as added lines (3 lines). The fix should return empty hunks because there
+	// are no actual unstaged changes.
+	if len(hunks) != 0 {
+		totalLines := 0
+		for _, h := range hunks {
+			totalLines += len(h.Lines)
+		}
+		t.Errorf("expected 0 hunks for committed 'added' file in unstaged scope, got %d hunks with %d lines", len(hunks), totalLines)
+	}
+}
+
+func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
+	// Truly untracked files should still show the full file as added in unstaged scope
+	s := newTestSession(t)
+	s.Files[1].Status = "untracked"
+	s.Files[1].Content = "package main\n\nfunc main() {}\n"
+
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	hunks := result["hunks"].([]DiffHunk)
+
+	// Untracked files should show full content as added
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk for untracked file, got %d", len(hunks))
+	}
+	addCount := 0
+	for _, l := range hunks[0].Lines {
+		if l.Type == "add" {
+			addCount++
+		}
+	}
+	if addCount != 3 {
+		t.Errorf("expected 3 added lines, got %d", addCount)
+	}
+}
+
 func TestSession_PerFileCommentIDs(t *testing.T) {
 	s := newTestSession(t)
 	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment")


### PR DESCRIPTION
## Summary

- Files with status "added" (committed on branch, new relative to merge-base) incorrectly showed their entire content when switching to "unstaged" scope, instead of showing only actual unstaged changes
- Root cause: `untrackedFilesInDir()` returned status `"added"` for untracked files, conflating them with git's `A` status from `--name-status`. The condition in `GetFileDiffSnapshotScoped` matched both
- Fix: return `"untracked"` status for truly untracked files and tighten the unstaged-scope condition to only match `"untracked"`

Closes #25

## Test plan

- [x] New test `TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope` — confirms "added" files return empty hunks in unstaged scope
- [x] New test `TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope` — confirms untracked files still show full content
- [x] Updated existing tests to expect `"untracked"` status
- [x] All 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)