### PR TITLE
Simplify device auth: use verification_uri_complete

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -76,8 +76,9 @@ func runAuthLogin(args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Fprintf(os.Stderr, "\n  Visit %s and enter code: %s\n\n", code.VerificationURI, code.UserCode)
-	go openBrowser(code.VerificationURI + "?code=" + code.UserCode)
+	fmt.Fprintf(os.Stderr, "\n  Opening browser to sign in...\n")
+	fmt.Fprintf(os.Stderr, "  If it doesn't open, visit: %s\n\n", code.VerificationURIComplete)
+	go openBrowser(code.VerificationURIComplete)
 
 	token, err := pollForToken(serverURL, code)
 	if err != nil {
@@ -115,11 +116,10 @@ func confirmReauth() bool {
 
 // deviceCodeResponse holds the response from POST /api/device/code.
 type deviceCodeResponse struct {
-	DeviceCode      string `json:"device_code"`
-	UserCode        string `json:"user_code"`
-	VerificationURI string `json:"verification_uri"`
-	Interval        int    `json:"interval"`
-	ExpiresIn       int    `json:"expires_in"`
+	DeviceCode              string `json:"device_code"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	Interval                int    `json:"interval"`
+	ExpiresIn               int    `json:"expires_in"`
 }
 
 // requestDeviceCode initiates the device flow by requesting a device code.

--- a/auth_test.go
+++ b/auth_test.go
@@ -19,11 +19,10 @@ func TestRequestDeviceCode_Success(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]any{
-			"device_code":      "dc_test123",
-			"user_code":        "BCDF-GHJK",
-			"verification_uri": "https://crit.md/device",
-			"interval":         5,
-			"expires_in":       900,
+			"device_code":               "dc_test123",
+			"verification_uri_complete": "https://crit.md/auth/cli?code=sc_test456",
+			"interval":                  5,
+			"expires_in":                900,
 		})
 	}))
 	defer srv.Close()
@@ -35,11 +34,8 @@ func TestRequestDeviceCode_Success(t *testing.T) {
 	if code.DeviceCode != "dc_test123" {
 		t.Errorf("device_code = %q, want dc_test123", code.DeviceCode)
 	}
-	if code.UserCode != "BCDF-GHJK" {
-		t.Errorf("user_code = %q, want BCDF-GHJK", code.UserCode)
-	}
-	if code.VerificationURI != "https://crit.md/device" {
-		t.Errorf("verification_uri = %q", code.VerificationURI)
+	if code.VerificationURIComplete != "https://crit.md/auth/cli?code=sc_test456" {
+		t.Errorf("verification_uri_complete = %q", code.VerificationURIComplete)
 	}
 	if code.Interval != 5 {
 		t.Errorf("interval = %d, want 5", code.Interval)


### PR DESCRIPTION
## Summary

- CLI now uses `verification_uri_complete` from server response to open browser directly
- Removes user code display ("Visit X and enter code: BCDF-GHJK") 
- New UX: "Opening browser to sign in..." with fallback URL for SSH/headless users

## Changes

- **`deviceCodeResponse` struct**: Replace `UserCode`/`VerificationURI` fields with `VerificationURIComplete`
- **`runAuthLogin`**: Open `verification_uri_complete` directly, update messaging
- **Tests**: Updated for new response shape

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [ ] CI passes
- [ ] Depends on crit-web PR for server-side changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)