### PR TITLE
fix: install SKILL.md files with crit install, use foreground crit listen for non-Claude agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Crit ships with plugins and configuration files for popular AI coding tools. Eac
 
 ### Per-project install
 
-The fastest way to get started. Installs a `/crit` slash command into your project:
+The fastest way to get started. Installs a `/crit` slash command plus any integration companion files available for that tool (for example `SKILL.md` files) into your project:
 
 ```bash
 crit install claude-code   # or: cursor, opencode, windsurf, github-copilot, cline

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -13,9 +13,9 @@ This installs a `/crit` slash command into your project. Safe to re-run — exis
 
 | Tool | Install command | Destination |
 |------|----------------|-------------|
-| Claude Code | `crit install claude-code` | `.claude/commands/crit.md` |
-| Cursor | `crit install cursor` | `.cursor/commands/crit.md` |
-| GitHub Copilot | `crit install github-copilot` | `.github/prompts/crit.prompt.md` |
+| Claude Code | `crit install claude-code` | `.claude/commands/crit.md` + `.claude/skills/crit-cli/SKILL.md` |
+| Cursor | `crit install cursor` | `.cursor/commands/crit.md` + `.cursor/skills/crit-cli/SKILL.md` |
+| GitHub Copilot | `crit install github-copilot` | `.github/prompts/crit.prompt.md` + `.github/skills/crit-cli/SKILL.md` |
 | OpenCode | `crit install opencode` | `.opencode/commands/crit.md` + `.opencode/skills/crit/SKILL.md` |
 | Windsurf | `crit install windsurf` | `.windsurf/rules/crit.md` |
 | Cline | `crit install cline` | `.clinerules/crit.md` |

--- a/integrations/cline/crit.md
+++ b/integrations/cline/crit.md
@@ -22,15 +22,13 @@ crit $PLAN_FILE
 crit
 ```
 
-**CRITICAL — you MUST run `crit listen <port>` after launching crit.** Run it in the background if supported:
+**CRITICAL — you MUST run `crit listen <port>` after launching crit.** Run it in the foreground and block until it exits:
 
 ```bash
 crit listen <port>
 ```
 
 **Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. `crit listen` blocks until the user clicks Finish Review — that is how you know they are done.
-
-**Fallback:** If background tasks are NOT supported, tell the user: "Leave inline comments, then click Finish Review. Let me know when you're done." and wait for a response.
 
 ## After review
 

--- a/integrations/cursor/commands/crit.md
+++ b/integrations/cursor/commands/crit.md
@@ -32,7 +32,7 @@ Note the port from crit's startup output.
 
 **CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
 
-If background tasks are supported, run `crit listen <port>` in the background:
+Run `crit listen <port>` in the foreground and block until it exits:
 
 ```bash
 crit listen <port>
@@ -40,9 +40,7 @@ crit listen <port>
 
 Tell the user: **"Crit is open in your browser. Leave inline comments, then click Finish Review."**
 
-**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the background task to finish — that is how you know the human is done reviewing.
-
-**Fallback:** If background tasks are NOT supported, tell the user: **"Type 'go' here when you're done."** and wait for the user to respond.
+**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
 
 ## Step 4: Read the review output
 
@@ -87,7 +85,7 @@ crit go <port>
 
 This triggers a new review round in the browser with a diff of what changed.
 
-**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again.** This is the same as Step 3. Do NOT skip it.
+**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again in the foreground and block until it exits.** This is the same as Step 3. Do NOT skip it.
 
 ```bash
 crit listen <port>

--- a/integrations/github-copilot/commands/crit.prompt.md
+++ b/integrations/github-copilot/commands/crit.prompt.md
@@ -32,7 +32,7 @@ Note the port from crit's startup output.
 
 **CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
 
-If background tasks are supported, run `crit listen <port>` in the background:
+Run `crit listen <port>` in the foreground and block until it exits:
 
 ```bash
 crit listen <port>
@@ -40,9 +40,7 @@ crit listen <port>
 
 Tell the user: **"Crit is open in your browser. Leave inline comments, then click Finish Review."**
 
-**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the background task to finish — that is how you know the human is done reviewing.
-
-**Fallback:** If background tasks are NOT supported, tell the user: **"Type 'go' here when you're done."** and wait for the user to respond.
+**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
 
 ## Step 4: Read the review output
 
@@ -87,7 +85,7 @@ crit go <port>
 
 This triggers a new review round in the browser with a diff of what changed.
 
-**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again.** This is the same as Step 3. Do NOT skip it.
+**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again in the foreground and block until it exits.** This is the same as Step 3. Do NOT skip it.
 
 ```bash
 crit listen <port>

--- a/integrations/opencode/crit.md
+++ b/integrations/opencode/crit.md
@@ -39,7 +39,7 @@ Note the port from Crit's startup output.
 
 **CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
 
-If background tasks are supported, run `crit listen <port>` in the background:
+Run `crit listen <port>` in the foreground and block until it exits:
 
 ```bash
 crit listen <port>
@@ -47,9 +47,7 @@ crit listen <port>
 
 Tell the user: **"Crit is open in your browser. Leave inline comments, then click Finish Review."**
 
-**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the background task to finish — that is how you know the human is done reviewing.
-
-**Fallback:** If background tasks are NOT supported, tell the user: **"Type 'go' here when you're done."** and wait for the user to respond.
+**Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
 
 ## Step 4: Read the review output
 
@@ -94,7 +92,7 @@ crit go <port>
 
 This triggers a new review round in the browser with a diff of what changed.
 
-**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again.** This is the same as Step 3. Do NOT skip it.
+**CRITICAL — immediately after `crit go`, you MUST run `crit listen <port>` again in the foreground and block until it exits.** This is the same as Step 3. Do NOT skip it.
 
 ```bash
 crit listen <port>

--- a/integrations/windsurf/crit.md
+++ b/integrations/windsurf/crit.md
@@ -22,15 +22,13 @@ crit $PLAN_FILE
 crit
 ```
 
-**CRITICAL — you MUST run `crit listen <port>` after launching crit.** Run it in the background if supported:
+**CRITICAL — you MUST run `crit listen <port>` after launching crit.** Run it in the foreground and block until it exits:
 
 ```bash
 crit listen <port>
 ```
 
 **Do NOT proceed until `crit listen` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. `crit listen` blocks until the user clicks Finish Review — that is how you know they are done.
-
-**Fallback:** If background tasks are NOT supported, tell the user: "Leave inline comments, then click Finish Review. Let me know when you're done." and wait for a response.
 
 ## After review
 

--- a/main.go
+++ b/main.go
@@ -1036,9 +1036,11 @@ type integration struct {
 var integrationMap = map[string][]integration{
 	"claude-code": {
 		{source: "integrations/claude-code/commands/crit.md", dest: ".claude/commands/crit.md", hint: "Run /crit in Claude Code to start a review loop"},
+		{source: "integrations/claude-code/skills/crit-cli/SKILL.md", dest: ".claude/skills/crit-cli/SKILL.md", hint: "The crit skill is available to Claude Code agents when needed"},
 	},
 	"cursor": {
 		{source: "integrations/cursor/commands/crit.md", dest: ".cursor/commands/crit.md", hint: "Run /crit in Cursor to start a review loop"},
+		{source: "integrations/cursor/skills/crit-cli/SKILL.md", dest: ".cursor/skills/crit-cli/SKILL.md", hint: "The crit skill is available to Cursor agents when needed"},
 	},
 	"opencode": {
 		{source: "integrations/opencode/crit.md", dest: ".opencode/commands/crit.md", hint: "Run /crit in OpenCode to start a review loop"},
@@ -1049,6 +1051,7 @@ var integrationMap = map[string][]integration{
 	},
 	"github-copilot": {
 		{source: "integrations/github-copilot/commands/crit.prompt.md", dest: ".github/prompts/crit.prompt.md", hint: "Run /crit in GitHub Copilot to start a review loop"},
+		{source: "integrations/github-copilot/skills/crit-cli/SKILL.md", dest: ".github/skills/crit-cli/SKILL.md", hint: "The crit skill is available to GitHub Copilot agents when needed"},
 	},
 	"cline": {
 		{source: "integrations/cline/crit.md", dest: ".clinerules/crit.md", hint: "Cline will suggest Crit when writing plans"},


### PR DESCRIPTION
## Summary
- `crit install` now copies SKILL.md files alongside command files for claude-code, cursor, and github-copilot (opencode already had it)
- Changed `crit listen` from "run in background" to "run in foreground and block" for all non-Claude agents (Cursor, OpenCode, GitHub Copilot, Windsurf, Cline)
- Only Claude Code retains background mode — it has proper async support without polling
- Updated README and integrations/README to document SKILL.md installation

## Context
Cursor was polling `crit listen` background tasks every few seconds, spamming the conversation. Research confirmed OpenCode, GitHub Copilot, Cline, and Windsurf all lack true async background support, so foreground blocking is the correct approach for all of them.

## Test plan
- Verified `crit install cursor` copies both command and SKILL.md files
- Confirmed Claude Code command file still uses `run_in_background: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)