### PR TITLE
fix: quote highlight on wrong line in unified diff mode (#133)

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -426,6 +426,49 @@ test.describe('Select-to-comment (git mode)', () => {
       await expect(section.locator('mark.quote-highlight')).toBeVisible();
     });
 
+    test('quote highlight appears on addition line, not deletion line in unified diff (issue #133)', async ({ page }) => {
+      // Switch to unified mode
+      const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+      await expect(unifiedBtn).toBeVisible();
+      await unifiedBtn.click();
+
+      const section = goSection(page);
+      // Find an addition line with enough text for a partial selection
+      const additionLines = section.locator('.diff-line.addition');
+      let targetLine: any = null;
+      let targetBox: any = null;
+      const count = await additionLines.count();
+      for (let i = 0; i < count; i++) {
+        const line = additionLines.nth(i);
+        const content = line.locator('.diff-content');
+        const text = await content.textContent();
+        if (text && text.trim().length > 20) {
+          await line.scrollIntoViewIfNeeded();
+          targetLine = line;
+          targetBox = await content.boundingBox();
+          break;
+        }
+      }
+      expect(targetBox).toBeTruthy();
+      if (!targetBox || !targetLine) return;
+
+      // Partial selection on the addition line
+      await page.mouse.move(targetBox.x + 10, targetBox.y + targetBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 150), targetBox.y + targetBox.height / 2, { steps: 5 });
+      await page.mouse.up();
+
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+
+      // The quote highlight must be inside an .addition line, NOT a .deletion line
+      const highlightMark = section.locator('mark.quote-highlight').first();
+      await expect(highlightMark).toBeVisible();
+      const parentLine = highlightMark.locator('xpath=ancestor::div[contains(@class, "diff-line")]');
+      await expect(parentLine).toHaveClass(/addition/);
+      await expect(parentLine).not.toHaveClass(/deletion/);
+    });
+
     test('quote highlight appears in markdown diff view while form is open', async ({ page }) => {
       // Markdown file in git mode defaults to split diff view
       const section = mdSection(page);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4111,7 +4111,7 @@
     const formQuotes = getFormsForFile(file.path)
       .filter(function(f) { return f.quote && !f.editingId; })
       .map(function(f) {
-        return { start_line: f.startLine, end_line: f.endLine, quote: f.quote, id: 'draft-' + f.formKey };
+        return { start_line: f.startLine, end_line: f.endLine, quote: f.quote, id: 'draft-' + f.formKey, side: f.side };
       });
     const allQuoted = quotedComments.concat(formQuotes);
     if (allQuoted.length === 0) return;
@@ -4131,7 +4131,11 @@
           }
         });
         // Diff view: diff lines with data-diff-line-num
+        // Filter by side to avoid matching the wrong line in unified diff
+        // (deleted and added lines can share the same line number)
+        var commentSide = comment.side || '';
         sectionEl.querySelectorAll('[data-diff-file-path="' + CSS.escape(file.path) + '"][data-diff-line-num="' + ln + '"]').forEach(function(el) {
+          if (el.dataset.diffSide !== commentSide) return;
           const content = el.querySelector('.diff-content');
           if (content && contentEls.indexOf(content) === -1) contentEls.push(content);
         });
@@ -5728,9 +5732,11 @@
                 if (content) fullText += (fullText ? '\n' : '') + content.textContent.trim();
               }
             });
-            // Diff view
+            // Diff view — filter by side so unified diff doesn't double-count
+            var selSide = range.side || '';
             document.querySelectorAll('[data-diff-file-path][data-diff-line-num="' + ln + '"]').forEach(function(el) {
               if (el.dataset.diffFilePath !== range.filePath) return;
+              if (el.dataset.diffSide !== selSide) return;
               const content = el.querySelector('.diff-content');
               if (content) fullText += (fullText ? '\n' : '') + content.textContent.trim();
             });


### PR DESCRIPTION
## Summary
- In unified diff mode, selecting text on an added line caused the quote highlight to appear on the corresponding deleted line instead
- Root cause: the highlight query matched elements by line number without filtering by `data-diff-side` — deleted and added lines can share the same line number value
- Fix filters by side in three places: highlight application, draft quote mapping, and full-text comparison for partial selection detection

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web has no quote highlighting)

## Test plan
- Added E2E test that selects text on an addition line in unified diff and asserts the highlight mark is inside `.addition`, not `.deletion`

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)