### PR TITLE
feat: add crit auth login/logout/whoami via OAuth Device Flow

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// runAuth dispatches to auth subcommands: login, logout, whoami.
+func runAuth(args []string) {
+	if len(args) == 0 {
+		printAuthUsage()
+		return
+	}
+	switch args[0] {
+	case "login":
+		runAuthLogin(args[1:])
+	case "logout":
+		runAuthLogout(args[1:])
+	case "whoami":
+		runAuthWhoami(args[1:])
+	default:
+		printAuthUsage()
+	}
+}
+
+func printAuthUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: crit auth <command>")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  login     Log in to crit-web")
+	fmt.Fprintln(os.Stderr, "  logout    Log out and revoke token")
+	fmt.Fprintln(os.Stderr, "  whoami    Show current user info")
+	os.Exit(1)
+}
+
+// authLoginFlags holds parsed flags for crit auth login.
+type authLoginFlags struct {
+	force bool
+}
+
+func parseAuthLoginFlags(args []string) authLoginFlags {
+	var f authLoginFlags
+	for _, arg := range args {
+		if arg == "--force" {
+			f.force = true
+		}
+	}
+	return f
+}
+
+func runAuthLogin(args []string) {
+	flags := parseAuthLoginFlags(args)
+	cfg := loadShareConfig()
+	serverURL := resolveShareURL("", cfg)
+	existingToken := resolveAuthToken(cfg)
+
+	if existingToken != "" && !flags.force {
+		if !confirmReauth() {
+			return
+		}
+	}
+
+	code, err := requestDeviceCode(serverURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "\n  Visit %s and enter code: %s\n\n", code.VerificationURI, code.UserCode)
+	go openBrowser(code.VerificationURI + "?code=" + code.UserCode)
+
+	token, err := pollForToken(serverURL, code)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := saveAuthToken(token.AccessToken); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving token: %v\n", err)
+		os.Exit(1)
+	}
+
+	greeting := "Logged in."
+	if token.UserName != "" {
+		greeting = fmt.Sprintf("Logged in as %s.", token.UserName)
+	}
+	fmt.Fprintf(os.Stderr, "  %s Token saved to %s\n", greeting, globalConfigPath())
+}
+
+// confirmReauth prompts the user to confirm re-authentication.
+// Returns true if the user confirms, false otherwise.
+func confirmReauth() bool {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprintln(os.Stderr, "Already logged in. Use --force to re-authenticate.")
+		return false
+	}
+	fmt.Fprint(os.Stderr, "Already logged in. Log in again? (y/n) ")
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		return answer == "y" || answer == "yes"
+	}
+	return false
+}
+
+// deviceCodeResponse holds the response from POST /api/device/code.
+type deviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	Interval        int    `json:"interval"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+// requestDeviceCode initiates the device flow by requesting a device code.
+func requestDeviceCode(serverURL string) (deviceCodeResponse, error) {
+	var result deviceCodeResponse
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(serverURL+"/api/device/code", "application/json", nil)
+	if err != nil {
+		return result, fmt.Errorf("contacting %s: %w", serverURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		var errBody struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&errBody)
+		if errBody.Error != "" {
+			return result, fmt.Errorf("%s", errBody.Error)
+		}
+		return result, fmt.Errorf("login is not available on this server")
+	}
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return result, fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return result, fmt.Errorf("decoding response: %w", err)
+	}
+	return result, nil
+}
+
+// tokenResponse holds a successful response from POST /api/device/token.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	UserName    string `json:"user_name"`
+}
+
+// pollForToken polls the device token endpoint until success, expiry, or cancellation.
+func pollForToken(serverURL string, code deviceCodeResponse) (tokenResponse, error) {
+	var result tokenResponse
+	interval := code.Interval
+	if interval < 1 {
+		interval = 5
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	dots := 0
+	for {
+		select {
+		case <-ctx.Done():
+			clearSpinner(dots)
+			return result, fmt.Errorf("interrupted")
+		case <-time.After(time.Duration(interval) * time.Second):
+		}
+
+		dots = printSpinner(dots)
+
+		resp, err := pollDeviceToken(serverURL, code.DeviceCode)
+		if err != nil {
+			clearSpinner(dots)
+			return result, err
+		}
+
+		if resp.done {
+			clearSpinner(dots)
+			return resp.token, nil
+		}
+
+		interval = resp.nextInterval(interval)
+	}
+}
+
+// pollResult holds the parsed result of a single poll attempt.
+type pollResult struct {
+	done     bool
+	token    tokenResponse
+	slowDown bool
+}
+
+// nextInterval returns the interval to use for the next poll.
+func (r pollResult) nextInterval(current int) int {
+	if r.slowDown {
+		next := current + 5
+		if next > 60 {
+			return 60
+		}
+		return next
+	}
+	return current
+}
+
+// pollDeviceToken makes a single poll request to the device token endpoint.
+func pollDeviceToken(serverURL string, deviceCode string) (pollResult, error) {
+	body, _ := json.Marshal(map[string]string{"device_code": deviceCode})
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(serverURL+"/api/device/token", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return pollResult{}, fmt.Errorf("contacting server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var token tokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+			return pollResult{}, fmt.Errorf("decoding token response: %w", err)
+		}
+		return pollResult{done: true, token: token}, nil
+	}
+
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&errBody)
+
+	return handlePollError(errBody.Error)
+}
+
+// handlePollError interprets the error string from a poll response.
+func handlePollError(errStr string) (pollResult, error) {
+	switch errStr {
+	case "authorization_pending":
+		return pollResult{}, nil
+	case "slow_down":
+		return pollResult{slowDown: true}, nil
+	case "expired_token":
+		return pollResult{}, fmt.Errorf("login timed out. Run 'crit auth login' to try again")
+	default:
+		return pollResult{}, fmt.Errorf("server error: %s", errStr)
+	}
+}
+
+// printSpinner prints a dot and returns the updated count.
+func printSpinner(dots int) int {
+	fmt.Fprint(os.Stderr, ".")
+	return dots + 1
+}
+
+// clearSpinner clears the spinner dots and moves to a new line.
+func clearSpinner(dots int) {
+	if dots > 0 {
+		fmt.Fprint(os.Stderr, "\r"+strings.Repeat(" ", dots+2)+"\r")
+	}
+}
+
+// saveAuthToken writes the auth_token to the global config file.
+func saveAuthToken(token string) error {
+	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		raw, err := json.Marshal(token)
+		if err != nil {
+			return err
+		}
+		m["auth_token"] = raw
+		return nil
+	})
+}
+
+// removeAuthToken removes auth_token from the global config file.
+func removeAuthToken() error {
+	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		delete(m, "auth_token")
+		return nil
+	})
+}
+
+func runAuthLogout(args []string) {
+	_ = args
+	cfg := loadShareConfig()
+	token := resolveAuthToken(cfg)
+
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "  Not logged in.")
+		return
+	}
+
+	if _, ok := os.LookupEnv("CRIT_AUTH_TOKEN"); ok {
+		fmt.Fprintln(os.Stderr, "  Token is set via CRIT_AUTH_TOKEN environment variable and cannot be cleared by logout.")
+		return
+	}
+
+	serverURL := resolveShareURL("", cfg)
+	revoked := revokeToken(serverURL, token)
+
+	if err := removeAuthToken(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing token from config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if revoked {
+		fmt.Fprintln(os.Stderr, "  Logged out.")
+	} else {
+		fmt.Fprintln(os.Stderr, "  Logged out locally. Could not reach server to revoke token.")
+	}
+}
+
+// revokeToken calls DELETE /api/auth/token to revoke the token server-side.
+// Returns true if the server acknowledged the revocation (204 or 401).
+func revokeToken(serverURL string, token string) bool {
+	req, err := http.NewRequest(http.MethodDelete, serverURL+"/api/auth/token", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusUnauthorized
+}
+
+func runAuthWhoami(args []string) {
+	_ = args
+	cfg := loadShareConfig()
+	token := resolveAuthToken(cfg)
+
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "  Not logged in. Run 'crit auth login' to authenticate.")
+		return
+	}
+
+	serverURL := resolveShareURL("", cfg)
+	name, email, err := fetchWhoami(serverURL, token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Token is invalid or revoked. Run 'crit auth login' to re-authenticate.\n")
+		return
+	}
+
+	if email != "" {
+		fmt.Fprintf(os.Stderr, "  Logged in as %s (%s)\n", name, email)
+	} else {
+		fmt.Fprintf(os.Stderr, "  Logged in as %s\n", name)
+	}
+}
+
+// whoamiResponse holds the response from GET /api/auth/whoami.
+type whoamiResponse struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// fetchWhoami calls the whoami endpoint and returns the user's name and email.
+func fetchWhoami(serverURL string, token string) (string, string, error) {
+	req, err := http.NewRequest(http.MethodGet, serverURL+"/api/auth/whoami", nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("contacting server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", "", fmt.Errorf("invalid or revoked token")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	var result whoamiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", fmt.Errorf("decoding response: %w", err)
+	}
+	return result.Name, result.Email, nil
+}
+
+// showLoginHint prints a one-time hint about crit auth login after anonymous shares.
+// Reads the config to check if the hint was already shown, then persists the flag.
+func showLoginHint() {
+	path := globalConfigPath()
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	var raw map[string]json.RawMessage
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return
+		}
+	}
+	if v, ok := raw["login_hint_shown"]; ok && string(v) == "true" {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "  Tip: Run 'crit auth login' to link reviews to your account.")
+
+	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		m["login_hint_shown"] = json.RawMessage("true")
+		return nil
+	})
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRequestDeviceCode_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/device/code" {
+			t.Errorf("expected /api/device/code, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "dc_test123",
+			"user_code":        "BCDF-GHJK",
+			"verification_uri": "https://crit.md/device",
+			"interval":         5,
+			"expires_in":       900,
+		})
+	}))
+	defer srv.Close()
+
+	code, err := requestDeviceCode(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code.DeviceCode != "dc_test123" {
+		t.Errorf("device_code = %q, want dc_test123", code.DeviceCode)
+	}
+	if code.UserCode != "BCDF-GHJK" {
+		t.Errorf("user_code = %q, want BCDF-GHJK", code.UserCode)
+	}
+	if code.VerificationURI != "https://crit.md/device" {
+		t.Errorf("verification_uri = %q", code.VerificationURI)
+	}
+	if code.Interval != 5 {
+		t.Errorf("interval = %d, want 5", code.Interval)
+	}
+	if code.ExpiresIn != 900 {
+		t.Errorf("expires_in = %d, want 900", code.ExpiresIn)
+	}
+}
+
+func TestRequestDeviceCode_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Login is not configured on this server.",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := requestDeviceCode(srv.URL)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if got := err.Error(); got != "Login is not configured on this server." {
+		t.Errorf("error = %q", got)
+	}
+}
+
+func TestRequestDeviceCode_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := requestDeviceCode(srv.URL)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestPollDeviceToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["device_code"] != "dc_test" {
+			t.Errorf("device_code = %q, want dc_test", body["device_code"])
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "crit_abc123",
+			"token_type":   "bearer",
+			"user_name":    "tomasz",
+		})
+	}))
+	defer srv.Close()
+
+	result, err := pollDeviceToken(srv.URL, "dc_test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.done {
+		t.Error("expected done=true on success")
+	}
+	if result.token.AccessToken != "crit_abc123" {
+		t.Errorf("access_token = %q", result.token.AccessToken)
+	}
+	if result.token.UserName != "tomasz" {
+		t.Errorf("user_name = %q", result.token.UserName)
+	}
+}
+
+func TestPollDeviceToken_Pending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "authorization_pending",
+		})
+	}))
+	defer srv.Close()
+
+	result, err := pollDeviceToken(srv.URL, "dc_test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.done {
+		t.Error("expected done=false for pending")
+	}
+	if result.slowDown {
+		t.Error("expected slowDown=false for pending")
+	}
+}
+
+func TestPollDeviceToken_SlowDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "slow_down",
+		})
+	}))
+	defer srv.Close()
+
+	result, err := pollDeviceToken(srv.URL, "dc_test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.done {
+		t.Error("expected done=false for slow_down")
+	}
+	if !result.slowDown {
+		t.Error("expected slowDown=true")
+	}
+}
+
+func TestPollDeviceToken_Expired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "expired_token",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := pollDeviceToken(srv.URL, "dc_test")
+	if err == nil {
+		t.Fatal("expected error for expired_token")
+	}
+}
+
+func TestPollDeviceToken_UnknownError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "server_error",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := pollDeviceToken(srv.URL, "dc_test")
+	if err == nil {
+		t.Fatal("expected error for unknown error value")
+	}
+}
+
+func TestPollResult_NextInterval(t *testing.T) {
+	t.Run("normal keeps interval", func(t *testing.T) {
+		r := pollResult{}
+		if got := r.nextInterval(5); got != 5 {
+			t.Errorf("nextInterval = %d, want 5", got)
+		}
+	})
+
+	t.Run("slow_down adds 5", func(t *testing.T) {
+		r := pollResult{slowDown: true}
+		if got := r.nextInterval(5); got != 10 {
+			t.Errorf("nextInterval = %d, want 10", got)
+		}
+	})
+
+	t.Run("slow_down caps at 60", func(t *testing.T) {
+		r := pollResult{slowDown: true}
+		if got := r.nextInterval(58); got != 60 {
+			t.Errorf("nextInterval = %d, want 60", got)
+		}
+	})
+}
+
+func TestHandlePollError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		wantErr  bool
+		slowDown bool
+	}{
+		{"pending", "authorization_pending", false, false},
+		{"slow_down", "slow_down", false, true},
+		{"expired", "expired_token", true, false},
+		{"unknown", "something_else", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := handlePollError(tt.errStr)
+			if tt.wantErr && err == nil {
+				t.Error("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result.slowDown != tt.slowDown {
+				t.Errorf("slowDown = %v, want %v", result.slowDown, tt.slowDown)
+			}
+		})
+	}
+}
+
+func TestSaveAndRemoveAuthToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Save a token
+	if err := saveAuthToken("crit_test_token"); err != nil {
+		t.Fatalf("saveAuthToken: %v", err)
+	}
+
+	// Verify it was written
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	var token string
+	json.Unmarshal(raw["auth_token"], &token)
+	if token != "crit_test_token" {
+		t.Errorf("auth_token = %q, want crit_test_token", token)
+	}
+
+	// Remove the token
+	if err := removeAuthToken(); err != nil {
+		t.Fatalf("removeAuthToken: %v", err)
+	}
+
+	data, err = os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config after remove: %v", err)
+	}
+	raw = make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config after remove: %v", err)
+	}
+	if _, ok := raw["auth_token"]; ok {
+		t.Error("auth_token should be removed after removeAuthToken")
+	}
+}
+
+func TestSaveGlobalConfig_PreservesUnknownKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write a config with an existing key
+	initial := `{"share_url": "https://example.com", "port": 3000}` + "\n"
+	os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600)
+
+	// Save auth_token
+	if err := saveAuthToken("crit_tok"); err != nil {
+		t.Fatalf("saveAuthToken: %v", err)
+	}
+
+	// Verify both old keys and new key are present
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+
+	if _, ok := raw["share_url"]; !ok {
+		t.Error("share_url should be preserved")
+	}
+	if _, ok := raw["port"]; !ok {
+		t.Error("port should be preserved")
+	}
+	if _, ok := raw["auth_token"]; !ok {
+		t.Error("auth_token should be set")
+	}
+}
+
+func TestSaveGlobalConfig_FilePermissions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := saveAuthToken("crit_tok"); err != nil {
+		t.Fatalf("saveAuthToken: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("permissions = %o, want 0600", perm)
+	}
+}
+
+func TestRevokeToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/auth/token" {
+			t.Errorf("expected /api/auth/token, got %s", r.URL.Path)
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer crit_tok" {
+			t.Errorf("Authorization = %q", auth)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if !revokeToken(srv.URL, "crit_tok") {
+		t.Error("expected revokeToken to return true for 204")
+	}
+}
+
+func TestRevokeToken_AlreadyGone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if !revokeToken(srv.URL, "crit_tok") {
+		t.Error("expected revokeToken to return true for 401")
+	}
+}
+
+func TestRevokeToken_NetworkError(t *testing.T) {
+	if revokeToken("http://127.0.0.1:1", "crit_tok") {
+		t.Error("expected revokeToken to return false for network error")
+	}
+}
+
+func TestFetchWhoami_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/auth/whoami" {
+			t.Errorf("expected /api/auth/whoami, got %s", r.URL.Path)
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer crit_tok" {
+			t.Errorf("Authorization = %q", auth)
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"name":  "Tomasz",
+			"email": "tomasz@example.com",
+		})
+	}))
+	defer srv.Close()
+
+	name, email, err := fetchWhoami(srv.URL, "crit_tok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "Tomasz" {
+		t.Errorf("name = %q, want Tomasz", name)
+	}
+	if email != "tomasz@example.com" {
+		t.Errorf("email = %q", email)
+	}
+}
+
+func TestFetchWhoami_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, _, err := fetchWhoami(srv.URL, "bad_token")
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+}
+
+func TestShowLoginHint_FirstTime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	showLoginHint()
+
+	// Verify flag was persisted
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+	if string(raw["login_hint_shown"]) != "true" {
+		t.Errorf("login_hint_shown = %s, want true", raw["login_hint_shown"])
+	}
+}
+
+func TestShowLoginHint_AlreadyShown(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write config with hint already shown
+	os.WriteFile(filepath.Join(home, ".crit.config.json"),
+		[]byte(`{"login_hint_shown": true}`), 0o600)
+
+	showLoginHint()
+
+	// Verify the config was not rewritten (no new keys added)
+	data, _ := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+	if len(raw) != 1 {
+		t.Errorf("expected 1 key in config, got %d", len(raw))
+	}
+}
+
+func TestShowLoginHint_PreservesExistingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write config with existing keys
+	os.WriteFile(filepath.Join(home, ".crit.config.json"),
+		[]byte(`{"share_url": "https://example.com"}`), 0o600)
+
+	showLoginHint()
+
+	data, _ := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+	if _, ok := raw["share_url"]; !ok {
+		t.Error("share_url should be preserved after showLoginHint")
+	}
+}

--- a/config.go
+++ b/config.go
@@ -211,6 +211,37 @@ func globalConfigPath() string {
 	return filepath.Join(home, ".crit.config.json")
 }
 
+// saveGlobalConfig performs a read-modify-write on ~/.crit.config.json.
+// It uses map[string]json.RawMessage to preserve unknown keys.
+// The apply function receives the raw map and should set or delete keys as needed.
+// The file is written with 0600 permissions since it may contain auth_token.
+func saveGlobalConfig(apply func(m map[string]json.RawMessage) error) error {
+	path := globalConfigPath()
+	if path == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+
+	raw := make(map[string]json.RawMessage)
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	if err := apply(raw); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
 // matchPattern checks if a file path matches an ignore pattern.
 // Pattern types:
 //   - "*.ext"         → matches files ending in .ext anywhere

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.26.0
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.1
+	golang.org/x/term v0.13.0
 	rsc.io/qr v0.2.0
 )
 
-require (
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.13.0 // indirect
-)
+require golang.org/x/sys v0.29.0 // indirect

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ var commandDispatch = map[string]func([]string){
 	"review":    runReview,
 	"plan":      runPlan,
 	"plan-hook": func([]string) { runPlanHook() },
+	"auth":      runAuth,
 	"stop":      runStop,
 	"_serve":    runServe,
 }
@@ -201,6 +202,10 @@ func runShareNew(critDir string, files []shareFile, filePaths []string, svcURL, 
 
 	fmt.Println(url)
 	printQR(url, showQR)
+
+	if authToken == "" {
+		showLoginHint()
+	}
 }
 
 func runShare(args []string) {
@@ -1859,6 +1864,9 @@ Usage:
   crit push [--dry-run] [--event <type>] [-m <msg>] [-o <dir>] [pr-number]  Post .crit.json comments to a GitHub PR
   crit plan --name <slug> <file>             Review a plan file (manages versioned copies)
   crit plan --name <slug>                    Read plan from stdin
+  crit auth login                            Log in to crit-web via browser
+  crit auth logout                           Log out and revoke token
+  crit auth whoami                           Show current user info
   crit install <agent>                       Install integration files for an AI coding tool
   crit check                                 Check if installed integrations are up to date
   crit config [--generate]                    Show resolved configuration
@@ -1882,6 +1890,7 @@ Environment:
   CRIT_SHARE_URL              Override the share service URL
   CRIT_PORT                   Override the default port
   CRIT_NO_UPDATE_CHECK        Disable update check on startup
+  CRIT_AUTH_TOKEN              Override the auth token (skip login)
   CRIT_NO_INTEGRATION_CHECK   Disable integration staleness check
 
 Configuration:


### PR DESCRIPTION
## Summary

- Adds `crit auth login` using OAuth Device Flow (RFC 8628) — user gets a code, enters it at the web UI, CLI polls until authorized
- Adds `crit auth logout` with server-side token revocation and env var detection
- Adds `crit auth whoami` to verify token and display user info
- New `saveGlobalConfig` function (read-modify-write with raw JSON map, 0600 permissions)
- One-time login hint after anonymous shares suggesting `crit auth login`
- Browser auto-opens with pre-filled code URL

## Test plan

- [ ] 21 new tests covering device code request, poll loop states, config save/load/remove, token revocation, whoami, login hint
- [ ] `go build` compiles cleanly
- [ ] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)