### PR TITLE
feat: show quote highlight while comment form is open

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -156,6 +156,27 @@ test.describe('Select-to-comment (git mode)', () => {
       await switchToDocumentView(page);
     });
 
+    test('quote highlight appears while comment form is still open', async ({ page }) => {
+      const section = mdSection(page);
+      const block = section.locator('.line-block', { hasText: 'API key authentication' });
+      await expect(block).toBeVisible();
+      const content = block.locator('.line-content');
+      const box = await content.boundingBox();
+      expect(box).toBeTruthy();
+      if (!box) return;
+
+      // Select just a portion of the text
+      await page.mouse.move(box.x + 80, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + 250, box.y + box.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      // Form is open but NOT yet submitted — highlight should already be visible
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+      await expect(section.locator('mark.quote-highlight')).toBeVisible();
+    });
+
     test('partial text selection saves quote and shows highlight mark', async ({ page }) => {
       const section = mdSection(page);
       // Line 5: "We're adding API key authentication to the server..."

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3741,9 +3741,17 @@
 
   function highlightQuotesInSection(sectionEl, file) {
     const quotedComments = file.comments.filter(function(c) { return c.quote && !c.resolved; });
-    if (quotedComments.length === 0) return;
 
-    quotedComments.forEach(function(comment) {
+    // Also highlight quotes from open (unsaved) comment forms
+    const formQuotes = getFormsForFile(file.path)
+      .filter(function(f) { return f.quote && !f.editingId; })
+      .map(function(f) {
+        return { start_line: f.startLine, end_line: f.endLine, quote: f.quote, id: 'draft-' + f.formKey };
+      });
+    const allQuoted = quotedComments.concat(formQuotes);
+    if (allQuoted.length === 0) return;
+
+    allQuoted.forEach(function(comment) {
       // Find the content elements in this comment's line range
       const contentEls = [];
       for (let ln = comment.start_line; ln <= comment.end_line; ln++) {


### PR DESCRIPTION
## Summary

- Previously, selected text was only highlighted (with the yellow `quote-highlight` mark) after the comment was submitted
- Now the highlight appears immediately when the comment form opens from a text selection, giving instant visual feedback for which words the comment targets
- Works by including active form quotes alongside saved comment quotes in `highlightQuotesInSection()`

## Test plan

- [x] New E2E test: `quote highlight appears while comment form is still open`
- [ ] Existing select-to-comment tests still pass (13 tests)
- [ ] Manual: select text in document view, verify highlight appears before submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)