### PR TITLE
fix: pendingWrite flag prevents merge/delete race, bidirectional resolved sync

### DIFF
--- a/session.go
+++ b/session.go
@@ -88,6 +88,7 @@ type Session struct {
 	subMu             sync.Mutex
 	writeTimer        *time.Timer
 	writeGen          int
+	pendingWrite      bool
 	sharedURL         string
 	deleteToken       string
 	shareScope        string
@@ -759,6 +760,7 @@ func (s *Session) SignalRoundComplete() {
 		s.writeTimer.Stop()
 	}
 	s.writeGen++
+	s.pendingWrite = false
 	s.lastRoundEdits = s.pendingEdits
 	s.pendingEdits = 0
 	s.ReviewRound++
@@ -800,6 +802,7 @@ func (s *Session) ClearAllComments() {
 	s.Files = filtered
 	s.ReviewRound = 1
 	s.lastCritJSONMtime = time.Time{}
+	s.pendingWrite = false
 	critPath := s.critJSONPath()
 	s.mu.Unlock()
 	// Delete .crit.json from disk so it is no longer listed as an untracked git file.
@@ -813,6 +816,7 @@ func (s *Session) RoundCompleteChan() <-chan struct{} {
 
 // scheduleWrite debounces writes to disk.
 func (s *Session) scheduleWrite() {
+	s.pendingWrite = true
 	if s.writeTimer != nil {
 		s.writeTimer.Stop()
 	}
@@ -959,6 +963,7 @@ func (s *Session) WriteFiles() {
 		os.Remove(snap.critPath)
 		s.mu.Lock()
 		s.lastCritJSONMtime = time.Time{}
+		s.pendingWrite = false
 		s.mu.Unlock()
 		return
 	}
@@ -976,6 +981,7 @@ func (s *Session) WriteFiles() {
 	if info, err := os.Stat(snap.critPath); err == nil {
 		s.mu.Lock()
 		s.lastCritJSONMtime = info.ModTime()
+		s.pendingWrite = false
 		s.mu.Unlock()
 	}
 }
@@ -1049,6 +1055,15 @@ func (s *Session) mergeExternalCritJSON() bool {
 		return false
 	}
 
+	// If a debounced write is pending, skip the merge to avoid re-adding
+	// comments that the user just deleted (race between delete + debounce).
+	s.mu.RLock()
+	pending := s.pendingWrite
+	s.mu.RUnlock()
+	if pending {
+		return false
+	}
+
 	data, err := os.ReadFile(critPath)
 	if err != nil {
 		return false
@@ -1109,9 +1124,9 @@ func (s *Session) mergeExternalCritJSON() bool {
 							changed = true
 						}
 					}
-					// Sync resolved state from disk
-					if dc.Resolved && !mc.Resolved {
-						f.Comments[i].Resolved = true
+					// Sync resolved state bidirectionally from disk
+					if dc.Resolved != mc.Resolved {
+						f.Comments[i].Resolved = dc.Resolved
 						changed = true
 					}
 					break

--- a/session_test.go
+++ b/session_test.go
@@ -1670,3 +1670,137 @@ func TestSession_CarryForward_PreservesReplies(t *testing.T) {
 		t.Errorf("reply ID = %q after carry-forward", carried.Replies[0].ID)
 	}
 }
+
+func TestSession_MergeExternalCritJSON_SkippedDuringPendingWrite(t *testing.T) {
+	dir := t.TempDir()
+	s := &Session{
+		RepoRoot:    dir,
+		Branch:      "main",
+		ReviewRound: 1,
+		Files: []*FileEntry{
+			{Path: "main.go", Status: "modified", Comments: []Comment{
+				{ID: "c1", StartLine: 1, EndLine: 1, Body: "existing"},
+			}, nextID: 2},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	// Write initial .crit.json so merge has something to read
+	s.WriteFiles()
+
+	// Delete the comment (this sets pendingWrite)
+	s.DeleteComment("main.go", "c1")
+
+	// Write .crit.json externally with the old comment still present
+	cj := CritJSON{
+		Branch: "main", ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "existing"},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	// Touch with different mtime to bypass own-write check
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+
+	// Merge should be skipped because a write is pending
+	changed := s.mergeExternalCritJSON()
+	if changed {
+		t.Error("expected merge to be skipped during pending write")
+	}
+
+	// Comment should still be deleted
+	comments := s.GetComments("main.go")
+	if len(comments) != 0 {
+		t.Errorf("expected 0 comments, got %d — deleted comment was re-added", len(comments))
+	}
+}
+
+func TestSession_MergeExternalCritJSON_SyncsResolvedState(t *testing.T) {
+	dir := t.TempDir()
+	s := &Session{
+		RepoRoot:    dir,
+		Branch:      "main",
+		ReviewRound: 1,
+		Files: []*FileEntry{
+			{Path: "main.go", Status: "modified", Comments: []Comment{
+				{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: false},
+			}, nextID: 2},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	s.WriteFiles()
+
+	cj := CritJSON{
+		Branch: "main", ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: true},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+
+	changed := s.mergeExternalCritJSON()
+	if !changed {
+		t.Fatal("expected change detected")
+	}
+
+	comments := s.GetComments("main.go")
+	if !comments[0].Resolved {
+		t.Error("expected comment to be resolved after external edit")
+	}
+}
+
+func TestSession_MergeExternalCritJSON_SyncsUnresolve(t *testing.T) {
+	dir := t.TempDir()
+	s := &Session{
+		RepoRoot:    dir,
+		Branch:      "main",
+		ReviewRound: 1,
+		Files: []*FileEntry{
+			{Path: "main.go", Status: "modified", Comments: []Comment{
+				{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: true},
+			}, nextID: 2},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	s.WriteFiles()
+
+	cj := CritJSON{
+		Branch: "main", ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: false},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+
+	changed := s.mergeExternalCritJSON()
+	if !changed {
+		t.Fatal("expected change detected")
+	}
+
+	comments := s.GetComments("main.go")
+	if comments[0].Resolved {
+		t.Error("expected comment to be unresolved after external edit")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pendingWrite` flag to Session that blocks `mergeExternalCritJSON` during the debounce window, preventing deleted comments from being re-added (#129)
- Make resolved-state sync bidirectional so external unresolve edits are picked up, not just resolve (#77)

## Review
- [x] Code review: passed
- [x] Tests: 3 new tests (SkippedDuringPendingWrite, SyncsResolvedState, SyncsUnresolve)

## Test plan
- `go test ./... -count=1` passes
- Manual: start crit, add comment, delete via API, verify it stays deleted (no race)

Closes #129, closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)