### PR TITLE
fix: merge adjacent word-diff highlights and drop whitespace-only ranges

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2209,8 +2209,11 @@
     if (oldUnchanged === oldTokens.length && newUnchanged === newTokens.length) return null;
 
 
-    // Build character ranges for changed tokens
-    function buildRanges(tokens, keep) {
+    // Build character ranges for changed tokens.
+    // Whitespace-only tokens between two changed tokens are absorbed into the
+    // range so that "word1 word2" highlights as one continuous span instead of
+    // two spans with an unhighlighted gap on the space.
+    function buildRanges(tokens, keep, line) {
       var ranges = [];
       var charIdx = 0;
       var rangeStart = -1;
@@ -2219,6 +2222,16 @@
           if (rangeStart === -1) rangeStart = charIdx;
         } else {
           if (rangeStart !== -1) {
+            // If this kept token is whitespace and a later token is changed,
+            // absorb the whitespace into the current range.
+            if (/^\s+$/.test(tokens[i])) {
+              var hasMoreChanged = false;
+              for (var j = i + 1; j < tokens.length; j++) {
+                if (!keep[j]) { hasMoreChanged = true; break; }
+                if (!/^\s+$/.test(tokens[j])) break;
+              }
+              if (hasMoreChanged) { charIdx += tokens[i].length; continue; }
+            }
             ranges.push([rangeStart, charIdx]);
             rangeStart = -1;
           }
@@ -2226,12 +2239,14 @@
         charIdx += tokens[i].length;
       }
       if (rangeStart !== -1) ranges.push([rangeStart, charIdx]);
-      return ranges;
+      // Drop ranges that cover only whitespace (e.g. indentation changes) —
+      // the line is already colored as added/removed so highlighting spaces is noise.
+      return ranges.filter(function(r) { return !/^\s+$/.test(line.slice(r[0], r[1])); });
     }
 
     return {
-      oldRanges: buildRanges(oldTokens, oldKeep),
-      newRanges: buildRanges(newTokens, newKeep),
+      oldRanges: buildRanges(oldTokens, oldKeep, oldLine),
+      newRanges: buildRanges(newTokens, newKeep, newLine),
     };
   }
 

--- a/test/test-diff.sh
+++ b/test/test-diff.sh
@@ -58,6 +58,36 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 GOEOF
+
+# Create an Elixir file to test adjacent word-diff merging and whitespace-only filtering
+cat > "$WORD_DIFF_DIR/accounts.ex" << 'EXEOF'
+defmodule MyApp.Accounts do
+  def reset_password(token) do
+    case verify_reset_password_token(token) do
+      {:ok, provider} ->
+        case Accounts.update_provider_password(provider, %{
+               "password" => password,
+               "password_confirmation" => password_confirmation
+             }) do
+          {:ok, _} -> :ok
+          {:error, changeset} -> {:error, changeset}
+        end
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def provider_password_change(provider, params) do
+    provider
+    |> cast(params, [:password, :password_confirmation])
+    |> validate_required([:password, :password_confirmation])
+    |> validate_length(:password, min: 4)
+    |> validate_confirmation(:password)
+    |> hash_password()
+  end
+end
+EXEOF
+
 git -C "$WORD_DIFF_DIR" add -A && git -C "$WORD_DIFF_DIR" commit -q -m "initial"
 
 # Modify the file to produce good word-level diff pairs
@@ -86,6 +116,32 @@ func main() {
 	}
 }
 GOEOF
+
+# Modify the Elixir file — tests both adjacent word merging and whitespace-only filtering
+cat > "$WORD_DIFF_DIR/accounts.ex" << 'EXEOF'
+defmodule MyApp.Accounts do
+  def reset_password(token) do
+    case verify_reset_password_token(token) do
+      {:ok, provider} ->
+        require_complex? =
+          provider.org_id
+          |> Entities.org_preferences(["org.complex_passwords"])
+          |> Entities.is_pref_enabled?("org.complex_passwords")
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def provider_password_change(provider, params, opts \\ []) do
+      changeset =
+        provider
+        |> cast(params, [:password, :password_confirmation])
+        |> validate_required([:password, :password_confirmation])
+        |> validate_length(:password, min: 8)
+        |> validate_confirmation(:password)
+  end
+end
+EXEOF
 
 echo ""
 echo "Starting git-mode crit for word-level diff on port $WORD_DIFF_PORT..."


### PR DESCRIPTION
## Summary

- Merges adjacent word-diff highlight spans separated only by whitespace into one continuous span, eliminating distracting gaps when multiple consecutive words all changed
- Drops highlight ranges that consist entirely of whitespace (e.g. indentation changes), since the line is already colored as added/removed
- Adds Elixir fixture to `make test-diff` covering both scenarios

## Test plan

- [x] `go test ./...` passes
- [x] `make test-diff` — verify word-level diffs on instance 2: adjacent changed words show as one continuous highlight, indentation-only changes have no small highlight blocks
- [x] `make e2e` — existing E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)