### PR TITLE
refactor: extract buildLineBlocks branch handlers into named functions

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -539,35 +539,264 @@
     return blocks;
   }
 
+  // ===== buildLineBlocks helpers =====
+
+  // Find the matching close token for an open token at openIdx.
+  function findCloseToken(tokens, openIdx) {
+    const openType = tokens[openIdx].type;
+    const closeType = openType.replace('_open', '_close');
+    let depth = 1;
+    for (let j = openIdx + 1; j < tokens.length; j++) {
+      if (tokens[j].type === openType) depth++;
+      if (tokens[j].type === closeType) { depth--; if (depth === 0) return j; }
+    }
+    return openIdx;
+  }
+
+  // Emit gap-line blocks for uncovered source lines up to (but not including) `upTo`.
+  function addGapLineBlocks(blocks, sourceLines, coveredUpTo, upTo) {
+    while (coveredUpTo < upTo) {
+      const lineText = sourceLines[coveredUpTo];
+      blocks.push({
+        startLine: coveredUpTo + 1,
+        endLine: coveredUpTo + 1,
+        html: lineText === '' ? '' : escapeHtml(lineText),
+        isEmpty: lineText.trim() === ''
+      });
+      coveredUpTo++;
+    }
+    return coveredUpTo;
+  }
+
+  // Handle a fence (code block) token — split into per-line blocks.
+  function handleFenceToken(token, blocks, sourceLines, coveredUpTo, blockStart, blockEnd) {
+    const lang = token.info.trim().split(/\s+/)[0] || '';
+
+    // Mermaid diagrams: render as a single block (not split per-line)
+    if (lang === 'mermaid') {
+      blocks.push({
+        startLine: blockStart + 1, endLine: blockEnd,
+        html: '<pre><code class="language-mermaid">' + escapeHtml(token.content) + '</code></pre>',
+        isEmpty: false, cssClass: 'mermaid-block'
+      });
+      coveredUpTo = blockEnd;
+      coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
+      return coveredUpTo;
+    }
+
+    let highlighted = '';
+    if (lang && hljs.getLanguage(lang)) {
+      try { highlighted = hljs.highlight(token.content, { language: lang }).value; } catch (_) {}
+    }
+    if (!highlighted) highlighted = escapeHtml(token.content);
+
+    const codeLines = splitHighlightedCode(highlighted);
+    // Remove trailing empty line from fence
+    if (codeLines.length > 0 && codeLines[codeLines.length - 1] === '') codeLines.pop();
+
+    // Opening fence line
+    blocks.push({
+      startLine: blockStart + 1, endLine: blockStart + 1,
+      html: '<span class="fence-marker">' + escapeHtml(sourceLines[blockStart]) + '</span>',
+      isEmpty: false, cssClass: 'code-line code-first'
+    });
+    coveredUpTo = blockStart + 1;
+
+    // Code content lines
+    for (let ci = 0; ci < codeLines.length; ci++) {
+      const ln = blockStart + 2 + ci;
+      if (ln > blockEnd) break;
+      const isLast = (ci === codeLines.length - 1 && blockEnd <= ln);
+      blocks.push({
+        startLine: ln, endLine: ln,
+        html: '<code class="hljs">' + (codeLines[ci] || '&nbsp;') + '</code>',
+        isEmpty: false, cssClass: 'code-line' + (isLast ? ' code-last' : '')
+      });
+      coveredUpTo = ln;
+    }
+
+    // Closing fence line
+    if (blockEnd > coveredUpTo) {
+      blocks.push({
+        startLine: blockEnd, endLine: blockEnd,
+        html: '<span class="fence-marker">' + escapeHtml(sourceLines[blockEnd - 1]) + '</span>',
+        isEmpty: false, cssClass: 'code-line code-last'
+      });
+      coveredUpTo = blockEnd;
+    }
+
+    coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
+    return coveredUpTo;
+  }
+
+  // Handle a list token (bullet or ordered) — split into per-item blocks.
+  function handleListToken(tokens, i, token, md, blocks, sourceLines, coveredUpTo, blockEnd) {
+    const listCloseIdx = findCloseToken(tokens, i);
+    const listTag = token.type === 'bullet_list_open' ? 'ul' : 'ol';
+    let j = i + 1;
+
+    while (j < listCloseIdx) {
+      if (tokens[j].type === 'list_item_open') {
+        const itemMap = tokens[j].map;
+        const itemCloseIdx = findCloseToken(tokens, j);
+
+        if (itemMap) {
+          coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, itemMap[0]);
+          let effectiveEnd = itemMap[1];
+          while (effectiveEnd > itemMap[0] + 1 && sourceLines[effectiveEnd - 1].trim() === '') {
+            effectiveEnd--;
+          }
+
+          const itemTokens = tokens.slice(j, itemCloseIdx + 1);
+          const startAttr = listTag === 'ol' && tokens[j].info ? ' start="' + tokens[j].info + '"' : '';
+          const itemHtml = '<' + listTag + startAttr + '>' +
+            md.renderer.render(itemTokens, md.options, {}) +
+            '</' + listTag + '>';
+
+          blocks.push({
+            startLine: itemMap[0] + 1,
+            endLine: effectiveEnd,
+            html: itemHtml,
+            isEmpty: false
+          });
+          coveredUpTo = effectiveEnd;
+        }
+        j = itemCloseIdx + 1;
+      } else {
+        j++;
+      }
+    }
+
+    coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
+    return { nextIndex: listCloseIdx + 1, coveredUpTo: coveredUpTo };
+  }
+
+  // Handle a table token — split into per-row blocks.
+  function handleTableToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockEnd) {
+    const tableCloseIdx = findCloseToken(tokens, i);
+
+    // Build colgroup from header cell alignments
+    let colgroup = '';
+    const aligns = [];
+    for (let j = i + 1; j < tableCloseIdx; j++) {
+      if (tokens[j].type === 'th_open') {
+        aligns.push(tokens[j].attrGet('style') || '');
+      }
+    }
+    if (aligns.length) {
+      colgroup = '<colgroup>' +
+        aligns.map(s => '<col' + (s ? ' style="' + s + '"' : '') + '>').join('') +
+        '</colgroup>';
+    }
+
+    let j = i + 1;
+    let inThead = false;
+    let rowIndex = 0;
+    let bodyRowIndex = 0;
+
+    while (j < tableCloseIdx) {
+      if (tokens[j].type === 'thead_open') { inThead = true; j++; continue; }
+      if (tokens[j].type === 'thead_close') { inThead = false; j++; continue; }
+      if (tokens[j].type === 'tbody_open' || tokens[j].type === 'tbody_close') { j++; continue; }
+
+      if (tokens[j].type === 'tr_open') {
+        const trCloseIdx = findCloseToken(tokens, j);
+        const trMap = tokens[j].map;
+
+        if (trMap) {
+          // Emit separator / gap lines between rows
+          for (let ln = coveredUpTo; ln < trMap[0]; ln++) {
+            const lineText = sourceLines[ln].trim();
+            if (/^\|[\s\-:|]+\|$/.test(lineText) || /^[-:|][\s\-:|]*$/.test(lineText)) {
+              blocks.push({ startLine: ln + 1, endLine: ln + 1, html: '', isEmpty: false, cssClass: 'table-separator' });
+            } else {
+              blocks.push({ startLine: ln + 1, endLine: ln + 1, html: lineText === '' ? '' : escapeHtml(lineText), isEmpty: lineText === '' });
+            }
+          }
+          coveredUpTo = trMap[0];
+
+          const trTokens = tokens.slice(j, trCloseIdx + 1);
+          const section = inThead ? 'thead' : 'tbody';
+          const rowHtml = '<table class="split-table">' + colgroup +
+            '<' + section + '>' +
+            md.renderer.render(trTokens, md.options, {}) +
+            '</' + section + '></table>';
+
+          let cls = 'table-row';
+          if (rowIndex === 0) cls += ' table-first';
+          if (!inThead && bodyRowIndex % 2 === 1) cls += ' table-even';
+          blocks.push({
+            startLine: trMap[0] + 1, endLine: trMap[1],
+            html: rowHtml, isEmpty: false, cssClass: cls
+          });
+          coveredUpTo = trMap[1];
+          rowIndex++;
+          if (!inThead) bodyRowIndex++;
+        }
+        j = trCloseIdx + 1;
+      } else {
+        j++;
+      }
+    }
+
+    // Mark the last table row
+    if (blocks.length > 0 && blocks[blocks.length - 1].cssClass &&
+        blocks[blocks.length - 1].cssClass.includes('table-row')) {
+      blocks[blocks.length - 1].cssClass += ' table-last';
+    }
+
+    coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
+    return { nextIndex: tableCloseIdx + 1, coveredUpTo: coveredUpTo };
+  }
+
+  // Handle a blockquote token — split into child blocks.
+  function handleBlockquoteToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockStart, blockEnd) {
+    const bqCloseIdx = findCloseToken(tokens, i);
+    let j = i + 1;
+    let hasChildren = false;
+
+    while (j < bqCloseIdx) {
+      if (tokens[j].nesting === -1 || !tokens[j].map) { j++; continue; }
+      hasChildren = true;
+      const childMap = tokens[j].map;
+      let childCloseIdx = j;
+      if (tokens[j].nesting === 1) childCloseIdx = findCloseToken(tokens, j);
+      coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, childMap[0]);
+      const childTokens = tokens.slice(j, childCloseIdx + 1);
+      const childHtml = '<blockquote>' +
+        md.renderer.render(childTokens, md.options, {}) +
+        '</blockquote>';
+      blocks.push({
+        startLine: childMap[0] + 1, endLine: childMap[1],
+        html: childHtml, isEmpty: false
+      });
+      coveredUpTo = childMap[1];
+      j = childCloseIdx + 1;
+    }
+
+    if (!hasChildren) {
+      const bqTokens = tokens.slice(i, bqCloseIdx + 1);
+      blocks.push({
+        startLine: blockStart + 1, endLine: blockEnd,
+        html: md.renderer.render(bqTokens, md.options, {}),
+        isEmpty: false
+      });
+      coveredUpTo = blockEnd;
+    }
+
+    coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
+    return { nextIndex: bqCloseIdx + 1, coveredUpTo: coveredUpTo };
+  }
+
+  // ===== buildLineBlocks =====
+  // Parses markdown tokens into a flat array of commentable line blocks.
+  // Delegates to per-token-type handlers for fence, list, table, and blockquote tokens.
+
   function buildLineBlocks(tokens, md, content) {
     const sourceLines = content.split('\n');
     const totalLines = sourceLines.length;
     const blocks = [];
     let coveredUpTo = 0;
-
-    function addGapLines(upTo) {
-      while (coveredUpTo < upTo) {
-        const lineText = sourceLines[coveredUpTo];
-        blocks.push({
-          startLine: coveredUpTo + 1,
-          endLine: coveredUpTo + 1,
-          html: lineText === '' ? '' : escapeHtml(lineText),
-          isEmpty: lineText.trim() === ''
-        });
-        coveredUpTo++;
-      }
-    }
-
-    function findClose(openIdx) {
-      const openType = tokens[openIdx].type;
-      const closeType = openType.replace('_open', '_close');
-      let depth = 1;
-      for (let j = openIdx + 1; j < tokens.length; j++) {
-        if (tokens[j].type === openType) depth++;
-        if (tokens[j].type === closeType) { depth--; if (depth === 0) return j; }
-      }
-      return openIdx;
-    }
 
     let i = 0;
     while (i < tokens.length) {
@@ -577,228 +806,42 @@
       const blockStart = token.map[0];
       const blockEnd = token.map[1];
 
-      addGapLines(blockStart);
+      coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockStart);
 
-      // === Code blocks (fence): split into per-line blocks ===
+      // Code blocks (fence): split into per-line blocks
       if (token.type === 'fence') {
-        const lang = token.info.trim().split(/\s+/)[0] || '';
-
-        // Mermaid diagrams: render as a single block (not split per-line)
-        if (lang === 'mermaid') {
-          blocks.push({
-            startLine: blockStart + 1, endLine: blockEnd,
-            html: '<pre><code class="language-mermaid">' + escapeHtml(token.content) + '</code></pre>',
-            isEmpty: false, cssClass: 'mermaid-block'
-          });
-          i++;
-          coveredUpTo = blockEnd;
-          addGapLines(blockEnd);
-          continue;
-        }
-
-        let highlighted = '';
-        if (lang && hljs.getLanguage(lang)) {
-          try { highlighted = hljs.highlight(token.content, { language: lang }).value; } catch (_) {}
-        }
-        if (!highlighted) highlighted = escapeHtml(token.content);
-
-        const codeLines = splitHighlightedCode(highlighted);
-        // Remove trailing empty line from fence
-        if (codeLines.length > 0 && codeLines[codeLines.length - 1] === '') codeLines.pop();
-
-        // Opening fence line
-        blocks.push({
-          startLine: blockStart + 1, endLine: blockStart + 1,
-          html: '<span class="fence-marker">' + escapeHtml(sourceLines[blockStart]) + '</span>',
-          isEmpty: false, cssClass: 'code-line code-first'
-        });
-        coveredUpTo = blockStart + 1;
-
-        // Code content lines
-        for (let ci = 0; ci < codeLines.length; ci++) {
-          const ln = blockStart + 2 + ci;
-          if (ln > blockEnd) break;
-          const isLast = (ci === codeLines.length - 1 && blockEnd <= ln);
-          blocks.push({
-            startLine: ln, endLine: ln,
-            html: '<code class="hljs">' + (codeLines[ci] || '&nbsp;') + '</code>',
-            isEmpty: false, cssClass: 'code-line' + (isLast ? ' code-last' : '')
-          });
-          coveredUpTo = ln;
-        }
-
-        // Closing fence line
-        if (blockEnd > coveredUpTo) {
-          blocks.push({
-            startLine: blockEnd, endLine: blockEnd,
-            html: '<span class="fence-marker">' + escapeHtml(sourceLines[blockEnd - 1]) + '</span>',
-            isEmpty: false, cssClass: 'code-line code-last'
-          });
-          coveredUpTo = blockEnd;
-        }
-
+        coveredUpTo = handleFenceToken(token, blocks, sourceLines, coveredUpTo, blockStart, blockEnd);
         i++;
-        addGapLines(blockEnd);
         continue;
       }
 
-      // === Lists: split into per-item blocks ===
+      // Lists: split into per-item blocks
       if (token.type === 'bullet_list_open' || token.type === 'ordered_list_open') {
-        const listCloseIdx = findClose(i);
-        const listTag = token.type === 'bullet_list_open' ? 'ul' : 'ol';
-        let j = i + 1;
-
-        while (j < listCloseIdx) {
-          if (tokens[j].type === 'list_item_open') {
-            const itemMap = tokens[j].map;
-            const itemCloseIdx = findClose(j);
-
-            if (itemMap) {
-              addGapLines(itemMap[0]);
-              let effectiveEnd = itemMap[1];
-              while (effectiveEnd > itemMap[0] + 1 && sourceLines[effectiveEnd - 1].trim() === '') {
-                effectiveEnd--;
-              }
-
-              const itemTokens = tokens.slice(j, itemCloseIdx + 1);
-              const startAttr = listTag === 'ol' && tokens[j].info ? ' start="' + tokens[j].info + '"' : '';
-              const itemHtml = '<' + listTag + startAttr + '>' +
-                md.renderer.render(itemTokens, md.options, {}) +
-                '</' + listTag + '>';
-
-              blocks.push({
-                startLine: itemMap[0] + 1,
-                endLine: effectiveEnd,
-                html: itemHtml,
-                isEmpty: false
-              });
-              coveredUpTo = effectiveEnd;
-            }
-            j = itemCloseIdx + 1;
-          } else {
-            j++;
-          }
-        }
-
-        i = listCloseIdx + 1;
-        addGapLines(blockEnd);
+        var listResult = handleListToken(tokens, i, token, md, blocks, sourceLines, coveredUpTo, blockEnd);
+        i = listResult.nextIndex;
+        coveredUpTo = listResult.coveredUpTo;
         continue;
       }
 
-      // === Tables: split into per-row blocks ===
+      // Tables: split into per-row blocks
       if (token.type === 'table_open') {
-        const tableCloseIdx = findClose(i);
-        let colgroup = '';
-        const aligns = [];
-        for (let j = i + 1; j < tableCloseIdx; j++) {
-          if (tokens[j].type === 'th_open') {
-            aligns.push(tokens[j].attrGet('style') || '');
-          }
-        }
-        if (aligns.length) {
-          colgroup = '<colgroup>' +
-            aligns.map(s => '<col' + (s ? ' style="' + s + '"' : '') + '>').join('') +
-            '</colgroup>';
-        }
-
-        let j = i + 1;
-        let inThead = false;
-        let rowIndex = 0;
-        let bodyRowIndex = 0;
-
-        while (j < tableCloseIdx) {
-          if (tokens[j].type === 'thead_open') { inThead = true; j++; continue; }
-          if (tokens[j].type === 'thead_close') { inThead = false; j++; continue; }
-          if (tokens[j].type === 'tbody_open' || tokens[j].type === 'tbody_close') { j++; continue; }
-
-          if (tokens[j].type === 'tr_open') {
-            const trCloseIdx = findClose(j);
-            const trMap = tokens[j].map;
-
-            if (trMap) {
-              for (let ln = coveredUpTo; ln < trMap[0]; ln++) {
-                const lineText = sourceLines[ln].trim();
-                if (/^\|[\s\-:|]+\|$/.test(lineText) || /^[-:|][\s\-:|]*$/.test(lineText)) {
-                  blocks.push({ startLine: ln + 1, endLine: ln + 1, html: '', isEmpty: false, cssClass: 'table-separator' });
-                } else {
-                  blocks.push({ startLine: ln + 1, endLine: ln + 1, html: lineText === '' ? '' : escapeHtml(lineText), isEmpty: lineText === '' });
-                }
-              }
-              coveredUpTo = trMap[0];
-
-              const trTokens = tokens.slice(j, trCloseIdx + 1);
-              const section = inThead ? 'thead' : 'tbody';
-              const rowHtml = '<table class="split-table">' + colgroup +
-                '<' + section + '>' +
-                md.renderer.render(trTokens, md.options, {}) +
-                '</' + section + '></table>';
-
-              let cls = 'table-row';
-              if (rowIndex === 0) cls += ' table-first';
-              if (!inThead && bodyRowIndex % 2 === 1) cls += ' table-even';
-              blocks.push({
-                startLine: trMap[0] + 1, endLine: trMap[1],
-                html: rowHtml, isEmpty: false, cssClass: cls
-              });
-              coveredUpTo = trMap[1];
-              rowIndex++;
-              if (!inThead) bodyRowIndex++;
-            }
-            j = trCloseIdx + 1;
-          } else {
-            j++;
-          }
-        }
-        if (blocks.length > 0 && blocks[blocks.length - 1].cssClass &&
-            blocks[blocks.length - 1].cssClass.includes('table-row')) {
-          blocks[blocks.length - 1].cssClass += ' table-last';
-        }
-
-        i = tableCloseIdx + 1;
-        addGapLines(blockEnd);
+        var tableResult = handleTableToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockEnd);
+        i = tableResult.nextIndex;
+        coveredUpTo = tableResult.coveredUpTo;
         continue;
       }
 
-      // === Blockquotes: split into child blocks ===
+      // Blockquotes: split into child blocks
       if (token.type === 'blockquote_open') {
-        const bqCloseIdx = findClose(i);
-        let j = i + 1;
-        let hasChildren = false;
-        while (j < bqCloseIdx) {
-          if (tokens[j].nesting === -1 || !tokens[j].map) { j++; continue; }
-          hasChildren = true;
-          const childMap = tokens[j].map;
-          let childCloseIdx = j;
-          if (tokens[j].nesting === 1) childCloseIdx = findClose(j);
-          addGapLines(childMap[0]);
-          const childTokens = tokens.slice(j, childCloseIdx + 1);
-          const childHtml = '<blockquote>' +
-            md.renderer.render(childTokens, md.options, {}) +
-            '</blockquote>';
-          blocks.push({
-            startLine: childMap[0] + 1, endLine: childMap[1],
-            html: childHtml, isEmpty: false
-          });
-          coveredUpTo = childMap[1];
-          j = childCloseIdx + 1;
-        }
-        if (!hasChildren) {
-          const bqTokens = tokens.slice(i, bqCloseIdx + 1);
-          blocks.push({
-            startLine: blockStart + 1, endLine: blockEnd,
-            html: md.renderer.render(bqTokens, md.options, {}),
-            isEmpty: false
-          });
-          coveredUpTo = blockEnd;
-        }
-        i = bqCloseIdx + 1;
-        addGapLines(blockEnd);
+        var bqResult = handleBlockquoteToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockStart, blockEnd);
+        i = bqResult.nextIndex;
+        coveredUpTo = bqResult.coveredUpTo;
         continue;
       }
 
-      // === Default: render as single block ===
+      // Default: render as single block
       let closeIdx = i;
-      if (token.nesting === 1) closeIdx = findClose(i);
+      if (token.nesting === 1) closeIdx = findCloseToken(tokens, i);
 
       const blockTokens = tokens.slice(i, closeIdx + 1);
       let html;
@@ -817,7 +860,7 @@
       coveredUpTo = blockEnd;
     }
 
-    addGapLines(totalLines);
+    coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, totalLines);
     return blocks;
   }
 


### PR DESCRIPTION
## Summary

- Extract the 4 major token-type branches from `buildLineBlocks()` into standalone helper functions: `handleFenceToken`, `handleListToken`, `handleTableToken`, and `handleBlockquoteToken`
- Extract shared utilities `findCloseToken` and `addGapLineBlocks` to the top level (previously closures inside `buildLineBlocks`)
- `buildLineBlocks()` is now a ~50-line dispatcher that loops tokens and delegates to the appropriate handler, down from ~280 lines with 5 deeply nested branches

## Test plan

- [x] `go build -o crit .` succeeds
- [x] All 403 E2E tests pass (all 5 Playwright projects: git-mode, file-mode, single-file, no-git, multi-file)
- [x] No behavioral changes -- pure readability refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)