### PR TITLE
chore: release audit fixes

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -396,31 +396,23 @@ func fetchWhoami(serverURL string, token string) (string, string, error) {
 	return result.Name, result.Email, nil
 }
 
+// errHintAlreadyShown is a sentinel error used by showLoginHint to skip
+// the write when the hint was already shown.
+var errHintAlreadyShown = fmt.Errorf("login hint already shown")
+
 // showLoginHint prints a one-time hint about crit auth login after anonymous shares.
-// Reads the config to check if the hint was already shown, then persists the flag.
+// Uses saveGlobalConfig for both read and write to avoid TOCTOU races.
 func showLoginHint() {
-	path := globalConfigPath()
-	if path == "" {
-		return
-	}
-	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return
-	}
-	var raw map[string]json.RawMessage
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return
+	err := saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		if v, ok := m["login_hint_shown"]; ok && string(v) == "true" {
+			return errHintAlreadyShown
 		}
-	}
-	if v, ok := raw["login_hint_shown"]; ok && string(v) == "true" {
-		return
-	}
-
-	fmt.Fprintln(os.Stderr, "  Tip: Run 'crit auth login' to link reviews to your account.")
-
-	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		fmt.Fprintln(os.Stderr, "  Tip: Run 'crit auth login' to link reviews to your account.")
 		m["login_hint_shown"] = json.RawMessage("true")
 		return nil
 	})
+	if err != nil && err != errHintAlreadyShown {
+		// Silently ignore config errors — this is a best-effort hint.
+		_ = err
+	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -458,5 +459,46 @@ func TestShowLoginHint_PreservesExistingConfig(t *testing.T) {
 	json.Unmarshal(data, &raw)
 	if _, ok := raw["share_url"]; !ok {
 		t.Error("share_url should be preserved after showLoginHint")
+	}
+}
+
+func TestPollForToken_Integration(t *testing.T) {
+	// Server returns authorization_pending for the first 2 requests,
+	// then returns a valid token on the 3rd request.
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "authorization_pending",
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "crit_integration_test",
+			"user_name":    "testuser",
+		})
+	}))
+	defer srv.Close()
+
+	code := deviceCodeResponse{
+		DeviceCode: "dc_integration",
+		Interval:   1, // 1 second per poll to keep the test fast
+		ExpiresIn:  30,
+	}
+
+	token, err := pollForToken(srv.URL, code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "crit_integration_test" {
+		t.Errorf("access_token = %q, want crit_integration_test", token.AccessToken)
+	}
+	if token.UserName != "testuser" {
+		t.Errorf("user_name = %q, want testuser", token.UserName)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("server received %d requests, want 3", got)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -52,12 +52,13 @@ func defaultConfig() generatedConfig {
 			".crit.json",
 			".crit/",
 		},
-		AgentCmd:  "",
-		AuthToken: "",
+		AgentCmd: "",
 	}
 }
 
 // generatedConfig is like Config but without omitempty, so all keys appear in output.
+// auth_token is intentionally excluded — it is global-only and should not appear
+// in project config files where it could be accidentally committed.
 type generatedConfig struct {
 	Port               int      `json:"port"`
 	NoOpen             bool     `json:"no_open"`
@@ -69,7 +70,6 @@ type generatedConfig struct {
 	IgnorePatterns     []string `json:"ignore_patterns"`
 	NoIntegrationCheck bool     `json:"no_integration_check"`
 	AgentCmd           string   `json:"agent_cmd"`
-	AuthToken          string   `json:"auth_token"`
 }
 
 func (c generatedConfig) String() string {


### PR DESCRIPTION
## Summary
- Remove `AuthToken` from `generatedConfig` so `crit config --generate` doesn't suggest putting tokens in project config files
- Refactor `showLoginHint` to use `saveGlobalConfig` atomically, eliminating TOCTOU race
- Add `TestPollForToken_Integration` covering the full auth polling loop

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)