### PR TITLE
feat: improve README config docs, add no_update_check config key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Two-level JSON config files, merged (project overrides global):
 - **Global**: `~/.crit.config.json` — user-wide defaults
 - **Project**: `.crit.config.json` in repo root — per-project overrides
 
-Config keys: `port`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `cleanup_on_approve`.
+Config keys: `port`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `cleanup_on_approve`, `no_update_check`, `no_integration_check`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to `git config user.name` if not set

--- a/README.md
+++ b/README.md
@@ -248,28 +248,40 @@ Project config overrides global. CLI flags and env vars override both.
 ```bash
 crit config --generate > ~/.crit.config.json   # scaffold a starter config file
 crit config                                    # view resolved config (merged global + project)
-crit config --help                             # document all config keys
 ```
 
-### Example
+### Config keys
 
-```json
-{
-  "port": 0,
-  "base_branch": "main",
-  "no_open": false,
-  "share_url": "https://crit.md",
-  "quiet": false,
-  "output": "",
-  "author": "John",
-  "agent_cmd": "claude -p",
-  "auth_token": "",
-  "cleanup_on_approve": true,
-  "ignore_patterns": [".crit.json"]
-}
-```
+All keys are optional — omit any you don't need.
 
-All keys are optional - omit any you don't need.
+| Key                    | Type     | Default                  | Description                                                                                                                                                                |
+| ---------------------- | -------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `port`                 | int      | `0` (random)             | Port for the local server. `0` picks a random available port.                                                                                                              |
+| `no_open`              | bool     | `false`                  | Don't auto-open the browser when starting a review.                                                                                                                        |
+| `share_url`            | string   | `"https://crit.md"`      | Base URL of the share service. Set to `""` to disable sharing entirely. Self-host with [`crit-web`](https://github.com/tomasz-tomczyk/crit-web).                           |
+| `quiet`                | bool     | `false`                  | Suppress terminal status output.                                                                                                                                           |
+| `output`               | string   | repo root or file dir    | Output directory for review files. Reviews are stored in `~/.crit/reviews/` by default.                                                                                    |
+| `author`               | string   | `git config user.name`   | Author name shown on comments. Falls back to your git user name.                                                                                                           |
+| `base_branch`          | string   | auto-detected            | Base branch to diff against (e.g. `"main"`, `"develop"`). Overrides auto-detection.                                                                                       |
+| `ignore_patterns`      | string[] | `[".crit.json", ".crit/"]` | File patterns to exclude from git-mode file lists. Global and project patterns are merged.                                                                                |
+| `agent_cmd`            | string   | `""`                     | Shell command for "Send to agent" (e.g. `"claude -p"`). **Global config only** — project config cannot set this for security reasons. See [Send to agent](#send-to-agent-experimental). |
+| `auth_token`           | string   | `""`                     | Authentication token for crit.md. Set automatically by `crit auth login`. **Global config only.**                                                                          |
+| `cleanup_on_approve`   | bool     | `true`                   | Automatically delete the review file when you approve with no unresolved comments. Set to `false` to preserve review history.                                              |
+| `no_update_check`      | bool     | `false`                  | Don't check for new versions on startup.                                                                                                                                   |
+| `no_integration_check` | bool     | `false`                  | Skip the integration config freshness check on startup.                                                                                                                    |
+
+### CLI flags
+
+| Flag             | Short | Equivalent config key | Description                              |
+| ---------------- | ----- | --------------------- | ---------------------------------------- |
+| `--port`         | `-p`  | `port`                | Port to listen on                        |
+| `--no-open`      |       | `no_open`             | Don't auto-open browser                  |
+| `--share-url`    |       | `share_url`           | Share service URL                        |
+| `--output`       | `-o`  | `output`              | Output directory for review files        |
+| `--quiet`        | `-q`  | `quiet`               | Suppress status output                   |
+| `--base-branch`  |       | `base_branch`         | Base branch to diff against              |
+| `--no-ignore`    |       |                       | Temporarily bypass all ignore patterns   |
+| `--version`      | `-v`  |                       | Print version and exit                   |
 
 ### Ignore patterns
 
@@ -290,11 +302,13 @@ crit --no-ignore
 
 ### Environment variables
 
-| Variable               | Description                                                                |
-| ---------------------- | -------------------------------------------------------------------------- |
-| `CRIT_SHARE_URL`       | Enable the Share button (e.g. `https://crit.md` or a self-hosted instance) |
-| `CRIT_PORT`            | Default port for the local server                                          |
-| `CRIT_NO_UPDATE_CHECK` | Set to any value to disable the update check on startup                    |
+| Variable                     | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `CRIT_PORT`                  | Default port for the local server                            |
+| `CRIT_SHARE_URL`             | Override the share service URL                               |
+| `CRIT_AUTH_TOKEN`            | Override the auth token (skips `crit auth login`)            |
+| `CRIT_NO_UPDATE_CHECK`       | Disable the update check on startup                          |
+| `CRIT_NO_INTEGRATION_CHECK`  | Skip integration config freshness checks                     |
 
 ## Other Install Methods
 

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	BaseBranch         string   `json:"base_branch,omitempty"`
 	IgnorePatterns     []string `json:"ignore_patterns,omitempty"`
 	NoIntegrationCheck bool     `json:"no_integration_check,omitempty"`
+	NoUpdateCheck      bool     `json:"no_update_check,omitempty"`
 	AgentCmd           string   `json:"agent_cmd,omitempty"`
 	AuthToken          string   `json:"auth_token,omitempty"`
 	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
@@ -80,6 +81,7 @@ type generatedConfig struct {
 	BaseBranch         string   `json:"base_branch"`
 	IgnorePatterns     []string `json:"ignore_patterns"`
 	NoIntegrationCheck bool     `json:"no_integration_check"`
+	NoUpdateCheck      bool     `json:"no_update_check"`
 	AgentCmd           string   `json:"agent_cmd"`
 	CleanupOnApprove   bool     `json:"cleanup_on_approve"`
 }
@@ -100,6 +102,7 @@ type configPresence struct {
 	NoOpen             bool
 	Quiet              bool
 	NoIntegrationCheck bool
+	NoUpdateCheck      bool
 	CleanupOnApprove   bool
 }
 
@@ -126,6 +129,7 @@ func loadConfigFile(path string) (Config, configPresence, error) {
 	_, presence.NoOpen = raw["no_open"]
 	_, presence.Quiet = raw["quiet"]
 	_, presence.NoIntegrationCheck = raw["no_integration_check"]
+	_, presence.NoUpdateCheck = raw["no_update_check"]
 	_, presence.CleanupOnApprove = raw["cleanup_on_approve"]
 
 	if err := json.Unmarshal(data, &cfg); err != nil {
@@ -163,6 +167,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	}
 	if projectPresence.NoIntegrationCheck {
 		merged.NoIntegrationCheck = project.NoIntegrationCheck
+	}
+	if projectPresence.NoUpdateCheck {
+		merged.NoUpdateCheck = project.NoUpdateCheck
 	}
 	if projectPresence.CleanupOnApprove {
 		merged.CleanupOnApprove = project.CleanupOnApprove

--- a/config_test.go
+++ b/config_test.go
@@ -534,6 +534,31 @@ func TestNoIntegrationCheckMerge(t *testing.T) {
 	}
 }
 
+func TestNoUpdateCheckConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crit.config.json")
+	if err := os.WriteFile(configPath, []byte(`{"no_update_check": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _, err := loadConfigFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.NoUpdateCheck {
+		t.Error("expected NoUpdateCheck to be true")
+	}
+}
+
+func TestNoUpdateCheckMerge(t *testing.T) {
+	global := Config{NoUpdateCheck: false}
+	project := Config{NoUpdateCheck: true}
+	presence := configPresence{NoUpdateCheck: true}
+	merged := mergeConfigs(global, project, presence)
+	if !merged.NoUpdateCheck {
+		t.Error("project NoUpdateCheck=true should override global")
+	}
+}
+
 func TestSaveGlobalConfig_RoundTrip(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/main.go
+++ b/main.go
@@ -1554,6 +1554,7 @@ type serverConfig struct {
 	ignorePatterns     []string
 	files              []string // explicit file arguments (empty = git mode)
 	noIntegrationCheck bool
+	noUpdateCheck      bool
 	agentCmd           string
 	planDir            string // managed storage directory for plan mode
 	planName           string // display name for plan content
@@ -1689,6 +1690,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		author:             cfg.Author,
 		ignorePatterns:     ignorePatterns,
 		noIntegrationCheck: cfg.NoIntegrationCheck,
+		noUpdateCheck:      cfg.NoUpdateCheck,
 		agentCmd:           cfg.AgentCmd,
 		files:              sf.fileArgs,
 		planDir:            sf.planDir,
@@ -1913,6 +1915,10 @@ func runServe(args []string) {
 	}
 
 	checkStaleIntegrations(sc, srv, cwd)
+
+	if !sc.noUpdateCheck && os.Getenv("CRIT_NO_UPDATE_CHECK") == "" {
+		go srv.CheckForUpdates()
+	}
 
 	srv.SetSession(session)
 

--- a/server.go
+++ b/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	latestVersion     string
 	versionMu         sync.RWMutex
 	staleIntegrations []staleFile
+	githubAPIURL      string // override for testing; defaults to "https://api.github.com"
 	port              int
 	status            *Status
 	ready             atomic.Bool
@@ -157,8 +158,12 @@ func (s *Server) CheckForUpdates() {
 	if s.currentVersion == "" || s.currentVersion == "dev" {
 		return
 	}
+	base := s.githubAPIURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get("https://api.github.com/repos/tomasz-tomczyk/crit/releases/latest")
+	resp, err := client.Get(base + "/repos/tomasz-tomczyk/crit/releases/latest")
 	if err != nil {
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"net/http"
@@ -147,6 +148,37 @@ func (s *Server) SetPRInfo(prInfo *PRInfo) {
 func (s *Server) SetInitErr(err error) {
 	e := err
 	s.initErr.Store(&e)
+}
+
+// CheckForUpdates fetches the latest release tag from GitHub and stores
+// it so the frontend can display an update notification. Safe to call
+// from a goroutine — the result is written under versionMu.
+func (s *Server) CheckForUpdates() {
+	if s.currentVersion == "" || s.currentVersion == "dev" {
+		return
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/tomasz-tomczyk/crit/releases/latest")
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &release); err != nil || release.TagName == "" {
+		return
+	}
+	s.versionMu.Lock()
+	s.latestVersion = release.TagName
+	s.versionMu.Unlock()
 }
 
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -626,24 +626,9 @@ func TestCheckForUpdates(t *testing.T) {
 
 	s, _ := newTestServer(t)
 	s.currentVersion = "v1.0.0"
+	s.githubAPIURL = gh.URL
 
-	// Test the parsing logic via our mock
-	req, _ := http.NewRequest("GET", gh.URL+"/repos/tomasz-tomczyk/crit/releases/latest", nil)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		t.Fatal(err)
-	}
-	s.versionMu.Lock()
-	s.latestVersion = release.TagName
-	s.versionMu.Unlock()
+	s.CheckForUpdates()
 
 	s.versionMu.RLock()
 	got := s.latestVersion
@@ -652,16 +637,48 @@ func TestCheckForUpdates(t *testing.T) {
 		t.Errorf("latestVersion = %q, want v9.9.9", got)
 	}
 
-	// Verify config reflects it
-	req2 := httptest.NewRequest("GET", "/api/config", nil)
-	w2 := httptest.NewRecorder()
-	s.ServeHTTP(w2, req2)
+	// Verify config API reflects it
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
 	var cfg map[string]any
-	if err := json.Unmarshal(w2.Body.Bytes(), &cfg); err != nil {
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatal(err)
 	}
 	if cfg["latest_version"] != "v9.9.9" {
 		t.Errorf("config latest_version = %v, want v9.9.9", cfg["latest_version"])
+	}
+}
+
+func TestCheckForUpdates_SkipsDevVersion(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.currentVersion = "dev"
+	s.CheckForUpdates()
+
+	s.versionMu.RLock()
+	got := s.latestVersion
+	s.versionMu.RUnlock()
+	if got != "" {
+		t.Errorf("latestVersion should be empty for dev builds, got %q", got)
+	}
+}
+
+func TestCheckForUpdates_HandlesServerError(t *testing.T) {
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer gh.Close()
+
+	s, _ := newTestServer(t)
+	s.currentVersion = "v1.0.0"
+	s.githubAPIURL = gh.URL
+	s.CheckForUpdates()
+
+	s.versionMu.RLock()
+	got := s.latestVersion
+	s.versionMu.RUnlock()
+	if got != "" {
+		t.Errorf("latestVersion should be empty on server error, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace the bare JSON example in the Configuration section with a proper reference table covering all config keys (types, defaults, descriptions), CLI flags, and environment variables
- Wire up the update check that was scaffolded but never connected — `CheckForUpdates()` fetches the latest GitHub release in a background goroutine so the frontend can show an update notification
- Add `no_update_check` config key (mirrors the existing `CRIT_NO_UPDATE_CHECK` env var)
- Add missing `CRIT_AUTH_TOKEN` and `CRIT_NO_INTEGRATION_CHECK` to env vars docs

## Test plan

- [x] All existing tests pass
- [x] New config tests for `no_update_check` loading and merging
- [x] Go expert review: no bugs, races, or issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)