### PR TITLE
fix: don't hijack text selection when a comment form is open

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -72,7 +72,7 @@ test.describe('Select-to-comment (git mode)', () => {
       await expect(comment).toContainText('Hello from text selection');
     });
 
-    test('coexists with already-open comment form (multi-form)', async ({ page }) => {
+    test('text selection does not open a second form when one is already open', async ({ page }) => {
       const section = mdSection(page);
 
       // Open a comment form via gutter click first
@@ -84,7 +84,8 @@ test.describe('Select-to-comment (git mode)', () => {
 
       await expect(section.locator('.comment-form')).toHaveCount(1);
 
-      // Now select text in a different block — should open a second form
+      // Now select text in a different block — should NOT open a second form,
+      // the selection should persist so the user can copy text
       const thirdBlock = section.locator('.line-block').nth(2);
       await thirdBlock.scrollIntoViewIfNeeded();
       const blockBox = await thirdBlock.boundingBox();
@@ -95,7 +96,12 @@ test.describe('Select-to-comment (git mode)', () => {
       await page.mouse.move(blockBox.x + blockBox.width - 10, blockBox.y + blockBox.height / 2, { steps: 5 });
       await page.mouse.up();
 
-      await expect(section.locator('.comment-form')).toHaveCount(2);
+      // Still only one form — text selection is for copying, not commenting
+      await expect(section.locator('.comment-form')).toHaveCount(1);
+
+      // Browser selection should persist
+      const selectedText = await page.evaluate(() => window.getSelection()?.toString().trim());
+      expect(selectedText).toBeTruthy();
     });
 
     test('multi-block selection spans correct line range', async ({ page }) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5698,6 +5698,10 @@
       const range = getLineRangeFromSelection(selection);
       if (!range) return;
 
+      // If any comment form is already open, don't hijack text selection —
+      // the user is selecting text to copy, not to open another comment.
+      if (activeForms.length > 0) return;
+
       // Capture the selected text before clearing, for the quote field.
       // If the selection covers the full text of the line range, skip it — redundant.
       let quote = null;


### PR DESCRIPTION
## Summary
- When a comment form was already open, selecting text to copy would instead open another comment form and clear the selection
- Now the select-to-comment mouseup handler bails out when any form is open, letting text selection work normally for copying
- Users can still open additional forms via gutter clicks or keyboard shortcuts

Closes #130

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (select-to-comment doesn't exist in crit-web)

## Test plan
- [x] All 17 select-to-comment E2E tests pass
- [x] Updated multi-form test to verify new behavior (selection persists, no second form opened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)