### PR TITLE
feat: globally unique comment IDs across files

### DIFF
--- a/github.go
+++ b/github.go
@@ -84,14 +84,17 @@ func fetchPRComments(prNumber int) ([]ghComment, error) {
 	return comments, nil
 }
 
-// nextCommentID scans existing comments and returns the next available cN ID.
-func nextCommentID(comments []Comment) int {
+// nextCommentID scans ALL files' comments in a CritJSON and returns the next
+// available globally-unique cN ID. This ensures IDs don't collide across files.
+func nextCommentID(files map[string]CritJSONFile) int {
 	next := 1
-	for _, c := range comments {
-		id := 0
-		_, _ = fmt.Sscanf(c.ID, "c%d", &id)
-		if id >= next {
-			next = id + 1
+	for _, cf := range files {
+		for _, c := range cf.Comments {
+			id := 0
+			_, _ = fmt.Sscanf(c.ID, "c%d", &id)
+			if id >= next {
+				next = id + 1
+			}
 		}
 	}
 	return next
@@ -216,7 +219,7 @@ func mergeGHComments(cj *CritJSON, ghComments []ghComment) int {
 			continue
 		}
 
-		commentID := fmt.Sprintf("c%d", nextCommentID(cf.Comments))
+		commentID := fmt.Sprintf("c%d", nextCommentID(cj.Files))
 		comment := Comment{
 			ID:        commentID,
 			StartLine: startLine,
@@ -565,7 +568,7 @@ func appendComment(cj *CritJSON, filePath string, startLine, endLine int, body, 
 	}
 
 	cf.Comments = append(cf.Comments, Comment{
-		ID:        fmt.Sprintf("c%d", nextCommentID(cf.Comments)),
+		ID:        fmt.Sprintf("c%d", nextCommentID(cj.Files)),
 		StartLine: startLine,
 		EndLine:   endLine,
 		Body:      body,

--- a/server_test.go
+++ b/server_test.go
@@ -25,6 +25,7 @@ func newTestServer(t *testing.T) (*Server, *Session) {
 		Mode:          "files",
 		RepoRoot:      dir,
 		ReviewRound:   1,
+		nextID:        1,
 		subscribers:   make(map[chan SSEEvent]struct{}),
 		roundComplete: make(chan struct{}, 1),
 		Files: []*FileEntry{
@@ -36,7 +37,6 @@ func newTestServer(t *testing.T) (*Server, *Session) {
 				Content:  "line1\nline2\nline3\n",
 				FileHash: "sha256:testhash",
 				Comments: []Comment{},
-				nextID:   1,
 			},
 		},
 	}
@@ -691,7 +691,6 @@ func TestGetFileDiff_CodeFile(t *testing.T) {
 		FileType: "code",
 		Content:  "package main",
 		Comments: []Comment{},
-		nextID:   1,
 		DiffHunks: []DiffHunk{
 			{OldStart: 1, OldCount: 3, NewStart: 1, NewCount: 4, Header: "@@ -1,3 +1,4 @@"},
 		},
@@ -848,7 +847,6 @@ func TestGetFileDiff_ScopeAll_SameAsNoScope(t *testing.T) {
 		FileType: "code",
 		Content:  "package main",
 		Comments: []Comment{},
-		nextID:   1,
 		DiffHunks: []DiffHunk{
 			{OldStart: 1, OldCount: 3, NewStart: 1, NewCount: 4, Header: "@@ -1,3 +1,4 @@"},
 		},
@@ -884,7 +882,6 @@ func TestGetFileDiff_ScopeStaged_ValidResponse(t *testing.T) {
 		FileType: "code",
 		Content:  "package main",
 		Comments: []Comment{},
-		nextID:   1,
 		DiffHunks: []DiffHunk{
 			{OldStart: 1, OldCount: 3, NewStart: 1, NewCount: 4, Header: "@@ -1,3 +1,4 @@"},
 		},

--- a/session.go
+++ b/session.go
@@ -60,7 +60,6 @@ type FileEntry struct {
 	Content  string    `json:"-"`         // current file content
 	FileHash string    `json:"-"`         // sha256 hash of content
 	Comments []Comment `json:"-"`         // this file's comments
-	nextID   int
 
 	// Diff hunks for code files (from git diff)
 	DiffHunks []DiffHunk `json:"-"`
@@ -82,6 +81,7 @@ type Session struct {
 	IgnorePatterns []string
 
 	mu                  sync.RWMutex
+	nextID              int // session-global comment ID counter (c1, c2, c3... across ALL files)
 	subscribers         map[chan SSEEvent]struct{}
 	subMu               sync.Mutex
 	writeTimer          *time.Timer
@@ -163,6 +163,7 @@ func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 		BaseRef:             baseRef,
 		RepoRoot:            root,
 		ReviewRound:         1,
+		nextID:              1,
 		IgnorePatterns:      ignorePatterns,
 		subscribers:         make(map[chan SSEEvent]struct{}),
 		roundComplete:       make(chan struct{}, 1),
@@ -175,7 +176,6 @@ func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 			Path:    fc.Path,
 			AbsPath: absPath,
 			Status:  fc.Status,
-			nextID:  1,
 		}
 		fe.FileType = detectFileType(fc.Path)
 
@@ -283,6 +283,7 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 		BaseRef:             baseRef,
 		RepoRoot:            root,
 		ReviewRound:         1,
+		nextID:              1,
 		IgnorePatterns:      ignorePatterns,
 		subscribers:         make(map[chan SSEEvent]struct{}),
 		roundComplete:       make(chan struct{}, 1),
@@ -310,7 +311,6 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 			Content:  string(data),
 			FileHash: fileHash(data),
 			Comments: []Comment{},
-			nextID:   1,
 		}
 
 		// Load diff hunks in a git repo
@@ -426,7 +426,7 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	c := Comment{
-		ID:          fmt.Sprintf("c%d", f.nextID),
+		ID:          fmt.Sprintf("c%d", s.nextID),
 		StartLine:   startLine,
 		EndLine:     endLine,
 		Side:        side,
@@ -437,7 +437,7 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 		UpdatedAt:   now,
 		ReviewRound: s.ReviewRound,
 	}
-	f.nextID++
+	s.nextID++
 	f.Comments = append(f.Comments, c)
 	s.scheduleWrite()
 	return c, true
@@ -723,7 +723,6 @@ func (s *Session) EnsureFileEntry(path string) bool {
 		Content:  string(data),
 		FileHash: fileHash(data),
 		Comments: []Comment{},
-		nextID:   1,
 	}
 
 	// Generate diff hunks
@@ -842,11 +841,11 @@ func (s *Session) SignalRoundComplete() {
 	s.lastRoundEdits = s.pendingEdits
 	s.pendingEdits = 0
 	s.ReviewRound++
-	// Clear comments on all files, reset IDs
+	// Clear comments on all files, reset session-global ID counter
 	for _, f := range s.Files {
 		f.Comments = []Comment{}
-		f.nextID = 1
 	}
+	s.nextID = 1
 	s.mu.Unlock()
 	select {
 	case s.roundComplete <- struct{}{}:
@@ -872,12 +871,12 @@ func (s *Session) ClearAllComments() {
 			continue
 		}
 		f.Comments = []Comment{}
-		f.nextID = 1
 		f.PreviousComments = nil
 		f.PreviousContent = ""
 		filtered = append(filtered, f)
 	}
 	s.Files = filtered
+	s.nextID = 1
 	s.ReviewRound = 1
 	s.lastCritJSONMtime = time.Time{}
 	s.pendingWrite = false
@@ -968,10 +967,10 @@ func (s *Session) WriteFiles() {
 			for _, f := range s.Files {
 				if len(f.Comments) > 0 {
 					f.Comments = []Comment{}
-					f.nextID = 1
 					anyComments = true
 				}
 			}
+			s.nextID = 1
 			s.mu.Unlock()
 			if anyComments {
 				s.notify(SSEEvent{Type: "comments-changed"})
@@ -1116,10 +1115,10 @@ func (s *Session) mergeExternalCritJSON() bool {
 			for _, f := range s.Files {
 				if len(f.Comments) > 0 {
 					f.Comments = []Comment{}
-					f.nextID = 1
 					anyComments = true
 				}
 			}
+			s.nextID = 1
 			s.mu.Unlock()
 			if anyComments {
 				s.notify(SSEEvent{Type: "comments-changed"})
@@ -1163,7 +1162,6 @@ func (s *Session) mergeExternalCritJSON() bool {
 			// File not in .crit.json — if we have comments, they were cleared externally.
 			if len(f.Comments) > 0 {
 				f.Comments = []Comment{}
-				f.nextID = 1
 				changed = true
 			}
 			continue
@@ -1181,8 +1179,8 @@ func (s *Session) mergeExternalCritJSON() bool {
 				f.Comments = append(f.Comments, dc)
 				id := 0
 				fmt.Sscanf(dc.ID, "c%d", &id)
-				if id >= f.nextID {
-					f.nextID = id + 1
+				if id >= s.nextID {
+					s.nextID = id + 1
 				}
 				changed = true
 			} else {
@@ -1273,15 +1271,16 @@ func (s *Session) loadCritJSON() {
 		s.ReviewRound = cj.ReviewRound
 	}
 
-	// Restore comments for files that match by path
+	// Restore comments for files that match by path.
+	// Scan ALL files' comments to find the global max ID for session-level nextID.
 	for _, f := range s.Files {
 		if cf, ok := cj.Files[f.Path]; ok {
 			f.Comments = cf.Comments
 			for _, c := range f.Comments {
 				id := 0
 				_, _ = fmt.Sscanf(c.ID, "c%d", &id)
-				if id >= f.nextID {
-					f.nextID = id + 1
+				if id >= s.nextID {
+					s.nextID = id + 1
 				}
 			}
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -21,6 +21,7 @@ func newTestSession(t *testing.T) *Session {
 	s := &Session{
 		RepoRoot:      dir,
 		ReviewRound:   1,
+		nextID:        1,
 		subscribers:   make(map[chan SSEEvent]struct{}),
 		roundComplete: make(chan struct{}, 1),
 		Files: []*FileEntry{
@@ -32,7 +33,6 @@ func newTestSession(t *testing.T) *Session {
 				Content:  "# Plan\n\n## Step 1\n\nDo the thing\n",
 				FileHash: "sha256:test1",
 				Comments: []Comment{},
-				nextID:   1,
 			},
 			{
 				Path:     "main.go",
@@ -42,7 +42,6 @@ func newTestSession(t *testing.T) *Session {
 				Content:  "package main\n\nfunc main() {}\n",
 				FileHash: "sha256:test2",
 				Comments: []Comment{},
-				nextID:   1,
 			},
 		},
 	}
@@ -681,17 +680,17 @@ func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
 	}
 }
 
-func TestSession_PerFileCommentIDs(t *testing.T) {
+func TestSession_GlobalCommentIDs(t *testing.T) {
 	s := newTestSession(t)
 	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "")
 	c2, _ := s.AddComment("main.go", 1, 1, "", "go comment", "", "")
 
-	// Each file has independent ID sequences
+	// IDs are globally unique across files
 	if c1.ID != "c1" {
 		t.Errorf("plan.md first comment ID = %q, want c1", c1.ID)
 	}
-	if c2.ID != "c1" {
-		t.Errorf("main.go first comment ID = %q, want c1", c2.ID)
+	if c2.ID != "c2" {
+		t.Errorf("main.go first comment ID = %q, want c2", c2.ID)
 	}
 }
 
@@ -1064,10 +1063,11 @@ func TestSession_WriteFiles_MergesExternalComments(t *testing.T) {
 		Branch:      "main",
 		BaseRef:     "abc123",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", FileHash: "hash1", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "from browser", CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1118,8 +1118,9 @@ func TestSession_MergeExternalCritJSON_NewComment(t *testing.T) {
 		Branch:      "main",
 		BaseRef:     "abc123",
 		ReviewRound: 1,
+		nextID:      1,
 		Files: []*FileEntry{
-			{Path: "main.go", Status: "modified", Comments: []Comment{}, nextID: 1},
+			{Path: "main.go", Status: "modified", Comments: []Comment{}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1156,7 +1157,7 @@ func TestSession_MergeExternalCritJSON_NewComment(t *testing.T) {
 	}
 
 	s.mu.RLock()
-	nextID := s.Files[0].nextID
+	nextID := s.nextID
 	s.mu.RUnlock()
 	if nextID != 2 {
 		t.Errorf("expected nextID=2, got %d", nextID)
@@ -1195,10 +1196,11 @@ func TestSession_MergeExternalCritJSON_IgnoresOwnWrites(t *testing.T) {
 		Branch:      "main",
 		BaseRef:     "abc123",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "existing"},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1219,10 +1221,11 @@ func TestSession_MergeExternalCritJSON_ClearDetected(t *testing.T) {
 		RepoRoot:    dir,
 		Branch:      "main",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "existing"},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1363,11 +1366,11 @@ func TestComment_NoRepliesBackwardCompat(t *testing.T) {
 func TestSession_AddReply(t *testing.T) {
 	s := &Session{
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{
 				Path:     "test.md",
 				Comments: []Comment{{ID: "c1", StartLine: 1, EndLine: 1, Body: "Fix this"}},
-				nextID:   2,
 			},
 		},
 	}
@@ -1622,10 +1625,11 @@ func TestSession_MergeExternalCritJSON_SkippedDuringPendingWrite(t *testing.T) {
 		RepoRoot:    dir,
 		Branch:      "main",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "existing"},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1672,10 +1676,11 @@ func TestSession_MergeExternalCritJSON_SyncsResolvedState(t *testing.T) {
 		RepoRoot:    dir,
 		Branch:      "main",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: false},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -1727,9 +1732,9 @@ func TestSession_EnsureFileEntry_NewFile(t *testing.T) {
 				Content:  "package main\n",
 				FileHash: "sha256:test",
 				Comments: []Comment{},
-				nextID:   1,
 			},
 		},
+		nextID:        1,
 		subscribers:   make(map[chan SSEEvent]struct{}),
 		roundComplete: make(chan struct{}, 1),
 	}
@@ -1762,8 +1767,8 @@ func TestSession_EnsureFileEntry_NewFile(t *testing.T) {
 	if len(f.Comments) != 0 {
 		t.Errorf("expected 0 comments, got %d", len(f.Comments))
 	}
-	if f.nextID != 1 {
-		t.Errorf("nextID = %d, want 1", f.nextID)
+	if s.nextID != 1 {
+		t.Errorf("nextID = %d, want 1", s.nextID)
 	}
 }
 
@@ -1803,6 +1808,7 @@ func TestSession_EnsureFileEntry_ThenAddComment(t *testing.T) {
 		Mode:          "git",
 		RepoRoot:      dir,
 		ReviewRound:   1,
+		nextID:        1,
 		Files:         []*FileEntry{},
 		subscribers:   make(map[chan SSEEvent]struct{}),
 		roundComplete: make(chan struct{}, 1),
@@ -1866,10 +1872,11 @@ func TestSession_MergeExternalCritJSON_SyncsUnresolve(t *testing.T) {
 		RepoRoot:    dir,
 		Branch:      "main",
 		ReviewRound: 1,
+		nextID:      2,
 		Files: []*FileEntry{
 			{Path: "main.go", Status: "modified", Comments: []Comment{
 				{ID: "c1", StartLine: 1, EndLine: 1, Body: "fix this", Resolved: true},
-			}, nextID: 2},
+			}},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}

--- a/watch.go
+++ b/watch.go
@@ -105,7 +105,6 @@ func (s *Session) RefreshFileList() {
 				Status:   fc.Status,
 				FileType: detectFileType(fc.Path),
 				Comments: []Comment{},
-				nextID:   1,
 			}
 			if fc.Status != "deleted" {
 				if data, err := os.ReadFile(absPath); err == nil {
@@ -225,7 +224,6 @@ func (s *Session) watchFileMtimes(stop <-chan struct{}) {
 				f.Content = string(data)
 				f.FileHash = hash
 				f.Comments = []Comment{}
-				f.nextID = 1
 				s.mu.Unlock()
 				changed = true
 			}
@@ -289,8 +287,8 @@ func (s *Session) handleRoundCompleteGit() {
 	for _, f := range s.Files {
 		now := time.Now().UTC().Format(time.RFC3339)
 		for _, c := range f.PreviousComments {
-			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
-			f.nextID++
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", s.nextID), now)
+			s.nextID++
 			f.Comments = append(f.Comments, carried)
 		}
 	}
@@ -329,8 +327,8 @@ func (s *Session) handleRoundCompleteFiles() {
 		}
 		// Carry forward all remaining comments from PreviousComments
 		for _, c := range f.PreviousComments {
-			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
-			f.nextID++
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", s.nextID), now)
+			s.nextID++
 			f.Comments = append(f.Comments, carried)
 		}
 	}
@@ -473,10 +471,10 @@ func (s *Session) carryForwardComments() {
 			if newEnd < newStart {
 				newEnd = newStart
 			}
-			carried := carryForwardComment(c, fmt.Sprintf("c%d", f.nextID), now)
+			carried := carryForwardComment(c, fmt.Sprintf("c%d", s.nextID), now)
 			carried.StartLine = newStart
 			carried.EndLine = newEnd
-			f.nextID++
+			s.nextID++
 			f.Comments = append(f.Comments, carried)
 		}
 		s.mu.Unlock()

--- a/watch_test.go
+++ b/watch_test.go
@@ -26,6 +26,7 @@ func TestWatchFileMtimes_CommentNotLostOnFileChange(t *testing.T) {
 		Mode:        "files",
 		RepoRoot:    dir,
 		ReviewRound: 1,
+		nextID:      1,
 		Files: []*FileEntry{
 			{
 				Path:     "plan.md",
@@ -35,7 +36,6 @@ func TestWatchFileMtimes_CommentNotLostOnFileChange(t *testing.T) {
 				Content:  content,
 				FileHash: fileHash([]byte(content)),
 				Comments: []Comment{},
-				nextID:   1,
 			},
 		},
 		subscribers:   make(map[chan SSEEvent]struct{}),
@@ -80,6 +80,7 @@ func TestWatchFileMtimes_ConcurrentAddDuringChange(t *testing.T) {
 		Mode:        "files",
 		RepoRoot:    dir,
 		ReviewRound: 1,
+		nextID:      1,
 		Files: []*FileEntry{
 			{
 				Path:     "plan.md",
@@ -89,7 +90,6 @@ func TestWatchFileMtimes_ConcurrentAddDuringChange(t *testing.T) {
 				Content:  content,
 				FileHash: fileHash([]byte(content)),
 				Comments: []Comment{},
-				nextID:   1,
 			},
 		},
 		subscribers:   make(map[chan SSEEvent]struct{}),


### PR DESCRIPTION
## Summary

- Fixes #157
- Moves `nextID` counter from per-file (`FileEntry`) to session-level (`Session`), so comment IDs (c1, c2, c3...) are globally unique across all files
- `--reply-to c1` no longer needs `--path` for disambiguation since IDs can't repeat between files
- Backward compatible with existing `.crit.json` files — loading scans all files to find the global max ID

### Files changed
- `session.go` — `nextID` moved to Session; updated AddComment, SignalRoundComplete, ClearAllComments, loadCritJSON, mergeExternalCritJSON, WriteFiles, EnsureFileEntry
- `watch.go` — carry-forward and file-change handlers use session-level nextID
- `github.go` — `nextCommentID()` scans all files globally
- `*_test.go` — updated all test constructors and assertions

## Test plan

- [ ] `go test ./...` passes
- [ ] Add comments to two different files — IDs should be c1, c2, c3... with no repeats
- [ ] `crit comment` CLI should generate globally unique IDs
- [ ] Loading existing `.crit.json` with per-file c1/c2 duplicates should work (finds global max)
- [ ] Multi-round review: carry-forward comments get unique IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)