### PR TITLE
fix: resolve go vet, staticcheck, and gofmt issues

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -337,11 +337,10 @@ func TestRepoRoot_RealRepo(t *testing.T) {
 func TestDefaultBranchOverride(t *testing.T) {
 	// Save and restore global state
 	origOverride := defaultBranchOverride
-	origOnce := defaultBranchOnce
 	origResult := defaultBranchResult
 	t.Cleanup(func() {
 		defaultBranchOverride = origOverride
-		defaultBranchOnce = origOnce
+		defaultBranchOnce = sync.Once{}
 		defaultBranchResult = origResult
 	})
 

--- a/github_test.go
+++ b/github_test.go
@@ -288,12 +288,18 @@ func TestMergeGHComments_Threading(t *testing.T) {
 	cj := &CritJSON{Files: map[string]CritJSONFile{}}
 	ghComments := []ghComment{
 		{ID: 101, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Too complex", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Too complex", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 102, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Agreed, split it", User: struct{ Login string `json:"login"` }{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Agreed, split it", User: struct {
+				Login string `json:"login"`
+			}{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 101},
 		{ID: 103, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Will do", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:02:00Z",
+			Body: "Will do", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:02:00Z",
 			InReplyToID: 101},
 	}
 
@@ -325,13 +331,17 @@ func TestMergeGHComments_ThreadDedup(t *testing.T) {
 	cj := &CritJSON{Files: map[string]CritJSONFile{}}
 	ghComments := []ghComment{
 		{ID: 101, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Fix this", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Fix this", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 102, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Done", User: struct{ Login string `json:"login"` }{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Done", User: struct {
+				Login string `json:"login"`
+			}{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 101},
 	}
 
-	mergeGHComments(cj, ghComments) // first pull
+	mergeGHComments(cj, ghComments)          // first pull
 	added := mergeGHComments(cj, ghComments) // second pull (should dedup)
 
 	cf := cj.Files["server.go"]
@@ -351,9 +361,13 @@ func TestMergeGHComments_NewReplyOnExistingRoot(t *testing.T) {
 	// First pull: root + 1 reply
 	ghComments1 := []ghComment{
 		{ID: 101, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Fix this", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Fix this", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 102, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Done", User: struct{ Login string `json:"login"` }{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Done", User: struct {
+				Login string `json:"login"`
+			}{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 101},
 	}
 	mergeGHComments(cj, ghComments1)
@@ -361,12 +375,18 @@ func TestMergeGHComments_NewReplyOnExistingRoot(t *testing.T) {
 	// Second pull: same root + old reply + new reply
 	ghComments2 := []ghComment{
 		{ID: 101, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Fix this", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Fix this", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 102, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Done", User: struct{ Login string `json:"login"` }{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Done", User: struct {
+				Login string `json:"login"`
+			}{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 101},
 		{ID: 103, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Thanks!", User: struct{ Login string `json:"login"` }{"reviewer"}, CreatedAt: "2025-01-01T00:02:00Z",
+			Body: "Thanks!", User: struct {
+				Login string `json:"login"`
+			}{"reviewer"}, CreatedAt: "2025-01-01T00:02:00Z",
 			InReplyToID: 101},
 	}
 	added := mergeGHComments(cj, ghComments2)
@@ -398,7 +418,9 @@ func TestMergeGHComments_OrphanReply(t *testing.T) {
 	// Pull only the reply (root is not in the ghComments list)
 	ghComments := []ghComment{
 		{ID: 102, Path: "server.go", Line: 42, Side: "RIGHT",
-			Body: "Done", User: struct{ Login string `json:"login"` }{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Done", User: struct {
+				Login string `json:"login"`
+			}{"author"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 101},
 	}
 	added := mergeGHComments(cj, ghComments)
@@ -422,9 +444,13 @@ func TestMergeGHComments_FlatCommentsStillWork(t *testing.T) {
 	cj := &CritJSON{Files: map[string]CritJSONFile{}}
 	ghComments := []ghComment{
 		{ID: 201, Path: "main.go", Line: 10, Side: "RIGHT",
-			Body: "Fix this bug", User: struct{ Login string `json:"login"` }{"reviewer1"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Fix this bug", User: struct {
+				Login string `json:"login"`
+			}{"reviewer1"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 202, Path: "main.go", Line: 25, StartLine: 20, Side: "RIGHT",
-			Body: "Refactor this", User: struct{ Login string `json:"login"` }{"reviewer2"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Refactor this", User: struct {
+				Login string `json:"login"`
+			}{"reviewer2"}, CreatedAt: "2025-01-01T00:00:00Z"},
 	}
 
 	added := mergeGHComments(cj, ghComments)
@@ -452,12 +478,18 @@ func TestMergeGHComments_ReplySortedByCreatedAt(t *testing.T) {
 	// Replies intentionally out of order
 	ghComments := []ghComment{
 		{ID: 301, Path: "util.go", Line: 5, Side: "RIGHT",
-			Body: "Root", User: struct{ Login string `json:"login"` }{"alice"}, CreatedAt: "2025-01-01T00:00:00Z"},
+			Body: "Root", User: struct {
+				Login string `json:"login"`
+			}{"alice"}, CreatedAt: "2025-01-01T00:00:00Z"},
 		{ID: 303, Path: "util.go", Line: 5, Side: "RIGHT",
-			Body: "Third", User: struct{ Login string `json:"login"` }{"alice"}, CreatedAt: "2025-01-01T00:03:00Z",
+			Body: "Third", User: struct {
+				Login string `json:"login"`
+			}{"alice"}, CreatedAt: "2025-01-01T00:03:00Z",
 			InReplyToID: 301},
 		{ID: 302, Path: "util.go", Line: 5, Side: "RIGHT",
-			Body: "Second", User: struct{ Login string `json:"login"` }{"bob"}, CreatedAt: "2025-01-01T00:01:00Z",
+			Body: "Second", User: struct {
+				Login string `json:"login"`
+			}{"bob"}, CreatedAt: "2025-01-01T00:01:00Z",
 			InReplyToID: 301},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -381,10 +381,9 @@ func TestHelperProcess_CommentJSONMix(t *testing.T) {
 func TestResolveServerConfig_BaseBranch(t *testing.T) {
 	// Reset global state before and after
 	orig := defaultBranchOverride
-	origOnce := defaultBranchOnce
 	defer func() {
 		defaultBranchOverride = orig
-		defaultBranchOnce = origOnce
+		defaultBranchOnce = sync.Once{}
 	}()
 
 	t.Run("CLI flag sets override", func(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -28,20 +28,20 @@ type Reply struct {
 
 // Comment represents a single inline review comment.
 type Comment struct {
-	ID              string  `json:"id"`
-	StartLine       int     `json:"start_line"`
-	EndLine         int     `json:"end_line"`
-	Side            string  `json:"side,omitempty"`
-	Body            string  `json:"body"`
-	Quote           string  `json:"quote,omitempty"`
-	Author          string  `json:"author,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	UpdatedAt       string  `json:"updated_at"`
-	Resolved       bool `json:"resolved,omitempty"`
-	CarriedForward bool `json:"carried_forward,omitempty"`
-	ReviewRound     int     `json:"review_round,omitempty"`
-	Replies         []Reply `json:"replies,omitempty"`
-	GitHubID        int64   `json:"github_id,omitempty"`
+	ID             string  `json:"id"`
+	StartLine      int     `json:"start_line"`
+	EndLine        int     `json:"end_line"`
+	Side           string  `json:"side,omitempty"`
+	Body           string  `json:"body"`
+	Quote          string  `json:"quote,omitempty"`
+	Author         string  `json:"author,omitempty"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+	Resolved       bool    `json:"resolved,omitempty"`
+	CarriedForward bool    `json:"carried_forward,omitempty"`
+	ReviewRound    int     `json:"review_round,omitempty"`
+	Replies        []Reply `json:"replies,omitempty"`
+	GitHubID       int64   `json:"github_id,omitempty"`
 }
 
 // SSEEvent is sent to the browser via server-sent events.

--- a/session_test.go
+++ b/session_test.go
@@ -1531,18 +1531,18 @@ func TestSession_LoadCritJSON_RestoresReviewRound(t *testing.T) {
 
 func TestCarryForwardComment(t *testing.T) {
 	old := Comment{
-		ID:              "original-id",
-		StartLine:       5,
-		EndLine:         10,
-		Side:            "RIGHT",
-		Body:            "needs refactoring",
-		Quote:           "func foo() {}",
-		Author:          "reviewer-bot",
-		CreatedAt:       "2026-01-01T00:00:00Z",
-		UpdatedAt:       "2026-01-01T00:00:00Z",
+		ID:             "original-id",
+		StartLine:      5,
+		EndLine:        10,
+		Side:           "RIGHT",
+		Body:           "needs refactoring",
+		Quote:          "func foo() {}",
+		Author:         "reviewer-bot",
+		CreatedAt:      "2026-01-01T00:00:00Z",
+		UpdatedAt:      "2026-01-01T00:00:00Z",
 		Resolved:       true,
 		CarriedForward: false,
-		ReviewRound:     1,
+		ReviewRound:    1,
 	}
 
 	carried := carryForwardComment(old, "c42", "2026-02-01T00:00:00Z")

--- a/share_test.go
+++ b/share_test.go
@@ -618,7 +618,7 @@ func TestLoadExistingShareState_ScopeMismatch(t *testing.T) {
 	}
 
 	// Same file set — should return share state
-	url, token = loadExistingShareState(dir, []string{"old-plan.md"})
+	url, _ = loadExistingShareState(dir, []string{"old-plan.md"})
 	if url != "https://crit.md/r/old" {
 		t.Errorf("expected URL for matching scope, got %q", url)
 	}

--- a/watch.go
+++ b/watch.go
@@ -245,18 +245,18 @@ func (s *Session) watchFileMtimes(stop <-chan struct{}) {
 
 func carryForwardComment(old Comment, newID string, now string) Comment {
 	return Comment{
-		ID:              newID,
-		StartLine:       old.StartLine,
-		EndLine:         old.EndLine,
-		Side:            old.Side,
-		Body:            old.Body,
-		Author:          old.Author,
-		CreatedAt:       old.CreatedAt,
+		ID:             newID,
+		StartLine:      old.StartLine,
+		EndLine:        old.EndLine,
+		Side:           old.Side,
+		Body:           old.Body,
+		Author:         old.Author,
+		CreatedAt:      old.CreatedAt,
 		UpdatedAt:      now,
 		Resolved:       old.Resolved,
 		CarriedForward: true,
-		ReviewRound:     old.ReviewRound,
-		Replies:         old.Replies,
+		ReviewRound:    old.ReviewRound,
+		Replies:        old.Replies,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `sync.Once` copy warnings in `git_test.go` and `main_test.go` by resetting with fresh `sync.Once{}` instead of save/restore
- Fix unused `token` variable in `share_test.go` (staticcheck SA4006)
- Run `gofmt` on 4 files with formatting drift (`session.go`, `session_test.go`, `watch.go`, `github_test.go`)

## Test plan

- [x] `go vet ./...` passes clean
- [x] `staticcheck ./...` passes clean
- [x] `gofmt -l .` returns no files
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)