### PR TITLE
fix: rename skill from crit to crit-cli to avoid command collision

### DIFF
--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -1,9 +1,11 @@
 ---
-name: crit
+name: crit-cli
 description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
 ---
 
 # Crit CLI Reference
+
+> If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
 ## .crit.json Format
 

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -1,9 +1,11 @@
 ---
-name: crit
+name: crit-cli
 description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
 ---
 
 # Crit CLI Reference
+
+> If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
 ## .crit.json Format
 

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -1,9 +1,11 @@
 ---
-name: crit
+name: crit-cli
 description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
 ---
 
 # Crit CLI Reference
+
+> If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
 ## .crit.json Format
 


### PR DESCRIPTION
## Summary

- Renamed the skill directory from `skills/crit/` to `skills/crit-cli/` across all three integrations (claude-code, cursor, github-copilot)
- Updated frontmatter `name: crit` → `name: crit-cli`
- Added a delegation clause: if a plan was just written and the user said `/crit`, invoke the command instead of loading this reference skill

The skill and command both resolved to `crit:crit` in Claude's skill list, so typing `/crit` after writing a plan would load the reference SKILL.md instead of executing the review workflow command.

## Test plan

- [x] Install plugin locally, verify `/crit` triggers the command (review workflow), not the skill
- [x] Verify the skill still loads when working with `.crit.json`, `crit comment`, `crit pull/push`, `crit share`

🤖 Generated with [Claude Code](https://claude.com/claude-code)