### PR TITLE
fix: syntax highlighting in comments + sidebar link styling

### DIFF
--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -306,6 +306,35 @@ test.describe('Comments Panel — Git Mode', () => {
     await expect(inlineResolved).toHaveClass(/comment-card-highlight/);
   });
 
+  test('sidebar panel renders links with accent styling', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Check https://example.com for details');
+    await loadPage(page);
+    await page.keyboard.press('Shift+C');
+
+    const card = panelCards(page).first();
+    await expect(card).toBeVisible();
+    const link = card.locator('.comments-panel-card-body a');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', 'https://example.com');
+    // Link should have accent color, not default browser blue
+    const color = await link.evaluate(el => getComputedStyle(el).color);
+    expect(color).not.toBe('rgb(0, 0, 238)');
+  });
+
+  test('sidebar panel renders syntax-highlighted code blocks', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, '```go\nfunc main() {}\n```');
+    await loadPage(page);
+    await page.keyboard.press('Shift+C');
+
+    const card = panelCards(page).first();
+    await expect(card).toBeVisible();
+    const codeBlock = card.locator('.comments-panel-card-body pre code');
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock.locator('span[class^="hljs-"]').first()).toBeVisible();
+  });
+
   test('new comments do not show carried-forward badges', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Fresh comment');

--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -57,6 +57,43 @@ test.describe('Markdown Comments — Git Mode', () => {
     await expect(card.locator('.comment-body')).toContainText('This is a test comment on markdown');
   });
 
+  test('comment with fenced code block gets syntax highlighting', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlock = section.locator('.line-block').first();
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Check this:\n```go\nfunc main() {\n\tfmt.Println("hello")\n}\n```');
+    await page.locator('.comment-form .btn-primary').click();
+
+    const body = section.locator('.comment-card .comment-body');
+    await expect(body).toBeVisible();
+    // hljs should produce spans with hljs-* classes inside the code block
+    const codeBlock = body.locator('pre code');
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock.locator('span[class^="hljs-"]').first()).toBeVisible();
+  });
+
+  test('comment with URL renders styled link', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlock = section.locator('.line-block').first();
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('See https://example.com for details');
+    await page.locator('.comment-form .btn-primary').click();
+
+    const body = section.locator('.comment-card .comment-body');
+    const link = body.locator('a');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', 'https://example.com');
+    // Link should have accent color styling (not default browser blue)
+    const color = await link.evaluate(el => getComputedStyle(el).color);
+    expect(color).not.toBe('rgb(0, 0, 238)'); // not default blue
+  });
+
   test('comment count updates in header after adding a comment', async ({ page }) => {
     const section = mdSection(page);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,7 +2,18 @@
   'use strict';
 
   // ===== Comment Markdown Renderer =====
-  const commentMd = window.markdownit({ html: false, linkify: true, typographer: true });
+  const commentMd = window.markdownit({
+    html: false,
+    linkify: true,
+    typographer: true,
+    highlight: function(str, lang) {
+      if (lang && hljs.getLanguage(lang)) {
+        try { return hljs.highlight(str, { language: lang }).value; } catch (_) {}
+      }
+      try { return hljs.highlightAuto(str).value; } catch (_) {}
+      return '';
+    }
+  });
 
   // ===== Document Markdown Renderer =====
   const documentMd = window.markdownit({

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1726,6 +1726,16 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   background: var(--bg-tertiary);
   border-radius: 3px;
 }
+.comments-panel-card-body a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-subtle);
+  transition: color 0.15s, border-color 0.15s;
+}
+.comments-panel-card-body a:hover {
+  color: var(--accent-hover);
+  border-bottom-color: var(--accent-hover);
+}
 
 /* Resolved state */
 .comments-panel-card-resolved {


### PR DESCRIPTION
## Summary

- **Comment syntax highlighting**: Added `highlight` function to the `commentMd` markdown-it renderer so fenced code blocks (```go, ```js, etc.) in comments get proper syntax highlighting via highlight.js — previously only the document renderer had this
- **Sidebar link styling**: Added `.comments-panel-card-body a` CSS rules matching the existing `.comment-body a` styles (accent color, underline, hover effect) — links in the sidebar panel were unstyled

## Test plan

- [x] E2E: comment with fenced code block renders hljs-highlighted spans (inline + sidebar)
- [x] E2E: comment with URL renders styled `<a>` tag (inline + sidebar)
- [x] All 41 comment/panel tests pass
- [x] Go unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)