### PR TITLE
fix: duplicate comments after carry-forward & cleanup-on-approve

### DIFF
--- a/main.go
+++ b/main.go
@@ -1185,6 +1185,14 @@ func killDaemonOnApproval(approved bool, pid int) {
 	}
 }
 
+// cleanupOnApproval deletes the review file when the review is approved
+// and cleanup is enabled.
+func cleanupOnApproval(approved bool, reviewPath string, cleanupEnabled bool) {
+	if approved && cleanupEnabled && reviewPath != "" {
+		os.Remove(reviewPath)
+	}
+}
+
 func runPlan(args []string) {
 	pc := resolvePlanConfig(args)
 	content := readPlanContent(pc)
@@ -1216,6 +1224,7 @@ func runPlan(args []string) {
 
 	approved := runReviewClient(entry)
 	killDaemonOnApproval(approved, entry.PID)
+	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 }
 
 type planHookEvent struct {
@@ -1325,6 +1334,7 @@ func runPlanHook() {
 
 	approved, prompt := runReviewClientRaw(entry)
 	killDaemonOnApproval(approved, entry.PID)
+	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 	emitHookDecision(approved, prompt)
 }
 
@@ -1408,6 +1418,7 @@ func runReview(args []string) {
 
 	approved := runReviewClient(entry)
 	killDaemonOnApproval(approved, entry.PID)
+	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 }
 
 // runReviewClient connects to a running daemon/server, blocks until the user

--- a/main_test.go
+++ b/main_test.go
@@ -868,3 +868,41 @@ func TestDeleteStaleReviews(t *testing.T) {
 		t.Error("stale review file should be deleted")
 	}
 }
+
+func TestCleanupOnApproval_DeletesReviewFile(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+	os.WriteFile(reviewPath, []byte(`{"branch":"main"}`), 0644)
+
+	// approved=true with cleanup enabled should delete the file.
+	cleanupOnApproval(true, reviewPath, true)
+
+	if _, err := os.Stat(reviewPath); !os.IsNotExist(err) {
+		t.Error("expected review file to be deleted after approval")
+	}
+}
+
+func TestCleanupOnApproval_KeepsFileWhenNotApproved(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+	os.WriteFile(reviewPath, []byte(`{"branch":"main"}`), 0644)
+
+	cleanupOnApproval(false, reviewPath, true)
+
+	if _, err := os.Stat(reviewPath); os.IsNotExist(err) {
+		t.Error("expected review file to still exist when not approved")
+	}
+}
+
+func TestCleanupOnApproval_KeepsFileWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+	os.WriteFile(reviewPath, []byte(`{"branch":"main"}`), 0644)
+
+	// approved=true but cleanup disabled — file should stay.
+	cleanupOnApproval(true, reviewPath, false)
+
+	if _, err := os.Stat(reviewPath); os.IsNotExist(err) {
+		t.Error("expected review file to still exist when cleanup is disabled")
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1934,8 +1934,8 @@ func TestCarryForwardComment(t *testing.T) {
 	if carried.ReviewRound != 1 {
 		t.Errorf("ReviewRound = %d, want 1", carried.ReviewRound)
 	}
-	if carried.Quote != "" {
-		t.Errorf("Quote = %q, should not be carried forward", carried.Quote)
+	if carried.Quote != "func foo() {}" {
+		t.Errorf("Quote = %q, want %q", carried.Quote, "func foo() {}")
 	}
 }
 

--- a/watch.go
+++ b/watch.go
@@ -473,6 +473,10 @@ func (s *Session) carryForwardComments() {
 		f.Comments = nil // Clear before carry-forward to prevent duplicates
 		now := time.Now().UTC().Format(time.RFC3339)
 		for _, c := range prevComments {
+			// Track the old ID as deleted so mergeFileSnapshotIntoCritJSON
+			// won't re-add the original from disk alongside the carried-forward copy.
+			s.trackDeletedComment(f.Path, c.ID)
+
 			// File-level comments have no line references — carry forward as-is.
 			if c.Scope == "file" {
 				carried := carryForwardComment(c, randomCommentID(), now)

--- a/watch.go
+++ b/watch.go
@@ -266,6 +266,8 @@ func carryForwardComment(old Comment, newID string, now string) Comment {
 		EndLine:        old.EndLine,
 		Side:           old.Side,
 		Body:           old.Body,
+		Quote:          old.Quote,
+		QuoteOffset:    old.QuoteOffset,
 		Author:         old.Author,
 		Scope:          old.Scope,
 		CreatedAt:      old.CreatedAt,

--- a/watch.go
+++ b/watch.go
@@ -288,8 +288,10 @@ func (s *Session) carryForwardAllComments() {
 		}
 		for _, c := range f.PreviousComments {
 			carried := carryForwardComment(c, randomCommentID(), now)
-
 			f.Comments = append(f.Comments, carried)
+			// Track the old ID as deleted so mergeFileSnapshotIntoCritJSON
+			// won't re-add the original from disk alongside the carried-forward copy.
+			s.trackDeletedComment(f.Path, c.ID)
 		}
 	}
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -137,4 +138,116 @@ func TestWatchFileMtimes_ConcurrentAddDuringChange(t *testing.T) {
 	_ = f.Comments // access under lock — no race
 	_ = f.FileHash
 	s.mu.RUnlock()
+}
+
+// TestCarryForwardAllComments_NoDuplicateOnDisk verifies that carried-forward
+// comments don't produce duplicates when WriteFiles merges with disk state.
+// The old comment ID must be tracked as deleted so mergeFileSnapshotIntoCritJSON
+// skips it, leaving only the new carried-forward copy.
+func TestCarryForwardAllComments_NoDuplicateOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+
+	s := &Session{
+		Mode:           "git",
+		RepoRoot:       dir,
+		ReviewFilePath: reviewPath,
+		Files: []*FileEntry{
+			{
+				Path:     "main.go",
+				AbsPath:  filepath.Join(dir, "main.go"),
+				Status:   "modified",
+				FileType: "code",
+				Comments: []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_old1",
+						StartLine: 10,
+						EndLine:   10,
+						Body:      "Fix this",
+						Author:    "Tomasz",
+						Scope:     "line",
+						CreatedAt: "2026-04-13T10:00:00Z",
+						UpdatedAt: "2026-04-13T10:00:00Z",
+						Resolved:  true,
+						Replies: []Reply{
+							{ID: "rp_1", Body: "Fixed", Author: "Agent", CreatedAt: "2026-04-13T10:01:00Z"},
+						},
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	// Write the "old" version to disk (simulates the state before round-complete).
+	oldCJ := CritJSON{
+		Branch:      "main",
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{
+						ID:        "c_old1",
+						StartLine: 10,
+						EndLine:   10,
+						Body:      "Fix this",
+						Author:    "Tomasz",
+						Scope:     "line",
+						CreatedAt: "2026-04-13T10:00:00Z",
+						UpdatedAt: "2026-04-13T10:00:00Z",
+						Resolved:  true,
+						Replies: []Reply{
+							{ID: "rp_1", Body: "Fixed", Author: "Agent", CreatedAt: "2026-04-13T10:01:00Z"},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(oldCJ, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run carry-forward (simulates what handleRoundCompleteGit does).
+	s.mu.Lock()
+	s.carryForwardAllComments()
+	s.mu.Unlock()
+
+	// Verify in-memory state: exactly 1 comment with a NEW id.
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 carried-forward comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if carried.ID == "c_old1" {
+		t.Error("carried-forward comment should have a new ID")
+	}
+	if !carried.CarriedForward {
+		t.Error("expected CarriedForward=true")
+	}
+
+	// Now write to disk (this is where the duplicate appears without the fix).
+	s.WriteFiles()
+
+	diskData, err := os.ReadFile(reviewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var diskCJ CritJSON
+	if err := json.Unmarshal(diskData, &diskCJ); err != nil {
+		t.Fatal(err)
+	}
+
+	diskComments := diskCJ.Files["main.go"].Comments
+	if len(diskComments) != 1 {
+		t.Errorf("expected 1 comment on disk after WriteFiles, got %d", len(diskComments))
+		for _, c := range diskComments {
+			t.Logf("  id=%s carried_forward=%v resolved=%v", c.ID, c.CarriedForward, c.Resolved)
+		}
+	}
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -251,3 +251,95 @@ func TestCarryForwardAllComments_NoDuplicateOnDisk(t *testing.T) {
 		}
 	}
 }
+
+func TestCarryForwardComments_NoDuplicateOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+	mdPath := filepath.Join(dir, "plan.md")
+	os.WriteFile(mdPath, []byte("# Plan\n\nStep 1\n\nStep 2\n"), 0644)
+
+	s := &Session{
+		Mode:           "files",
+		RepoRoot:       dir,
+		ReviewFilePath: reviewPath,
+		Files: []*FileEntry{
+			{
+				Path:            "plan.md",
+				AbsPath:         mdPath,
+				Status:          "modified",
+				FileType:        "markdown",
+				Content:         "# Plan\n\nStep 1\n\nStep 2\n",
+				PreviousContent: "# Plan\n\nStep 1\n",
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_old_md",
+						StartLine: 3,
+						EndLine:   3,
+						Body:      "Expand this",
+						Author:    "Tomasz",
+						Scope:     "line",
+						CreatedAt: "2026-04-13T10:00:00Z",
+						UpdatedAt: "2026-04-13T10:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	// Write old version to disk.
+	oldCJ := CritJSON{
+		Branch:      "main",
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Status: "modified",
+				Comments: []Comment{
+					{
+						ID:        "c_old_md",
+						StartLine: 3,
+						EndLine:   3,
+						Body:      "Expand this",
+						Author:    "Tomasz",
+						Scope:     "line",
+						CreatedAt: "2026-04-13T10:00:00Z",
+						UpdatedAt: "2026-04-13T10:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(oldCJ, "", "  ")
+	os.WriteFile(reviewPath, data, 0644)
+
+	// Run markdown carry-forward.
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 carried-forward comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if carried.ID == "c_old_md" {
+		t.Error("carried-forward comment should have a new ID")
+	}
+	// Line 3 in old content ("Step 1") is still line 3 in new content.
+	if carried.StartLine != 3 || carried.EndLine != 3 {
+		t.Errorf("expected line 3, got start=%d end=%d", carried.StartLine, carried.EndLine)
+	}
+
+	// Write to disk — should not produce duplicates.
+	s.WriteFiles()
+
+	diskData, _ := os.ReadFile(reviewPath)
+	var diskCJ CritJSON
+	json.Unmarshal(diskData, &diskCJ)
+
+	diskComments := diskCJ.Files["plan.md"].Comments
+	if len(diskComments) != 1 {
+		t.Errorf("expected 1 comment on disk, got %d", len(diskComments))
+		for _, c := range diskComments {
+			t.Logf("  id=%s carried_forward=%v", c.ID, c.CarriedForward)
+		}
+	}
+}

--- a/watch_test.go
+++ b/watch_test.go
@@ -343,3 +343,33 @@ func TestCarryForwardComments_NoDuplicateOnDisk(t *testing.T) {
 		}
 	}
 }
+
+func TestCarryForwardComment_PreservesQuote(t *testing.T) {
+	offset := 5
+	old := Comment{
+		ID:          "c_old",
+		StartLine:   10,
+		EndLine:     10,
+		Body:        "Fix this",
+		Quote:       "the quoted text",
+		QuoteOffset: &offset,
+		Author:      "Tomasz",
+		Scope:       "line",
+		CreatedAt:   "2026-04-13T10:00:00Z",
+		UpdatedAt:   "2026-04-13T10:00:00Z",
+		Resolved:    true,
+		ReviewRound: 1,
+		Replies: []Reply{
+			{ID: "rp_1", Body: "Done", Author: "Agent"},
+		},
+	}
+
+	carried := carryForwardComment(old, "c_new", "2026-04-13T11:00:00Z")
+
+	if carried.Quote != "the quoted text" {
+		t.Errorf("Quote not preserved: got %q", carried.Quote)
+	}
+	if carried.QuoteOffset == nil || *carried.QuoteOffset != 5 {
+		t.Error("QuoteOffset not preserved")
+	}
+}


### PR DESCRIPTION
## Summary

- **Duplicate comments bug**: During round-complete, `carryForwardAllComments`/`carryForwardComments` create new IDs for carried-forward comments, but the originals persist on disk with old IDs. When `WriteFiles` merges memory with disk via `mergeFileSnapshotIntoCritJSON`, both survive — producing duplicates. Fix: track old IDs in `deletedCommentIDs` so the merge excludes them.
- **Quote/QuoteOffset lost**: `carryForwardComment` didn't copy `Quote` or `QuoteOffset` fields. Carried-forward comments lost their text-selection context.
- **Review file not deleted on approve**: `CleanupOnApproveEnabled()` config (defaults to `true`) existed but was never called. Wire it into all 3 approval paths (`runPlan`, `runPlanHook`, `runReview`).

## Test plan

- [x] `TestCarryForwardAllComments_NoDuplicateOnDisk` — git mode: carry-forward + WriteFiles → exactly 1 comment on disk
- [x] `TestCarryForwardComments_NoDuplicateOnDisk` — file mode: markdown carry-forward + WriteFiles → exactly 1 comment on disk, line remapping verified
- [x] `TestCarryForwardComment_PreservesQuote` — Quote and QuoteOffset preserved through carry-forward
- [x] `TestCleanupOnApproval_DeletesReviewFile` — approved + enabled → file deleted
- [x] `TestCleanupOnApproval_KeepsFileWhenNotApproved` — not approved → file kept
- [x] `TestCleanupOnApproval_KeepsFileWhenDisabled` — approved but disabled → file kept
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] `gofmt` clean, builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)