### PR TITLE
fix: refresh TOC when file content changes via SSE

### DIFF
--- a/e2e/tests/toc-refresh.singlefile.spec.ts
+++ b/e2e/tests/toc-refresh.singlefile.spec.ts
@@ -82,12 +82,10 @@ test.describe('TOC Refresh on File Change — Single File Mode', () => {
     // Trigger round-complete
     await request.post('/api/round-complete');
 
-    // Wait for the new heading to appear in the TOC
+    // Wait for the new heading to appear in the TOC and count to increase
     await expect(async () => {
       await expect(tocList.locator('a', { hasText: 'New Section Added' })).toBeVisible();
+      await expect(tocList.locator('a')).toHaveCount(initialCount + 1);
     }).toPass({ timeout: 5000 });
-
-    // TOC should have one more entry
-    await expect(tocList.locator('a')).toHaveCount(initialCount + 1);
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4525,6 +4525,7 @@
         updateDiffModeToggle();
         renderFileTree();
         renderAllFiles();
+        buildToc();
         updateCommentCount();
         updateViewedCount();
         updateTreeViewedState();


### PR DESCRIPTION
## Summary
- The file-changed SSE handler called `renderAllFiles()` but never called `buildToc()`, so the TOC panel showed stale headings after the markdown file was modified on disk
- Added the missing `buildToc()` call, matching the pattern used in `loadApp` and `handleDiffScopeChange`
- Added E2E tests verifying TOC updates on heading rename and heading addition

## Review
- [x] Code review: passed (spec compliance + code quality)
- [x] Parity audit: N/A (crit-web already has this call)

## Test plan
- [x] New E2E tests: heading rename + heading addition after round-complete
- [x] All 14 single-file TOC tests pass
- [x] Full E2E suite: 434 tests across 5 projects pass
- [x] Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)