### PR TITLE
fix: Approve button to check unresolved comments only

### DIFF
--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -502,6 +502,46 @@ test.describe('Multi-Round — Frontend', () => {
     await expect(sections).toHaveCount(sectionsBefore);
   });
 
+  test('finish button shows Approve when all comments are resolved', async ({ page, request }) => {
+    const filePath = await getTestFilePath(request);
+
+    // Add a comment
+    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: 1, end_line: 1, body: 'Will resolve this' },
+    });
+
+    await page.reload();
+    await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
+
+    // With an unresolved comment, button should say "Finish Review"
+    await expect(page.locator('#finishBtn')).toHaveText('Finish Review');
+
+    // Click Finish to write .crit.json
+    await page.locator('#finishBtn').click();
+    await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
+
+    // Read .crit.json path and mark comment as resolved
+    const finishRes = await request.post('/api/finish');
+    const finishData = await finishRes.json();
+    const critJsonPath = finishData.review_file;
+
+    const critJson = JSON.parse(fs.readFileSync(critJsonPath, 'utf-8'));
+    for (const fileKey of Object.keys(critJson.files)) {
+      for (const comment of critJson.files[fileKey].comments) {
+        comment.resolved = true;
+        comment.resolution_note = 'Done';
+      }
+    }
+    fs.writeFileSync(critJsonPath, JSON.stringify(critJson, null, 2));
+
+    // Trigger round-complete
+    await request.post('/api/round-complete');
+    await expect(page.locator('#waitingOverlay')).not.toHaveClass(/active/, { timeout: 5_000 });
+
+    // All comments resolved — button should say "Approve"
+    await expect(page.locator('#finishBtn')).toHaveText('Approve');
+  });
+
   test('round badge displays on comments', async ({ page, request }) => {
     const filePath = await getTestFilePath(request);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3964,7 +3964,7 @@
     }
     renderCommentsPanel();
     if (uiState === 'reviewing') {
-      document.getElementById('finishBtn').textContent = total === 0 ? 'Approve' : 'Finish Review';
+      document.getElementById('finishBtn').textContent = unresolved === 0 ? 'Approve' : 'Finish Review';
     }
   }
 
@@ -4128,11 +4128,11 @@
 
     switch (state) {
       case 'reviewing':
-        let totalComments = 0;
+        let unresolvedComments = 0;
         for (let fi = 0; fi < files.length; fi++) {
-          if (files[fi].comments) totalComments += files[fi].comments.length;
+          if (files[fi].comments) unresolvedComments += files[fi].comments.filter(function(c) { return !c.resolved; }).length;
         }
-        finishBtn.textContent = totalComments === 0 ? 'Approve' : 'Finish Review';
+        finishBtn.textContent = unresolvedComments === 0 ? 'Approve' : 'Finish Review';
         finishBtn.disabled = false;
         finishBtn.classList.add('btn-primary');
         document.getElementById('waitingEdits').textContent = '';


### PR DESCRIPTION
## Summary

- Previously the finish button showed "Approve" only when there were zero total comments (resolved + unresolved)
- Now it shows "Approve" when there are no **unresolved** comments, so resolving all comments correctly switches the label
- Fixed in both `updateCommentCount()` and `setUIState('reviewing')`

## Test plan

- [x] Added E2E test: adds a comment, resolves it via round-complete, asserts button says "Approve"
- [x] Existing round-complete tests still pass (unresolved comment → "Finish Review")
- [x] Manual: add comments, resolve all, verify button says "Approve"

🤖 Generated with [Claude Code](https://claude.com/claude-code)