### PR TITLE
refactor: pre-release audit — Go backend cleanup

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -61,7 +62,7 @@ func parseAuthLoginFlags(args []string) authLoginFlags {
 func runAuthLogin(args []string) {
 	flags := parseAuthLoginFlags(args)
 	cfg := loadShareConfig()
-	serverURL := resolveShareURL("", cfg)
+	serverURL := resolveShareURL("", cfg, defaultShareURL)
 	existingToken := resolveAuthToken(cfg)
 
 	if existingToken != "" && !flags.force {
@@ -319,7 +320,7 @@ func runAuthLogout(args []string) {
 		return
 	}
 
-	serverURL := resolveShareURL("", cfg)
+	serverURL := resolveShareURL("", cfg, defaultShareURL)
 	revoked := revokeToken(serverURL, token)
 
 	if err := removeAuthToken(); err != nil {
@@ -370,7 +371,7 @@ func runAuthWhoami(args []string) {
 		return
 	}
 
-	serverURL := resolveShareURL("", cfg)
+	serverURL := resolveShareURL("", cfg, defaultShareURL)
 	name, email, err := fetchWhoami(serverURL, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  Token is invalid or revoked. Run 'crit auth login' to re-authenticate.\n")
@@ -421,7 +422,7 @@ func fetchWhoami(serverURL string, token string) (string, string, error) {
 
 // errHintAlreadyShown is a sentinel error used by showLoginHint to skip
 // the write when the hint was already shown.
-var errHintAlreadyShown = fmt.Errorf("login hint already shown")
+var errHintAlreadyShown = errors.New("login hint already shown")
 
 // showLoginHint prints a one-time hint about crit auth login after anonymous shares.
 // Uses saveGlobalConfig for both read and write to avoid TOCTOU races.
@@ -434,7 +435,7 @@ func showLoginHint() {
 		m["login_hint_shown"] = json.RawMessage("true")
 		return nil
 	})
-	if err != nil && err != errHintAlreadyShown {
+	if err != nil && !errors.Is(err, errHintAlreadyShown) {
 		// Silently ignore config errors — this is a best-effort hint.
 		_ = err
 	}

--- a/github.go
+++ b/github.go
@@ -227,7 +227,7 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment) in
 			continue
 		}
 		comments[ci].Replies = append(comments[ci].Replies, Reply{
-			ID:        newReplyID(),
+			ID:        randomReplyID(),
 			Body:      r.Body,
 			Author:    r.User.Login,
 			CreatedAt: r.CreatedAt,
@@ -275,7 +275,7 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 	if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
 		for _, r := range childReplies {
 			comment.Replies = append(comment.Replies, Reply{
-				ID:        newReplyID(),
+				ID:        randomReplyID(),
 				Body:      r.Body,
 				Author:    r.User.Login,
 				CreatedAt: r.CreatedAt,
@@ -773,7 +773,7 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 	for i, c := range cj.ReviewComments {
 		if c.ID == commentID {
 			reply := Reply{
-				ID:        newReplyID(),
+				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
 				CreatedAt: now,
@@ -800,7 +800,7 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 				if !found {
 					found = true
 					reply := Reply{
-						ID:        newReplyID(),
+						ID:        randomReplyID(),
 						Body:      body,
 						Author:    author,
 						CreatedAt: now,

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func runShare(args []string) {
 	}
 
 	cfg := loadShareConfig()
-	sf.svcURL = resolveShareURL(sf.svcURL, cfg)
+	sf.svcURL = resolveShareURL(sf.svcURL, cfg, defaultShareURL)
 	authToken := resolveAuthToken(cfg)
 
 	files := loadShareFiles(sf.files)
@@ -407,7 +407,7 @@ func runUnpublish(args []string) {
 	}
 
 	unpubCfg := loadShareConfig()
-	unpubSvcURL = resolveShareURL(unpubSvcURL, unpubCfg)
+	unpubSvcURL = resolveShareURL(unpubSvcURL, unpubCfg, defaultShareURL)
 	unpubAuthToken := resolveAuthToken(unpubCfg)
 
 	critPath, err := resolveReviewPath(unpubOutputDir)
@@ -436,12 +436,7 @@ func runUnpublish(args []string) {
 	}
 
 	// Clear share state from the review file
-	cj.ShareURL = ""
-	cj.DeleteToken = ""
-	cj.ShareScope = ""
-	cj.LastShareHash = ""
-	cj.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := saveCritJSON(critPath, cj); err != nil {
+	if err := clearShareState(critPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not clear share state: %v\n", err)
 	}
 
@@ -1338,30 +1333,38 @@ func runPlanHook() {
 	emitHookDecision(approved, prompt)
 }
 
+// waitForDaemonReady polls the daemon's /api/session endpoint until it stops
+// returning 503 Service Unavailable (session not yet initialized). Returns the
+// last response status code and body, or an error if the daemon is unreachable
+// or the 5-minute deadline expires.
+func waitForDaemonReady(client *http.Client, port int) (statusCode int, body []byte, err error) {
+	deadline := time.Now().Add(5 * time.Minute)
+	for {
+		resp, reqErr := client.Get(fmt.Sprintf("http://localhost:%d/api/session", port))
+		if reqErr != nil {
+			return 0, nil, fmt.Errorf("could not reach daemon on port %d: %w", port, reqErr)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			return resp.StatusCode, respBody, nil
+		}
+		if time.Now().After(deadline) {
+			return 0, nil, fmt.Errorf("daemon did not become ready within 5 minutes")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
 // runReviewClientRaw is like runReviewClient but returns (approved, prompt)
 // without writing to stdout — used by runPlanHook to construct hookSpecificOutput.
 func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	// The daemon signals readiness as soon as the port is bound, but session
-	// creation (git operations) may still be in progress.
-	initDeadline := time.Now().Add(5 * time.Minute)
-	for {
-		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/session", entry.Port))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "crit plan-hook: could not reach daemon: %v\n", err)
-			return true, ""
-		}
-		resp.Body.Close()
-		if resp.StatusCode != http.StatusServiceUnavailable {
-			break
-		}
-		if time.Now().After(initDeadline) {
-			fmt.Fprintf(os.Stderr, "crit plan-hook: daemon did not become ready within 5 minutes\n")
-			return true, ""
-		}
-		time.Sleep(500 * time.Millisecond)
+	if _, _, err := waitForDaemonReady(client, entry.Port); err != nil {
+		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
+		return true, ""
 	}
 
 	resp, err := client.Post(
@@ -1450,37 +1453,21 @@ func runReviewClient(entry sessionEntry) (approved bool) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	// The daemon signals readiness as soon as the port is bound, but session
-	// creation (git operations) may still be in progress.
-	initDeadline := time.Now().Add(5 * time.Minute)
-	for {
-		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/session", entry.Port))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: could not reach crit daemon on port %d: %v\n", entry.Port, err)
-			os.Exit(1)
+	statusCode, body, err := waitForDaemonReady(client, entry.Port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if statusCode == http.StatusInternalServerError {
+		var status struct {
+			Message string `json:"message"`
 		}
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode == http.StatusServiceUnavailable {
-			if time.Now().After(initDeadline) {
-				fmt.Fprintf(os.Stderr, "Error: server did not finish initializing within 5 minutes\n")
-				os.Exit(1)
-			}
-			time.Sleep(500 * time.Millisecond)
-			continue
+		if json.Unmarshal(body, &status) == nil && status.Message != "" {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", status.Message)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", body)
 		}
-		if resp.StatusCode == http.StatusInternalServerError {
-			var status struct {
-				Message string `json:"message"`
-			}
-			if json.Unmarshal(body, &status) == nil && status.Message != "" {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", status.Message)
-			} else {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", body)
-			}
-			os.Exit(1)
-		}
-		break
+		os.Exit(1)
 	}
 
 	resp, err := client.Post(
@@ -1499,7 +1486,7 @@ func runReviewClient(entry sessionEntry) (approved bool) {
 		os.Exit(1)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading response: %v\n", err)
 		os.Exit(1)
@@ -1679,22 +1666,12 @@ func resolvePort(flagPort, cfgPort int) int {
 	return cfgPort
 }
 
-func resolveShareURLFromEnv(flagURL, cfgURL string) string {
-	if flagURL != "" {
-		return flagURL
-	}
-	if envShare, ok := os.LookupEnv("CRIT_SHARE_URL"); ok {
-		return envShare
-	}
-	return cfgURL
-}
-
 func applyConfigDefaults(sf *serverFlagSet, cfg Config) {
 	sf.port = resolvePort(sf.port, cfg.Port)
 	if !sf.noOpen && cfg.NoOpen {
 		sf.noOpen = true
 	}
-	sf.shareURL = resolveShareURLFromEnv(sf.shareURL, cfg.ShareURL)
+	sf.shareURL = resolveShareURL(sf.shareURL, cfg, "")
 	if !sf.quiet && cfg.Quiet {
 		sf.quiet = true
 	}

--- a/session.go
+++ b/session.go
@@ -668,7 +668,7 @@ func (s *Session) AddReviewCommentReply(commentID, body, author string) (Reply, 
 		if c.ID == commentID {
 			now := time.Now().UTC().Format(time.RFC3339)
 			r := Reply{
-				ID:        newReplyID(),
+				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
 				CreatedAt: now,
@@ -792,11 +792,6 @@ func (s *Session) trackDeletedComment(filePath, id string) {
 	s.deletedCommentIDs[filePath][id] = struct{}{}
 }
 
-// newReplyID generates a random reply ID (e.g. "rp_d7e2a0").
-func newReplyID() string {
-	return randomReplyID()
-}
-
 // RefreshFileContent re-reads all file content from disk.
 func (s *Session) RefreshFileContent() {
 	s.mu.Lock()
@@ -829,7 +824,7 @@ func (s *Session) AddReply(filePath, commentID, body, author string) (Reply, boo
 		if c.ID == commentID {
 			now := time.Now().UTC().Format(time.RFC3339)
 			r := Reply{
-				ID:        newReplyID(),
+				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
 				CreatedAt: now,

--- a/share.go
+++ b/share.go
@@ -11,10 +11,13 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 )
+
+// defaultShareURL is the production crit-web service URL, used as the fallback
+// when no share URL is configured via flag, env, or config.
+const defaultShareURL = "https://crit.md"
 
 // shareScope computes a hash of sorted file paths, used to detect when
 // share state belongs to a different file set.
@@ -195,6 +198,7 @@ func buildShareFromSession(s *Session) ([]shareFile, []shareComment, int) {
 				Body:      c.Body,
 				Quote:     c.Quote,
 				Author:    c.Author,
+				Scope:     c.Scope,
 			}
 			if c.ReviewRound >= 1 {
 				sc.ReviewRound = c.ReviewRound
@@ -527,19 +531,7 @@ func mergeWebComments(critPath string, newComments []webComment) error {
 
 	// Find the highest existing web-N index so new IDs are globally unique
 	// even if earlier ones were deleted from .crit.json.
-	webCount := 0
-	for _, f := range cj.Files {
-		for _, c := range f.Comments {
-			if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && strings.HasPrefix(c.ID, "web-") && n > webCount {
-				webCount = n
-			}
-		}
-	}
-	for _, c := range cj.ReviewComments {
-		if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && strings.HasPrefix(c.ID, "web-") && n > webCount {
-			webCount = n
-		}
-	}
+	webCount := highestWebIndex(cj)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, wc := range newComments {
@@ -603,7 +595,9 @@ func persistShareState(critPath string, shareURL string, deleteToken string, sco
 	return saveCritJSON(critPath, cj)
 }
 
-// clearShareState removes share URL and delete token from the review file.
+// clearShareState removes share URL, delete token, share scope, and last-share
+// hash from the review file. It is the single source of truth for "undo share
+// metadata" — used by both the unpublish CLI path and tests.
 func clearShareState(critPath string) error {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
@@ -616,6 +610,7 @@ func clearShareState(critPath string) error {
 	cj.ShareURL = ""
 	cj.DeleteToken = ""
 	cj.ShareScope = ""
+	cj.LastShareHash = ""
 	cj.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 
 	return saveCritJSON(critPath, cj)
@@ -634,9 +629,12 @@ func loadShareConfig() Config {
 	return LoadConfig(cfgDir)
 }
 
-// resolveShareURL resolves the share service URL from flag > env > config > default.
+// resolveShareURL resolves the share service URL from flag > env > config > fallback.
 // cfg is the already-loaded Config so callers avoid redundant config parsing.
-func resolveShareURL(flagValue string, cfg Config) string {
+// fallback is returned when no other source provides a value (typically
+// "https://crit.md" for share/auth commands, or "" for the serve path where an
+// empty URL means "sharing not configured").
+func resolveShareURL(flagValue string, cfg Config, fallback string) string {
 	if flagValue != "" {
 		return flagValue
 	}
@@ -646,7 +644,7 @@ func resolveShareURL(flagValue string, cfg Config) string {
 	if cfg.ShareURL != "" {
 		return cfg.ShareURL
 	}
-	return "https://crit.md"
+	return fallback
 }
 
 // resolveAuthToken returns the auth token from env > config.

--- a/share_test.go
+++ b/share_test.go
@@ -938,7 +938,7 @@ func TestResolveShareURL(t *testing.T) {
 				t.Setenv("CRIT_SHARE_URL", "")
 				os.Unsetenv("CRIT_SHARE_URL")
 			}
-			got := resolveShareURL(tt.flag, Config{})
+			got := resolveShareURL(tt.flag, Config{}, defaultShareURL)
 			if got != tt.expected {
 				t.Errorf("resolveShareURL(%q) = %q, want %q", tt.flag, got, tt.expected)
 			}


### PR DESCRIPTION
## Summary

Pre-release audit of v0.9.0..HEAD found duplicated logic and dead code accumulated during iterative development.

- Delete `newReplyID()` wrapper, use `randomReplyID()` directly (6 call sites)
- Wire `clearShareState()` into `runUnpublish()`, replacing inline reimplementation
- Replace inline web-N ID scan in `mergeWebComments()` with `highestWebIndex()` call
- Consolidate `resolveShareURL`/`resolveShareURLFromEnv` into single function with `fallback` param
- Change `errHintAlreadyShown` to `errors.New`, use `errors.Is()` for sentinel comparison
- Add missing `Scope` field to `buildShareFromSession`
- Extract `waitForDaemonReady` helper from duplicated readiness-poll loops

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Independent Go expert review confirmed correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)