### PR TITLE
fix: isolate E2E tests from user config

### DIFF
--- a/e2e/setup-fixtures-filemode.sh
+++ b/e2e/setup-fixtures-filemode.sh
@@ -170,5 +170,8 @@ if [ -z "${CRIT_BIN:-}" ]; then
   (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" .)
 fi
 
+# Isolate from user's ~/.crit.config.json
+export HOME="$DIR"
+
 # Run crit in file mode (explicit file args, inside a git repo)
 exec "$CRIT_BIN" --no-open --quiet --port "$PORT" plan.md server.go handler.js

--- a/e2e/setup-fixtures-multifile.sh
+++ b/e2e/setup-fixtures-multifile.sh
@@ -152,5 +152,8 @@ if [ -z "${CRIT_BIN:-}" ]; then
   (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" .)
 fi
 
+# Isolate from user's ~/.crit.config.json
+export HOME="$DIR"
+
 # Run crit in file mode with explicit files AND a directory
 exec "$CRIT_BIN" --no-open --quiet --port "$PORT" plan.md main.go handler.ex lib/

--- a/e2e/setup-fixtures-nogit.sh
+++ b/e2e/setup-fixtures-nogit.sh
@@ -163,5 +163,8 @@ if [ -z "${CRIT_BIN:-}" ]; then
   (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" .)
 fi
 
+# Isolate from user's ~/.crit.config.json
+export HOME="$DIR"
+
 # Run crit in file mode outside any git repository
 exec "$CRIT_BIN" --no-open --quiet --port "$PORT" plan.md server.go handler.js

--- a/e2e/setup-fixtures-singlefile.sh
+++ b/e2e/setup-fixtures-singlefile.sh
@@ -80,5 +80,8 @@ if [ -z "${CRIT_BIN:-}" ]; then
   (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" .)
 fi
 
+# Isolate from user's ~/.crit.config.json
+export HOME="$DIR"
+
 # Run crit in single-file mode
 exec "$CRIT_BIN" --no-open --quiet --port "$PORT" plan.md

--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -297,5 +297,8 @@ fi
 echo "CRIT_BIN=$CRIT_BIN" > "/tmp/crit-e2e-state-$PORT"
 echo "CRIT_FIXTURE_DIR=$DIR" >> "/tmp/crit-e2e-state-$PORT"
 
+# Isolate from user's ~/.crit.config.json
+export HOME="$DIR"
+
 # Run crit in the fixture repo
 exec "$CRIT_BIN" --no-open --quiet --port "$PORT"


### PR DESCRIPTION
## Summary
- Set `HOME` to the temp fixture directory in all 5 E2E setup scripts before launching crit
- Prevents `LoadConfig` from reading `~/.crit.config.json`, which caused share button tests to fail when the user had `share_url` configured globally

Closes #53

## Test plan
- [x] `make e2e` passes (all share tests pass; 2 pre-existing failures in `comment-count-badge.spec.ts` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)