### PR TITLE
chore: rename crit.live to crit.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/tomasz-tomczyk/crit.git",
         "path": "integrations/claude-code"
       },
-      "homepage": "https://crit.live",
+      "homepage": "https://crit.md",
       "category": "development"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ crit share plan.md --qr               # also print a QR code in the terminal
 crit unpublish                        # remove the shared review
 ```
 
-Sharing uses [crit.live](https://crit.live) by default. To self-host, deploy [`crit-web`](https://github.com/tomasz-tomczyk/crit-web) (Elixir/Phoenix) and point `CRIT_SHARE_URL` (or `--share-url`, or `share_url` in config) at your instance. Set `share_url` to `""` to disable sharing entirely.
+Sharing uses [crit.md](https://crit.md) by default. To self-host, deploy [`crit-web`](https://github.com/tomasz-tomczyk/crit-web) (Elixir/Phoenix) and point `CRIT_SHARE_URL` (or `--share-url`, or `share_url` in config) at your instance. Set `share_url` to `""` to disable sharing entirely.
 
 ### GitHub PR Sync
 
@@ -214,7 +214,7 @@ crit config --help                             # document all config keys
 {
   "port": 0,
   "no_open": false,
-  "share_url": "https://crit.live",
+  "share_url": "https://crit.md",
   "quiet": false,
   "output": "",
   "author": "John",
@@ -245,7 +245,7 @@ crit --no-ignore
 
 | Variable               | Description                                                                  |
 | ---------------------- | ---------------------------------------------------------------------------- |
-| `CRIT_SHARE_URL`       | Enable the Share button (e.g. `https://crit.live` or a self-hosted instance) |
+| `CRIT_SHARE_URL`       | Enable the Share button (e.g. `https://crit.md` or a self-hosted instance) |
 | `CRIT_PORT`            | Default port for the local server                                            |
 | `CRIT_NO_UPDATE_CHECK` | Set to any value to disable the update check on startup                      |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 - Split & unified diff between review rounds
 - AI review loop (finish review → clipboard prompt → agent edits → diff)
 - Vim keybindings (`j`/`k`/`c`/`Shift+F`)
-- Share reviews via crit.live
+- Share reviews via crit.md
 - Syntax highlighting (13+ languages)
 - Mermaid diagrams
 - Suggestion mode (before/after edits in comments)
@@ -51,9 +51,9 @@ A subtle `AudioContext`-generated tone when the agent signals round complete. Th
 
 A small "Insert template" dropdown in the comment form with pre-defined starters: "Consider using X instead of Y", "This will fail when...", "Missing error handling for...". Stored in `localStorage`, user-editable. Reduces friction of typing the same comment patterns.
 
-### "Reviewing as..." identity pill (crit.live)
+### "Reviewing as..." identity pill (crit.md)
 
-On shared reviews at crit.live, show a persistent header pill: `Reviewing as: Tomasz (purple)`. Makes multi-reviewer sessions feel collaborative rather than anonymous. The color-coding per identity already exists - this surfaces it explicitly.
+On shared reviews at crit.md, show a persistent header pill: `Reviewing as: Tomasz (purple)`. Makes multi-reviewer sessions feel collaborative rather than anonymous. The color-coding per identity already exists - this surfaces it explicitly.
 
 ---
 
@@ -79,14 +79,14 @@ After each review cycle, generate or append to a `crit-knowledge.md` that captur
 
 Export comments as GitHub PR review format, Jira issues, or structured JSON for downstream tooling. Useful when crit is embedded in larger workflows where review artifacts need to flow elsewhere.
 
-### Review history and analytics (crit.live)
+### Review history and analytics (crit.md)
 
-For teams using crit.live: aggregate data on review patterns, comment types, average rounds per plan. Surfaces which plan patterns generate the most review friction and helps teams calibrate their agent prompting. Enterprise-only, hosted, does not touch the CLI.
+For teams using crit.md: aggregate data on review patterns, comment types, average rounds per plan. Surfaces which plan patterns generate the most review friction and helps teams calibrate their agent prompting. Enterprise-only, hosted, does not touch the CLI.
 
 ### File-based plans (daemon mode)
 
 Support a persistent `crit` daemon that watches a directory for new `.md` files matching a pattern and automatically opens them for review. Eliminates the need to manually invoke `crit` per session - suitable for fully automated agent pipelines. Plannotator has open requests for this exact pattern.
 
-### Self-hosted crit.live
+### Self-hosted crit.md
 
 `docker run crit-web` for teams that need private sharing without data leaving their infrastructure. The Phoenix app is already open source - provide a production-ready Docker image and configuration guide.

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ func defaultConfig() generatedConfig {
 	return generatedConfig{
 		Port:       0,
 		NoOpen:     false,
-		ShareURL:   "https://crit.live",
+		ShareURL:   "https://crit.md",
 		Quiet:      false,
 		Output:     "",
 		Author:     "",
@@ -165,7 +165,7 @@ func LoadConfig(projectDir string) Config {
 
 	// 4. Apply runtime defaults for fields not explicitly set in any config file
 	if !globalPresence.ShareURL && !projectPresence.ShareURL {
-		merged.ShareURL = "https://crit.live"
+		merged.ShareURL = "https://crit.md"
 	}
 	if !globalPresence.IgnorePatterns && !projectPresence.IgnorePatterns {
 		merged.IgnorePatterns = []string{".crit.json"}

--- a/config_test.go
+++ b/config_test.go
@@ -307,8 +307,8 @@ func TestLoadConfigRuntimeDefaults(t *testing.T) {
 	projectDir := t.TempDir()
 
 	cfg := LoadConfig(projectDir)
-	if cfg.ShareURL != "https://crit.live" {
-		t.Errorf("ShareURL = %q, want runtime default https://crit.live", cfg.ShareURL)
+	if cfg.ShareURL != "https://crit.md" {
+		t.Errorf("ShareURL = %q, want runtime default https://crit.md", cfg.ShareURL)
 	}
 	if len(cfg.IgnorePatterns) != 1 || cfg.IgnorePatterns[0] != ".crit.json" {
 		t.Errorf("IgnorePatterns = %v, want [.crit.json]", cfg.IgnorePatterns)

--- a/integrations/aider/CONVENTIONS.md
+++ b/integrations/aider/CONVENTIONS.md
@@ -68,7 +68,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -108,7 +108,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/cline/crit.md
+++ b/integrations/cline/crit.md
@@ -68,7 +68,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -108,7 +108,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -108,7 +108,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/opencode/SKILL.md
+++ b/integrations/opencode/SKILL.md
@@ -110,7 +110,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/integrations/windsurf/crit.md
+++ b/integrations/windsurf/crit.md
@@ -68,7 +68,7 @@ Examples:
 ```bash
 crit share <file>                                # Share a single file
 crit share <file1> <file2>                       # Share multiple files
-crit share --share-url https://crit.live <file>  # Explicit share URL
+crit share --share-url https://crit.md <file>  # Explicit share URL
 ```
 
 Rules:

--- a/main.go
+++ b/main.go
@@ -947,7 +947,7 @@ Options:
       --no-open               Don't auto-open browser
       --no-ignore             Disable all file ignore patterns
   -q, --quiet                 Suppress status output
-      --share-url <url>       Share service URL (e.g. https://crit.live or self-hosted)
+      --share-url <url>       Share service URL (e.g. https://crit.md or self-hosted)
       --base-branch <branch>  Base branch to diff against (overrides auto-detection)
       --qr                    Print QR code of share URL (with crit share)
   -v, --version               Print version
@@ -962,7 +962,7 @@ Configuration:
   Project config:  .crit.config.json (in repo root)
   Run 'crit config' to see resolved configuration.
 
-Learn more: https://crit.live
+Learn more: https://crit.md
 `)
 }
 
@@ -1001,7 +1001,7 @@ Ignore pattern syntax:
 Example config:
   {
     "port": 3456,
-    "share_url": "https://crit.live",
+    "share_url": "https://crit.md",
     "ignore_patterns": ["*.lock", "*.min.js", "vendor/", "generated/"]
   }
 `)

--- a/server_test.go
+++ b/server_test.go
@@ -449,7 +449,7 @@ func TestHandleFiles_MethodNotAllowed(t *testing.T) {
 
 func TestGetConfig(t *testing.T) {
 	s, _ := newTestServer(t)
-	s.shareURL = "https://crit.live"
+	s.shareURL = "https://crit.md"
 	s.currentVersion = "v1.2.3"
 
 	req := httptest.NewRequest("GET", "/api/config", nil)
@@ -463,8 +463,8 @@ func TestGetConfig(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
-	if resp["share_url"] != "https://crit.live" {
-		t.Errorf("share_url = %q, want https://crit.live", resp["share_url"])
+	if resp["share_url"] != "https://crit.md" {
+		t.Errorf("share_url = %q, want https://crit.md", resp["share_url"])
 	}
 	if resp["hosted_url"] != "" {
 		t.Errorf("hosted_url should be empty initially, got %q", resp["hosted_url"])
@@ -542,7 +542,7 @@ func TestGetConfig_MethodNotAllowed(t *testing.T) {
 func TestPostShareURL(t *testing.T) {
 	s, session := newTestServer(t)
 
-	body := `{"url":"https://crit.live/r/abc123"}`
+	body := `{"url":"https://crit.md/r/abc123"}`
 	req := httptest.NewRequest("POST", "/api/share-url", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -551,8 +551,8 @@ func TestPostShareURL(t *testing.T) {
 	if w.Code != 200 {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
-	if session.GetSharedURL() != "https://crit.live/r/abc123" {
-		t.Errorf("shared URL = %q, want https://crit.live/r/abc123", session.GetSharedURL())
+	if session.GetSharedURL() != "https://crit.md/r/abc123" {
+		t.Errorf("shared URL = %q, want https://crit.md/r/abc123", session.GetSharedURL())
 	}
 
 	// Verify config now reflects the stored URL
@@ -563,8 +563,8 @@ func TestPostShareURL(t *testing.T) {
 	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
-	if resp["hosted_url"] != "https://crit.live/r/abc123" {
-		t.Errorf("hosted_url = %q, want https://crit.live/r/abc123", resp["hosted_url"])
+	if resp["hosted_url"] != "https://crit.md/r/abc123" {
+		t.Errorf("hosted_url = %q, want https://crit.md/r/abc123", resp["hosted_url"])
 	}
 }
 
@@ -598,7 +598,7 @@ func TestGetConfig_IncludesDeleteToken(t *testing.T) {
 func TestPostShareURL_SavesDeleteToken(t *testing.T) {
 	s, session := newTestServer(t)
 
-	body := `{"url":"https://crit.live/r/abc","delete_token":"deletetoken1234567890x"}`
+	body := `{"url":"https://crit.md/r/abc","delete_token":"deletetoken1234567890x"}`
 	req := httptest.NewRequest("POST", "/api/share-url", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -614,7 +614,7 @@ func TestPostShareURL_SavesDeleteToken(t *testing.T) {
 
 func TestDeleteShareURL(t *testing.T) {
 	s, session := newTestServer(t)
-	session.SetSharedURLAndToken("https://crit.live/r/abc", "sometoken1234567890123")
+	session.SetSharedURLAndToken("https://crit.md/r/abc", "sometoken1234567890123")
 
 	req := httptest.NewRequest("DELETE", "/api/share-url", nil)
 	w := httptest.NewRecorder()

--- a/session_test.go
+++ b/session_test.go
@@ -285,7 +285,7 @@ func TestSession_WriteFiles_NoCommentsSkips(t *testing.T) {
 
 func TestSession_WriteFiles_SharedURLOnly(t *testing.T) {
 	s := newTestSession(t)
-	s.SetSharedURLAndToken("https://crit.live/r/abc", "token123")
+	s.SetSharedURLAndToken("https://crit.md/r/abc", "token123")
 
 	flushWrites(s)
 	s.WriteFiles()
@@ -296,7 +296,7 @@ func TestSession_WriteFiles_SharedURLOnly(t *testing.T) {
 	}
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
-	if cj.ShareURL != "https://crit.live/r/abc" {
+	if cj.ShareURL != "https://crit.md/r/abc" {
 		t.Errorf("share_url = %q", cj.ShareURL)
 	}
 }
@@ -1250,7 +1250,7 @@ func TestLoadCritJSON_IgnoresStaleShareState(t *testing.T) {
 	// Write .crit.json with share state for a different file set
 	scope := shareScope([]string{"old-plan.md"})
 	cj := CritJSON{
-		ShareURL:    "https://crit.live/r/old",
+		ShareURL:    "https://crit.md/r/old",
 		DeleteToken: "old-token",
 		ShareScope:  scope,
 		Files:       map[string]CritJSONFile{},
@@ -1278,7 +1278,7 @@ func TestLoadCritJSON_RestoresMatchingShareState(t *testing.T) {
 
 	scope := shareScope([]string{"plan.md"})
 	cj := CritJSON{
-		ShareURL:    "https://crit.live/r/current",
+		ShareURL:    "https://crit.md/r/current",
 		DeleteToken: "current-token",
 		ShareScope:  scope,
 		Files:       map[string]CritJSONFile{},
@@ -1295,7 +1295,7 @@ func TestLoadCritJSON_RestoresMatchingShareState(t *testing.T) {
 	sess.loadCritJSON()
 
 	url, token := sess.GetShareState()
-	if url != "https://crit.live/r/current" {
+	if url != "https://crit.md/r/current" {
 		t.Errorf("expected share state restored, got url=%q", url)
 	}
 	if token != "current-token" {

--- a/share.go
+++ b/share.go
@@ -299,5 +299,5 @@ func resolveShareURL(flagValue string) string {
 	if cfg.ShareURL != "" {
 		return cfg.ShareURL
 	}
-	return "https://crit.live"
+	return "https://crit.md"
 }

--- a/share_test.go
+++ b/share_test.go
@@ -98,7 +98,7 @@ func TestShareFilesToWeb_Success(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]string{
-			"url":          "https://crit.live/r/abc123",
+			"url":          "https://crit.md/r/abc123",
 			"delete_token": "tok_secret",
 		})
 	}))
@@ -109,8 +109,8 @@ func TestShareFilesToWeb_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if url != "https://crit.live/r/abc123" {
-		t.Errorf("expected url https://crit.live/r/abc123, got %s", url)
+	if url != "https://crit.md/r/abc123" {
+		t.Errorf("expected url https://crit.md/r/abc123, got %s", url)
 	}
 	if token != "tok_secret" {
 		t.Errorf("expected token tok_secret, got %s", token)
@@ -256,7 +256,7 @@ func TestPersistShareState(t *testing.T) {
 	dir := t.TempDir()
 
 	// Persist to new .crit.json
-	err := persistShareState(dir, "https://crit.live/r/abc", "tok_123", "")
+	err := persistShareState(dir, "https://crit.md/r/abc", "tok_123", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestPersistShareState(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
-	if cj.ShareURL != "https://crit.live/r/abc" {
+	if cj.ShareURL != "https://crit.md/r/abc" {
 		t.Errorf("expected share_url, got %s", cj.ShareURL)
 	}
 	if cj.DeleteToken != "tok_123" {
@@ -288,7 +288,7 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
 	// Persist share state
-	err := persistShareState(dir, "https://crit.live/r/def", "tok_456", "")
+	err := persistShareState(dir, "https://crit.md/r/def", "tok_456", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
-	if cj.ShareURL != "https://crit.live/r/def" {
+	if cj.ShareURL != "https://crit.md/r/def" {
 		t.Errorf("expected share_url")
 	}
 	if cj.Branch != "main" {
@@ -312,7 +312,7 @@ func TestClearShareState(t *testing.T) {
 	dir := t.TempDir()
 
 	cj := CritJSON{
-		ShareURL:    "https://crit.live/r/old",
+		ShareURL:    "https://crit.md/r/old",
 		DeleteToken: "tok_old",
 		Files:       map[string]CritJSONFile{"plan.md": {Comments: []Comment{{ID: "c1", Body: "test"}}}},
 	}
@@ -418,7 +418,7 @@ func TestHandleShare_Success(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]string{
-			"url":          "https://crit.live/r/test123",
+			"url":          "https://crit.md/r/test123",
 			"delete_token": "tok_test",
 		})
 	}))
@@ -451,7 +451,7 @@ func TestHandleShare_Success(t *testing.T) {
 
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
-	if result["url"] != "https://crit.live/r/test123" {
+	if result["url"] != "https://crit.md/r/test123" {
 		t.Errorf("expected url, got %v", result["url"])
 	}
 	if result["delete_token"] != "tok_test" {
@@ -501,7 +501,7 @@ func TestHandleShare_NoShareURL(t *testing.T) {
 }
 
 func TestHandleShare_WrongMethod(t *testing.T) {
-	srv := &Server{session: &Session{}, shareURL: "https://crit.live"}
+	srv := &Server{session: &Session{}, shareURL: "https://crit.md"}
 	req := httptest.NewRequest(http.MethodGet, "/api/share", nil)
 	w := httptest.NewRecorder()
 	srv.handleShare(w, req)
@@ -518,7 +518,7 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]string{
-			"url":          "https://crit.live/r/new-token",
+			"url":          "https://crit.md/r/new-token",
 			"delete_token": "new-del-token",
 		})
 	}))
@@ -530,7 +530,7 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 		Files:       []*FileEntry{{Path: "plan.md", Content: "# Plan"}},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
-	sess.SetSharedURLAndToken("https://crit.live/r/existing", "existing-del-token")
+	sess.SetSharedURLAndToken("https://crit.md/r/existing", "existing-del-token")
 
 	srv := &Server{session: sess, shareURL: mockServer.URL}
 
@@ -544,7 +544,7 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
-	if result["url"] != "https://crit.live/r/existing" {
+	if result["url"] != "https://crit.md/r/existing" {
 		t.Errorf("expected existing URL, got %v", result["url"])
 	}
 	if result["delete_token"] != "existing-del-token" {
@@ -561,7 +561,7 @@ func TestLoadExistingShareState(t *testing.T) {
 
 	// Legacy .crit.json without scope — loads unconditionally
 	cj := CritJSON{
-		ShareURL:    "https://crit.live/r/existing",
+		ShareURL:    "https://crit.md/r/existing",
 		DeleteToken: "del-token-123",
 		Files:       map[string]CritJSONFile{},
 	}
@@ -569,7 +569,7 @@ func TestLoadExistingShareState(t *testing.T) {
 	os.WriteFile(critPath, data, 0644)
 
 	url, token := loadExistingShareState(dir, []string{"anything.md"})
-	if url != "https://crit.live/r/existing" {
+	if url != "https://crit.md/r/existing" {
 		t.Errorf("expected existing URL, got %q", url)
 	}
 	if token != "del-token-123" {
@@ -603,7 +603,7 @@ func TestLoadExistingShareState_ScopeMismatch(t *testing.T) {
 	critPath := filepath.Join(dir, ".crit.json")
 
 	cj := CritJSON{
-		ShareURL:    "https://crit.live/r/old",
+		ShareURL:    "https://crit.md/r/old",
 		DeleteToken: "old-token",
 		ShareScope:  shareScope([]string{"old-plan.md"}),
 		Files:       map[string]CritJSONFile{},
@@ -619,7 +619,7 @@ func TestLoadExistingShareState_ScopeMismatch(t *testing.T) {
 
 	// Same file set — should return share state
 	url, token = loadExistingShareState(dir, []string{"old-plan.md"})
-	if url != "https://crit.live/r/old" {
+	if url != "https://crit.md/r/old" {
 		t.Errorf("expected URL for matching scope, got %q", url)
 	}
 }
@@ -651,7 +651,7 @@ func TestResolveShareURL(t *testing.T) {
 			name:     "default when nothing set",
 			flag:     "",
 			env:      "",
-			expected: "https://crit.live",
+			expected: "https://crit.md",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Rename all `crit.live` URL and text references to `crit.md` across 17 files
- Covers config defaults, CLI help text, README, roadmap, integration docs, and all test fixtures
- Tests pass with updated URLs

See also: tomasz-tomczyk/crit-web#30 (same rename for the web app, plus 301 redirect from crit.live)

## Review
- [x] Code review: passed (pure text replacement, no logic changes)
- [x] Tests: all passing

## Test plan
- `go test ./...` passes
- Verified zero remaining `crit.live` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)