### PR TITLE
feat: crit skill reuses existing instance for multi-round review

### DIFF
--- a/integrations/claude-code/crit.md
+++ b/integrations/claude-code/crit.md
@@ -1,13 +1,25 @@
 ---
 description: "Review code changes or a plan with crit inline comments"
-allowed-tools: Bash(crit:*), Bash(command ls:*), Read, Edit, Glob
+allowed-tools: Bash(crit:*), Bash(curl:*), Bash(command ls:*), Bash(pgrep:*), Read, Edit, Glob
 ---
 
 # Review with Crit
 
 Review and revise code changes or a plan using `crit` for inline comment review.
 
-## Step 1: Determine review mode
+## Step 1: Check for existing crit instance
+
+Before launching a new instance, check if crit is already running from a previous `/crit` invocation:
+
+```bash
+curl -s http://localhost:${CRIT_PORT:-0}/api/session 2>/dev/null
+```
+
+If you remember the port from a previous `/crit` run in this conversation AND the curl succeeds (returns JSON), skip to **Step 3a** — crit is already running. Call `crit go <port>` to trigger a new review round with inline diffs of your changes, then tell the user to review the new round.
+
+If no existing instance is found, continue to Step 2.
+
+## Step 2: Determine review mode
 
 Choose what to review based on context:
 
@@ -25,7 +37,7 @@ Choose what to review based on context:
 
 Show the selected mode/file to the user and ask for confirmation.
 
-## Step 2: Run crit for review
+## Step 3: Run crit for review
 
 Run `crit` **in the background** using `run_in_background: true`:
 
@@ -37,11 +49,25 @@ crit <plan-file>
 crit
 ```
 
+**Remember the port** from crit's startup output — you'll need it for `crit go` later and for detecting the running instance if `/crit` is called again.
+
 Tell the user: **"Crit is open in your browser. Leave inline comments on the plan, then click 'Finish Review'. Type 'go' here when you're done."**
 
 Wait for the user to respond before proceeding.
 
-## Step 3: Read the review output
+### Step 3a: Reuse existing crit instance
+
+If crit was already running (detected in Step 1), trigger a new round:
+
+```bash
+crit go <port>
+```
+
+This opens a new review round in the browser showing a diff of changes since the last round. Tell the user: **"Crit has a new review round showing your changes. Leave inline comments, then click 'Finish Review'. Type 'go' here when you're done."**
+
+Wait for the user to respond before proceeding.
+
+## Step 4: Read the review output
 
 After the user confirms, read the `.crit.json` file in the repo root (or working directory) using the Read tool.
 
@@ -61,7 +87,7 @@ The file contains structured JSON with comments per file:
 
 Identify all comments where `"resolved": false`.
 
-## Step 4: Address each review comment
+## Step 5: Address each review comment
 
 For each unresolved comment:
 
@@ -74,7 +100,7 @@ Editing the plan file triggers Crit's live reload - the user sees changes in the
 
 **If there are zero review comments**: inform the user no changes were requested and stop the background `crit` process.
 
-## Step 5: Signal completion
+## Step 6: Signal completion
 
 After all comments are addressed, signal to crit that edits are done:
 
@@ -84,7 +110,7 @@ crit go <port>
 
 The port is shown in crit's startup output (default: a random available port). This triggers a new review round in the browser with a diff of what changed.
 
-## Step 6: Summary
+## Step 7: Summary
 
 Show a summary:
 - Number of review comments found

--- a/integrations/cursor/crit-command.md
+++ b/integrations/cursor/crit-command.md
@@ -2,7 +2,19 @@
 
 Review and revise code changes or a plan using `crit` for inline comment review.
 
-## Step 1: Determine review mode
+## Step 1: Check for existing crit instance
+
+Before launching a new instance, check if crit is already running from a previous `/crit` invocation. If you remember the port from a previous run in this conversation, try reaching the server:
+
+```bash
+curl -s http://localhost:<port>/api/session 2>/dev/null
+```
+
+If the curl succeeds (returns JSON), skip to **Step 3a** — crit is already running. Call `crit go <port>` to trigger a new review round with inline diffs of your changes, then tell the user to review the new round.
+
+If no existing instance is found, continue to Step 2.
+
+## Step 2: Determine review mode
 
 Choose what to review based on context:
 
@@ -12,7 +24,7 @@ Choose what to review based on context:
 
 Show the selected mode/file to the user and ask for confirmation before proceeding.
 
-## Step 2: Run crit for review
+## Step 3: Run crit for review
 
 Run `crit` in a terminal:
 
@@ -20,11 +32,25 @@ Run `crit` in a terminal:
 crit <plan-file>
 ```
 
+**Remember the port** from crit's startup output — you'll need it for `crit go` later and for detecting the running instance if `/crit` is called again.
+
 Tell the user: **"Crit is open in your browser. Leave inline comments on the plan, then click 'Finish Review'. Type 'go' here when you're done."**
 
 Wait for the user to respond before proceeding.
 
-## Step 3: Read the review output
+### Step 3a: Reuse existing crit instance
+
+If crit was already running (detected in Step 1), trigger a new round:
+
+```bash
+crit go <port>
+```
+
+This opens a new review round in the browser showing a diff of changes since the last round. Tell the user: **"Crit has a new review round showing your changes. Leave inline comments, then click 'Finish Review'. Type 'go' here when you're done."**
+
+Wait for the user to respond before proceeding.
+
+## Step 4: Read the review output
 
 After the user confirms, read the `.crit.json` file in the repo root (or working directory).
 
@@ -44,7 +70,7 @@ The file contains structured JSON with comments per file:
 
 Identify all comments where `"resolved": false`.
 
-## Step 4: Address each review comment
+## Step 5: Address each review comment
 
 For each unresolved comment:
 
@@ -56,7 +82,7 @@ Editing the plan file triggers Crit's live reload - the user sees changes in the
 
 **If there are zero review comments**: inform the user no changes were requested.
 
-## Step 5: Signal completion
+## Step 6: Signal completion
 
 After all comments are addressed, signal to crit that edits are done:
 
@@ -66,7 +92,7 @@ crit go <port>
 
 The port is shown in crit's startup output. This triggers a new review round in the browser with a diff of what changed.
 
-## Step 6: Summary
+## Step 7: Summary
 
 Show a summary:
 - Number of review comments found

--- a/integrations/github-copilot/crit.prompt.md
+++ b/integrations/github-copilot/crit.prompt.md
@@ -2,7 +2,19 @@
 
 Review and revise code changes or a plan using `crit` for inline comment review.
 
-## Step 1: Determine review mode
+## Step 1: Check for existing crit instance
+
+Before launching a new instance, check if crit is already running from a previous `/crit` invocation. If you remember the port from a previous run in this conversation, try reaching the server:
+
+```bash
+curl -s http://localhost:<port>/api/session 2>/dev/null
+```
+
+If the curl succeeds (returns JSON), skip to **Step 3a** — crit is already running. Call `crit go <port>` to trigger a new review round with inline diffs of your changes, then tell the user to review the new round.
+
+If no existing instance is found, continue to Step 2.
+
+## Step 2: Determine review mode
 
 Choose what to review based on context:
 
@@ -12,7 +24,7 @@ Choose what to review based on context:
 
 Show the selected mode/file to the user and ask for confirmation before proceeding.
 
-## Step 2: Run crit for review
+## Step 3: Run crit for review
 
 Run `crit` in a terminal:
 
@@ -20,11 +32,25 @@ Run `crit` in a terminal:
 crit <plan-file>
 ```
 
+**Remember the port** from crit's startup output — you'll need it for `crit go` later and for detecting the running instance if `/crit` is called again.
+
 Tell the user: **"Crit is open in your browser. Leave inline comments on the plan, then click 'Finish Review'. Type 'go' here when you're done."**
 
 Wait for the user to respond before proceeding.
 
-## Step 3: Read the review output
+### Step 3a: Reuse existing crit instance
+
+If crit was already running (detected in Step 1), trigger a new round:
+
+```bash
+crit go <port>
+```
+
+This opens a new review round in the browser showing a diff of changes since the last round. Tell the user: **"Crit has a new review round showing your changes. Leave inline comments, then click 'Finish Review'. Type 'go' here when you're done."**
+
+Wait for the user to respond before proceeding.
+
+## Step 4: Read the review output
 
 After the user confirms, read the `.crit.json` file in the repo root (or working directory).
 
@@ -44,7 +70,7 @@ The file contains structured JSON with comments per file:
 
 Identify all comments where `"resolved": false`.
 
-## Step 4: Address each review comment
+## Step 5: Address each review comment
 
 For each unresolved comment:
 
@@ -56,7 +82,7 @@ Editing the plan file triggers Crit's live reload - the user sees changes in the
 
 **If there are zero review comments**: inform the user no changes were requested.
 
-## Step 5: Signal completion
+## Step 6: Signal completion
 
 After all comments are addressed, signal to crit that edits are done:
 
@@ -66,7 +92,7 @@ crit go <port>
 
 The port is shown in crit's startup output. This triggers a new review round in the browser with a diff of what changed.
 
-## Step 6: Summary
+## Step 7: Summary
 
 Show a summary:
 - Number of review comments found


### PR DESCRIPTION
## Summary

- When `/crit` is called again in the same conversation, the skill now checks if a crit server is already running on a remembered port
- If found, it triggers a new review round via `crit go <port>` instead of launching a fresh instance, so the user sees inline diffs of changes since the last round
- Updated integrations: **Claude Code**, **Cursor**, and **GitHub Copilot**

## Changes

All three step-by-step integration files get the same update:
- New **Step 1** checks for an existing crit instance via `curl` to the remembered port
- New **Step 3a** reuses the running instance with `crit go <port>` instead of launching fresh
- Instructs the agent to remember the port for subsequent invocations

Windsurf, Cline, and Aider integrations are rule-based (no step-by-step flow) so they don't need this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)