### PR TITLE
fix: add --author flag to all reply-to examples

### DIFF
--- a/integrations/aider/CONVENTIONS.md
+++ b/integrations/aider/CONVENTIONS.md
@@ -34,7 +34,7 @@ crit listen <port>
 
 ## After review
 
-Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`.
+Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve --author 'Aider' '<what you did>'`.
 
 When done, run `crit go <port>` to trigger a new round, then **immediately run `crit listen <port>` again** to wait for the next review. Do NOT skip `crit listen` between rounds.
 

--- a/integrations/claude-code/commands/crit.md
+++ b/integrations/claude-code/commands/crit.md
@@ -77,7 +77,7 @@ For each unresolved comment:
 2. If a comment contains a suggestion block, apply that specific change
 3. Revise the **referenced file** to address the feedback - this could be the plan file or any code file from the git diff
 4. Use the Edit tool to make targeted changes
-5. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`
+5. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve --author 'Claude Code' '<what you did>'`
 
 Editing the plan file triggers Crit's live reload - the user sees changes in the browser immediately.
 

--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -46,7 +46,7 @@ After a crit review session, comments are in `.crit.json`. Comments are grouped 
 After addressing a comment, reply to it using the CLI:
 
 ```bash
-crit comment --reply-to c1 --resolve 'Fixed by extracting to helper'
+crit comment --reply-to c1 --resolve --author 'Claude Code' 'Fixed by extracting to helper'
 ```
 
 This adds a reply to the comment thread and marks it resolved. You can also reply without resolving (omit `--resolve`) if discussion is ongoing.
@@ -57,22 +57,22 @@ Use `crit comment` to add inline review comments to `.crit.json` programmaticall
 
 ```bash
 # Single line comment
-crit comment --author 'Claude' <path>:<line> '<body>'
+crit comment --author 'Claude Code' <path>:<line> '<body>'
 
 # Multi-line comment (range)
-crit comment --author 'Claude' <path>:<start>-<end> '<body>'
+crit comment --author 'Claude Code' <path>:<start>-<end> '<body>'
 
 # Reply to an existing comment (with optional --resolve)
-crit comment --reply-to <id> --author 'Claude' '<body>'
-crit comment --reply-to <id> --resolve --author 'Claude' '<body>'
+crit comment --reply-to <id> --author 'Claude Code' '<body>'
+crit comment --reply-to <id> --resolve --author 'Claude Code' '<body>'
 ```
 
 Examples:
 
 ```bash
-crit comment --author 'Claude' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
-crit comment --author 'Claude' src/handler.go:15-28 'This error is swallowed silently'
-crit comment --reply-to c1 --resolve --author 'Claude' 'Added null check on line 42'
+crit comment --author 'Claude Code' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
+crit comment --author 'Claude Code' src/handler.go:15-28 'This error is swallowed silently'
+crit comment --reply-to c1 --resolve --author 'Claude Code' 'Added null check on line 42'
 ```
 
 Rules:

--- a/integrations/cline/crit.md
+++ b/integrations/cline/crit.md
@@ -34,7 +34,7 @@ crit listen <port>
 
 ## After review
 
-Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`.
+Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve --author 'Cline' '<what you did>'`.
 
 When done, run `crit go <port>` to trigger a new round, then **immediately run `crit listen <port>` again** to wait for the next review. Do NOT skip `crit listen` between rounds.
 

--- a/integrations/cursor/commands/crit.md
+++ b/integrations/cursor/commands/crit.md
@@ -71,7 +71,7 @@ For each unresolved comment:
 1. Understand what the comment asks for (clarification, change, addition, removal)
 2. If a comment contains a suggestion block, apply that specific change
 3. Revise the **referenced file** to address the feedback - this could be the plan file or any code file
-4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`
+4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve --author 'Cursor' '<what you did>'`
 
 Editing the plan file triggers Crit's live reload - the user sees changes in the browser immediately.
 

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -46,7 +46,7 @@ After a crit review session, comments are in `.crit.json`. Comments are grouped 
 After addressing a comment, reply to it using the CLI:
 
 ```bash
-crit comment --reply-to c1 --resolve 'Fixed by extracting to helper'
+crit comment --reply-to c1 --resolve --author 'Cursor' 'Fixed by extracting to helper'
 ```
 
 This adds a reply to the comment thread and marks it resolved. You can also reply without resolving (omit `--resolve`) if discussion is ongoing.
@@ -57,22 +57,22 @@ Use `crit comment` to add inline review comments to `.crit.json` programmaticall
 
 ```bash
 # Single line comment
-crit comment --author 'Claude' <path>:<line> '<body>'
+crit comment --author 'Cursor' <path>:<line> '<body>'
 
 # Multi-line comment (range)
-crit comment --author 'Claude' <path>:<start>-<end> '<body>'
+crit comment --author 'Cursor' <path>:<start>-<end> '<body>'
 
 # Reply to an existing comment (with optional --resolve)
-crit comment --reply-to <id> --author 'Claude' '<body>'
-crit comment --reply-to <id> --resolve --author 'Claude' '<body>'
+crit comment --reply-to <id> --author 'Cursor' '<body>'
+crit comment --reply-to <id> --resolve --author 'Cursor' '<body>'
 ```
 
 Examples:
 
 ```bash
-crit comment --author 'Claude' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
-crit comment --author 'Claude' src/handler.go:15-28 'This error is swallowed silently'
-crit comment --reply-to c1 --resolve --author 'Claude' 'Added null check on line 42'
+crit comment --author 'Cursor' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
+crit comment --author 'Cursor' src/handler.go:15-28 'This error is swallowed silently'
+crit comment --reply-to c1 --resolve --author 'Cursor' 'Added null check on line 42'
 ```
 
 Rules:

--- a/integrations/github-copilot/commands/crit.prompt.md
+++ b/integrations/github-copilot/commands/crit.prompt.md
@@ -71,7 +71,7 @@ For each unresolved comment:
 1. Understand what the comment asks for (clarification, change, addition, removal)
 2. If a comment contains a suggestion block, apply that specific change
 3. Revise the **referenced file** to address the feedback - this could be the plan file or any code file
-4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`
+4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve --author 'Copilot' '<what you did>'`
 
 Editing the plan file triggers Crit's live reload - the user sees changes in the browser immediately.
 

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -46,7 +46,7 @@ After a crit review session, comments are in `.crit.json`. Comments are grouped 
 After addressing a comment, reply to it using the CLI:
 
 ```bash
-crit comment --reply-to c1 --resolve 'Fixed by extracting to helper'
+crit comment --reply-to c1 --resolve --author 'Copilot' 'Fixed by extracting to helper'
 ```
 
 This adds a reply to the comment thread and marks it resolved. You can also reply without resolving (omit `--resolve`) if discussion is ongoing.
@@ -57,22 +57,22 @@ Use `crit comment` to add inline review comments to `.crit.json` programmaticall
 
 ```bash
 # Single line comment
-crit comment --author 'Claude' <path>:<line> '<body>'
+crit comment --author 'Copilot' <path>:<line> '<body>'
 
 # Multi-line comment (range)
-crit comment --author 'Claude' <path>:<start>-<end> '<body>'
+crit comment --author 'Copilot' <path>:<start>-<end> '<body>'
 
 # Reply to an existing comment (with optional --resolve)
-crit comment --reply-to <id> --author 'Claude' '<body>'
-crit comment --reply-to <id> --resolve --author 'Claude' '<body>'
+crit comment --reply-to <id> --author 'Copilot' '<body>'
+crit comment --reply-to <id> --resolve --author 'Copilot' '<body>'
 ```
 
 Examples:
 
 ```bash
-crit comment --author 'Claude' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
-crit comment --author 'Claude' src/handler.go:15-28 'This error is swallowed silently'
-crit comment --reply-to c1 --resolve --author 'Claude' 'Added null check on line 42'
+crit comment --author 'Copilot' src/auth.go:42 'Missing null check on user.session — will panic if session expired'
+crit comment --author 'Copilot' src/handler.go:15-28 'This error is swallowed silently'
+crit comment --reply-to c1 --resolve --author 'Copilot' 'Added null check on line 42'
 ```
 
 Rules:

--- a/integrations/opencode/SKILL.md
+++ b/integrations/opencode/SKILL.md
@@ -56,7 +56,7 @@ After a crit review session, comments are in `.crit.json`. Comments are grouped 
 After addressing a comment, reply to it using the CLI:
 
 ```bash
-crit comment --reply-to c1 --resolve 'Fixed by extracting to helper'
+crit comment --reply-to c1 --resolve --author 'OpenCode' 'Fixed by extracting to helper'
 ```
 
 This adds a reply to the comment thread and marks it resolved. You can also reply without resolving (omit `--resolve`) if discussion is ongoing.
@@ -67,14 +67,14 @@ Use `crit comment` to add inline review comments to `.crit.json` programmaticall
 
 ```bash
 # Single line comment
-crit comment --author 'Claude' <path>:<line> '<body>'
+crit comment --author 'OpenCode' <path>:<line> '<body>'
 
 # Multi-line comment (range)
-crit comment --author 'Claude' <path>:<start>-<end> '<body>'
+crit comment --author 'OpenCode' <path>:<start>-<end> '<body>'
 
 # Reply to an existing comment (with optional --resolve)
-crit comment --reply-to <id> --author 'Claude' '<body>'
-crit comment --reply-to <id> --resolve --author 'Claude' '<body>'
+crit comment --reply-to <id> --author 'OpenCode' '<body>'
+crit comment --reply-to <id> --resolve --author 'OpenCode' '<body>'
 ```
 
 Rules:

--- a/integrations/opencode/crit.md
+++ b/integrations/opencode/crit.md
@@ -78,7 +78,7 @@ For each unresolved comment:
 1. Understand what the comment asks for.
 2. If a comment contains a suggestion block, apply that specific change.
 3. Revise the referenced file to address the feedback - this could be the plan file or any code file from the git diff.
-4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`
+4. Reply to the comment with what you did: `crit comment --reply-to <id> --resolve --author 'OpenCode' '<what you did>'`
 
 Editing the plan file triggers Crit's live reload - the user sees changes in the browser immediately.
 

--- a/integrations/windsurf/crit.md
+++ b/integrations/windsurf/crit.md
@@ -34,7 +34,7 @@ crit listen <port>
 
 ## After review
 
-Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve '<what you did>'`.
+Read `.crit.json` to find the user's inline comments. Comments are grouped per file with `start_line`/`end_line` referencing the source. A comment is unresolved if `"resolved": false` or if the `resolved` field is missing. Address each unresolved comment by revising the referenced file. After addressing, reply with what you did: `crit comment --reply-to <id> --resolve --author 'Windsurf' '<what you did>'`.
 
 When done, run `crit go <port>` to trigger a new round, then **immediately run `crit listen <port>` again** to wait for the next review. Do NOT skip `crit listen` between rounds.
 

--- a/main.go
+++ b/main.go
@@ -631,7 +631,7 @@ func runComment(args []string) {
 		fmt.Fprintln(os.Stderr, "Examples:")
 		fmt.Fprintln(os.Stderr, "  crit comment --author 'Claude' main.go:42 'Fix this bug'")
 		fmt.Fprintln(os.Stderr, "  crit comment --author 'Claude' src/auth.go:10-25 'This block needs refactoring'")
-		fmt.Fprintln(os.Stderr, "  crit comment --reply-to c1 --resolve 'Split into two functions'")
+		fmt.Fprintln(os.Stderr, "  crit comment --reply-to c1 --resolve --author 'Claude' 'Split into two functions'")
 		fmt.Fprintln(os.Stderr, "  crit comment --output /tmp/reviews main.go:42 'Fix this bug'")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Tips:")
@@ -928,7 +928,7 @@ Usage:
   crit go <port>                             Signal round-complete to a running crit instance
   crit listen <port>                         Wait for review to finish on a running crit instance
   crit comment <path>:<line[-end]> <body>    Add a review comment to .crit.json
-  crit comment --reply-to <id> [--resolve] <body>  Reply to a comment
+  crit comment --reply-to <id> [--resolve] [--author <name>] <body>  Reply to a comment
   crit comment --clear                       Remove all comments from .crit.json
   crit share <file> [file...]                Share files to crit-web and print the URL
   crit unpublish                             Remove a shared review from crit-web


### PR DESCRIPTION
## Summary

- Added `--author '<name>'` to every `crit comment --reply-to` example that was missing it across all integration docs
- Fixed SKILL.md files (opencode, cursor, github-copilot, claude-code) that used generic `'Claude'` as author — now each uses the correct integration name (`'OpenCode'`, `'Cursor'`, `'Copilot'`, `'Claude Code'`)
- Updated `main.go` help text and usage examples to include `--author`

## Files changed

| Integration | Files | Author name |
|---|---|---|
| opencode | `SKILL.md`, `crit.md` | `'OpenCode'` |
| aider | `CONVENTIONS.md` | `'Aider'` |
| cline | `crit.md` | `'Cline'` |
| windsurf | `crit.md` | `'Windsurf'` |
| cursor | `SKILL.md`, `crit.md` | `'Cursor'` |
| github-copilot | `SKILL.md`, `crit.prompt.md` | `'Copilot'` |
| claude-code | `SKILL.md`, `crit.md` | `'Claude Code'` |
| main.go | help text + usage example | `'Claude'` / generic |

## Test plan

- [x] `go build ./...` passes
- [ ] Verify each integration file shows correct author in examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)