### PR TITLE
feat: idempotent sharing with scope-aware stale detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,8 +152,12 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Idempotent: if already shared, print the existing URL.
-		existingURL, _ := loadExistingShareState(critDir)
+		// Idempotent: if already shared (same file set), print the existing URL.
+		sharePaths := make([]string, len(files))
+		for i, f := range files {
+			sharePaths[i] = f.Path
+		}
+		existingURL, _ := loadExistingShareState(critDir, sharePaths)
 		if existingURL != "" {
 			fmt.Println(existingURL)
 			if showQR {
@@ -180,7 +184,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err := persistShareState(critDir, url, deleteToken); err != nil {
+		if err := persistShareState(critDir, url, deleteToken, shareScope(filePaths)); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not save share state to .crit.json: %v\n", err)
 		}
 

--- a/server.go
+++ b/server.go
@@ -183,7 +183,12 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	paths := make([]string, len(files))
+	for i, f := range files {
+		paths[i] = f.Path
+	}
 	s.session.SetSharedURLAndToken(url, deleteToken)
+	s.session.SetShareScope(shareScope(paths))
 	writeJSON(w, map[string]any{"url": url, "delete_token": deleteToken})
 }
 

--- a/session.go
+++ b/session.go
@@ -77,6 +77,7 @@ type Session struct {
 	writeGen          int
 	sharedURL         string
 	deleteToken       string
+	shareScope        string
 	status            *Status
 	roundComplete     chan struct{}
 	pendingEdits      int
@@ -92,6 +93,7 @@ type CritJSON struct {
 	ReviewRound int                     `json:"review_round"`
 	ShareURL    string                  `json:"share_url,omitempty"`
 	DeleteToken string                  `json:"delete_token,omitempty"`
+	ShareScope  string                  `json:"share_scope,omitempty"`
 	Files       map[string]CritJSONFile `json:"files"`
 }
 
@@ -546,6 +548,20 @@ func (s *Session) SetSharedURLAndToken(url, token string) {
 	s.scheduleWrite()
 }
 
+// SetShareScope stores the scope hash for the current share.
+func (s *Session) SetShareScope(scope string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shareScope = scope
+}
+
+// GetShareScope returns the stored share scope hash.
+func (s *Session) GetShareScope() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.shareScope
+}
+
 // GetShareState returns the shared URL and delete token atomically.
 func (s *Session) GetShareState() (string, string) {
 	s.mu.RLock()
@@ -719,6 +735,7 @@ func (s *Session) WriteFiles() {
 	cj.ReviewRound = s.ReviewRound
 	cj.ShareURL = s.sharedURL
 	cj.DeleteToken = s.deleteToken
+	cj.ShareScope = s.shareScope
 
 	// Overlay session files: merge with disk comments, remove entries with no comments.
 	for _, f := range s.Files {
@@ -757,7 +774,7 @@ func (s *Session) WriteFiles() {
 	s.mu.RUnlock()
 
 	// Only remove if nothing meaningful remains
-	if len(cj.Files) == 0 && cj.ShareURL == "" && cj.DeleteToken == "" {
+	if len(cj.Files) == 0 && cj.ShareURL == "" && cj.DeleteToken == "" && cj.ShareScope == "" {
 		os.Remove(critPath)
 		s.mu.Lock()
 		s.lastCritJSONMtime = time.Time{}
@@ -905,8 +922,22 @@ func (s *Session) loadCritJSON() {
 		return
 	}
 
-	s.sharedURL = cj.ShareURL
-	s.deleteToken = cj.DeleteToken
+	// Only restore share state if the file set matches what was shared.
+	if cj.ShareScope != "" {
+		paths := make([]string, 0, len(s.Files))
+		for _, f := range s.Files {
+			paths = append(paths, f.Path)
+		}
+		if shareScope(paths) == cj.ShareScope {
+			s.sharedURL = cj.ShareURL
+			s.deleteToken = cj.DeleteToken
+			s.shareScope = cj.ShareScope
+		}
+	} else {
+		// Legacy .crit.json without scope — load unconditionally for backwards compat.
+		s.sharedURL = cj.ShareURL
+		s.deleteToken = cj.DeleteToken
+	}
 
 	// Restore comments for files that match by path
 	for _, f := range s.Files {

--- a/session_test.go
+++ b/session_test.go
@@ -1223,3 +1223,63 @@ func TestSession_MergeExternalCritJSON_ClearDetected(t *testing.T) {
 		t.Errorf("expected 0 comments after clear, got %d", len(comments))
 	}
 }
+
+func TestLoadCritJSON_IgnoresStaleShareState(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	// Write .crit.json with share state for a different file set
+	scope := shareScope([]string{"old-plan.md"})
+	cj := CritJSON{
+		ShareURL:    "https://crit.live/r/old",
+		DeleteToken: "old-token",
+		ShareScope:  scope,
+		Files:       map[string]CritJSONFile{},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	// Create session with DIFFERENT files
+	sess := &Session{
+		OutputDir:   dir,
+		Files:       []*FileEntry{{Path: "new-plan.md", Content: "# New"}},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+	sess.loadCritJSON()
+
+	url, token := sess.GetShareState()
+	if url != "" || token != "" {
+		t.Errorf("expected stale share state to be ignored, got url=%q token=%q", url, token)
+	}
+}
+
+func TestLoadCritJSON_RestoresMatchingShareState(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	scope := shareScope([]string{"plan.md"})
+	cj := CritJSON{
+		ShareURL:    "https://crit.live/r/current",
+		DeleteToken: "current-token",
+		ShareScope:  scope,
+		Files:       map[string]CritJSONFile{},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	// Create session with SAME files
+	sess := &Session{
+		OutputDir:   dir,
+		Files:       []*FileEntry{{Path: "plan.md", Content: "# Plan"}},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+	sess.loadCritJSON()
+
+	url, token := sess.GetShareState()
+	if url != "https://crit.live/r/current" {
+		t.Errorf("expected share state restored, got url=%q", url)
+	}
+	if token != "current-token" {
+		t.Errorf("expected token restored, got token=%q", token)
+	}
+}

--- a/share.go
+++ b/share.go
@@ -2,13 +2,27 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 )
+
+// shareScope computes a hash of sorted file paths, used to detect when
+// share state belongs to a different file set.
+func shareScope(paths []string) string {
+	sorted := make([]string, len(paths))
+	copy(sorted, paths)
+	sort.Strings(sorted)
+	h := sha256.Sum256([]byte(strings.Join(sorted, "\n")))
+	return hex.EncodeToString(h[:8]) // 16-char hex prefix is enough
+}
 
 // shareFile represents a file to be shared.
 type shareFile struct {
@@ -188,9 +202,9 @@ func loadCommentsForShare(dir string, filePaths []string) ([]shareComment, int) 
 	return comments, round
 }
 
-// persistShareState writes the share URL and delete token to .crit.json,
+// persistShareState writes the share URL, delete token, and scope hash to .crit.json,
 // preserving any existing content.
-func persistShareState(dir string, shareURL string, deleteToken string) error {
+func persistShareState(dir string, shareURL string, deleteToken string, scope string) error {
 	critPath := filepath.Join(dir, ".crit.json")
 	var cj CritJSON
 	if data, err := os.ReadFile(critPath); err == nil {
@@ -201,6 +215,7 @@ func persistShareState(dir string, shareURL string, deleteToken string) error {
 	}
 	cj.ShareURL = shareURL
 	cj.DeleteToken = deleteToken
+	cj.ShareScope = scope
 	cj.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 
 	data, err := json.MarshalIndent(cj, "", "  ")
@@ -223,6 +238,7 @@ func clearShareState(dir string) error {
 	}
 	cj.ShareURL = ""
 	cj.DeleteToken = ""
+	cj.ShareScope = ""
 	cj.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 
 	out, err := json.MarshalIndent(cj, "", "  ")
@@ -233,8 +249,8 @@ func clearShareState(dir string) error {
 }
 
 // loadExistingShareState reads .crit.json and returns any persisted share URL and delete token.
-// Returns ("", "") if no share state exists.
-func loadExistingShareState(dir string) (string, string) {
+// Returns ("", "") if no share state exists or if the scope doesn't match the given paths.
+func loadExistingShareState(dir string, paths []string) (string, string) {
 	critPath := filepath.Join(dir, ".crit.json")
 	data, err := os.ReadFile(critPath)
 	if err != nil {
@@ -242,6 +258,10 @@ func loadExistingShareState(dir string) (string, string) {
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
+		return "", ""
+	}
+	// If scope is set, only return share state if it matches the current file set.
+	if cj.ShareScope != "" && cj.ShareScope != shareScope(paths) {
 		return "", ""
 	}
 	return cj.ShareURL, cj.DeleteToken

--- a/share_test.go
+++ b/share_test.go
@@ -256,7 +256,7 @@ func TestPersistShareState(t *testing.T) {
 	dir := t.TempDir()
 
 	// Persist to new .crit.json
-	err := persistShareState(dir, "https://crit.live/r/abc", "tok_123")
+	err := persistShareState(dir, "https://crit.live/r/abc", "tok_123", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
 	// Persist share state
-	err := persistShareState(dir, "https://crit.live/r/def", "tok_456")
+	err := persistShareState(dir, "https://crit.live/r/def", "tok_456", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -559,6 +559,7 @@ func TestLoadExistingShareState(t *testing.T) {
 	dir := t.TempDir()
 	critPath := filepath.Join(dir, ".crit.json")
 
+	// Legacy .crit.json without scope — loads unconditionally
 	cj := CritJSON{
 		ShareURL:    "https://crit.live/r/existing",
 		DeleteToken: "del-token-123",
@@ -567,7 +568,7 @@ func TestLoadExistingShareState(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(critPath, data, 0644)
 
-	url, token := loadExistingShareState(dir)
+	url, token := loadExistingShareState(dir, []string{"anything.md"})
 	if url != "https://crit.live/r/existing" {
 		t.Errorf("expected existing URL, got %q", url)
 	}
@@ -578,7 +579,7 @@ func TestLoadExistingShareState(t *testing.T) {
 
 func TestLoadExistingShareState_NoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	url, token := loadExistingShareState(dir)
+	url, token := loadExistingShareState(dir, []string{"plan.md"})
 	if url != "" || token != "" {
 		t.Errorf("expected empty, got url=%q token=%q", url, token)
 	}
@@ -591,9 +592,35 @@ func TestLoadExistingShareState_NoShareState(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(critPath, data, 0644)
 
-	url, token := loadExistingShareState(dir)
+	url, token := loadExistingShareState(dir, []string{"plan.md"})
 	if url != "" || token != "" {
 		t.Errorf("expected empty, got url=%q token=%q", url, token)
+	}
+}
+
+func TestLoadExistingShareState_ScopeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	cj := CritJSON{
+		ShareURL:    "https://crit.live/r/old",
+		DeleteToken: "old-token",
+		ShareScope:  shareScope([]string{"old-plan.md"}),
+		Files:       map[string]CritJSONFile{},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	// Different file set — should NOT return share state
+	url, token := loadExistingShareState(dir, []string{"new-plan.md"})
+	if url != "" || token != "" {
+		t.Errorf("expected empty for mismatched scope, got url=%q token=%q", url, token)
+	}
+
+	// Same file set — should return share state
+	url, token = loadExistingShareState(dir, []string{"old-plan.md"})
+	if url != "https://crit.live/r/old" {
+		t.Errorf("expected URL for matching scope, got %q", url)
 	}
 }
 
@@ -641,5 +668,26 @@ func TestResolveShareURL(t *testing.T) {
 				t.Errorf("resolveShareURL(%q) = %q, want %q", tt.flag, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestShareScope(t *testing.T) {
+	// Same paths in different order produce same hash
+	h1 := shareScope([]string{"b.md", "a.md"})
+	h2 := shareScope([]string{"a.md", "b.md"})
+	if h1 != h2 {
+		t.Errorf("expected same hash regardless of order, got %q vs %q", h1, h2)
+	}
+
+	// Different paths produce different hash
+	h3 := shareScope([]string{"c.md"})
+	if h1 == h3 {
+		t.Error("different file sets should produce different hashes")
+	}
+
+	// Empty produces a hash (not empty string)
+	h4 := shareScope([]string{})
+	if h4 == "" {
+		t.Error("empty file set should still produce a hash")
 	}
 }


### PR DESCRIPTION
## Summary

- **Idempotent `POST /api/share`**: If the session already has a shared URL, return it without calling crit-web. Uses `GetShareState()` to read URL + token atomically under one lock.
- **Idempotent `crit share` CLI**: If `.crit.json` already has share state for the same file set, print the existing URL and exit.
- **Share scope hash**: Stores a hash of sorted file paths (`share_scope`) alongside share state in `.crit.json`. On session load or CLI share, only restores/returns share state if the current file set matches. Prevents stale "Shared" badge when reviewing different files in the same repo.
- **Backwards compatible**: Legacy `.crit.json` without `share_scope` loads share state unconditionally (same as before).

To re-sync a shared review: `crit unpublish && crit share`.

## Test plan

- [x] `TestHandleShare_AlreadyShared` — server returns existing URL, mock crit-web NOT called
- [x] `TestLoadExistingShareState` — CLI returns share state from `.crit.json`
- [x] `TestLoadExistingShareState_ScopeMismatch` — different file set returns empty
- [x] `TestLoadCritJSON_IgnoresStaleShareState` — session startup skips stale share state
- [x] `TestLoadCritJSON_RestoresMatchingShareState` — session startup restores matching share state
- [x] `TestShareScope` — order-independent, unique per file set
- [x] Manual: share → modify → share again (same URL) → share different file (new URL)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)