### PR TITLE
fix: prevent agents from proactively resolving comments

### DIFF
--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -70,7 +70,7 @@ crit comment --reply-to c_a1b2c3 --author 'Claude Code' 'Fixed by extracting to 
 crit comment --reply-to r_f1e2d3 --author 'Claude Code' 'All issues addressed'
 ```
 
-This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Resolving is a user action — do not mark comments resolved from AI.
+This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Only use `--resolve` when the user explicitly asks you to resolve a comment — never resolve proactively.
 
 **Multi-file disambiguation**: Comment IDs are unique per session, but if you encounter an error like "comment found in multiple files", use `--path` to specify which file:
 
@@ -113,9 +113,8 @@ crit comment --author 'Claude Code' <path>:<line> '<body>'
 # Line comment (range)
 crit comment --author 'Claude Code' <path>:<start>-<end> '<body>'
 
-# Reply to an existing comment (with optional --resolve)
+# Reply to an existing comment
 crit comment --reply-to <id> --author 'Claude Code' '<body>'
-crit comment --reply-to <id> --resolve --author 'Claude Code' '<body>'
 ```
 
 Examples:
@@ -165,7 +164,7 @@ JSON schema per entry:
 | `author` | string | no | Per-entry override (falls back to `--author`) |
 | `scope` | string | no | `"review"`, `"file"`, or omit to infer from context |
 | `reply_to` | string | yes (reply) | Comment ID (e.g. `"c_a1b2c3"` or `"r_f1e2d3"`) |
-| `resolve` | bool | no | Mark the parent comment resolved (user action — don't set from AI) |
+| `resolve` | bool | no | Only set when user explicitly asks to resolve — never resolve proactively |
 
 Scope inference when `scope` is omitted:
 - Has `reply_to` → reply

--- a/integrations/codex/skills/crit-cli/SKILL.md
+++ b/integrations/codex/skills/crit-cli/SKILL.md
@@ -70,7 +70,7 @@ crit comment --reply-to c_a1b2c3 --author 'Codex' 'Fixed by extracting to helper
 crit comment --reply-to r_f1e2d3 --author 'Codex' 'All issues addressed'
 ```
 
-This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Resolving is a user action — do not mark comments resolved from AI.
+This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Only use `--resolve` when the user explicitly asks you to resolve a comment — never resolve proactively.
 
 **Multi-file disambiguation**: Comment IDs are unique per session, but if you encounter an error like "comment found in multiple files", use `--path` to specify which file:
 
@@ -112,9 +112,8 @@ crit comment --author 'Codex' <path>:<line> '<body>'
 # Line comment (range)
 crit comment --author 'Codex' <path>:<start>-<end> '<body>'
 
-# Reply to an existing comment (with optional --resolve)
+# Reply to an existing comment
 crit comment --reply-to <id> --author 'Codex' '<body>'
-crit comment --reply-to <id> --resolve --author 'Codex' '<body>'
 ```
 
 Examples:
@@ -164,7 +163,7 @@ JSON schema per entry:
 | `author` | string | no | Per-entry override (falls back to `--author`) |
 | `scope` | string | no | `"review"`, `"file"`, or omit to infer from context |
 | `reply_to` | string | yes (reply) | Comment ID (e.g. `"c_a1b2c3"` or `"r_f1e2d3"`) |
-| `resolve` | bool | no | Mark the parent comment resolved (user action — don't set from AI) |
+| `resolve` | bool | no | Only set when user explicitly asks to resolve — never resolve proactively |
 
 Scope inference when `scope` is omitted:
 - Has `reply_to` → reply

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -70,7 +70,7 @@ crit comment --reply-to c_a1b2c3 --author 'Cursor' 'Fixed by extracting to helpe
 crit comment --reply-to r_f1e2d3 --author 'Cursor' 'All issues addressed'
 ```
 
-This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Resolving is a user action — do not mark comments resolved from AI.
+This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Only use `--resolve` when the user explicitly asks you to resolve a comment — never resolve proactively.
 
 **Multi-file disambiguation**: Comment IDs are unique per session, but if you encounter an error like "comment found in multiple files", use `--path` to specify which file:
 
@@ -112,9 +112,8 @@ crit comment --author 'Cursor' <path>:<line> '<body>'
 # Line comment (range)
 crit comment --author 'Cursor' <path>:<start>-<end> '<body>'
 
-# Reply to an existing comment (with optional --resolve)
+# Reply to an existing comment
 crit comment --reply-to <id> --author 'Cursor' '<body>'
-crit comment --reply-to <id> --resolve --author 'Cursor' '<body>'
 ```
 
 Examples:
@@ -164,7 +163,7 @@ JSON schema per entry:
 | `author` | string | no | Per-entry override (falls back to `--author`) |
 | `scope` | string | no | `"review"`, `"file"`, or omit to infer from context |
 | `reply_to` | string | yes (reply) | Comment ID (e.g. `"c_a1b2c3"` or `"r_f1e2d3"`) |
-| `resolve` | bool | no | Mark the parent comment resolved (user action — don't set from AI) |
+| `resolve` | bool | no | Only set when user explicitly asks to resolve — never resolve proactively |
 
 Scope inference when `scope` is omitted:
 - Has `reply_to` → reply

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -70,7 +70,7 @@ crit comment --reply-to c_a1b2c3 --author 'Copilot' 'Fixed by extracting to help
 crit comment --reply-to r_f1e2d3 --author 'Copilot' 'All issues addressed'
 ```
 
-This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Resolving is a user action — do not mark comments resolved from AI.
+This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Only use `--resolve` when the user explicitly asks you to resolve a comment — never resolve proactively.
 
 **Multi-file disambiguation**: Comment IDs are unique per session, but if you encounter an error like "comment found in multiple files", use `--path` to specify which file:
 
@@ -112,9 +112,8 @@ crit comment --author 'Copilot' <path>:<line> '<body>'
 # Line comment (range)
 crit comment --author 'Copilot' <path>:<start>-<end> '<body>'
 
-# Reply to an existing comment (with optional --resolve)
+# Reply to an existing comment
 crit comment --reply-to <id> --author 'Copilot' '<body>'
-crit comment --reply-to <id> --resolve --author 'Copilot' '<body>'
 ```
 
 Examples:
@@ -164,7 +163,7 @@ JSON schema per entry:
 | `author` | string | no | Per-entry override (falls back to `--author`) |
 | `scope` | string | no | `"review"`, `"file"`, or omit to infer from context |
 | `reply_to` | string | yes (reply) | Comment ID (e.g. `"c_a1b2c3"` or `"r_f1e2d3"`) |
-| `resolve` | bool | no | Mark the parent comment resolved (user action — don't set from AI) |
+| `resolve` | bool | no | Only set when user explicitly asks to resolve — never resolve proactively |
 
 Scope inference when `scope` is omitted:
 - Has `reply_to` → reply

--- a/integrations/opencode/SKILL.md
+++ b/integrations/opencode/SKILL.md
@@ -78,7 +78,7 @@ crit comment --reply-to c_a1b2c3 --author 'OpenCode' 'Fixed by extracting to hel
 crit comment --reply-to r_f1e2d3 --author 'OpenCode' 'All issues addressed'
 ```
 
-This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Resolving is a user action — do not mark comments resolved from AI.
+This adds a reply to the comment thread. Works for both file comment IDs (e.g. `c_a1b2c3`) and review comment IDs (e.g. `r_f1e2d3`). Only use `--resolve` when the user explicitly asks you to resolve a comment — never resolve proactively.
 
 **Multi-file disambiguation**: Comment IDs are unique per session, but if you encounter an error like "comment found in multiple files", use `--path` to specify which file:
 
@@ -111,9 +111,8 @@ crit comment --author 'OpenCode' <path>:<line> '<body>'
 # Line comment (range)
 crit comment --author 'OpenCode' <path>:<start>-<end> '<body>'
 
-# Reply to an existing comment (with optional --resolve)
+# Reply to an existing comment
 crit comment --reply-to <id> --author 'OpenCode' '<body>'
-crit comment --reply-to <id> --resolve --author 'OpenCode' '<body>'
 ```
 
 Rules:
@@ -152,7 +151,7 @@ JSON schema per entry:
 | `author` | string | no | Per-entry override (falls back to `--author`) |
 | `scope` | string | no | `"review"`, `"file"`, or omit to infer from context |
 | `reply_to` | string | yes (reply) | Comment ID (e.g. `"c_a1b2c3"` or `"r_f1e2d3"`) |
-| `resolve` | bool | no | Mark the parent comment resolved (user action — don't set from AI) |
+| `resolve` | bool | no | Only set when user explicitly asks to resolve — never resolve proactively |
 
 Scope inference when `scope` is omitted:
 - Has `reply_to` → reply


### PR DESCRIPTION
## Summary

- Remove `--resolve` example line from all crit-cli SKILL.md files — agents were copying it and auto-resolving comments
- Update wording from "do not resolve" to "only resolve when user explicitly asks" so the capability is still available on request
- Applied across all 5 integrations: claude-code, codex, cursor, github-copilot, opencode

## Test plan

- [ ] Run crit review with an agent, verify it no longer auto-resolves comments
- [ ] Ask an agent to resolve a specific comment, verify it still works


🤖 Generated with [Claude Code](https://claude.com/claude-code)