### PR TITLE
refactor: Go cleanup batch (extract config, remove dead code, fix docs, test helper)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ crit comment <path>:<line[-end]> <body>  # Add a comment to .crit.json (no serve
 crit share <file> [file...]   # Share files to crit-web, print URL
 crit unpublish                # Remove shared review from crit-web
 crit config                   # Print resolved configuration (merged global + project)
-crit init                     # Generate a starter .crit.config.json in the current directory
+crit config --generate        # Print a starter .crit.config.json template
 crit install <agent>          # Install integration config for an AI tool
 crit help                     # Show help
 ```

--- a/config.go
+++ b/config.go
@@ -231,6 +231,7 @@ func filterIgnored(files []FileChange, patterns []string) []FileChange {
 }
 
 // filterPathsIgnored removes string paths matching any ignore pattern.
+// Currently exercised only by tests, but kept as a utility parallel to filterIgnored.
 func filterPathsIgnored(paths []string, patterns []string) []string {
 	if len(patterns) == 0 {
 		return paths

--- a/main.go
+++ b/main.go
@@ -603,7 +603,23 @@ func runComment(args []string) {
 	fmt.Printf("Added comment on %s:%s\n", filePath, lineSpec)
 }
 
-func runServer(args []string) {
+// serverConfig holds the resolved configuration for running the server.
+// It combines CLI flags, environment variables, and config file settings.
+type serverConfig struct {
+	port           int
+	noOpen         bool
+	quiet          bool
+	shareURL       string
+	outputDir      string
+	author         string
+	ignorePatterns []string
+	files          []string // explicit file arguments (empty = git mode)
+}
+
+// resolveServerConfig parses flags, loads config files, and resolves the
+// final server configuration from all sources (CLI > env > config > defaults).
+// Returns nil when the command should exit early (e.g. --version).
+func resolveServerConfig(args []string) (*serverConfig, error) {
 	fs := flag.NewFlagSet("crit", flag.ExitOnError)
 	port := fs.Int("port", 0, "Port to listen on (default: random available port)")
 	fs.IntVar(port, "p", 0, "Port to listen on (shorthand)")
@@ -623,7 +639,7 @@ func runServer(args []string) {
 
 	if *showVersion {
 		printVersion()
-		return
+		return nil, nil
 	}
 
 	// Load configuration
@@ -672,10 +688,30 @@ func runServer(args []string) {
 		ignorePatterns = cfg.IgnorePatterns
 	}
 
-	var session *Session
-	var err error
+	return &serverConfig{
+		port:           *port,
+		noOpen:         *noOpen,
+		quiet:          *quiet,
+		shareURL:       *shareURL,
+		outputDir:      *outputDir,
+		author:         cfg.Author,
+		ignorePatterns: ignorePatterns,
+		files:          fs.Args(),
+	}, nil
+}
 
-	if fs.NArg() == 0 {
+func runServer(args []string) {
+	sc, err := resolveServerConfig(args)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	if sc == nil {
+		return // --version or similar early exit
+	}
+
+	var session *Session
+
+	if len(sc.files) == 0 {
 		// No-args: git mode — auto-detect changed files
 		if !IsGitRepo() {
 			fmt.Fprintln(os.Stderr, "Error: not in a git repository and no files specified")
@@ -683,33 +719,33 @@ func runServer(args []string) {
 			printHelp()
 			os.Exit(1)
 		}
-		session, err = NewSessionFromGit(ignorePatterns)
+		session, err = NewSessionFromGit(sc.ignorePatterns)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
 	} else {
 		// Explicit files
-		session, err = NewSessionFromFiles(fs.Args(), ignorePatterns)
+		session, err = NewSessionFromFiles(sc.files, sc.ignorePatterns)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
 	}
 
-	if *outputDir != "" {
-		abs, err := filepath.Abs(*outputDir)
+	if sc.outputDir != "" {
+		abs, err := filepath.Abs(sc.outputDir)
 		if err != nil {
 			log.Fatalf("Error resolving output directory: %v", err)
 		}
 		session.OutputDir = abs
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", sc.port))
 	if err != nil {
 		log.Fatalf("Error starting server: %v", err)
 	}
 	addr := listener.Addr().(*net.TCPAddr)
 
-	srv, err := NewServer(session, frontendFS, *shareURL, cfg.Author, version, addr.Port)
+	srv, err := NewServer(session, frontendFS, sc.shareURL, sc.author, version, addr.Port)
 	if err != nil {
 		log.Fatalf("Error creating server: %v", err)
 	}
@@ -724,7 +760,7 @@ func runServer(args []string) {
 	}
 
 	var statusWriter io.Writer = os.Stdout
-	if *quiet {
+	if sc.quiet {
 		statusWriter = io.Discard
 	}
 	status := newStatus(statusWriter)
@@ -735,7 +771,7 @@ func runServer(args []string) {
 	status.Listening(url)
 	status.ListenHint(fmt.Sprintf("%d", addr.Port))
 
-	if !*noOpen {
+	if !sc.noOpen {
 		go openBrowser(url)
 	}
 

--- a/session.go
+++ b/session.go
@@ -1079,28 +1079,6 @@ func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
 	return map[string]any{"hunks": hunks, "previous_content": prevContent}, true
 }
 
-// GetFileContent returns the content for a specific file path.
-func (s *Session) GetFileContent(path string) (string, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	f := s.fileByPathLocked(path)
-	if f == nil {
-		return "", false
-	}
-	return f.Content, true
-}
-
-// GetFileDiffHunks returns the diff hunks for a specific file.
-func (s *Session) GetFileDiffHunks(path string) ([]DiffHunk, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	f := s.fileByPathLocked(path)
-	if f == nil {
-		return nil, false
-	}
-	return f.DiffHunks, true
-}
-
 // SessionInfo returns metadata about the session for the API.
 type SessionInfo struct {
 	Mode            string            `json:"mode"` // "files" or "git"

--- a/session_test.go
+++ b/session_test.go
@@ -251,11 +251,7 @@ func TestSession_WriteFiles(t *testing.T) {
 	s := newTestSession(t)
 	s.AddComment("plan.md", 1, 1, "", "fix", "", "")
 
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	data, err := os.ReadFile(s.critJSONPath())
@@ -291,11 +287,7 @@ func TestSession_WriteFiles_SharedURLOnly(t *testing.T) {
 	s := newTestSession(t)
 	s.SetSharedURLAndToken("https://crit.live/r/abc", "token123")
 
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	data, err := os.ReadFile(s.critJSONPath())
@@ -313,11 +305,7 @@ func TestSession_LoadCritJSON(t *testing.T) {
 	s := newTestSession(t)
 	s.AddComment("plan.md", 1, 1, "", "persisted comment", "", "")
 
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	// Create a new session pointing to same dir
@@ -460,11 +448,7 @@ func TestSession_LoadResolvedComments_StringResolutionLines(t *testing.T) {
 	s := newTestSession(t)
 	s.AddComment("plan.md", 1, 1, "", "fix this", "", "")
 
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	// Simulate what an agent does: read .crit.json, add resolved + string resolution_lines, write back
@@ -615,22 +599,6 @@ func TestDetectFileType(t *testing.T) {
 	}
 }
 
-func TestSession_GetFileContent(t *testing.T) {
-	s := newTestSession(t)
-	content, ok := s.GetFileContent("plan.md")
-	if !ok {
-		t.Fatal("expected to find plan.md")
-	}
-	if content == "" {
-		t.Error("expected non-empty content")
-	}
-
-	_, ok = s.GetFileContent("nonexistent.txt")
-	if ok {
-		t.Error("expected false for nonexistent file")
-	}
-}
-
 func TestSession_CritJSONPath_Default(t *testing.T) {
 	s := newTestSession(t)
 	want := filepath.Join(s.RepoRoot, ".crit.json")
@@ -656,11 +624,7 @@ func TestSession_WriteFiles_OutputDir(t *testing.T) {
 	s.OutputDir = outDir
 
 	s.AddComment("plan.md", 1, 1, "", "output dir comment", "", "")
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	// Should be written to OutputDir, not RepoRoot
@@ -690,11 +654,7 @@ func TestSession_LoadCritJSON_OutputDir(t *testing.T) {
 	s.OutputDir = outDir
 
 	s.AddComment("plan.md", 1, 1, "", "persisted in output dir", "", "")
-	s.mu.Lock()
-	if s.writeTimer != nil {
-		s.writeTimer.Stop()
-	}
-	s.mu.Unlock()
+	flushWrites(s)
 	s.WriteFiles()
 
 	// Create a new session pointing to same output dir

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -46,3 +46,14 @@ func writeFile(t *testing.T, path, content string) {
 		t.Fatal(err)
 	}
 }
+
+// flushWrites stops any pending debounced write timer on the session.
+// Call this before WriteFiles() in tests to prevent the timer from
+// firing concurrently with explicit writes.
+func flushWrites(s *Session) {
+	s.mu.Lock()
+	if s.writeTimer != nil {
+		s.writeTimer.Stop()
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
## Summary

- **Extract `resolveServerConfig()`** from `runServer` — separates flag parsing, config loading, and env var resolution into a pure function returning a `serverConfig` struct. `runServer` now focuses on session creation, server lifecycle, and signal handling.
- **Remove dead exported methods** `GetFileContent` and `GetFileDiffHunks` from `Session` — neither is called in production code (the API uses `GetFileSnapshot`/`GetFileDiffSnapshot` instead). Removed accompanying test.
- **Fix `crit init` docs** in AGENTS.md — the command was folded into `crit config --generate` but docs still listed a standalone `crit init` subcommand.
- **Add `flushWrites()` test helper** in `testutil_test.go` — deduplicates the 6-instance "stop write timer before assertions" pattern in `session_test.go`.
- **Annotate `filterPathsIgnored`** in config.go — currently only exercised by tests but kept as a utility parallel to `filterIgnored`.

## Test plan

- [x] `go test ./...` passes
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)