### PR TITLE
refactor: remove dead code and consolidate duplicated helpers

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -436,7 +436,6 @@ func showLoginHint() {
 		return nil
 	})
 	if err != nil && !errors.Is(err, errHintAlreadyShown) {
-		// Silently ignore config errors — this is a best-effort hint.
-		_ = err
+		// best-effort; ignore error
 	}
 }

--- a/auth.go
+++ b/auth.go
@@ -435,7 +435,5 @@ func showLoginHint() {
 		m["login_hint_shown"] = json.RawMessage("true")
 		return nil
 	})
-	if err != nil && !errors.Is(err, errHintAlreadyShown) {
-		// best-effort; ignore error
-	}
+	_ = err // best-effort hint; non-hint errors are also harmless
 }

--- a/github.go
+++ b/github.go
@@ -427,41 +427,6 @@ func findLegacyReviewPath(cwd string) (string, bool) {
 	return "", false
 }
 
-// resolveCritDir returns the directory where .crit.json should be read/written.
-// If outputDir is non-empty it is used directly. Otherwise falls back to repo root then CWD.
-// Deprecated: use resolveReviewPath for centralized storage support.
-func resolveCritDir(outputDir string) (string, error) {
-	if outputDir != "" {
-		abs, err := filepath.Abs(outputDir)
-		if err != nil {
-			return "", fmt.Errorf("resolving output directory: %w", err)
-		}
-		return abs, nil
-	}
-	// When crit is launched as "crit file.md" outside a git repo, .crit.json
-	// is written to filepath.Dir(file.md). Inside a git repo, it goes to the
-	// repo root. Mirror the session's logic so crit comment finds the right
-	// .crit.json without needing --output.
-	if cwd, err := resolvedCWD(); err == nil {
-		if sessions, _ := listSessionsForCWD(cwd); len(sessions) == 1 && len(sessions[0].Args) > 0 {
-			// In a git repo, .crit.json lives at the repo root, not next
-			// to the file. Only use the file-relative path outside git.
-			if root, err := RepoRoot(); err == nil {
-				return root, nil
-			}
-			return filepath.Dir(filepath.Join(sessions[0].CWD, sessions[0].Args[0])), nil
-		}
-	}
-	root, err := RepoRoot()
-	if err != nil {
-		root, err = os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("getting working directory: %w", err)
-		}
-	}
-	return root, nil
-}
-
 // writeCritJSON resolves the review path and writes a CritJSON via saveCritJSON.
 func writeCritJSON(cj CritJSON, outputDir string) error {
 	path, err := resolveReviewPath(outputDir)

--- a/github_test.go
+++ b/github_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -974,102 +972,6 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 	}
 }
 
-// TestResolveCritDir_FileArgsInGitRepo verifies that resolveCritDir returns the
-// git repo root (not the file's parent directory) when a session has file args
-// inside a git repo. This was a real bug: "crit docs/plans/file.md" would write
-// .crit.json to the repo root, but "crit comment --reply-to c1" looked in
-// docs/plans/ and couldn't find the comments.
-func TestResolveCritDir_FileArgsInGitRepo(t *testing.T) {
-	dir := initTestRepo(t)
-	t.Chdir(dir)
-
-	// Create a file in a subdirectory (like "crit docs/plans/file.md")
-	subdir := filepath.Join(dir, "docs", "plans")
-	if err := os.MkdirAll(subdir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	writeFile(t, filepath.Join(subdir, "plan.md"), "# Plan")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add plan")
-
-	// Write .crit.json at repo root with a file comment
-	cj := CritJSON{
-		Branch:      "main",
-		ReviewRound: 1,
-		Files: map[string]CritJSONFile{
-			"docs/plans/plan.md": {
-				Status:   "modified",
-				Comments: []Comment{{ID: "c1", StartLine: 1, EndLine: 1, Body: "Fix this"}},
-			},
-		},
-	}
-	data, err := json.MarshalIndent(cj, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Start a health endpoint so isDaemonAlive returns true
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
-	})
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv := &http.Server{Handler: mux}
-	go srv.Serve(ln)
-	t.Cleanup(func() { srv.Close() })
-	port := ln.Addr().(*net.TCPAddr).Port
-
-	// Register a session with file args pointing to the subdirectory file
-	resolved, _ := filepath.EvalSymlinks(dir)
-	key := sessionKey(resolved, "", []string{"docs/plans/plan.md"})
-	err = writeSessionFile(key, sessionEntry{
-		PID:       os.Getpid(),
-		Port:      port,
-		CWD:       resolved,
-		Args:      []string{"docs/plans/plan.md"},
-		StartedAt: "2025-01-01T00:00:00Z",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { removeSessionFile(key) })
-
-	// resolveCritDir should return repo root, not docs/plans/
-	got, err := resolveCritDir("")
-	if err != nil {
-		t.Fatalf("resolveCritDir failed: %v", err)
-	}
-	if got != resolved {
-		t.Errorf("resolveCritDir() = %q, want repo root %q", got, resolved)
-	}
-
-	// End-to-end: replying to c1 should succeed (finds .crit.json at repo root)
-	err = addReplyToCritJSON("c1", "Fixed it", "agent", false, "", "")
-	if err != nil {
-		t.Fatalf("addReplyToCritJSON failed: %v (would have looked in wrong dir before fix)", err)
-	}
-
-	// Verify reply was written
-	data, err = os.ReadFile(filepath.Join(dir, ".crit.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var result CritJSON
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatal(err)
-	}
-	replies := result.Files["docs/plans/plan.md"].Comments[0].Replies
-	if len(replies) != 1 || replies[0].Body != "Fixed it" {
-		t.Errorf("expected reply 'Fixed it', got %+v", replies)
-	}
-}
 
 func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
 	cj := CritJSON{

--- a/github_test.go
+++ b/github_test.go
@@ -972,7 +972,6 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 	}
 }
 
-
 func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
 	cj := CritJSON{
 		Files: map[string]CritJSONFile{

--- a/main.go
+++ b/main.go
@@ -281,29 +281,6 @@ func printFetchedComments(webComments []webComment) {
 	}
 }
 
-// highestWebIndex returns the highest numeric suffix among "web-N" comment IDs
-// in a CritJSON structure. This ensures new web comment IDs are globally unique.
-func highestWebIndex(cj CritJSON) int {
-	max := 0
-	for _, f := range cj.Files {
-		for _, c := range f.Comments {
-			if strings.HasPrefix(c.ID, "web-") {
-				if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && n > max {
-					max = n
-				}
-			}
-		}
-	}
-	for _, c := range cj.ReviewComments {
-		if strings.HasPrefix(c.ID, "web-") {
-			if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && n > max {
-				max = n
-			}
-		}
-	}
-	return max
-}
-
 func runFetch(args []string) {
 	outputDir := parseFetchOutputDir(args)
 
@@ -343,36 +320,7 @@ func runFetch(args []string) {
 		return
 	}
 
-	// Merge web comments into the review file
-	if cj.Files == nil {
-		cj.Files = make(map[string]CritJSONFile)
-	}
-	webCount := highestWebIndex(cj)
-	now := time.Now().UTC().Format(time.RFC3339)
-	for _, wc := range webComments {
-		webCount++
-		c := Comment{
-			ID:          fmt.Sprintf("web-%d", webCount),
-			StartLine:   wc.StartLine,
-			EndLine:     wc.EndLine,
-			Body:        wc.Body,
-			Quote:       wc.Quote,
-			Author:      wc.AuthorDisplayName,
-			Scope:       wc.Scope,
-			ReviewRound: wc.ReviewRound,
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		}
-		if wc.Scope == "review" {
-			cj.ReviewComments = append(cj.ReviewComments, c)
-		} else {
-			entry := cj.Files[wc.FilePath]
-			entry.Comments = append(entry.Comments, c)
-			cj.Files[wc.FilePath] = entry
-		}
-	}
-	cj.UpdatedAt = now
-	if err := saveCritJSON(critPath, cj); err != nil {
+	if err := mergeWebComments(critPath, webComments); err != nil {
 		fmt.Fprintf(os.Stderr, "Error saving review file: %v\n", err)
 		os.Exit(1)
 	}

--- a/session.go
+++ b/session.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -20,9 +19,11 @@ import (
 // when the user expands them in the UI. Only applies when >threshold files.
 const lazyFileThreshold = 100
 
-// fileHash returns a stable hash string for file content.
+// fileHash returns a stable, prefixed hash string for file content tracking.
+// It delegates to computeFileHash and adds a "sha256:" prefix to distinguish
+// the hash algorithm used.
 func fileHash(data []byte) string {
-	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	return "sha256:" + computeFileHash(data)
 }
 
 // randomID generates a random ID with the given prefix using crypto/rand.

--- a/share.go
+++ b/share.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -512,6 +513,29 @@ func buildLocalIDSet(cj CritJSON) map[string]bool {
 		}
 	}
 	return ids
+}
+
+// highestWebIndex returns the highest numeric suffix among "web-N" comment IDs
+// in a CritJSON structure. This ensures new web comment IDs are globally unique.
+func highestWebIndex(cj CritJSON) int {
+	max := 0
+	for _, f := range cj.Files {
+		for _, c := range f.Comments {
+			if strings.HasPrefix(c.ID, "web-") {
+				if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && n > max {
+					max = n
+				}
+			}
+		}
+	}
+	for _, c := range cj.ReviewComments {
+		if strings.HasPrefix(c.ID, "web-") {
+			if n, err := strconv.Atoi(strings.TrimPrefix(c.ID, "web-")); err == nil && n > max {
+				max = n
+			}
+		}
+	}
+	return max
 }
 
 // mergeWebComments adds web-reviewer comments into the review file under their respective


### PR DESCRIPTION
## Summary
- Delete deprecated `resolveCritDir` and its test (dead code since `resolveReviewPath` replaced it)
- Replace `_ = err` no-op with clear comment in `auth.go`
- Make `fileHash` delegate to `computeFileHash` instead of duplicating SHA256 logic
- Replace inline web-comment merge in `runFetch` with `mergeWebComments` call
- Move `highestWebIndex` to `share.go` near its only consumer

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)