### PR TITLE
fix: persist share status across session relaunches

### DIFF
--- a/main.go
+++ b/main.go
@@ -1600,6 +1600,7 @@ type serverConfig struct {
 	agentCmd           string
 	planDir            string // managed storage directory for plan mode
 	planName           string // display name for plan content
+	reviewPath         string // centralized review file path (~/.crit/reviews/<key>.json)
 	cfg                Config // full resolved config for the settings panel
 }
 
@@ -1733,13 +1734,26 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 }
 
 func createSession(sc *serverConfig) (*Session, error) {
+	var session *Session
+	var err error
 	if len(sc.files) == 0 {
 		if !IsGitRepo() {
 			return nil, fmt.Errorf("not in a git repository and no files specified")
 		}
-		return NewSessionFromGit(sc.ignorePatterns)
+		session, err = NewSessionFromGit(sc.ignorePatterns)
+	} else {
+		session, err = NewSessionFromFiles(sc.files, sc.ignorePatterns)
 	}
-	return NewSessionFromFiles(sc.files, sc.ignorePatterns)
+	if err != nil {
+		return nil, err
+	}
+	// Set ReviewFilePath before loadCritJSON so it reads from the centralized
+	// review file, not the legacy repo-root .crit.json.
+	if sc.reviewPath != "" {
+		session.ReviewFilePath = sc.reviewPath
+		session.loadCritJSON()
+	}
+	return session, nil
 }
 
 func applySessionOverrides(session *Session, sc *serverConfig) {
@@ -1853,21 +1867,20 @@ func runServe(args []string) {
 	if IsGitRepo() {
 		branch = CurrentBranch()
 	}
-	var reviewPath string
 	if sc.outputDir != "" {
 		abs, _ := filepath.Abs(sc.outputDir)
-		reviewPath = filepath.Join(abs, ".crit.json")
+		sc.reviewPath = filepath.Join(abs, ".crit.json")
 	} else {
-		reviewPath, _ = reviewFilePath(key)
+		sc.reviewPath, _ = reviewFilePath(key)
 	}
-	srv.reviewPath = reviewPath
+	srv.reviewPath = sc.reviewPath
 	if err := writeSessionFile(key, sessionEntry{
 		PID:        os.Getpid(),
 		Port:       addr.Port,
 		CWD:        cwd,
 		Args:       sc.files,
 		Branch:     branch,
-		ReviewPath: reviewPath,
+		ReviewPath: sc.reviewPath,
 		StartedAt:  time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
 		daemonFatal(pipe, "Error writing session file: %v", err)
@@ -1942,11 +1955,6 @@ func runServe(args []string) {
 	}
 	applySessionOverrides(session, sc)
 	session.CLIArgs = sc.files
-
-	// Set centralized review file path
-	if sc.outputDir == "" {
-		session.ReviewFilePath = reviewPath
-	}
 
 	checkStaleIntegrations(sc, srv, cwd)
 

--- a/session.go
+++ b/session.go
@@ -325,7 +325,6 @@ func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 		s.Files = append(s.Files, fe)
 	}
 
-	s.loadCritJSON()
 	return s, nil
 }
 
@@ -448,7 +447,6 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 		s.Files = append(s.Files, fe)
 	}
 
-	s.loadCritJSON()
 	return s, nil
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -3459,3 +3459,211 @@ func TestSession_WriteFiles_IncludesResolvedComments(t *testing.T) {
 		t.Error("resolved state should be persisted to .crit.json")
 	}
 }
+
+func TestLoadCritJSON_RestoresShareState(t *testing.T) {
+	s := newTestSession(t)
+
+	// Compute the share scope for this session's files.
+	paths := make([]string, len(s.Files))
+	for i, f := range s.Files {
+		paths[i] = f.Path
+	}
+	scope := shareScope(paths)
+
+	// Write a review file with share state.
+	reviewPath := filepath.Join(s.RepoRoot, "review.json")
+	cj := CritJSON{
+		Branch:      "main",
+		BaseRef:     "abc123",
+		UpdatedAt:   time.Now().Format(time.RFC3339),
+		ReviewRound: 1,
+		ShareURL:    "https://crit.example.com/review/abc",
+		DeleteToken: "tok_secret123",
+		ShareScope:  scope,
+		Files:       map[string]CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, reviewPath, string(data))
+
+	// Point the session at the review file and load.
+	s.ReviewFilePath = reviewPath
+	s.loadCritJSON()
+
+	if s.sharedURL != "https://crit.example.com/review/abc" {
+		t.Errorf("sharedURL = %q, want %q", s.sharedURL, "https://crit.example.com/review/abc")
+	}
+	if s.deleteToken != "tok_secret123" {
+		t.Errorf("deleteToken = %q, want %q", s.deleteToken, "tok_secret123")
+	}
+	if s.shareScope != scope {
+		t.Errorf("shareScope = %q, want %q", s.shareScope, scope)
+	}
+}
+
+func TestLoadCritJSON_ShareScopeMismatch(t *testing.T) {
+	s := newTestSession(t)
+
+	// Write a review file with a share scope that does not match this session.
+	reviewPath := filepath.Join(s.RepoRoot, "review.json")
+	cj := CritJSON{
+		ShareURL:    "https://crit.example.com/review/old",
+		DeleteToken: "tok_old",
+		ShareScope:  "mismatched_scope_value",
+		Files:       map[string]CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, reviewPath, string(data))
+
+	s.ReviewFilePath = reviewPath
+	s.loadCritJSON()
+
+	// Share state should NOT be loaded because the scope doesn't match.
+	if s.sharedURL != "" {
+		t.Errorf("sharedURL = %q, want empty (scope mismatch)", s.sharedURL)
+	}
+	if s.deleteToken != "" {
+		t.Errorf("deleteToken = %q, want empty (scope mismatch)", s.deleteToken)
+	}
+}
+
+func TestLoadCritJSON_LegacyNoScope(t *testing.T) {
+	s := newTestSession(t)
+
+	// Legacy .crit.json without ShareScope — should load unconditionally.
+	reviewPath := filepath.Join(s.RepoRoot, "review.json")
+	cj := CritJSON{
+		ShareURL:    "https://crit.example.com/review/legacy",
+		DeleteToken: "tok_legacy",
+		Files:       map[string]CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, reviewPath, string(data))
+
+	s.ReviewFilePath = reviewPath
+	s.loadCritJSON()
+
+	if s.sharedURL != "https://crit.example.com/review/legacy" {
+		t.Errorf("sharedURL = %q, want %q", s.sharedURL, "https://crit.example.com/review/legacy")
+	}
+	if s.deleteToken != "tok_legacy" {
+		t.Errorf("deleteToken = %q, want %q", s.deleteToken, "tok_legacy")
+	}
+}
+
+func TestCreateSession_LoadsShareFromReviewPath(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Create a file on a feature branch so git mode detects changes.
+	runGit(t, dir, "checkout", "-b", "feat-share")
+	writeFile(t, filepath.Join(dir, "new.md"), "# New\n\nContent\n")
+	runGit(t, dir, "add", "new.md")
+	runGit(t, dir, "commit", "-m", "add new.md")
+
+	// Prepare a review file with share state.
+	reviewPath := filepath.Join(t.TempDir(), "review.json")
+	scope := shareScope([]string{"new.md"})
+	cj := CritJSON{
+		Branch:      "feat-share",
+		BaseRef:     "abc",
+		UpdatedAt:   time.Now().Format(time.RFC3339),
+		ReviewRound: 2,
+		ShareURL:    "https://crit.example.com/review/shared",
+		DeleteToken: "tok_shared",
+		ShareScope:  scope,
+		Files:       map[string]CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, reviewPath, string(data))
+
+	// Change to the repo dir so git operations work.
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	sc := &serverConfig{
+		reviewPath: reviewPath,
+	}
+	session, err := createSession(sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if session.ReviewFilePath != reviewPath {
+		t.Errorf("ReviewFilePath = %q, want %q", session.ReviewFilePath, reviewPath)
+	}
+	if session.sharedURL != "https://crit.example.com/review/shared" {
+		t.Errorf("sharedURL = %q, want %q", session.sharedURL, "https://crit.example.com/review/shared")
+	}
+	if session.deleteToken != "tok_shared" {
+		t.Errorf("deleteToken = %q, want %q", session.deleteToken, "tok_shared")
+	}
+	if session.ReviewRound != 2 {
+		t.Errorf("ReviewRound = %d, want 2", session.ReviewRound)
+	}
+}
+
+func TestCreateSession_FilesMode_LoadsShareFromReviewPath(t *testing.T) {
+	dir := initTestRepo(t)
+	mdPath := filepath.Join(dir, "doc.md")
+	writeFile(t, mdPath, "# Doc\n\nHello\n")
+
+	// createSession -> NewSessionFromFiles will resolve the path relative to
+	// the git repo root. Compute the expected relative path so we can build
+	// a matching share scope.
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	// NewSessionFromFiles resolves paths relative to repo root ("doc.md").
+	scope := shareScope([]string{"doc.md"})
+
+	// Prepare a review file with share state.
+	reviewPath := filepath.Join(t.TempDir(), "review.json")
+	cj := CritJSON{
+		ShareURL:    "https://crit.example.com/review/files",
+		DeleteToken: "tok_files",
+		ShareScope:  scope,
+		ReviewRound: 3,
+		Files:       map[string]CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, reviewPath, string(data))
+
+	sc := &serverConfig{
+		files:      []string{"doc.md"},
+		reviewPath: reviewPath,
+	}
+	session, err := createSession(sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if session.sharedURL != "https://crit.example.com/review/files" {
+		t.Errorf("sharedURL = %q, want %q", session.sharedURL, "https://crit.example.com/review/files")
+	}
+	if session.deleteToken != "tok_files" {
+		t.Errorf("deleteToken = %q, want %q", session.deleteToken, "tok_files")
+	}
+	if session.ReviewRound != 3 {
+		t.Errorf("ReviewRound = %d, want 3", session.ReviewRound)
+	}
+}


### PR DESCRIPTION
## Summary

- `ReviewFilePath` was set after `createSession()` returned, but `loadCritJSON()` ran inside the session constructors — so share state (URL, delete token) was never loaded from `~/.crit/reviews/<key>.json`
- Pass `reviewPath` through `serverConfig` into `createSession()`, set `ReviewFilePath` before calling `loadCritJSON()`
- Remove now-redundant `loadCritJSON()` calls from `NewSessionFromGit` and `NewSessionFromFiles` constructors

## Test plan

- [x] Added `TestLoadCritJSON_RestoresShareState` — verifies share URL/token loaded when scope matches
- [x] Added `TestLoadCritJSON_ShareScopeMismatch` — verifies share state rejected on scope mismatch
- [x] Added `TestLoadCritJSON_LegacyNoScope` — verifies legacy files without scope still load
- [x] Added `TestCreateSession_LoadsShareFromReviewPath` — end-to-end git mode via `createSession`
- [x] Added `TestCreateSession_FilesMode_LoadsShareFromReviewPath` — end-to-end files mode via `createSession`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)