### PR TITLE
fix: suggest button inserts correct content for old-side diff comments

### DIFF
--- a/e2e/tests/old-side-suggest.spec.ts
+++ b/e2e/tests/old-side-suggest.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, goSection } from './helpers';
+
+test.describe('Old-side suggest button', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('suggest on old-side deletion line inserts old content', async ({ page }) => {
+    await loadPage(page);
+    const section = goSection(page);
+
+    // server.go split diff: find a deletion line on the left side
+    const deletionSide = section.locator('.diff-split-side.deletion[data-diff-line-num]').first();
+    await deletionSide.scrollIntoViewIfNeeded();
+    await deletionSide.hover();
+    await deletionSide.locator('.diff-comment-btn').click();
+
+    // Click the suggest button
+    const suggestBtn = page.locator('.comment-form .btn', { hasText: '± Suggest' });
+    await suggestBtn.click();
+
+    // The textarea should contain a suggestion block with OLD file content, not new
+    const textarea = page.locator('.comment-form textarea');
+    const value = await textarea.inputValue();
+    expect(value).toContain('```suggestion');
+    expect(value).toContain('```');
+
+    // The deletion line's text content should appear in the suggestion
+    const diffContent = await deletionSide.locator('.diff-content').textContent();
+    expect(value).toContain(diffContent?.trim() || '');
+  });
+
+  test('suggest on new-side addition line still inserts new content', async ({ page }) => {
+    await loadPage(page);
+    const section = goSection(page);
+
+    // server.go split diff: find an addition line on the right side
+    const additionSide = section.locator('.diff-split-side.addition[data-diff-line-num]').first();
+    await additionSide.scrollIntoViewIfNeeded();
+    await additionSide.hover();
+    await additionSide.locator('.diff-comment-btn').click();
+
+    // Click suggest
+    const suggestBtn = page.locator('.comment-form .btn', { hasText: '± Suggest' });
+    await suggestBtn.click();
+
+    const textarea = page.locator('.comment-form textarea');
+    const value = await textarea.inputValue();
+    expect(value).toContain('```suggestion');
+
+    // The addition line content should appear in the suggestion
+    const diffContent = await additionSide.locator('.diff-content').textContent();
+    expect(value).toContain(diffContent?.trim() || '');
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3395,13 +3395,35 @@
     return wrapper;
   }
 
+  function getOldSideLinesFromHunks(file, startLine, endLine) {
+    var lines = [];
+    if (!file.diffHunks) return lines;
+    for (var h = 0; h < file.diffHunks.length; h++) {
+      var hunkLines = file.diffHunks[h].Lines || [];
+      for (var i = 0; i < hunkLines.length; i++) {
+        var dl = hunkLines[i];
+        if ((dl.Type === 'context' || dl.Type === 'del') && dl.OldNum >= startLine && dl.OldNum <= endLine) {
+          lines.push({ num: dl.OldNum, content: dl.Content });
+        }
+      }
+    }
+    lines.sort(function(a, b) { return a.num - b.num; });
+    return lines.map(function(l) { return l.content; });
+  }
+
   function insertSuggestion(textarea) {
     var key = textarea.dataset.formKey;
     var formObj = activeForms.find(function(f) { return f.formKey === key; });
     if (!formObj) return;
     const file = getFileByPath(formObj.filePath);
     if (!file) return;
-    const lines = file.content.split('\n').slice(formObj.startLine - 1, formObj.endLine);
+    var lines;
+    if (formObj.side === 'old') {
+      lines = getOldSideLinesFromHunks(file, formObj.startLine, formObj.endLine);
+    } else {
+      lines = file.content.split('\n').slice(formObj.startLine - 1, formObj.endLine);
+    }
+    if (lines.length === 0) return;
     const suggestion = '```suggestion\n' + lines.join('\n') + '\n```';
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;


### PR DESCRIPTION
## Summary

Fixes #89

When commenting on the left side (old/deletion) of a split diff view, the **Suggest** button was inserting lines from the new file version instead of the old. This happened because `insertSuggestion()` always read from `file.content` (the current version) using old-side line numbers.

**Fix:** Added `getOldSideLinesFromHunks()` helper that extracts old-side content directly from parsed diff hunks (lines with type "context" or "del"). `insertSuggestion()` now branches on `formObj.side === 'old'` to use this helper instead of `file.content`.

## Changes

- `frontend/app.js` — Added `getOldSideLinesFromHunks()` helper, modified `insertSuggestion()` to use it for old-side comments
- `e2e/tests/old-side-suggest.spec.ts` — E2E tests for old-side deletion suggest + new-side regression guard

## Test plan

- [x] E2E test: suggest on old-side deletion line inserts old content
- [x] E2E test: suggest on new-side addition line still inserts new content
- [x] Full E2E suite passes (574 tests, 0 failures)