### PR TITLE
fix: add blue link styling to resolved comment bodies

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -956,6 +956,15 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .resolved-comment .resolved-body > :first-child { margin-top: 0; }
 .resolved-comment .resolved-body > :last-child { margin-bottom: 0; }
+.resolved-body a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-subtle);
+}
+.resolved-body a:hover {
+  color: var(--accent-hover);
+  border-bottom-color: var(--accent-hover);
+}
 .resolved-comment .resolved-note {
   font-style: italic;
   color: var(--fg-muted);


### PR DESCRIPTION
## Summary

- Links inside resolved comment bodies were unstyled (no blue color) because `.resolved-body a` had no CSS rules
- `.comment-body a` already had correct blue link styling using `--accent` variables
- Added matching `.resolved-body a` and `.resolved-body a:hover` rules to `style.css`

## Test plan

- [x] Add a comment with a markdown link (e.g. `[text](url)`) and resolve it
- [x] Verify the link appears blue in the resolved comment body (both git mode and file mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)