### PR TITLE
Fix quote highlight visibility in diff view

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -358,5 +358,90 @@ test.describe('Select-to-comment (git mode)', () => {
       await expect(textarea).toBeVisible();
       await expect(textarea).toBeFocused();
     });
+
+    test('quote highlight appears in split diff view while form is open', async ({ page }) => {
+      const section = goSection(page);
+      // Find an addition line with enough text for a partial selection
+      const additionLine = section.locator('.diff-split-side.addition').first();
+      await additionLine.scrollIntoViewIfNeeded();
+      await expect(additionLine).toBeVisible();
+
+      const diffContent = additionLine.locator('.diff-content');
+      await expect(diffContent).toBeVisible();
+      const box = await diffContent.boundingBox();
+      expect(box).toBeTruthy();
+      if (!box) return;
+
+      // Partial selection (not full width) to ensure a quote is captured
+      await page.mouse.move(box.x + 10, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + Math.min(box.width / 2, 150), box.y + box.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      // Form should be open but NOT submitted — highlight should already show
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+      await expect(section.locator('mark.quote-highlight')).toBeVisible();
+    });
+
+    test('quote highlight appears in unified diff view while form is open', async ({ page }) => {
+      // Switch to unified mode via the header toggle
+      const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+      await expect(unifiedBtn).toBeVisible();
+      await unifiedBtn.click();
+
+      const section = goSection(page);
+      // Find an addition line with enough text for a meaningful partial selection
+      // Skip very short lines (like just `"log"`) — find one with substantial content
+      const additionLines = section.locator('.diff-line.addition');
+      let targetBox: any = null;
+      const count = await additionLines.count();
+      for (let i = 0; i < count; i++) {
+        const line = additionLines.nth(i);
+        const content = line.locator('.diff-content');
+        const text = await content.textContent();
+        if (text && text.trim().length > 20) {
+          await line.scrollIntoViewIfNeeded();
+          targetBox = await content.boundingBox();
+          break;
+        }
+      }
+      expect(targetBox).toBeTruthy();
+      if (!targetBox) return;
+
+      // Partial selection
+      await page.mouse.move(targetBox.x + 10, targetBox.y + targetBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 150), targetBox.y + targetBox.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+      await expect(section.locator('mark.quote-highlight')).toBeVisible();
+    });
+
+    test('quote highlight appears in markdown diff view while form is open', async ({ page }) => {
+      // Markdown file in git mode defaults to split diff view
+      const section = mdSection(page);
+      const additionLine = section.locator('.diff-split-side.addition').first();
+      await additionLine.scrollIntoViewIfNeeded();
+      await expect(additionLine).toBeVisible();
+
+      const diffContent = additionLine.locator('.diff-content');
+      await expect(diffContent).toBeVisible();
+      const box = await diffContent.boundingBox();
+      expect(box).toBeTruthy();
+      if (!box) return;
+
+      // Partial selection
+      await page.mouse.move(box.x + 10, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + Math.min(box.width / 2, 150), box.y + box.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+      await expect(section.locator('mark.quote-highlight')).toBeVisible();
+    });
   });
 });

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -507,7 +507,7 @@ body {
 }
 
 .diff-line.focused, .diff-split-row.focused {
-  background: var(--selection-bg);
+  background: var(--accent-subtle);
 }
 
 /* ===== Gutter ===== */
@@ -2386,8 +2386,8 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .diff-container.unified .diff-line.addition { background: var(--diff-add-bg); }
 .diff-container.unified .diff-line.deletion { background: var(--diff-del-bg); }
 .diff-container.unified .diff-line.has-comment { background: var(--comment-range-bg); }
-.diff-container.unified .diff-line.selected { background: var(--selection-bg); }
-.diff-container.unified .diff-line.form-selected { background: var(--selection-bg); }
+.diff-container.unified .diff-line.selected { background: var(--accent-subtle); }
+.diff-container.unified .diff-line.form-selected { background: var(--accent-subtle); }
 .diff-container.unified .diff-gutter {
   display: flex;
   flex-shrink: 0;
@@ -2425,8 +2425,8 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .diff-split-side.addition { background: var(--diff-add-bg); }
 .diff-split-side.has-comment { background: var(--comment-range-bg); }
 .diff-split-side.empty { background: var(--bg-secondary); }
-.diff-split-side.selected { background: var(--selection-bg); }
-.diff-split-side.form-selected { background: var(--selection-bg); }
+.diff-split-side.selected { background: var(--accent-subtle); }
+.diff-split-side.form-selected { background: var(--accent-subtle); }
 .diff-split-side .diff-gutter-num { min-width: 44px; }
 .diff-split-side.deletion .diff-gutter-num { background: var(--diff-del-gutter); }
 .diff-split-side.addition .diff-gutter-num { background: var(--diff-add-gutter); }

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -27,7 +27,6 @@
   --border: #292e42;
   --border-comment: #3d59a1;
   --comment-bg: #1a1f36;
-  --selection-bg: rgba(210, 153, 34, 0.13);
   --comment-range-bg: rgba(210, 153, 34, 0.13);
   --shadow: 0 2px 8px rgba(0,0,0,0.3);
   --code-bg: #1e2030;
@@ -71,7 +70,6 @@
     --border: #d8dee4;
     --border-comment: #0969da;
     --comment-bg: #f0f6ff;
-    --selection-bg: rgba(210, 153, 34, 0.15);
     --comment-range-bg: rgba(210, 153, 34, 0.15);
     --shadow: 0 2px 8px rgba(0,0,0,0.08);
     --code-bg: #f5f5f5;
@@ -115,7 +113,6 @@
   --border: #292e42;
   --border-comment: #3d59a1;
   --comment-bg: #1a1f36;
-  --selection-bg: rgba(210, 153, 34, 0.13);
   --comment-range-bg: rgba(210, 153, 34, 0.13);
   --shadow: 0 2px 8px rgba(0,0,0,0.3);
   --code-bg: #1e2030;
@@ -158,7 +155,6 @@
   --border: #d8dee4;
   --border-comment: #0969da;
   --comment-bg: #f0f6ff;
-  --selection-bg: rgba(210, 153, 34, 0.15);
   --comment-range-bg: rgba(210, 153, 34, 0.15);
   --shadow: 0 2px 8px rgba(0,0,0,0.08);
   --code-bg: #f5f5f5;


### PR DESCRIPTION
## Summary

- Quote highlight (`<mark>` element) was invisible in diff view because the line selection background (`--selection-bg`, golden) was nearly identical to the highlight color (`rgba(250, 200, 60, 0.12)`, also golden)
- Document view already used `--accent-subtle` (blue) for selected lines, making the highlight visible — diff view now matches
- Removed the unused `--selection-bg` CSS variable

Fixes the issue from #114 where quote highlights only appeared after comment submission in git mode.

## Test plan

- [x] E2E tests added for quote highlight in split diff, unified diff, and markdown diff views
- [ ] Visually verify quote highlight is visible on selected diff lines (both split and unified)
- [ ] Verify keyboard navigation focus highlight still looks correct in diff view
- [ ] Check both light and dark themes