### PR TITLE
fix: deduplicate ignore_patterns when config files resolve to same path

### DIFF
--- a/config.go
+++ b/config.go
@@ -141,11 +141,17 @@ func LoadConfig(projectDir string) Config {
 		fmt.Fprintf(os.Stderr, "Warning: reading global config: %v\n", err)
 	}
 
-	// 2. Project config
+	// 2. Project config (skip if same file as global config, e.g. when CWD is home dir)
+	var project Config
+	var projectPresence configPresence
 	projectConfigPath := filepath.Join(projectDir, ".crit.config.json")
-	project, projectPresence, err := loadConfigFile(projectConfigPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: reading project config: %v\n", err)
+	globalAbs, _ := filepath.Abs(globalConfigPath())
+	projectAbs, _ := filepath.Abs(projectConfigPath)
+	if globalAbs != projectAbs {
+		project, projectPresence, err = loadConfigFile(projectConfigPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: reading project config: %v\n", err)
+		}
 	}
 
 	// 3. Merge global + project

--- a/config_test.go
+++ b/config_test.go
@@ -367,6 +367,22 @@ func TestLoadConfigAuthorFromConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfigSameFileNoDuplicatePatterns(t *testing.T) {
+	// When CWD is the home dir, global and project config resolve to the same file.
+	// Patterns should not be duplicated. (GitHub issue #92)
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	os.WriteFile(filepath.Join(homeDir, ".crit.config.json"),
+		[]byte(`{"ignore_patterns": ["*.lock", "*.min.js", "*.min.css", ".crit.json"]}`), 0644)
+
+	cfg := LoadConfig(homeDir)
+
+	// Should have exactly 4 patterns, not 8
+	if len(cfg.IgnorePatterns) != 4 {
+		t.Errorf("IgnorePatterns = %v (len %d), want 4 unique entries (not duplicated)", cfg.IgnorePatterns, len(cfg.IgnorePatterns))
+	}
+}
+
 func TestNewSessionFromGitWithIgnore(t *testing.T) {
 	dir := initTestRepoForConfig(t)
 


### PR DESCRIPTION
## Summary

- When running `crit config` from the home directory, both global (`~/.crit.config.json`) and project (`.crit.config.json` in CWD) config paths resolve to the same file, causing `ignore_patterns` to be unioned with themselves and doubled
- Skip loading the project config when its absolute path matches the global config path

Fixes #92

## Test plan

- [x] Added `TestLoadConfigSameFileNoDuplicatePatterns` — sets HOME to a temp dir with 4 ignore patterns, loads config with that dir as project dir, asserts exactly 4 patterns (not 8)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)