### PR TITLE
fix: crit stop falls back to branch-based lookup

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -235,6 +235,23 @@ func listSessionsForCWD(cwd string) ([]sessionEntry, []string) {
 	return alive, keys
 }
 
+// findSessionForCWDBranch scans all alive sessions for the given cwd and branch.
+// Returns the session, its key, and the number of branch matches found.
+// The session and key are only valid when matchCount == 1.
+func findSessionForCWDBranch(cwd, branch string) (entry sessionEntry, key string, matchCount int) {
+	sessions, keys := listSessionsForCWD(cwd)
+	var matched []int
+	for i, s := range sessions {
+		if s.Branch == branch {
+			matched = append(matched, i)
+		}
+	}
+	if len(matched) == 1 {
+		return sessions[matched[0]], keys[matched[0]], 1
+	}
+	return sessionEntry{}, "", len(matched)
+}
+
 // isDaemonAlive checks if the daemon process is running AND responding to HTTP.
 // After PID recycling, a different process could listen on the same port,
 // so we validate that the response body contains {"status":"ok"}.

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -388,3 +388,98 @@ func TestIsDaemonAlive_AcceptsCritResponse(t *testing.T) {
 		t.Error("isDaemonAlive should return true for valid crit health response")
 	}
 }
+
+func TestFindSessionForCWDBranch_MatchesByBranch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := "/tmp/myrepo"
+
+	// Create a mock HTTP server that responds to /api/health
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+	port, _ := strconv.Atoi(ts.URL[strings.LastIndex(ts.URL, ":")+1:])
+
+	// Write a session with file args (simulates "crit README.md")
+	writeSessionFile("abc123def456", sessionEntry{
+		PID:        os.Getpid(),
+		Port:       port,
+		CWD:        cwd,
+		Args:       []string{"README.md"},
+		Branch:     "main",
+		ReviewPath: "/tmp/reviews/abc123def456.json",
+	})
+
+	// findSessionForCWDBranch should find it by cwd + branch
+	entry, key, matchCount := findSessionForCWDBranch(cwd, "main")
+	if matchCount != 1 {
+		t.Fatalf("expected matchCount 1, got %d", matchCount)
+	}
+	if key != "abc123def456" {
+		t.Errorf("expected key abc123def456, got %s", key)
+	}
+	if entry.Port != port {
+		t.Errorf("expected port %d, got %d", port, entry.Port)
+	}
+}
+
+func TestFindSessionForCWDBranch_NoBranchMatch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := "/tmp/myrepo"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+	port, _ := strconv.Atoi(ts.URL[strings.LastIndex(ts.URL, ":")+1:])
+
+	writeSessionFile("abc123def456", sessionEntry{
+		PID:    os.Getpid(),
+		Port:   port,
+		CWD:    cwd,
+		Branch: "feature/other",
+	})
+
+	_, _, matchCount := findSessionForCWDBranch(cwd, "main")
+	if matchCount != 0 {
+		t.Errorf("expected matchCount 0, got %d", matchCount)
+	}
+}
+
+func TestFindSessionForCWDBranch_MultipleMatches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := "/tmp/myrepo"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+	port, _ := strconv.Atoi(ts.URL[strings.LastIndex(ts.URL, ":")+1:])
+
+	// Two sessions on same branch (different file args)
+	writeSessionFile("session1aaaa", sessionEntry{
+		PID:    os.Getpid(),
+		Port:   port,
+		CWD:    cwd,
+		Args:   []string{"README.md"},
+		Branch: "main",
+	})
+	writeSessionFile("session2bbbb", sessionEntry{
+		PID:    os.Getpid(),
+		Port:   port,
+		CWD:    cwd,
+		Branch: "main",
+	})
+
+	// Should return matchCount > 1 when ambiguous
+	_, _, matchCount := findSessionForCWDBranch(cwd, "main")
+	if matchCount != 2 {
+		t.Errorf("expected matchCount 2 for ambiguous case, got %d", matchCount)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1519,8 +1519,41 @@ func runStop(args []string) {
 	if IsGitRepo() {
 		branch = CurrentBranch()
 	}
-	key := sessionKey(cwd, branch, fileArgs)
-	if err := stopDaemon(key); err != nil {
+
+	// If file args were given, use the exact key (user knows which session).
+	if len(fileArgs) > 0 {
+		key := sessionKey(cwd, branch, fileArgs)
+		if err := stopDaemon(key); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Daemon stopped.")
+		return
+	}
+
+	// No file args: try exact key first (git-mode session with no args).
+	key := sessionKey(cwd, branch, nil)
+	if entry, _ := readSessionFile(key); entry.PID > 0 {
+		if err := stopDaemon(key); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Daemon stopped.")
+		return
+	}
+
+	// Exact key not found — fall back to scanning by cwd + branch.
+	_, foundKey, matchCount := findSessionForCWDBranch(cwd, branch)
+	if matchCount > 1 {
+		fmt.Fprintf(os.Stderr, "Error: multiple daemons running on branch %q. Use 'crit stop --all' or specify file args.\n", branch)
+		os.Exit(1)
+	}
+	if matchCount == 0 {
+		fmt.Fprintln(os.Stderr, "Error: no running daemon found for current directory and branch.")
+		os.Exit(1)
+	}
+
+	if err := stopDaemon(foundKey); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- **Bug:** `crit stop` (no args) couldn't find sessions started with file args (e.g., `crit README.md`) because the session key includes file args — `sessionKey(cwd, branch, [])` ≠ `sessionKey(cwd, branch, ["README.md"])`
- **Fix:** When no file args are given, `crit stop` now tries the exact key first (backwards-compatible), then falls back to scanning all sessions by cwd+branch — the same approach `crit status` already uses
- **New helper:** `findSessionForCWDBranch()` in `daemon.go` returns session, key, and match count so `runStop` can distinguish 0/1/2+ matches and provide clear error messages

## Test plan

- [x] `go test ./...` — all pass
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] 3 new unit tests for `findSessionForCWDBranch` (single match, no match, ambiguous)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)