### PR TITLE
fix: plan-hook waits for daemon readiness before review-cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,12 @@ When the agent runs `crit` (or calls `POST /api/round-complete`):
 5. **`crit stop`**: kills the daemon for current cwd (no args). `crit stop --all` kills all daemons for current cwd
 6. **Idle timeout**: daemon exits after 1 hour of no HTTP activity
 
+### Deferred Initialization & Readiness
+
+The daemon signals readiness (via the OS pipe) as soon as the HTTP port is bound, but session initialization (git operations, file reads) continues in the background. Until `SetSession()` is called, most endpoints return **503 Service Unavailable**.
+
+**Any client code that connects to a daemon must poll `/api/session` until it stops returning 503 before calling other endpoints.** See `runReviewClient` and `runReviewClientRaw` for the canonical readiness loop pattern. Skipping this poll causes race conditions where endpoints return 503, and error-fallback paths may silently allow/approve when they shouldn't.
+
 ### Session Registry
 
 Daemon state lives in `~/.crit/sessions/` with one file per session, keyed by `sha256(cwd + "\0" + branch + "\0" + sorted(args))[:12]`:

--- a/main.go
+++ b/main.go
@@ -1342,6 +1342,28 @@ func runPlanHook() {
 // without writing to stdout — used by runPlanHook to construct hookSpecificOutput.
 func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 	client := &http.Client{Timeout: 24 * time.Hour}
+
+	// Wait for the server to finish initializing before calling review-cycle.
+	// The daemon signals readiness as soon as the port is bound, but session
+	// creation (git operations) may still be in progress.
+	initDeadline := time.Now().Add(5 * time.Minute)
+	for {
+		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/session", entry.Port))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "crit plan-hook: could not reach daemon: %v\n", err)
+			return true, ""
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			break
+		}
+		if time.Now().After(initDeadline) {
+			fmt.Fprintf(os.Stderr, "crit plan-hook: daemon did not become ready within 5 minutes\n")
+			return true, ""
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	resp, err := client.Post(
 		fmt.Sprintf("http://localhost:%d/api/review-cycle", entry.Port),
 		"application/json",

--- a/main_test.go
+++ b/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -904,5 +907,108 @@ func TestCleanupOnApproval_KeepsFileWhenDisabled(t *testing.T) {
 
 	if _, err := os.Stat(reviewPath); os.IsNotExist(err) {
 		t.Error("expected review file to still exist when cleanup is disabled")
+	}
+}
+
+// TestRunReviewClientRaw_WaitsForReadiness verifies that runReviewClientRaw
+// polls /api/session until the daemon is ready (non-503) before hitting
+// /api/review-cycle. Regression test for the plan-hook auto-approve bug where
+// review-cycle was called immediately after daemon start, got 503, and
+// allowed through on error.
+func TestRunReviewClientRaw_WaitsForReadiness(t *testing.T) {
+	var sessionCalls atomic.Int32
+	var reviewCycleCalled atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/session":
+			n := sessionCalls.Add(1)
+			if n <= 2 {
+				// First two calls return 503 (still initializing)
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(map[string]string{"status": "loading"})
+				return
+			}
+			// Third call: ready
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		case "/api/review-cycle":
+			reviewCycleCalled.Store(true)
+			// Verify session was polled past the 503 phase
+			if sessionCalls.Load() < 3 {
+				t.Errorf("review-cycle called after only %d session polls, expected >=3", sessionCalls.Load())
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"approved": true, "prompt": ""})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	// Extract port from test server URL
+	port := 0
+	fmt.Sscanf(ts.URL, "http://127.0.0.1:%d", &port)
+	if port == 0 {
+		fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
+	}
+	if port == 0 {
+		t.Fatalf("could not parse port from test server URL: %s", ts.URL)
+	}
+
+	entry := sessionEntry{Port: port}
+	approved, _ := runReviewClientRaw(entry)
+
+	if !reviewCycleCalled.Load() {
+		t.Error("review-cycle was never called")
+	}
+	if !approved {
+		t.Error("expected approved=true")
+	}
+	if n := sessionCalls.Load(); n < 3 {
+		t.Errorf("expected at least 3 session polls (2x503 + 1x200), got %d", n)
+	}
+}
+
+// TestRunReviewClientRaw_NoReadinessDelay verifies that when the daemon is
+// already ready, runReviewClientRaw proceeds immediately without extra delay.
+func TestRunReviewClientRaw_NoReadinessDelay(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/session":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/api/review-cycle":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"approved": false, "prompt": "fix this"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	port := 0
+	fmt.Sscanf(ts.URL, "http://127.0.0.1:%d", &port)
+	if port == 0 {
+		fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
+	}
+	if port == 0 {
+		t.Fatalf("could not parse port from test server URL: %s", ts.URL)
+	}
+
+	start := time.Now()
+	approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+	elapsed := time.Since(start)
+
+	if approved {
+		t.Error("expected approved=false")
+	}
+	if prompt != "fix this" {
+		t.Errorf("expected prompt='fix this', got %q", prompt)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("took %v, expected near-instant when daemon is already ready", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

- `runReviewClientRaw` (plan-hook path) was missing the `/api/session` readiness poll that `runReviewClient` (normal CLI path) already has. After deferred init (#240), the daemon returns 503 while session creation is in progress — the immediate `/api/review-cycle` call hit this 503, and the error fallback silently auto-approved plans.
- Added the same readiness loop, two regression tests, and a "Deferred Initialization & Readiness" section to AGENTS.md documenting the invariant for future daemon client code.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] Manual test: plan hook now waits for daemon, opens browser, blocks for review
- [x] `TestRunReviewClientRaw_WaitsForReadiness` — mock server returns 503 twice then 200; verifies poll retries before calling review-cycle
- [x] `TestRunReviewClientRaw_NoReadinessDelay` — verifies no delay when daemon is already ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)