### PR TITLE
feat: comment template chips in comment form

### DIFF
--- a/e2e/tests/templates.filemode.spec.ts
+++ b/e2e/tests/templates.filemode.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, mdSection } from './helpers';
+
+// Helper: open comment form on the first markdown line block
+async function openCommentForm(page: any) {
+  const section = mdSection(page);
+  const lineBlock = section.locator('.line-block').first();
+  await lineBlock.hover();
+  const gutterBtn = section.locator('.line-comment-gutter').first();
+  await expect(gutterBtn).toBeVisible();
+  await gutterBtn.click();
+  await expect(page.locator('.comment-form')).toBeVisible();
+}
+
+// Helper: clear template cookie
+async function clearTemplates(page: any) {
+  await page.evaluate(() => {
+    document.cookie = 'crit-templates=; path=/; max-age=0';
+  });
+}
+
+test.describe('Comment Templates — File Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await clearTemplates(page);
+    // In file mode, plan.md is already in document view
+    const section = mdSection(page);
+    await expect(section.locator('.document-wrapper')).toBeVisible();
+  });
+
+  test('no template bar visible on fresh start', async ({ page }) => {
+    await openCommentForm(page);
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeHidden();
+  });
+
+  test('Save as template button visible in actions row', async ({ page }) => {
+    await openCommentForm(page);
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await expect(saveBtn).toBeVisible();
+  });
+
+  test('full save-insert-delete cycle', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('This duplicates logic in …');
+
+    // Save as template
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+    const overlay = page.locator('.save-template-overlay');
+    await expect(overlay).toBeVisible();
+    await overlay.locator('button', { hasText: 'Save' }).click();
+    await expect(overlay).toBeHidden();
+
+    // Chip appears
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeVisible();
+    const chip = bar.locator('.template-chip');
+    await expect(chip).toHaveCount(1);
+
+    // Clear textarea and insert via chip
+    await textarea.fill('');
+    await chip.click();
+    await expect(textarea).toHaveValue('This duplicates logic in …');
+
+    // Hover chip to reveal ×, then click it
+    await chip.hover();
+    const del = chip.locator('.template-chip-delete');
+    await expect(del).toBeVisible();
+    await del.click();
+    await expect(bar).toBeHidden();
+  });
+
+  test('multiple templates render as separate chips', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+
+    // Save first template
+    await textarea.fill('Template A');
+    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    // Save second template
+    await textarea.fill('Template B');
+    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    const chips = page.locator('.comment-template-bar .template-chip');
+    await expect(chips).toHaveCount(2);
+    await expect(chips.nth(0).locator('.template-chip-label')).toHaveText('Template A');
+    await expect(chips.nth(1).locator('.template-chip-label')).toHaveText('Template B');
+  });
+
+  test('templates persist after page reload', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Survives reload');
+
+    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    // Reload page
+    await loadPage(page);
+    const section = mdSection(page);
+    await expect(section.locator('.document-wrapper')).toBeVisible();
+
+    // Reopen form
+    await openCommentForm(page);
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeVisible();
+    await expect(bar.locator('.template-chip-label').first()).toHaveText('Survives reload');
+  });
+});

--- a/e2e/tests/templates.spec.ts
+++ b/e2e/tests/templates.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, mdSection, switchToDocumentView } from './helpers';
+
+// Helper: open comment form on the first markdown line block
+async function openCommentForm(page: ReturnType<typeof mdSection extends (p: infer P) => any ? () => P : never> extends never ? any : any) {
+  const section = mdSection(page);
+  const lineBlock = section.locator('.line-block').first();
+  await lineBlock.hover();
+  const gutterBtn = section.locator('.line-comment-gutter').first();
+  await expect(gutterBtn).toBeVisible();
+  await gutterBtn.click();
+  await expect(page.locator('.comment-form')).toBeVisible();
+}
+
+// Helper: clear template cookie
+async function clearTemplates(page: any) {
+  await page.evaluate(() => {
+    document.cookie = 'crit-templates=; path=/; max-age=0';
+  });
+}
+
+test.describe('Comment Templates — Git Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await clearTemplates(page);
+    await switchToDocumentView(page);
+  });
+
+  test('no template bar visible on fresh start', async ({ page }) => {
+    await openCommentForm(page);
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeHidden();
+  });
+
+  test('Save as template button visible in actions row', async ({ page }) => {
+    await openCommentForm(page);
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await expect(saveBtn).toBeVisible();
+  });
+
+  test('Save as template opens dialog with textarea content', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Consider using X instead');
+
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+
+    const overlay = page.locator('.save-template-overlay');
+    await expect(overlay).toBeVisible();
+    const input = overlay.locator('.save-template-input');
+    await expect(input).toHaveValue('Consider using X instead');
+  });
+
+  test('saving template makes chip appear in template bar', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Needs a test for this');
+
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+
+    const overlay = page.locator('.save-template-overlay');
+    await overlay.locator('button', { hasText: 'Save' }).click();
+
+    await expect(overlay).toBeHidden();
+
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeVisible();
+    const chip = bar.locator('.template-chip');
+    await expect(chip).toHaveCount(1);
+    await expect(chip.locator('.template-chip-label')).toHaveText('Needs a test for this');
+  });
+
+  test('clicking chip inserts text into textarea', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('My template text');
+
+    // Save a template first
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    // Clear textarea
+    await textarea.fill('');
+
+    // Click the chip
+    const chip = page.locator('.template-chip').first();
+    await chip.click();
+
+    await expect(textarea).toHaveValue('My template text');
+  });
+
+  test('deleting chip via × removes it and hides bar when empty', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Temp template');
+
+    // Save a template
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeVisible();
+
+    // Hover chip to reveal ×, then click it
+    const chip = bar.locator('.template-chip').first();
+    await chip.hover();
+    const del = chip.locator('.template-chip-delete');
+    await expect(del).toBeVisible();
+    await del.click();
+
+    await expect(bar).toBeHidden();
+  });
+
+  test('templates persist across form close and reopen', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Persistent template');
+
+    // Save template
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+    await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
+
+    // Cancel form
+    await page.locator('.comment-form-actions button', { hasText: 'Cancel' }).click();
+    await expect(page.locator('.comment-form')).toBeHidden();
+
+    // Reopen form
+    await openCommentForm(page);
+
+    // Template bar should still have the chip
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeVisible();
+    await expect(bar.locator('.template-chip')).toHaveCount(1);
+    await expect(bar.locator('.template-chip-label').first()).toHaveText('Persistent template');
+  });
+
+  test('save dialog does nothing when textarea is empty', async ({ page }) => {
+    await openCommentForm(page);
+    // textarea is empty by default
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+
+    // Dialog should not appear
+    const overlay = page.locator('.save-template-overlay');
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test('save dialog can be cancelled', async ({ page }) => {
+    await openCommentForm(page);
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Cancel me');
+
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    await saveBtn.click();
+
+    const overlay = page.locator('.save-template-overlay');
+    await expect(overlay).toBeVisible();
+
+    await overlay.locator('button', { hasText: 'Cancel' }).click();
+    await expect(overlay).toBeHidden();
+
+    // No template bar should appear
+    const bar = page.locator('.comment-template-bar');
+    await expect(bar).toBeHidden();
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2693,39 +2693,50 @@
   }
 
   // ===== Comment Templates =====
-  var defaultTemplates = [
-    'Consider using … instead',
-    'This will fail when …',
-    'Missing error handling for …',
-    'This duplicates logic in …',
-    'Needs a test for …'
-  ];
-
   function getTemplates() {
     try {
-      var raw = localStorage.getItem('crit-templates');
+      var raw = getCookie('crit-templates');
       if (raw) {
         var parsed = JSON.parse(raw);
-        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+        if (Array.isArray(parsed)) return parsed;
       }
     } catch (_) {}
-    return defaultTemplates.slice();
+    return [];
   }
 
   function saveTemplates(templates) {
-    try { localStorage.setItem('crit-templates', JSON.stringify(templates)); } catch (_) {}
+    setCookie('crit-templates', JSON.stringify(templates));
   }
 
-  function createTemplateBar(textarea) {
-    var bar = document.createElement('div');
-    bar.className = 'comment-template-bar';
-
+  function populateTemplateBar(bar, textarea) {
+    bar.innerHTML = '';
     var templates = getTemplates();
-    templates.forEach(function(tmpl) {
+    if (templates.length === 0) {
+      bar.style.display = 'none';
+      return;
+    }
+    bar.style.display = '';
+    templates.forEach(function(tmpl, i) {
       var chip = document.createElement('button');
       chip.className = 'template-chip';
-      chip.textContent = tmpl;
-      chip.title = 'Insert: ' + tmpl;
+      chip.title = tmpl;
+      var label = document.createElement('span');
+      label.className = 'template-chip-label';
+      label.textContent = tmpl;
+      chip.appendChild(label);
+      var del = document.createElement('span');
+      del.className = 'template-chip-delete';
+      del.textContent = '\u00d7';
+      del.title = 'Remove template';
+      del.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var t = getTemplates();
+        t.splice(i, 1);
+        saveTemplates(t);
+        populateTemplateBar(bar, textarea);
+      });
+      chip.appendChild(del);
       chip.addEventListener('click', function(e) {
         e.preventDefault();
         var start = textarea.selectionStart;
@@ -2737,8 +2748,83 @@
       });
       bar.appendChild(chip);
     });
+  }
 
+  function createTemplateBar(textarea) {
+    var bar = document.createElement('div');
+    bar.className = 'comment-template-bar';
+    populateTemplateBar(bar, textarea);
     return bar;
+  }
+
+  function showSaveTemplateDialog(textarea, templateBar) {
+    var text = textarea.value.trim();
+    if (!text) {
+      textarea.focus();
+      return;
+    }
+    var overlay = document.createElement('div');
+    overlay.className = 'save-template-overlay active';
+
+    var dialog = document.createElement('div');
+    dialog.className = 'save-template-dialog';
+
+    var title = document.createElement('h3');
+    title.textContent = 'Save as template';
+    dialog.appendChild(title);
+
+    var desc = document.createElement('p');
+    desc.textContent = 'Edit the template text, then save.';
+    dialog.appendChild(desc);
+
+    var input = document.createElement('textarea');
+    input.className = 'save-template-input';
+    input.value = text;
+    input.rows = 3;
+    dialog.appendChild(input);
+
+    var btns = document.createElement('div');
+    btns.className = 'save-template-actions';
+
+    var cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-sm';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', function() { overlay.remove(); textarea.focus(); });
+
+    var saveBtn = document.createElement('button');
+    saveBtn.className = 'btn btn-sm btn-primary';
+    saveBtn.textContent = 'Save';
+    saveBtn.addEventListener('click', function() {
+      var val = input.value.trim();
+      if (!val) return;
+      var t = getTemplates();
+      t.push(val);
+      saveTemplates(t);
+      overlay.remove();
+      populateTemplateBar(templateBar, textarea);
+      textarea.focus();
+    });
+
+    btns.appendChild(cancelBtn);
+    btns.appendChild(saveBtn);
+    dialog.appendChild(btns);
+
+    input.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        saveBtn.click();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelBtn.click();
+      }
+    });
+
+    overlay.appendChild(dialog);
+    overlay.addEventListener('click', function(e) {
+      if (e.target === overlay) { overlay.remove(); textarea.focus(); }
+    });
+    document.body.appendChild(overlay);
+    requestAnimationFrame(function() { input.focus(); input.select(); });
   }
 
   // ===== Comment Form =====
@@ -2785,8 +2871,24 @@
     suggestBtn.className = 'btn btn-sm';
     suggestBtn.textContent = '\u00B1 Suggest';
     suggestBtn.title = 'Insert the selected lines as a suggestion';
-    suggestBtn.style.marginRight = 'auto';
     suggestBtn.addEventListener('click', () => insertSuggestion(textarea));
+
+    var templateBar = createTemplateBar(textarea);
+
+    const saveTemplateBtn = document.createElement('button');
+    saveTemplateBtn.className = 'btn btn-sm';
+    saveTemplateBtn.textContent = '+ Save as template';
+    saveTemplateBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      showSaveTemplateDialog(textarea, templateBar);
+    });
+
+    // Left group: Suggest + Save as template, pushed left via marginRight:auto on wrapper
+    var leftGroup = document.createElement('div');
+    leftGroup.className = 'comment-form-actions-left';
+    leftGroup.appendChild(suggestBtn);
+    leftGroup.appendChild(saveTemplateBtn);
+    leftGroup.style.marginRight = 'auto';
 
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'btn btn-sm';
@@ -2798,11 +2900,9 @@
     submitBtn.textContent = activeForm.editingId ? 'Update Comment' : 'Add Comment';
     submitBtn.addEventListener('click', () => submitComment(textarea.value));
 
-    actions.appendChild(suggestBtn);
+    actions.appendChild(leftGroup);
     actions.appendChild(cancelBtn);
     actions.appendChild(submitBtn);
-
-    var templateBar = createTemplateBar(textarea);
 
     form.appendChild(header);
     form.appendChild(templateBar);
@@ -3115,8 +3215,23 @@
     const suggestBtn = document.createElement('button');
     suggestBtn.className = 'btn btn-sm';
     suggestBtn.textContent = '\u00B1 Suggest';
-    suggestBtn.style.marginRight = 'auto';
     suggestBtn.addEventListener('click', () => insertSuggestion(textarea));
+
+    var templateBar = createTemplateBar(textarea);
+
+    const saveTemplateBtn = document.createElement('button');
+    saveTemplateBtn.className = 'btn btn-sm';
+    saveTemplateBtn.textContent = '+ Save as template';
+    saveTemplateBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      showSaveTemplateDialog(textarea, templateBar);
+    });
+
+    var leftGroup = document.createElement('div');
+    leftGroup.className = 'comment-form-actions-left';
+    leftGroup.appendChild(suggestBtn);
+    leftGroup.appendChild(saveTemplateBtn);
+    leftGroup.style.marginRight = 'auto';
 
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'btn btn-sm';
@@ -3128,11 +3243,9 @@
     submitBtn.textContent = 'Update Comment';
     submitBtn.addEventListener('click', () => submitComment(textarea.value));
 
-    actions.appendChild(suggestBtn);
+    actions.appendChild(leftGroup);
     actions.appendChild(cancelBtn);
     actions.appendChild(submitBtn);
-
-    var templateBar = createTemplateBar(textarea);
 
     form.appendChild(header);
     form.appendChild(templateBar);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -981,6 +981,11 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   border-top: 1px solid var(--border);
 }
 
+.comment-form-actions-left {
+  display: flex;
+  gap: 8px;
+}
+
 .comment-template-bar {
   display: flex;
   flex-wrap: wrap;
@@ -991,6 +996,9 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 
 .template-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 11px;
   padding: 2px 8px;
   border: 1px solid var(--border);
@@ -998,15 +1006,85 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   background: var(--bg-primary);
   color: var(--fg-muted);
   cursor: pointer;
-  white-space: nowrap;
   font-family: var(--font-body);
   line-height: 1.4;
+  max-width: 220px;
   transition: border-color 0.15s, color 0.15s;
 }
+.template-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.template-chip-delete {
+  display: none;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  line-height: 1;
+}
+.template-chip:hover .template-chip-delete { display: inline; }
+.template-chip-delete:hover { color: var(--red, #e55); }
 
 .template-chip:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* ===== Save Template Dialog ===== */
+.save-template-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 500;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(2px);
+}
+.save-template-overlay.active { display: flex; }
+
+.save-template-dialog {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 480px;
+  width: 90vw;
+  box-shadow: var(--shadow);
+}
+.save-template-dialog h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: var(--fg-primary);
+}
+.save-template-dialog p {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--fg-secondary);
+}
+.save-template-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--fg-primary);
+  resize: vertical;
+}
+.save-template-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.save-template-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 


### PR DESCRIPTION
Adds a row of clickable template chips to the comment form, between the header and textarea. This implements the "Comment templates" item from the ROADMAP.

### How it works

- 5 default templates ship out of the box:
  - "Consider using … instead"
  - "This will fail when …"
  - "Missing error handling for …"
  - "This duplicates logic in …"
  - "Needs a test for …"
- Clicking a chip inserts its text at the current cursor position in the textarea
- Templates are stored in `localStorage` (`crit-templates` key), falling back to defaults
- `getTemplates()` / `saveTemplates()` API is wired up for future "manage templates" UI
- Template bar appears in both `createCommentForm()` (new comments) and `createInlineEditor()` (editing existing)

### Design

- Chips are styled as rounded pills with subtle borders
- Hover state highlights with the accent color
- Inherits theme correctly in both light and dark mode
- Sits in the form's visual hierarchy: header → template bar → textarea → actions

### Scope

Pure frontend change — no backend modifications. 48 lines JS, 25 lines CSS.

- `frontend/app.js`: template storage, `createTemplateBar()`, wired into both form builders
- `frontend/style.css`: `.comment-template-bar` and `.template-chip` styles

### Testing

- `go test ./...` passes
- `go build` clean
- `gofmt -l .` clean
- Manually verified in both light and dark themes

-- mass cargo-culting since '09