### PR TITLE
Compact comment form button labels

### DIFF
--- a/e2e/tests/templates.filemode.spec.ts
+++ b/e2e/tests/templates.filemode.spec.ts
@@ -37,7 +37,7 @@ test.describe('Comment Templates — File Mode', () => {
 
   test('Save as template button visible in actions row', async ({ page }) => {
     await openCommentForm(page);
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await expect(saveBtn).toBeVisible();
   });
 
@@ -47,7 +47,7 @@ test.describe('Comment Templates — File Mode', () => {
     await textarea.fill('This duplicates logic in …');
 
     // Save as template
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
     const overlay = page.locator('.save-template-overlay');
     await expect(overlay).toBeVisible();
@@ -78,12 +78,12 @@ test.describe('Comment Templates — File Mode', () => {
 
     // Save first template
     await textarea.fill('Template A');
-    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.comment-form-actions button', { hasText: '+ Template' }).click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
     // Save second template
     await textarea.fill('Template B');
-    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.comment-form-actions button', { hasText: '+ Template' }).click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
     const chips = page.locator('.comment-template-bar .template-chip');
@@ -97,7 +97,7 @@ test.describe('Comment Templates — File Mode', () => {
     const textarea = page.locator('.comment-form textarea');
     await textarea.fill('Survives reload');
 
-    await page.locator('.comment-form-actions button', { hasText: '+ Save as template' }).click();
+    await page.locator('.comment-form-actions button', { hasText: '+ Template' }).click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
     // Reload page

--- a/e2e/tests/templates.spec.ts
+++ b/e2e/tests/templates.spec.ts
@@ -35,7 +35,7 @@ test.describe('Comment Templates — Git Mode', () => {
 
   test('Save as template button visible in actions row', async ({ page }) => {
     await openCommentForm(page);
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await expect(saveBtn).toBeVisible();
   });
 
@@ -44,7 +44,7 @@ test.describe('Comment Templates — Git Mode', () => {
     const textarea = page.locator('.comment-form textarea');
     await textarea.fill('Consider using X instead');
 
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
 
     const overlay = page.locator('.save-template-overlay');
@@ -58,7 +58,7 @@ test.describe('Comment Templates — Git Mode', () => {
     const textarea = page.locator('.comment-form textarea');
     await textarea.fill('Needs a test for this');
 
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
 
     const overlay = page.locator('.save-template-overlay');
@@ -79,7 +79,7 @@ test.describe('Comment Templates — Git Mode', () => {
     await textarea.fill('My template text');
 
     // Save a template first
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
@@ -99,7 +99,7 @@ test.describe('Comment Templates — Git Mode', () => {
     await textarea.fill('Temp template');
 
     // Save a template
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
@@ -121,7 +121,7 @@ test.describe('Comment Templates — Git Mode', () => {
     await textarea.fill('Persistent template');
 
     // Save template
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
     await page.locator('.save-template-overlay button', { hasText: 'Save' }).click();
 
@@ -142,7 +142,7 @@ test.describe('Comment Templates — Git Mode', () => {
   test('save dialog does nothing when textarea is empty', async ({ page }) => {
     await openCommentForm(page);
     // textarea is empty by default
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
 
     // Dialog should not appear
@@ -155,7 +155,7 @@ test.describe('Comment Templates — Git Mode', () => {
     const textarea = page.locator('.comment-form textarea');
     await textarea.fill('Cancel me');
 
-    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Save as template' });
+    const saveBtn = page.locator('.comment-form-actions button', { hasText: '+ Template' });
     await saveBtn.click();
 
     const overlay = page.locator('.save-template-overlay');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2860,7 +2860,7 @@
 
     var saveTemplateBtn = document.createElement('button');
     saveTemplateBtn.className = 'btn btn-sm';
-    saveTemplateBtn.textContent = '+ Save as template';
+    saveTemplateBtn.textContent = '+ Template';
     saveTemplateBtn.addEventListener('click', function(e) {
       e.preventDefault();
       showSaveTemplateDialog(textarea, templateBar);
@@ -3005,7 +3005,7 @@
 
     const submitBtn = document.createElement('button');
     submitBtn.className = 'btn btn-sm btn-primary';
-    submitBtn.textContent = formObj.editingId ? 'Update Comment' : 'Add Comment';
+    submitBtn.textContent = formObj.editingId ? 'Update' : 'Submit';
     submitBtn.addEventListener('click', function() { submitComment(textarea.value, formObj); });
 
     actions.appendChild(cancelBtn);


### PR DESCRIPTION
## Summary
- Shorten button labels to fit on one line: "Add Comment" → "Submit", "Update Comment" → "Update", "+ Save as template" → "+ Template"
- Update E2E tests to match new labels

## Test plan
- [x] Open a comment form — buttons should fit on one line
- [ ] Verify "Submit" button adds a comment
- [x] Edit a comment — verify "Update" button works
- [ ] Verify "+ Template" opens the save-as-template dialog
- [ ] Run `make e2e` — templates tests pass with new labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)