### PR TITLE
feat: add persistent config files and ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,11 +265,71 @@ crit push --message "Round 2"      # add a top-level review comment
 crit push 42                       # explicit PR number
 ```
 
+## Configuration
+
+Crit supports persistent configuration via JSON files so you don't have to pass the same flags every time.
+
+| File                    | Scope   | Location                          |
+| ----------------------- | ------- | --------------------------------- |
+| `~/.crit.config.json`   | Global  | Applies to all projects           |
+| `.crit.config.json`     | Project | Repo root (from `git rev-parse --show-toplevel`) |
+
+Project config overrides global. CLI flags and env vars override both.
+
+```bash
+# Generate a starter config with all available keys
+crit config --generate > .crit.config.json
+
+# View resolved config (merged global + project)
+crit config
+
+# See all available keys and pattern syntax
+crit config --help
+```
+
+### Example
+
+```json
+{
+  "port": 3456,
+  "no_open": false,
+  "share_url": "https://crit.live",
+  "quiet": false,
+  "output": "",
+  "ignore_patterns": [
+    "*.lock",
+    "*.min.js",
+    "vendor/",
+    "generated/*.pb.go"
+  ]
+}
+```
+
+All keys are optional — omit any you don't need.
+
+### Ignore patterns
+
+Patterns from global and project configs are merged (union). Supported syntax:
+
+| Pattern              | Matches                                          |
+| -------------------- | ------------------------------------------------ |
+| `*.lock`             | Files ending in `.lock` anywhere in tree         |
+| `vendor/`            | All files under `vendor/`                        |
+| `package-lock.json`  | Exact filename anywhere in tree                  |
+| `generated/*.pb.go`  | Path prefix with glob (`filepath.Match` syntax)  |
+
+Use `--no-ignore` to temporarily disable all ignore patterns:
+
+```bash
+crit --no-ignore   # review everything, including ignored files
+```
+
 ## Environment Variables
 
 | Variable               | Description                                                                                |
 | ---------------------- | ------------------------------------------------------------------------------------------ |
 | `CRIT_SHARE_URL`       | Enable the Share button (e.g. `https://crit.live` or a self-hosted instance) |
+| `CRIT_PORT`            | Override the default port (between config file and CLI flag in precedence)                  |
 | `CRIT_NO_UPDATE_CHECK` | Set to any value to disable the update check on startup                                    |
 
 ## Build from Source

--- a/config.go
+++ b/config.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Config holds all configuration values from config files.
+type Config struct {
+	Port           int      `json:"port,omitempty"`
+	NoOpen         bool     `json:"no_open,omitempty"`
+	ShareURL       string   `json:"share_url,omitempty"`
+	Quiet          bool     `json:"quiet,omitempty"`
+	Output         string   `json:"output,omitempty"`
+	IgnorePatterns []string `json:"ignore_patterns,omitempty"`
+}
+
+// String returns a human-readable JSON representation of the resolved config.
+func (c Config) String() string {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(data) + "\n"
+}
+
+// defaultConfig returns a config template with all keys present,
+// suitable for generating a starter config file.
+// Uses a map to avoid omitempty suppressing zero-value fields.
+func defaultConfig() generatedConfig {
+	return generatedConfig{
+		Port:     0,
+		NoOpen:   false,
+		ShareURL: "",
+		Quiet:    false,
+		Output:   "",
+		IgnorePatterns: []string{
+			"*.lock",
+			"*.min.js",
+			"*.min.css",
+		},
+	}
+}
+
+// generatedConfig is like Config but without omitempty, so all keys appear in output.
+type generatedConfig struct {
+	Port           int      `json:"port"`
+	NoOpen         bool     `json:"no_open"`
+	ShareURL       string   `json:"share_url"`
+	Quiet          bool     `json:"quiet"`
+	Output         string   `json:"output"`
+	IgnorePatterns []string `json:"ignore_patterns"`
+}
+
+func (c generatedConfig) String() string {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(data) + "\n"
+}
+
+// loadConfigFile reads and parses a single JSON config file.
+// Returns a zero Config if the file doesn't exist.
+func loadConfigFile(path string) (Config, error) {
+	var cfg Config
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// mergeConfigs merges project config on top of global config.
+// Non-zero project values override global. Ignore patterns are unioned.
+func mergeConfigs(global, project Config) Config {
+	merged := global
+	if project.Port != 0 {
+		merged.Port = project.Port
+	}
+	if project.NoOpen {
+		merged.NoOpen = true
+	}
+	if project.ShareURL != "" {
+		merged.ShareURL = project.ShareURL
+	}
+	if project.Quiet {
+		merged.Quiet = true
+	}
+	if project.Output != "" {
+		merged.Output = project.Output
+	}
+	// Union ignore patterns
+	merged.IgnorePatterns = append(merged.IgnorePatterns, project.IgnorePatterns...)
+	return merged
+}
+
+// LoadConfig loads and merges configuration from all sources.
+// projectDir is the repo root (or cwd if not in a git repo).
+func LoadConfig(projectDir string) Config {
+	// 1. Global config
+	global, err := loadConfigFile(globalConfigPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: reading global config: %v\n", err)
+	}
+
+	// 2. Project config
+	projectConfigPath := filepath.Join(projectDir, ".crit.config.json")
+	project, err := loadConfigFile(projectConfigPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: reading project config: %v\n", err)
+	}
+
+	// 3. Merge global + project
+	return mergeConfigs(global, project)
+}
+
+// globalConfigPath returns the path to the global config file.
+func globalConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".crit.config.json")
+}
+
+// matchPattern checks if a file path matches an ignore pattern.
+// Pattern types:
+//   - "*.ext"         → matches files ending in .ext anywhere
+//   - "dir/"          → matches all files under dir/
+//   - "exact.file"    → matches filename anywhere in tree
+//   - "path/*.ext"    → filepath.Match against full path
+func matchPattern(pattern, path string) bool {
+	// Directory prefix match
+	if strings.HasSuffix(pattern, "/") {
+		prefix := pattern // includes trailing /
+		return strings.HasPrefix(path, prefix) || strings.Contains(path, "/"+prefix)
+	}
+
+	// If pattern contains /, match against full path
+	if strings.Contains(pattern, "/") {
+		matched, _ := filepath.Match(pattern, path)
+		return matched
+	}
+
+	// Match against filename only
+	filename := filepath.Base(path)
+	matched, _ := filepath.Match(pattern, filename)
+	return matched
+}
+
+// filterIgnored removes FileChange entries matching any ignore pattern.
+func filterIgnored(files []FileChange, patterns []string) []FileChange {
+	if len(patterns) == 0 {
+		return files
+	}
+	var result []FileChange
+	for _, f := range files {
+		ignored := false
+		for _, p := range patterns {
+			if matchPattern(p, f.Path) {
+				ignored = true
+				break
+			}
+		}
+		if !ignored {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+// filterPathsIgnored removes string paths matching any ignore pattern.
+func filterPathsIgnored(paths []string, patterns []string) []string {
+	if len(patterns) == 0 {
+		return paths
+	}
+	var result []string
+	for _, p := range paths {
+		ignored := false
+		for _, pat := range patterns {
+			if matchPattern(pat, p) {
+				ignored = true
+				break
+			}
+		}
+		if !ignored {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLoadConfigFromFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crit.config.json")
+	os.WriteFile(configPath, []byte(`{
+  "port": 3456,
+  "no_open": true,
+  "share_url": "https://example.com",
+  "quiet": true,
+  "ignore_patterns": ["*.lock", "vendor/"]
+}`), 0644)
+
+	cfg, err := loadConfigFile(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 3456 {
+		t.Errorf("port = %d, want 3456", cfg.Port)
+	}
+	if !cfg.NoOpen {
+		t.Error("no_open should be true")
+	}
+	if cfg.ShareURL != "https://example.com" {
+		t.Errorf("share_url = %q", cfg.ShareURL)
+	}
+	if !cfg.Quiet {
+		t.Error("quiet should be true")
+	}
+	if len(cfg.IgnorePatterns) != 2 {
+		t.Errorf("ignore_patterns = %v", cfg.IgnorePatterns)
+	}
+}
+
+func TestLoadConfigFileMissing(t *testing.T) {
+	cfg, err := loadConfigFile("/nonexistent/.crit.config.json")
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if cfg.Port != 0 {
+		t.Errorf("expected zero config")
+	}
+}
+
+func TestLoadConfigFileInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crit.config.json")
+	os.WriteFile(configPath, []byte(`{invalid json`), 0644)
+
+	_, err := loadConfigFile(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestMergeConfigs(t *testing.T) {
+	global := Config{Port: 3000, ShareURL: "https://global.example.com"}
+	global.IgnorePatterns = []string{"*.lock"}
+
+	project := Config{Port: 8080}
+	project.IgnorePatterns = []string{"*.pb.go"}
+
+	merged := mergeConfigs(global, project)
+	if merged.Port != 8080 {
+		t.Errorf("port = %d, want 8080 (project override)", merged.Port)
+	}
+	if merged.ShareURL != "https://global.example.com" {
+		t.Errorf("share_url lost")
+	}
+	if len(merged.IgnorePatterns) != 2 {
+		t.Errorf("patterns = %v, want union", merged.IgnorePatterns)
+	}
+}
+
+func TestMergeConfigsZeroValues(t *testing.T) {
+	global := Config{Port: 3000, NoOpen: true, Quiet: true}
+	project := Config{} // all zero — should not override
+
+	merged := mergeConfigs(global, project)
+	if merged.Port != 3000 {
+		t.Errorf("port should stay 3000")
+	}
+	if !merged.NoOpen {
+		t.Error("no_open should stay true")
+	}
+	if !merged.Quiet {
+		t.Error("quiet should stay true")
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Set up global config
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	globalPath := filepath.Join(homeDir, ".crit.config.json")
+	os.WriteFile(globalPath, []byte(`{"port": 3000, "share_url": "https://global.example.com", "ignore_patterns": ["*.lock"]}`), 0644)
+
+	// Set up project dir with config
+	projectDir := t.TempDir()
+	os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), []byte(`{"port": 8080, "ignore_patterns": ["*.pb.go"]}`), 0644)
+
+	cfg := LoadConfig(projectDir)
+
+	if cfg.Port != 8080 {
+		t.Errorf("port = %d, want 8080 (project override)", cfg.Port)
+	}
+	if cfg.ShareURL != "https://global.example.com" {
+		t.Errorf("share_url = %q, want global value", cfg.ShareURL)
+	}
+	if len(cfg.IgnorePatterns) != 2 {
+		t.Errorf("ignore_patterns = %v, want 2 entries", cfg.IgnorePatterns)
+	}
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// Suffix match (pattern starts with *)
+		{"*.lock", "go.sum.lock", true},
+		{"*.lock", "vendor/go.lock", true},
+		{"*.lock", "lockfile", false},
+		{"*.pb.go", "api/v1/service.pb.go", true},
+		{"*.pb.go", "main.go", false},
+
+		// Directory prefix (pattern ends with /)
+		{"vendor/", "vendor/foo.go", true},
+		{"vendor/", "vendor/bar/baz.go", true},
+		{"vendor/", "myvendor/foo.go", false},
+		{"generated/", "generated/types.go", true},
+		{"node_modules/", "node_modules/lodash/index.js", true},
+
+		// Exact filename match (no / in pattern, no leading *)
+		{"package-lock.json", "package-lock.json", true},
+		{"package-lock.json", "sub/package-lock.json", true},
+		{".env", ".env", true},
+		{".env", "src/.env", true},
+
+		// Filename glob (no /, has wildcard)
+		{"*.min.js", "assets/app.min.js", true},
+		{"*.min.js", "app.min.js", true},
+		{"*.min.js", "app.js", false},
+
+		// Path with / (match against full path)
+		{"generated/*.pb.go", "generated/service.pb.go", true},
+		{"generated/*.pb.go", "other/service.pb.go", false},
+	}
+	for _, tt := range tests {
+		got := matchPattern(tt.pattern, tt.path)
+		if got != tt.want {
+			t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestFilterIgnored(t *testing.T) {
+	files := []FileChange{
+		{Path: "main.go", Status: "modified"},
+		{Path: "go.sum.lock", Status: "modified"},
+		{Path: "vendor/lib/foo.go", Status: "added"},
+		{Path: "api/service.pb.go", Status: "modified"},
+		{Path: "README.md", Status: "modified"},
+	}
+	patterns := []string{"*.lock", "vendor/", "*.pb.go"}
+	filtered := filterIgnored(files, patterns)
+	if len(filtered) != 2 {
+		t.Fatalf("got %d files, want 2: %v", len(filtered), filtered)
+	}
+	if filtered[0].Path != "main.go" {
+		t.Errorf("filtered[0] = %q", filtered[0].Path)
+	}
+	if filtered[1].Path != "README.md" {
+		t.Errorf("filtered[1] = %q", filtered[1].Path)
+	}
+}
+
+func TestFilterIgnoredEmpty(t *testing.T) {
+	files := []FileChange{{Path: "main.go", Status: "modified"}}
+	filtered := filterIgnored(files, nil)
+	if len(filtered) != 1 {
+		t.Errorf("expected no filtering with nil patterns")
+	}
+}
+
+func TestFilterPathsIgnored(t *testing.T) {
+	paths := []string{
+		"src/main.go",
+		"src/generated/types.go",
+		"package-lock.json",
+	}
+	patterns := []string{"generated/", "package-lock.json"}
+	filtered := filterPathsIgnored(paths, patterns)
+	if len(filtered) != 1 || filtered[0] != "src/main.go" {
+		t.Errorf("got %v", filtered)
+	}
+}
+
+func TestConfigString(t *testing.T) {
+	cfg := Config{Port: 3456, IgnorePatterns: []string{"*.lock"}}
+	s := cfg.String()
+	if s == "{}" {
+		t.Error("expected non-empty JSON output")
+	}
+}
+
+// Integration test helpers (reuse pattern from git_test.go)
+func initTestRepoForConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitForConfig(t, dir, "init")
+	runGitForConfig(t, dir, "config", "user.email", "test@test.com")
+	runGitForConfig(t, dir, "config", "user.name", "Test")
+	writeFileForConfig(t, filepath.Join(dir, "README.md"), "# Test")
+	runGitForConfig(t, dir, "add", "README.md")
+	runGitForConfig(t, dir, "commit", "-m", "initial")
+	runGitForConfig(t, dir, "branch", "-M", "main")
+	return dir
+}
+
+func runGitForConfig(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeFileForConfig(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewSessionFromGitWithIgnore(t *testing.T) {
+	dir := initTestRepoForConfig(t)
+
+	// Reset defaultBranch cache so it detects the temp repo's branch
+	defaultBranchOnce = sync.Once{}
+
+	// Create a feature branch with several files
+	runGitForConfig(t, dir, "checkout", "-b", "feature")
+	writeFileForConfig(t, filepath.Join(dir, "main.go"), "package main\n")
+	writeFileForConfig(t, filepath.Join(dir, "service.pb.go"), "package main\n// generated\n")
+	writeFileForConfig(t, filepath.Join(dir, "vendor", "lib.go"), "package vendor\n")
+	writeFileForConfig(t, filepath.Join(dir, "README.md"), "# Updated\n")
+	runGitForConfig(t, dir, "add", ".")
+	runGitForConfig(t, dir, "commit", "-m", "add files")
+
+	// cd into the repo
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	patterns := []string{"*.pb.go", "vendor/"}
+	session, err := NewSessionFromGit(patterns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only have main.go and README.md (not service.pb.go or vendor/lib.go)
+	paths := make(map[string]bool)
+	for _, f := range session.Files {
+		paths[f.Path] = true
+	}
+	if paths["service.pb.go"] {
+		t.Error("service.pb.go should be ignored")
+	}
+	if paths["vendor/lib.go"] {
+		t.Error("vendor/lib.go should be ignored")
+	}
+	if !paths["main.go"] {
+		t.Error("main.go should be present")
+	}
+	if !paths["README.md"] {
+		t.Error("README.md should be present")
+	}
+
+	// Verify patterns are stored on the session
+	if len(session.IgnorePatterns) != 2 {
+		t.Errorf("session.IgnorePatterns = %v, want 2 entries", session.IgnorePatterns)
+	}
+}
+
+func TestNewSessionFromFilesWithIgnore(t *testing.T) {
+	dir := t.TempDir()
+	writeFileForConfig(t, filepath.Join(dir, "main.go"), "package main\n")
+	writeFileForConfig(t, filepath.Join(dir, "generated", "types.go"), "package gen\n")
+	writeFileForConfig(t, filepath.Join(dir, "app.min.js"), "// minified\n")
+	writeFileForConfig(t, filepath.Join(dir, "readme.txt"), "hello\n")
+
+	patterns := []string{"generated/"}
+	session, err := NewSessionFromFiles([]string{dir}, patterns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range session.Files {
+		rel, _ := filepath.Rel(dir, f.AbsPath)
+		if strings.HasPrefix(rel, "generated/") || strings.HasPrefix(rel, "generated\\") {
+			t.Errorf("file %s should have been ignored by generated/ pattern", f.Path)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -84,6 +84,31 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Handle "crit config" subcommand — print resolved configuration
+	if len(os.Args) >= 2 && os.Args[1] == "config" {
+		// Check for flags
+		for _, arg := range os.Args[2:] {
+			if arg == "--help" || arg == "-h" || arg == "help" {
+				printConfigHelp()
+				os.Exit(0)
+			}
+			if arg == "--generate" || arg == "-g" {
+				fmt.Print(defaultConfig().String())
+				os.Exit(0)
+			}
+		}
+		configDir := ""
+		if IsGitRepo() {
+			configDir, _ = RepoRoot()
+		}
+		if configDir == "" {
+			configDir, _ = os.Getwd()
+		}
+		cfg := LoadConfig(configDir)
+		fmt.Print(cfg.String())
+		os.Exit(0)
+	}
+
 	// Handle "crit pull [--output <dir>] [pr-number]" subcommand — fetch GitHub PR comments to .crit.json
 	if len(os.Args) >= 2 && os.Args[1] == "pull" {
 		if err := requireGH(); err != nil {
@@ -352,6 +377,7 @@ func main() {
 	flag.StringVar(outputDir, "o", "", "Output directory for .crit.json (shorthand)")
 	quiet := flag.Bool("quiet", false, "Suppress status output")
 	flag.BoolVar(quiet, "q", false, "Suppress status output (shorthand)")
+	noIgnore := flag.Bool("no-ignore", false, "Disable all ignore patterns from config files")
 	flag.Usage = func() {
 		printHelp()
 	}
@@ -360,6 +386,47 @@ func main() {
 	if *showVersion {
 		printVersion()
 		return
+	}
+
+	// Load configuration
+	configDir := ""
+	if IsGitRepo() {
+		configDir, _ = RepoRoot()
+	}
+	if configDir == "" {
+		configDir, _ = os.Getwd()
+	}
+	cfg := LoadConfig(configDir)
+
+	// CRIT_PORT env var (precedence: CLI flag > env var > config > default)
+	if *port == 0 {
+		if envPort := os.Getenv("CRIT_PORT"); envPort != "" {
+			if p, err := strconv.Atoi(envPort); err == nil {
+				*port = p
+			}
+		}
+	}
+
+	// Apply config defaults (CLI flags and env vars override)
+	if *port == 0 && cfg.Port != 0 {
+		*port = cfg.Port
+	}
+	if !*noOpen && cfg.NoOpen {
+		*noOpen = true
+	}
+	if *shareURL == "" && cfg.ShareURL != "" {
+		*shareURL = cfg.ShareURL
+	}
+	if !*quiet && cfg.Quiet {
+		*quiet = true
+	}
+	if *outputDir == "" && cfg.Output != "" {
+		*outputDir = cfg.Output
+	}
+
+	var ignorePatterns []string
+	if !*noIgnore {
+		ignorePatterns = cfg.IgnorePatterns
 	}
 
 	var session *Session
@@ -373,13 +440,13 @@ func main() {
 			printHelp()
 			os.Exit(1)
 		}
-		session, err = NewSessionFromGit()
+		session, err = NewSessionFromGit(ignorePatterns)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
 	} else {
 		// Explicit files
-		session, err = NewSessionFromFiles(flag.Args())
+		session, err = NewSessionFromFiles(flag.Args(), ignorePatterns)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
@@ -468,6 +535,7 @@ Usage:
   crit pull [--output <dir>] [pr-number]     Fetch GitHub PR comments to .crit.json
   crit push [--dry-run] [--message <msg>] [--output <dir>] [pr-number]  Post .crit.json comments to a GitHub PR
   crit install <agent>                       Install integration files for an AI coding tool
+  crit config [--generate]                    Show resolved configuration
   crit help                                  Show this help message
 
   Agents:
@@ -477,15 +545,61 @@ Options:
   -p, --port <port>           Port to listen on (default: random)
   -o, --output <dir>          Output directory for .crit.json
       --no-open               Don't auto-open browser
+      --no-ignore             Disable all file ignore patterns
   -q, --quiet                 Suppress status output
       --share-url <url>       Share service URL (e.g. https://crit.live)
   -v, --version               Print version
 
 Environment:
   CRIT_SHARE_URL              Override the share service URL
+  CRIT_PORT                   Override the default port
   CRIT_NO_UPDATE_CHECK        Disable update check on startup
 
+Configuration:
+  Global config:   ~/.crit.config.json
+  Project config:  .crit.config.json (in repo root)
+  Run 'crit config' to see resolved configuration.
+
 Learn more: https://crit.live
+`)
+}
+
+func printConfigHelp() {
+	fmt.Fprintf(os.Stderr, `crit config — show resolved configuration
+
+Prints the merged configuration from global and project config files as JSON.
+CLI flags and environment variables are not reflected in this output.
+
+Config files:
+  ~/.crit.config.json          Global config (applies to all projects)
+  .crit.config.json            Project config (in repo root)
+
+Precedence (highest to lowest):
+  1. CLI flags / env vars
+  2. Project config
+  3. Global config
+  4. Built-in defaults
+
+Available keys:
+  port              int       Port to listen on (default: random)
+  no_open           bool      Don't auto-open browser (default: false)
+  share_url         string    Share service URL
+  quiet             bool      Suppress status output (default: false)
+  output            string    Output directory for .crit.json
+  ignore_patterns   []string  Gitignore-style patterns to exclude files from review
+
+Ignore pattern syntax:
+  *.lock            Match files by extension (anywhere in tree)
+  vendor/           Match all files under a directory
+  package-lock.json Match exact filename (anywhere in tree)
+  generated/*.pb.go Match with path prefix (filepath.Match syntax)
+
+Example config:
+  {
+    "port": 3456,
+    "share_url": "https://crit.live",
+    "ignore_patterns": ["*.lock", "*.min.js", "vendor/", "generated/"]
+  }
 `)
 }
 

--- a/session.go
+++ b/session.go
@@ -60,13 +60,14 @@ type FileEntry struct {
 
 // Session is the top-level state manager for a multi-file review.
 type Session struct {
-	Files       []*FileEntry
-	Mode        string // "files" (explicit markdown files) or "git" (auto-detected from git)
-	Branch      string
-	BaseRef     string
-	RepoRoot    string
-	OutputDir   string // custom output directory for .crit.json (empty = RepoRoot)
-	ReviewRound int
+	Files          []*FileEntry
+	Mode           string // "files" (explicit markdown files) or "git" (auto-detected from git)
+	Branch         string
+	BaseRef        string
+	RepoRoot       string
+	OutputDir      string // custom output directory for .crit.json (empty = RepoRoot)
+	ReviewRound    int
+	IgnorePatterns []string
 
 	mu             sync.RWMutex
 	subscribers    map[chan SSEEvent]struct{}
@@ -100,7 +101,7 @@ type CritJSONFile struct {
 }
 
 // NewSessionFromGit creates a session by auto-detecting changed files via git.
-func NewSessionFromGit() (*Session, error) {
+func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 	root, err := RepoRoot()
 	if err != nil {
 		return nil, fmt.Errorf("not a git repository: %w", err)
@@ -125,18 +126,22 @@ func NewSessionFromGit() (*Session, error) {
 	if err != nil {
 		return nil, fmt.Errorf("detecting changes: %w", err)
 	}
+	// Apply ignore patterns
+	changes = filterIgnored(changes, ignorePatterns)
+
 	if len(changes) == 0 {
-		return nil, fmt.Errorf("no changed files detected")
+		return nil, fmt.Errorf("no changed files detected (after applying ignore patterns)")
 	}
 
 	s := &Session{
-		Mode:          "git",
-		Branch:        branch,
-		BaseRef:       baseRef,
-		RepoRoot:      root,
-		ReviewRound:   1,
-		subscribers:   make(map[chan SSEEvent]struct{}),
-		roundComplete: make(chan struct{}, 1),
+		Mode:           "git",
+		Branch:         branch,
+		BaseRef:        baseRef,
+		RepoRoot:       root,
+		ReviewRound:    1,
+		IgnorePatterns: ignorePatterns,
+		subscribers:    make(map[chan SSEEvent]struct{}),
+		roundComplete:  make(chan struct{}, 1),
 	}
 
 	for _, fc := range changes {
@@ -184,7 +189,7 @@ func NewSessionFromGit() (*Session, error) {
 
 // NewSessionFromFiles creates a session from explicitly provided file or directory paths.
 // When a directory is passed, all files within it are included recursively.
-func NewSessionFromFiles(paths []string) (*Session, error) {
+func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no files provided")
 	}
@@ -201,12 +206,13 @@ func NewSessionFromFiles(paths []string) (*Session, error) {
 			return nil, fmt.Errorf("file not found: %s", p)
 		}
 		if info.IsDir() {
-			dirFiles, err := walkDirectory(absPath)
+			dirFiles, err := walkDirectory(absPath, ignorePatterns)
 			if err != nil {
 				return nil, fmt.Errorf("walking directory %s: %w", p, err)
 			}
 			expandedPaths = append(expandedPaths, dirFiles...)
 		} else {
+			// Explicit files are never filtered by ignore patterns
 			expandedPaths = append(expandedPaths, absPath)
 		}
 	}
@@ -244,13 +250,14 @@ func NewSessionFromFiles(paths []string) (*Session, error) {
 	}
 
 	s := &Session{
-		Mode:          "files",
-		Branch:        branch,
-		BaseRef:       baseRef,
-		RepoRoot:      root,
-		ReviewRound:   1,
-		subscribers:   make(map[chan SSEEvent]struct{}),
-		roundComplete: make(chan struct{}, 1),
+		Mode:           "files",
+		Branch:         branch,
+		BaseRef:        baseRef,
+		RepoRoot:       root,
+		ReviewRound:    1,
+		IgnorePatterns: ignorePatterns,
+		subscribers:    make(map[chan SSEEvent]struct{}),
+		roundComplete:  make(chan struct{}, 1),
 	}
 
 	for _, absPath := range expandedPaths {
@@ -296,7 +303,7 @@ func NewSessionFromFiles(paths []string) (*Session, error) {
 
 // walkDirectory recursively walks a directory and returns all file paths,
 // skipping hidden directories and common non-text directories.
-func walkDirectory(dir string) ([]string, error) {
+func walkDirectory(dir string, ignorePatterns []string) ([]string, error) {
 	var files []string
 	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -327,6 +334,15 @@ func walkDirectory(dir string) ([]string, error) {
 		ext := strings.ToLower(filepath.Ext(name))
 		if isBinaryExtension(ext) {
 			return nil
+		}
+
+		// Apply ignore patterns (use path relative to dir)
+		if relPath, relErr := filepath.Rel(dir, path); relErr == nil {
+			for _, pat := range ignorePatterns {
+				if matchPattern(pat, relPath) {
+					return nil
+				}
+			}
 		}
 
 		files = append(files, path)
@@ -825,6 +841,9 @@ func (s *Session) RefreshFileList() {
 	if err != nil {
 		return
 	}
+
+	// Apply ignore patterns
+	changes = filterIgnored(changes, s.IgnorePatterns)
 
 	// Snapshot existing files under read lock
 	s.mu.RLock()

--- a/session_test.go
+++ b/session_test.go
@@ -807,7 +807,7 @@ func TestNewSessionFromGit_SubdirectoryCwd(t *testing.T) {
 	os.Chdir(filepath.Join(dir, "src"))
 	defer os.Chdir(origDir)
 
-	session, err := NewSessionFromGit()
+	session, err := NewSessionFromGit(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -843,7 +843,7 @@ func TestNewSessionFromGit_SubdirectoryCwd_UntrackedFiles(t *testing.T) {
 	os.Chdir(filepath.Join(dir, "src"))
 	defer os.Chdir(origDir)
 
-	session, err := NewSessionFromGit()
+	session, err := NewSessionFromGit(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Add two-tier JSON configuration (`~/.crit.config.json` global, `.crit.config.json` per-project) with merged precedence: CLI flags > env vars > project config > global config > defaults
- Add `ignore_patterns` for excluding files from review (gitignore-style syntax: `*.lock`, `vendor/`, `generated/*.pb.go`)
- Add `crit config` subcommand with `--generate` (scaffold a starter config) and `--help` (document all keys)
- Add `--no-ignore` flag and `CRIT_PORT` env var
- Zero new dependencies — uses `encoding/json` from stdlib

## Test plan

- [x] Unit tests for config loading, merging, pattern matching, and filtering
- [x] Integration test with real git repo verifying ignore patterns exclude files from session
- [x] Integration test for file-mode directory walk filtering
- [x] All existing tests pass with updated function signatures
- [x] `gofmt` clean
- [x] Smoke tested `crit config`, `crit config --generate`, `crit config --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)