### PR TITLE
fix: flaky comment-count-badge E2E test race condition

### DIFF
--- a/e2e/tests/comment-count-badge.spec.ts
+++ b/e2e/tests/comment-count-badge.spec.ts
@@ -81,10 +81,14 @@ test.describe('Comment Count Badge', () => {
 
     await loadPage(page);
 
-    // 1 resolved + 2 unresolved → badge should show 2 (unresolved only)
-    await expect(countEl).toBeVisible();
-    await expect(countEl).not.toHaveClass(/comment-count-resolved/);
-    await expect(badgeEl).toHaveText('2');
+    // 1 resolved + 2 unresolved → badge should show 2 (unresolved only).
+    // Use toPass() to retry: an SSE comments-changed event may transiently
+    // update the badge after the initial page load.
+    await expect(async () => {
+      await expect(countEl).toBeVisible();
+      await expect(countEl).not.toHaveClass(/comment-count-resolved/);
+      await expect(badgeEl).toHaveText('2');
+    }).toPass({ timeout: 5000 });
   });
 
   test('badge increments when adding multiple comments', async ({ page, request }) => {
@@ -180,9 +184,13 @@ test.describe('Comment Count Badge', () => {
 
     await loadPage(page);
 
-    // 0 unresolved + 1 resolved → badge shows total (1) with muted styling
-    await expect(countEl).toBeVisible();
-    await expect(countEl).toHaveClass(/comment-count-resolved/);
-    await expect(badgeEl).toHaveText('1');
+    // 0 unresolved + 1 resolved → badge shows total (1) with muted styling.
+    // Use toPass() to retry: an SSE comments-changed event may transiently
+    // update the badge after the initial page load.
+    await expect(async () => {
+      await expect(countEl).toBeVisible();
+      await expect(countEl).toHaveClass(/comment-count-resolved/);
+      await expect(badgeEl).toHaveText('1');
+    }).toPass({ timeout: 5000 });
   });
 });

--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -327,10 +327,13 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     await request.post('/api/round-complete');
     await expect(page.locator('#waitingOverlay')).not.toHaveClass(/active/, { timeout: 5_000 });
 
-    // Only unresolved comment counts — icon visible, not in resolved state
+    // Only unresolved comment counts — icon visible, not in resolved state.
+    // Use toPass() to retry: SSE comments-changed may transiently update state.
     const countEl = page.locator('#commentCount');
-    await expect(countEl).toBeVisible();
-    await expect(countEl).not.toHaveClass(/comment-count-resolved/);
+    await expect(async () => {
+      await expect(countEl).toBeVisible();
+      await expect(countEl).not.toHaveClass(/comment-count-resolved/);
+    }).toPass({ timeout: 5000 });
 
     // Both should render: 1 resolved + 1 unresolved
     await expect(page.locator('.resolved-comment')).toHaveCount(1);

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -363,10 +363,13 @@ test.describe('Multi-Round — Frontend', () => {
     await request.post('/api/round-complete');
     await expect(page.locator('#waitingOverlay')).not.toHaveClass(/active/, { timeout: 5_000 });
 
-    // Only unresolved comment counts — icon visible, resolved-only would be dimmed
+    // Only unresolved comment counts — icon visible, resolved-only would be dimmed.
+    // Use toPass() to retry: SSE comments-changed may transiently update state.
     const countEl = page.locator('#commentCount');
-    await expect(countEl).toBeVisible();
-    await expect(countEl).not.toHaveClass(/comment-count-resolved/);
+    await expect(async () => {
+      await expect(countEl).toBeVisible();
+      await expect(countEl).not.toHaveClass(/comment-count-resolved/);
+    }).toPass({ timeout: 5000 });
 
     // Both should render: 1 resolved + 1 unresolved
     await expect(page.locator('.resolved-comment')).toHaveCount(1);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3779,6 +3779,7 @@
           f.comments = Array.isArray(commentsRes) ? commentsRes : [];
         }
         renderAllFiles();
+        updateCommentCount();
         updateTreeCommentBadges();
       } catch (err) {
         console.error('Error handling comments-changed:', err);

--- a/session.go
+++ b/session.go
@@ -1343,7 +1343,9 @@ func (s *Session) emitRoundStatus(edits int) {
 
 // loadResolvedComments reads .crit.json to pick up resolved fields the agent wrote.
 func (s *Session) loadResolvedComments() {
-	data, err := os.ReadFile(s.critJSONPath())
+	critPath := s.critJSONPath()
+	info, statErr := os.Stat(critPath)
+	data, err := os.ReadFile(critPath)
 	if err != nil {
 		// No .crit.json — clear all PreviousComments
 		s.mu.Lock()
@@ -1365,6 +1367,14 @@ func (s *Session) loadResolvedComments() {
 		} else {
 			f.PreviousComments = nil
 		}
+	}
+	// Record the current mtime so mergeExternalCritJSON does not re-process
+	// this same file. Without this, the file watcher could detect the
+	// externally-written .crit.json (e.g. from a test or crit comment) as a
+	// new change and wipe comments that were added via the API after the
+	// round completed.
+	if statErr == nil {
+		s.lastCritJSONMtime = info.ModTime()
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Server fix** (`session.go`): `loadResolvedComments()` now records `lastCritJSONMtime` after reading `.crit.json`, preventing the file watcher from re-processing it as an external change and wiping API-added comments
- **Frontend fix** (`frontend/app.js`): Added missing `updateCommentCount()` call in the `comments-changed` SSE handler so the header badge updates after external comment changes
- **Test resilience** (3 spec files): Wrapped transient class assertions in `toPass()` blocks for retry resilience in `comment-count-badge.spec.ts`, `round-complete.spec.ts`, and `round-complete.filemode.spec.ts`
- **Env var isolation** (5 fixture scripts): `unset CRIT_SHARE_URL` before launching crit — PR #56 isolated config files via `HOME` but env vars still leaked through, causing share tests to fail

## Root cause

The intermittent failure in `badge shows unresolved count, not total` was caused by a race between the file watcher and API-added comments:

1. `finishAndResolve()` writes `.crit.json` externally to mark a comment as resolved
2. `round-complete` calls `loadResolvedComments()` which reads `.crit.json` but **didn't record the mtime**
3. Test adds 2 new unresolved comments via API
4. File watcher tick fires `mergeExternalCritJSON()`, sees stale mtime, treats it as external change, and **wipes the API-added comments**
5. `comments-changed` SSE fires but **never called `updateCommentCount()`**, leaving the badge stale

## Test plan

- [x] Go tests pass
- [x] E2E suite: all 552 tests pass across all 5 projects (file 132, git 258, multi 18, nogit 132, single 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)