### PR TITLE
fix: hide commit picker when only one commit exists

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -88,6 +88,32 @@ git commit -q -m "initial commit"
 
 git checkout -q -b feat/add-auth
 
+# First commit: add notification handler (gives us 2 commits on branch)
+cat > handler.js << 'JSFILE'
+// Request handler for the notification service
+export function handleNotification(req, res) {
+  const { userId, message, channel } = req.body;
+
+  if (!userId || !message) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const notification = {
+    id: crypto.randomUUID(),
+    userId,
+    message,
+    channel: channel || 'email',
+    createdAt: new Date().toISOString(),
+  };
+
+  queue.push(notification);
+  res.status(201).json(notification);
+}
+JSFILE
+git add handler.js
+git commit -q -m "feat: add notification handler"
+
+# Second commit: auth middleware and plan
 # Modify server.go significantly to produce multi-hunk diff
 # Hunk 1: change imports. Hunk 2: add authMiddleware. Hunk 3: modify main (wraps handler, changes startup).
 # The unchanged helper functions and /version, /ready handlers create gaps between hunks.
@@ -225,29 +251,6 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 - **Week 2**: Validation endpoint + tests
 - **Week 3**: Dashboard UI for key management
 MDFILE
-
-# Add handler.js (new file, all-addition diff)
-cat > handler.js << 'JSFILE'
-// Request handler for the notification service
-export function handleNotification(req, res) {
-  const { userId, message, channel } = req.body;
-
-  if (!userId || !message) {
-    return res.status(400).json({ error: 'Missing required fields' });
-  }
-
-  const notification = {
-    id: crypto.randomUUID(),
-    userId,
-    message,
-    channel: channel || 'email',
-    createdAt: new Date().toISOString(),
-  };
-
-  queue.push(notification);
-  res.status(201).json(notification);
-}
-JSFILE
 
 git add -A
 git commit -q -m "feat: add auth middleware and plan"

--- a/e2e/tests/commit-selection.spec.ts
+++ b/e2e/tests/commit-selection.spec.ts
@@ -153,6 +153,28 @@ test.describe('Commit Selection', () => {
     await expect(page.locator('#commitDropdownLabel')).toHaveText('All commits');
   });
 
+  test('commit picker hidden when only one commit exists', async ({ page }) => {
+    // Precondition: picker is visible with the default 2-commit fixture
+    await expect(page.locator('#commitDropdown')).toBeVisible();
+
+    // Intercept /api/commits to return only one commit
+    await page.route('**/api/commits', async (route) => {
+      const response = await route.fetch();
+      const commits = await response.json();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(commits.slice(0, 1)),
+      });
+    });
+
+    const commitsResponse = page.waitForResponse(r => r.url().includes('/api/commits'));
+    await page.reload();
+    await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
+    await commitsResponse;
+    await expect(page.locator('#commitDropdown')).toBeHidden();
+  });
+
   test('selected commit item gets active class, "All" loses it', async ({ page }) => {
     // Select a commit
     await openCommitPicker(page);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5411,7 +5411,7 @@
       var res = await fetch('/api/commits');
       if (!res.ok) { commitDropdown.style.display = 'none'; return; }
       commitList = await res.json();
-      if (!commitList || commitList.length === 0) {
+      if (!commitList || commitList.length < 2) {
         commitDropdown.style.display = 'none';
         diffCommit = '';
         return;


### PR DESCRIPTION
## Summary
- Hide the commit picker dropdown when there's only 1 commit (no point picking between "All" and a single commit)
- Changed threshold from `commitList.length === 0` to `commitList.length < 2` in `fetchCommits()`
- Added a second commit to the git-mode e2e fixture so existing commit-selection tests still exercise the picker
- Added e2e test that intercepts `/api/commits` to simulate a single-commit scenario and verifies the picker is hidden

## Test plan
- [x] New e2e test: "commit picker hidden when only one commit exists"
- [x] All 13 commit-selection tests pass
- [x] Full e2e suite passes (447 tests across 5 projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)