### PR TITLE
test: fix flaky split diff quote highlight test

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -367,21 +367,29 @@ test.describe('Select-to-comment (git mode)', () => {
 
     test('quote highlight appears in split diff view while form is open', async ({ page }) => {
       const section = goSection(page);
-      // Find an addition line with enough text for a partial selection
-      const additionLine = section.locator('.diff-split-side.addition').first();
-      await additionLine.scrollIntoViewIfNeeded();
-      await expect(additionLine).toBeVisible();
-
-      const diffContent = additionLine.locator('.diff-content');
-      await expect(diffContent).toBeVisible();
-      const box = await diffContent.boundingBox();
-      expect(box).toBeTruthy();
-      if (!box) return;
+      // Find an addition line with enough text for a meaningful partial selection
+      // Skip very short lines (like just `"log"`) — partial selection on short
+      // lines may select the full text, producing no quote and no highlight
+      const additionLines = section.locator('.diff-split-side.addition');
+      let targetBox: any = null;
+      const count = await additionLines.count();
+      for (let i = 0; i < count; i++) {
+        const line = additionLines.nth(i);
+        const content = line.locator('.diff-content');
+        const text = await content.textContent();
+        if (text && text.trim().length > 20) {
+          await line.scrollIntoViewIfNeeded();
+          targetBox = await content.boundingBox();
+          break;
+        }
+      }
+      expect(targetBox).toBeTruthy();
+      if (!targetBox) return;
 
       // Partial selection (not full width) to ensure a quote is captured
-      await page.mouse.move(box.x + 10, box.y + box.height / 2);
+      await page.mouse.move(targetBox.x + 10, targetBox.y + targetBox.height / 2);
       await page.mouse.down();
-      await page.mouse.move(box.x + Math.min(box.width / 2, 150), box.y + box.height / 2, { steps: 5 });
+      await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 150), targetBox.y + targetBox.height / 2, { steps: 5 });
       await page.mouse.up();
 
       // Form should be open but NOT submitted — highlight should already show


### PR DESCRIPTION
## Summary
- The split diff quote highlight test (`select-to-comment.spec.ts:368`) was flaky because it selected `.diff-split-side.addition` first — which could be a very short line (e.g. just `"log"`)
- A partial drag on a short line selects the full text, producing no quote and no highlight mark
- Fix: iterate addition lines to find one with >20 chars before selecting, matching the pattern already used by the unified diff quote test

## Test plan
- This test was consistently flaky in CI across multiple recent main runs
- The fix ensures a meaningful partial selection by targeting a longer line

🤖 Generated with [Claude Code](https://claude.com/claude-code)