### PR TITLE
fix: use git-subdir source to avoid cloning entire repo on plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,11 @@
     {
       "name": "crit",
       "description": "Close the feedback loop on AI coding: review plans and code changes with GitHub-style inline comments, then let the agent address them.",
-      "source": "./integrations/claude-code",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/tomasz-tomczyk/crit.git",
+        "path": "integrations/claude-code"
+      },
       "homepage": "https://crit.live",
       "category": "development"
     }


### PR DESCRIPTION
## Summary

- Switch marketplace plugin source from relative path (`./integrations/claude-code`) to `git-subdir` source type
- `git-subdir` uses a **sparse, partial clone** to fetch only the `integrations/claude-code` subdirectory, avoiding downloading the entire repo (Go source, tests, e2e, frontend) when installing the plugin

Ref: [Plugin source docs — Git subdirectories](https://code.claude.com/docs/en/plugin-marketplaces#git-subdirectories)

Closes #85

## Test plan

- [ ] Uninstall and reinstall the plugin via `/plugin marketplace add tomasz-tomczyk/crit` and verify only plugin files are fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)