### PR TITLE
fix: settings panel polish — copy snippets, agent cmd layout

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6852,8 +6852,9 @@
       html += '<div class="config-card config-card--green"><div class="config-card-header">';
       html += '<span class="config-card-icon" style="color:var(--green)">&#10003;</span>';
       html += '<span class="config-card-title">Agent Command</span>';
-      html += '<span class="config-card-value"><code>' + escapeHtml(cfg.agent_cmd || cfg.agent_name || '') + '</code></span>';
-      html += '</div></div>';
+      html += '</div>';
+      html += '<div class="config-card-cmd-value"><code>' + escapeHtml(cfg.agent_cmd || cfg.agent_name || '') + '</code></div>';
+      html += '</div>';
     } else {
       html += '<div class="config-card config-card--orange config-card--unconfigured"><div class="config-card-header">';
       html += '<span class="config-card-icon" style="color:var(--yellow)">&#9675;</span>';
@@ -6879,8 +6880,19 @@
           html += '<span class="config-card-title">AI Integration</span>';
           html += '<span class="config-card-value">' + escapeHtml(name) + ' (update available)</span>';
           html += '</div>';
-          const hintCmd = si.hint.replace(/^Run:\s*/, '');
-          html += '<div class="config-card-cmd"><span>$ ' + escapeHtml(hintCmd) + '</span><button class="config-card-copy" data-copy="' + escapeHtml(hintCmd) + '">Copy</button></div>';
+          const hintLines = si.hint.split('\n').map(function(l) { return l.trim(); }).filter(Boolean);
+          hintLines.forEach(function(line) {
+            const parts = line.split('|');
+            let label = '';
+            let cmd = line.replace(/^Run:\s*/i, '');
+            if (parts.length === 2) {
+              label = parts[0];
+              cmd = parts[1];
+            }
+            html += '<div class="config-card-cmd">';
+            if (label) html += '<span class="config-card-cmd-label">' + escapeHtml(label) + '</span>';
+            html += '<span>$ ' + escapeHtml(cmd) + '</span><button class="config-card-copy" data-copy="' + escapeHtml(cmd) + '">Copy</button></div>';
+          });
           html += '</div>';
         } else if (current.length > 0) {
           const name = current[0].agent.replace(/\b\w/g, function(c) { return c.toUpperCase(); }).replace(/-/g, ' ');
@@ -6910,7 +6922,7 @@
       try { hostname = new URL(cfg.share_url).hostname; } catch (_) { hostname = cfg.share_url; }
       html += '<div class="config-card config-card--green"><div class="config-card-header">';
       html += '<span class="config-card-icon" style="color:var(--green)">&#10003;</span>';
-      html += '<span class="config-card-title">Share</span>';
+      html += '<span class="config-card-title">Sharing enabled</span>';
       html += '<span class="config-card-value">' + escapeHtml(hostname) + '</span>';
       html += '</div></div>';
     } else {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2050,6 +2050,19 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   font-family: var(--font-mono);
   font-size: 13px;
 }
+.config-card-cmd-value {
+  margin-top: 8px;
+  background: var(--bg-primary);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg-secondary);
+  word-break: break-all;
+}
+.config-card-cmd-value code {
+  font-family: inherit;
+}
 .config-card-badge {
   font-size: 12px;
   color: var(--accent);
@@ -2071,11 +2084,18 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   padding: 8px 12px;
   font-family: var(--font-mono);
   font-size: 13px;
-  color: var(--green);
+  color: var(--fg-primary);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+}
+.config-card-cmd-label {
+  color: var(--fg-muted);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  margin-right: 8px;
+  flex-shrink: 0;
 }
 .config-card-copy {
   font-size: 12px;

--- a/integrations.go
+++ b/integrations.go
@@ -60,7 +60,7 @@ func toolDirFromDest(dest string) string {
 
 // marketplaceUpdateHint returns tool-specific advice for updating a marketplace plugin.
 var marketplaceUpdateHints = map[string]string{
-	".claude": "In Claude Code: /plugin marketplace update crit\n    Then run: claude plugin update crit@crit",
+	".claude": "In Claude Code|/plugin marketplace update crit\nIn terminal|claude plugin update crit@crit",
 	".cursor": "Update the crit plugin in Cursor settings",
 }
 
@@ -238,7 +238,7 @@ func printStaleWarnings(stale []staleFile) int {
 			continue
 		}
 		seen[k] = true
-		fmt.Fprintf(os.Stderr, "Note: %s integration outdated (%s). %s\n", s.agent, s.dest, s.updateHint())
+		fmt.Fprintf(os.Stderr, "Note: %s integration outdated (%s). %s\n", s.agent, s.dest, strings.ReplaceAll(s.updateHint(), "|", ": "))
 	}
 	return len(seen)
 }
@@ -274,6 +274,8 @@ func runCheck() {
 		}
 		seenHints[hint] = true
 		fmt.Fprintf(os.Stderr, "  outdated: %s\n", s.dest)
-		fmt.Fprintf(os.Stderr, "    → %s\n\n", hint)
+		// Replace label|cmd separators with ": " for terminal display
+		termHint := strings.ReplaceAll(hint, "|", ": ")
+		fmt.Fprintf(os.Stderr, "    → %s\n\n", termHint)
 	}
 }


### PR DESCRIPTION
## Summary

- Split multi-line integration update hints into separate, independently copyable command blocks with labels ("In Claude Code", "In terminal")
- Move agent command value to its own styled block below the header so long commands don't wrap awkwardly
- Change command snippet text color from green to fg-primary for better readability
- Rename "Share" card title to "Sharing enabled"

## Test plan

- [ ] Open settings panel with a stale integration — verify two separate Copy buttons
- [ ] Set a long `agent_cmd` — verify it renders in its own block below "Agent Command"
- [ ] Verify command snippets are no longer green
- [ ] Verify share card says "Sharing enabled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)