### PR TITLE
fix: add --author to finish prompt, persist GitHubIDs after push

### DIFF
--- a/github.go
+++ b/github.go
@@ -352,13 +352,14 @@ func collectNewRepliesForPush(filePath string, cf CritJSONFile) []ghReplyForPush
 }
 
 // postGHReply posts a reply to an existing GitHub PR review comment.
-func postGHReply(prNumber int, parentGHID int64, body string) error {
+// Returns the GitHub ID of the newly created reply.
+func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
 	payload, err := json.Marshal(map[string]any{
 		"body":        body,
 		"in_reply_to": parentGHID,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal reply: %w", err)
+		return 0, fmt.Errorf("marshal reply: %w", err)
 	}
 	cmd := exec.Command("gh", "api",
 		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
@@ -368,9 +369,15 @@ func postGHReply(prNumber int, parentGHID int64, body string) error {
 	cmd.Stdin = bytes.NewReader(payload)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("gh api: %s: %w", string(output), err)
+		return 0, fmt.Errorf("gh api: %s: %w", string(output), err)
 	}
-	return nil
+	var resp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return 0, nil // non-fatal: reply was posted, just can't parse ID
+	}
+	return resp.ID, nil
 }
 
 // critJSONToGHComments converts .crit.json comments to GitHub review comment format.
@@ -381,6 +388,9 @@ func critJSONToGHComments(cj CritJSON) []map[string]any {
 		for _, c := range cf.Comments {
 			if c.Resolved {
 				continue // don't post resolved comments
+			}
+			if c.GitHubID != 0 {
+				continue // already pushed
 			}
 			comment := map[string]any{
 				"path": path,
@@ -410,27 +420,99 @@ func buildReviewPayload(comments []map[string]any, message string) ([]byte, erro
 
 // createGHReview posts a review with inline comments to a GitHub PR.
 // message is the top-level review body (empty string posts no top-level comment).
-func createGHReview(prNumber int, comments []map[string]any, message string) error {
+// Returns a map of "path:endLine" -> GitHubID for each created comment.
+func createGHReview(prNumber int, comments []map[string]any, message string) (map[string]int64, error) {
 	data, err := buildReviewPayload(comments, message)
 	if err != nil {
-		return fmt.Errorf("marshaling review: %w", err)
+		return nil, fmt.Errorf("marshaling review: %w", err)
 	}
 
-	var stderr bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("gh", "api",
 		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews", prNumber),
 		"--method", "POST",
 		"--input", "-",
 	)
 	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		if stderr.Len() > 0 {
-			return fmt.Errorf("creating review: %s", strings.TrimSpace(stderr.String()))
+			return nil, fmt.Errorf("creating review: %s", strings.TrimSpace(stderr.String()))
 		}
-		return fmt.Errorf("creating review: %w", err)
+		return nil, fmt.Errorf("creating review: %w", err)
 	}
-	return nil
+
+	// Parse response to extract comment IDs
+	var resp struct {
+		Comments []struct {
+			ID   int64  `json:"id"`
+			Path string `json:"path"`
+			Line int    `json:"line"`
+		} `json:"comments"`
+	}
+	idMap := make(map[string]int64)
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err == nil {
+		for _, c := range resp.Comments {
+			key := fmt.Sprintf("%s:%d", c.Path, c.Line)
+			idMap[key] = c.ID
+		}
+	}
+	return idMap, nil
+}
+
+// replyKey uniquely identifies a reply for GitHubID mapping after push.
+type replyKey struct {
+	ParentGHID int64
+	BodyPrefix string
+}
+
+// updateCritJSONWithGitHubIDs writes GitHub IDs back to .crit.json after a push.
+// commentIDs maps "path:endLine" -> GitHubID for root comments.
+// replyIDs maps replyKey -> GitHubID for replies.
+func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, replyIDs map[replyKey]int64) error {
+	data, err := os.ReadFile(critPath)
+	if err != nil {
+		return err
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return err
+	}
+
+	for path, cf := range cj.Files {
+		for i, c := range cf.Comments {
+			if c.GitHubID == 0 {
+				key := fmt.Sprintf("%s:%d", path, c.EndLine)
+				if id, ok := commentIDs[key]; ok {
+					cf.Comments[i].GitHubID = id
+				}
+			}
+			for j, r := range c.Replies {
+				if r.GitHubID == 0 && cf.Comments[i].GitHubID != 0 {
+					rk := replyKey{ParentGHID: cf.Comments[i].GitHubID, BodyPrefix: truncateStr(r.Body, 60)}
+					if id, ok := replyIDs[rk]; ok {
+						cf.Comments[i].Replies[j].GitHubID = id
+					}
+				}
+			}
+		}
+		cj.Files[path] = cf
+	}
+
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(critPath, append(out, '\n'), 0644)
+}
+
+// truncateStr returns the first n bytes of s, or all of s if shorter.
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 // addCommentToCritJSON appends a comment to .crit.json for the given file and line range.

--- a/github_test.go
+++ b/github_test.go
@@ -905,3 +905,106 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 		t.Errorf("error = %q, want 'not found'", err.Error())
 	}
 }
+
+func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Comments: []Comment{
+					{ID: "c1", EndLine: 5, Body: "new", GitHubID: 0},
+					{ID: "c2", EndLine: 10, Body: "already pushed", GitHubID: 123},
+				},
+			},
+		},
+	}
+	comments := critJSONToGHComments(cj)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment (skipping pushed), got %d", len(comments))
+	}
+	if comments[0]["body"] != "new" {
+		t.Errorf("wrong comment kept: %v", comments[0])
+	}
+}
+
+func TestUpdateCritJSONWithGitHubIDs(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	cj := CritJSON{
+		Branch: "main", BaseRef: "abc123", ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 5, Body: "fix this", GitHubID: 0},
+					{ID: "c2", StartLine: 10, EndLine: 10, Body: "also fix", GitHubID: 0},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	idMap := map[string]int64{
+		"main.go:5":  111,
+		"main.go:10": 222,
+	}
+
+	err := updateCritJSONWithGitHubIDs(critPath, idMap, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := os.ReadFile(critPath)
+	var got CritJSON
+	json.Unmarshal(result, &got)
+
+	comments := got.Files["main.go"].Comments
+	if comments[0].GitHubID != 111 {
+		t.Errorf("c1: expected GitHubID=111, got %d", comments[0].GitHubID)
+	}
+	if comments[1].GitHubID != 222 {
+		t.Errorf("c2: expected GitHubID=222, got %d", comments[1].GitHubID)
+	}
+}
+
+func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	cj := CritJSON{
+		Branch: "main", ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Comments: []Comment{
+					{
+						ID: "c1", EndLine: 5, Body: "fix", GitHubID: 100,
+						Replies: []Reply{
+							{ID: "c1-r1", Body: "Done, fixed it", GitHubID: 0},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	replyIDs := map[replyKey]int64{
+		{ParentGHID: 100, BodyPrefix: "Done, fixed it"}: 201,
+	}
+
+	err := updateCritJSONWithGitHubIDs(critPath, nil, replyIDs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := os.ReadFile(critPath)
+	var got CritJSON
+	json.Unmarshal(result, &got)
+
+	reply := got.Files["main.go"].Comments[0].Replies[0]
+	if reply.GitHubID != 201 {
+		t.Errorf("reply: expected GitHubID=201, got %d", reply.GitHubID)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -508,7 +508,8 @@ func runPush(args []string) {
 	}
 
 	fmt.Printf("Pushing %d comments to PR #%d...\n", len(ghComments), prNumber)
-	if err := createGHReview(prNumber, ghComments, message); err != nil {
+	commentIDs, err := createGHReview(prNumber, ghComments, message)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -516,15 +517,26 @@ func runPush(args []string) {
 
 	// Phase 2: Post new replies individually
 	replyCount := 0
+	replyIDs := make(map[replyKey]int64)
 	for _, reply := range allReplies {
-		if err := postGHReply(prNumber, reply.ParentGHID, reply.Body); err != nil {
+		replyID, err := postGHReply(prNumber, reply.ParentGHID, reply.Body)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to post reply: %v\n", err)
 		} else {
 			replyCount++
+			if replyID != 0 {
+				replyIDs[replyKey{ParentGHID: reply.ParentGHID, BodyPrefix: truncateStr(reply.Body, 60)}] = replyID
+			}
 		}
 	}
 	if replyCount > 0 {
 		fmt.Printf("Posted %d replies\n", replyCount)
+	}
+
+	// Write GitHub IDs back to .crit.json for idempotent re-push
+	critPath := filepath.Join(critDir, ".crit.json")
+	if err := updateCritJSONWithGitHubIDs(critPath, commentIDs, replyIDs); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to update .crit.json with GitHub IDs: %v\n", err)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -482,7 +482,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 		prompt = fmt.Sprintf(
 			"Review comments are in %s — comments are grouped per file with start_line/end_line referencing the source. "+
 				"Read the file, address each comment in the relevant file and location. "+
-				"For each comment: reply explaining what you did using `crit comment --reply-to <comment-id> --resolve \"<explanation>\"`, "+
+				"For each comment: reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> --resolve \"<explanation>\"`, "+
 				"or edit .crit.json directly to add a reply to the comment's \"replies\" array and set \"resolved\": true. "+
 				"When done run: `crit go %d`",
 			critJSON, s.port)

--- a/server_test.go
+++ b/server_test.go
@@ -983,6 +983,22 @@ func TestGetFile_NotInSession_PathTraversal(t *testing.T) {
 	}
 }
 
+func TestHandleFinish_PromptIncludesAuthor(t *testing.T) {
+	srv, session := newTestServer(t)
+	session.AddComment(session.Files[0].Path, 1, 1, "", "fix this", "", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/finish", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if !strings.Contains(resp["prompt"], "--author") {
+		t.Errorf("expected prompt to mention --author, got: %s", resp["prompt"])
+	}
+}
+
 func TestHandleFinishEmitsSSEEvent(t *testing.T) {
 	srv, session := newTestServer(t)
 	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "")


### PR DESCRIPTION
## Summary
- Include `--author <your-name>` in the finish prompt so agents attribute their replies (#125)
- `createGHReview` and `postGHReply` now return GitHub IDs from the API response (#127)
- `runPush` writes IDs back to `.crit.json` via `updateCritJSONWithGitHubIDs`
- `critJSONToGHComments` skips comments with `GitHubID != 0` for idempotent re-push

## Review
- [x] Code review: passed
- [x] Tests: 4 new tests (PromptIncludesAuthor, SkipsAlreadyPushed, UpdateCritJSONWithGitHubIDs, UpdateCritJSONWithGitHubIDs_Replies)

## Test plan
- `go test ./... -count=1` passes
- `crit push --dry-run` on a PR with existing pushed comments should skip them

Closes #125, closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)