### PR TITLE
docs: prefer nix run in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,11 @@ go install github.com/tomasz-tomczyk/crit@latest
 ### Nix
 
 ```bash
-nix profile install github:tomasz-tomczyk/crit
-
 # Run without installing
 nix run github:tomasz-tomczyk/crit -- --help
 ```
 
-Or in a `flake.nix`:
+Or add it to a `flake.nix`:
 
 ```nix
 inputs.crit.url = "github:tomasz-tomczyk/crit";


### PR DESCRIPTION
## Summary
- remove the `nix profile install` example from the README's Nix section
- keep the quick-start path focused on `nix run`
- keep the flake input example for downstream Nix users

## Testing
- docs only