### PR TITLE
refactor: deduplicate comment carry-forward logic

### DIFF
--- a/session.go
+++ b/session.go
@@ -1237,6 +1237,24 @@ func (s *Session) watchFileMtimes(stop <-chan struct{}) {
 	}
 }
 
+func carryForwardComment(old Comment, newID string, now string) Comment {
+	return Comment{
+		ID:              newID,
+		StartLine:       old.StartLine,
+		EndLine:         old.EndLine,
+		Side:            old.Side,
+		Body:            old.Body,
+		Author:          old.Author,
+		CreatedAt:       old.CreatedAt,
+		UpdatedAt:       now,
+		Resolved:        old.Resolved,
+		ResolutionNote:  old.ResolutionNote,
+		ResolutionLines: old.ResolutionLines,
+		CarriedForward:  true,
+		ReviewRound:     old.ReviewRound,
+	}
+}
+
 // handleRoundCompleteGit handles round completion in git mode.
 // Re-runs ChangedFiles, re-computes diffs, refreshes file list.
 // Must only be called from the single watcher goroutine (watchGit).
@@ -1266,21 +1284,7 @@ func (s *Session) handleRoundCompleteGit() {
 	for _, f := range s.Files {
 		now := time.Now().UTC().Format(time.RFC3339)
 		for _, c := range f.PreviousComments {
-			carried := Comment{
-				ID:              fmt.Sprintf("c%d", f.nextID),
-				StartLine:       c.StartLine,
-				EndLine:         c.EndLine,
-				Side:            c.Side,
-				Body:            c.Body,
-				Author:          c.Author,
-				CreatedAt:       c.CreatedAt,
-				UpdatedAt:       now,
-				Resolved:        c.Resolved,
-				ResolutionNote:  c.ResolutionNote,
-				ResolutionLines: c.ResolutionLines,
-				CarriedForward:  true,
-				ReviewRound:     c.ReviewRound,
-			}
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
 			f.nextID++
 			f.Comments = append(f.Comments, carried)
 		}
@@ -1320,21 +1324,7 @@ func (s *Session) handleRoundCompleteFiles() {
 		}
 		// Carry forward all remaining comments from PreviousComments
 		for _, c := range f.PreviousComments {
-			carried := Comment{
-				ID:              fmt.Sprintf("c%d", f.nextID),
-				StartLine:       c.StartLine,
-				EndLine:         c.EndLine,
-				Side:            c.Side,
-				Body:            c.Body,
-				Author:          c.Author,
-				CreatedAt:       c.CreatedAt,
-				UpdatedAt:       now,
-				Resolved:        c.Resolved,
-				ResolutionNote:  c.ResolutionNote,
-				ResolutionLines: c.ResolutionLines,
-				CarriedForward:  true,
-				ReviewRound:     c.ReviewRound,
-			}
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
 			f.nextID++
 			f.Comments = append(f.Comments, carried)
 		}
@@ -1478,21 +1468,9 @@ func (s *Session) carryForwardComments() {
 			if newEnd < newStart {
 				newEnd = newStart
 			}
-			carried := Comment{
-				ID:              fmt.Sprintf("c%d", f.nextID),
-				StartLine:       newStart,
-				EndLine:         newEnd,
-				Side:            c.Side,
-				Body:            c.Body,
-				Author:          c.Author,
-				CreatedAt:       c.CreatedAt,
-				UpdatedAt:       now,
-				Resolved:        c.Resolved,
-				ResolutionNote:  c.ResolutionNote,
-				ResolutionLines: c.ResolutionLines,
-				CarriedForward:  true,
-				ReviewRound:     c.ReviewRound,
-			}
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
+			carried.StartLine = newStart
+			carried.EndLine = newEnd
 			f.nextID++
 			f.Comments = append(f.Comments, carried)
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -1351,3 +1351,67 @@ func TestSession_LoadCritJSON_RestoresReviewRound(t *testing.T) {
 		t.Errorf("new comment ReviewRound = %d, want 3", c.ReviewRound)
 	}
 }
+
+func TestCarryForwardComment(t *testing.T) {
+	old := Comment{
+		ID:              "original-id",
+		StartLine:       5,
+		EndLine:         10,
+		Side:            "RIGHT",
+		Body:            "needs refactoring",
+		Quote:           "func foo() {}",
+		Author:          "reviewer-bot",
+		CreatedAt:       "2026-01-01T00:00:00Z",
+		UpdatedAt:       "2026-01-01T00:00:00Z",
+		Resolved:        true,
+		ResolutionNote:  "Fixed in round 2",
+		ResolutionLines: "5-8",
+		CarriedForward:  false,
+		ReviewRound:     1,
+	}
+
+	carried := carryForwardComment(old, "c42", "2026-02-01T00:00:00Z")
+
+	if carried.ID != "c42" {
+		t.Errorf("ID = %q, want c42", carried.ID)
+	}
+	if carried.StartLine != 5 {
+		t.Errorf("StartLine = %d, want 5", carried.StartLine)
+	}
+	if carried.EndLine != 10 {
+		t.Errorf("EndLine = %d, want 10", carried.EndLine)
+	}
+	if carried.Side != "RIGHT" {
+		t.Errorf("Side = %q, want RIGHT", carried.Side)
+	}
+	if carried.Body != "needs refactoring" {
+		t.Errorf("Body = %q", carried.Body)
+	}
+	if carried.Author != "reviewer-bot" {
+		t.Errorf("Author = %q, want reviewer-bot", carried.Author)
+	}
+	if carried.CreatedAt != "2026-01-01T00:00:00Z" {
+		t.Errorf("CreatedAt = %q, want original timestamp", carried.CreatedAt)
+	}
+	if carried.UpdatedAt != "2026-02-01T00:00:00Z" {
+		t.Errorf("UpdatedAt = %q, want new timestamp", carried.UpdatedAt)
+	}
+	if !carried.Resolved {
+		t.Error("Resolved should be preserved as true")
+	}
+	if carried.ResolutionNote != "Fixed in round 2" {
+		t.Errorf("ResolutionNote = %q", carried.ResolutionNote)
+	}
+	if carried.ResolutionLines != "5-8" {
+		t.Errorf("ResolutionLines = %v", carried.ResolutionLines)
+	}
+	if !carried.CarriedForward {
+		t.Error("CarriedForward should be true")
+	}
+	if carried.ReviewRound != 1 {
+		t.Errorf("ReviewRound = %d, want 1", carried.ReviewRound)
+	}
+	if carried.Quote != "" {
+		t.Errorf("Quote = %q, should not be carried forward", carried.Quote)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracted `carryForwardComment(old Comment, newID, now string) Comment` helper that constructs a carried-forward comment from an existing one
- Updated `handleRoundCompleteGit()`, `handleRoundCompleteFiles()`, and `carryForwardComments()` to use it, eliminating three copies of identical ~15-line struct construction
- Added `TestCarryForwardComment` verifying all fields are preserved correctly

## Test plan

- [x] `go test ./...` passes
- [x] `gofmt -l .` clean
- [x] New `TestCarryForwardComment` covers all Comment fields
- [x] Existing carry-forward tests (`TestSession_CarryForward_PreservesAuthor`, `TestCarryForwardPreservesReviewRound`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)