### PR TITLE
fix: style links in reply comments to match main comment links

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1210,6 +1210,17 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   padding: 0;
 }
 
+.reply-body a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-subtle);
+  transition: color 0.15s, border-color 0.15s;
+}
+.reply-body a:hover {
+  color: var(--accent-hover);
+  border-bottom-color: var(--accent-hover);
+}
+
 .reply-actions {
   display: flex;
   gap: 2px;


### PR DESCRIPTION
## Summary

- Reply comment bodies (`.reply-body`) were missing `a` tag styling, causing links to render with default browser colors (purple/blue with underline) instead of the theme's accent color
- Added `.reply-body a` and `.reply-body a:hover` rules matching the existing `.comment-body a` styling
- Parity fix — corresponding change in crit-web: https://github.com/tomasz-tomczyk/crit-web/pull/38

## Test plan

- [ ] Open a review with a comment that has a reply containing a link
- [ ] Verify the link uses the accent color with subtle bottom border, not default browser styling
- [ ] Verify hover state changes color and border
- [ ] Check in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)