### PR TITLE
feat: Remove strikethrough from file mode diff view

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2545,8 +2545,6 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .diff-view .line-block.diff-removed .line-content {
   background: var(--diff-del-bg);
-  text-decoration: line-through;
-  opacity: 0.7;
 }
 .diff-view-unified {
   max-width: 840px;
@@ -2557,8 +2555,6 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .diff-view-unified .line-block.diff-removed .line-content {
   background: var(--diff-del-bg);
-  text-decoration: line-through;
-  opacity: 0.7;
 }
 #diffToggle.active {
   background: var(--accent);


### PR DESCRIPTION
## Summary

- Removed `text-decoration: line-through` and `opacity: 0.7` from deleted lines in file mode markdown diffs (both split and unified views)
- Deleted lines now use only the red background (`--diff-del-bg`), matching git mode's visual style
- Improves readability and keeps both modes visually consistent

## Test plan

- [ ] Open a file mode review with inter-round changes and verify deleted lines show red background without strikethrough
- [ ] Check both split and unified diff views
- [ ] Compare with git mode — deleted lines should look the same


🤖 Generated with [Claude Code](https://claude.com/claude-code)