### PR TITLE
chore: replace .crit.json references with review file terminology

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -15,7 +15,7 @@ paths:
 ## Code Organization
 - This is `package main`. Do NOT export functions/types unless required by tests in `_test.go` files.
 - Never create wrapper functions that just call another function with the same signature.
-- Route all .crit.json writes through `saveCritJSON()`. Never write directly.
+- Route all review file writes through `saveCritJSON()`. Never write directly.
 - Before implementing logic inline, search for existing helper functions that do the same thing.
 - After replacing a function with a new implementation, delete the old function AND its tests in the same PR.
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 # Review session files (generated at runtime)
 *.comments.json
 *.review.md
-.crit.json
 
 # Dependencies
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A single-binary Go CLI tool that opens a browser-based UI for reviewing code changes and markdown files with GitHub PR-style inline commenting. Supports multi-file review with git diff rendering and structured `.crit.json` output for AI coding agents.
+A single-binary Go CLI tool that opens a browser-based UI for reviewing code changes and markdown files with GitHub PR-style inline commenting. Supports multi-file review with git diff rendering and structured review file output for AI coding agents.
 
 ## Project Structure
 
@@ -10,10 +10,10 @@ A single-binary Go CLI tool that opens a browser-based UI for reviewing code cha
 crit/
 ├── main.go              # Entry point: subcommand dispatcher + individual runX() functions
 ├── server.go            # HTTP handlers: REST API (session, file, comments CRUD, finish, share, config)
-├── session.go           # Core state: multi-file session, comment storage, .crit.json persistence, SSE
+├── session.go           # Core state: multi-file session, comment storage, review file persistence, SSE
 ├── watch.go             # File/git watching, round-complete handlers, comment carry-forward
 ├── git.go               # Git integration: branch detection, changed files, diff parsing
-├── github.go            # GitHub PR sync: fetch/post PR comments, crit comment CLI, .crit.json I/O
+├── github.go            # GitHub PR sync: fetch/post PR comments, crit comment CLI, review file I/O
 ├── config.go            # Config file loading: ~/.crit.config.json + .crit.config.json merge, ignore patterns
 ├── diff.go              # LCS-based line diff for inter-round markdown comparison
 ├── status.go            # Terminal status output formatting
@@ -60,15 +60,15 @@ crit/
 5. **markdown-it for parsing** — chosen because it provides `token.map` (source line mappings per block)
 6. **Block-level splitting** — lists, code blocks, tables, blockquotes are split into per-item/per-line/per-row blocks so each source line is independently commentable
 7. **Diff hunk rendering** — code files show git diffs with dual gutters (old/new line numbers)
-8. **Comments reference source line numbers** — stored in structured `.crit.json` with per-file sections
-9. **Real-time output** — `.crit.json` written on every comment change (200ms debounce)
+8. **Comments reference source line numbers** — stored in the review file (`~/.crit/reviews/<key>.json`) with per-file sections
+9. **Real-time output** — review file written on every comment change (200ms debounce)
 10. **GitHub-style gutter interaction** — click-and-drag on line numbers to select ranges
 11. **File watching** — git mode polls `git status --porcelain`; files mode polls mtimes; reloads via SSE
 12. **Localhost only** — server binds to `127.0.0.1`, no CORS headers needed
 13. **Two-level config** — `~/.crit.config.json` (global) merged with `.crit.config.json` (project), CLI flags override both. Exception: `agent_cmd` is global-only and cannot be set by project config (prevents malicious repos from hijacking the agent command)
-14. **GitHub PR sync** — `crit pull` / `crit push` bridge between `.crit.json` and GitHub PR review comments via `gh` CLI
-15. **Headless CLI comment** — `crit comment` writes directly to `.crit.json` without starting the server; SSE notifies any running server
-16. **Comment threading** — comments support nested replies and a `resolved` boolean. Agents reply with `crit comment --reply-to <id> --resolve`. The `.crit.json` schema nests replies inside each comment's `replies` array.
+14. **GitHub PR sync** — `crit pull` / `crit push` bridge between the review file and GitHub PR review comments via `gh` CLI
+15. **Headless CLI comment** — `crit comment` writes directly to the review file without starting the server; SSE notifies any running server
+16. **Comment threading** — comments support nested replies and a `resolved` boolean. Agents reply with `crit comment --reply-to <id> --resolve`. The review file schema nests replies inside each comment's `replies` array.
 17. **Commit selection** — in git mode, a sidebar lists individual commits. Selecting one scopes the file list and diffs to that commit only.
 18. **Centralized review storage** — review data stored in `~/.crit/reviews/<key>.json` (keyed by cwd + branch + args). `crit status` shows the review file path; `crit cleanup` removes stale reviews.
 
@@ -92,9 +92,9 @@ crit stop                     # Stop the daemon for current directory
 crit stop --all               # Stop all daemons for current directory
 crit status [--json]          # Show review file path, daemon status, comment stats
 crit cleanup [--days N] [--force]  # Delete stale review files from ~/.crit/reviews/
-crit pull [pr-number]         # Fetch GitHub PR comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
-crit comment <path>:<line[-end]> <body>         # Add a comment to .crit.json (no server needed)
+crit pull [pr-number]         # Fetch GitHub PR comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
+crit comment <path>:<line[-end]> <body>         # Add a comment to the review file (no server needed)
 crit comment --reply-to <id> [--resolve] <body> # Reply to a comment (optionally mark resolved)
 crit comment --json [--author <name>]           # Bulk add comments from stdin JSON
 crit share <file> [file...]   # Share files to crit-web, print URL
@@ -126,8 +126,8 @@ Config keys: `port`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_
 
 Requires `gh` CLI installed and authenticated.
 
-- `crit pull` fetches PR review comments (RIGHT-side only) and merges them into `.crit.json`, deduplicating by author+lines+body
-- `crit push` reads `.crit.json` and posts unresolved comments as a GitHub PR review
+- `crit pull` fetches PR review comments (RIGHT-side only) and merges them into the review file, deduplicating by author+lines+body
+- `crit push` reads the review file and posts unresolved comments as a GitHub PR review
 - `crit push --dry-run` shows what would be posted without actually creating the review
 - `crit push --event approve` submits an approval; `--event request-changes` requests changes (default: `comment`)
 - `crit push -m 'message'` adds a review-level body message
@@ -256,11 +256,11 @@ Session-scoped:
 
 - `GET  /api/session` — session metadata: mode, branch, baseRef, reviewRound, file list with stats
 - `GET  /api/config` — returns `{share_url, hosted_url, delete_token, version, latest_version}`
-- `POST /api/finish` — write `.crit.json`, return prompt for agent
+- `POST /api/finish` — write review file, return prompt for agent
 - `GET  /api/events` — SSE stream (file-changed, edit-detected, server-shutdown events)
 - `GET  /api/wait-for-event` — long-poll that blocks until finish, returns event JSON (used by `crit` in daemon mode)
 - `POST /api/round-complete` — agent signals all edits are done; triggers new round
-- `POST /api/share-url` — persist `{url, delete_token}` to `.crit.json` after upload
+- `POST /api/share-url` — persist `{url, delete_token}` to the review file after upload
 - `DELETE /api/share-url` — unpublish: calls crit-web DELETE and clears local persisted URL
 - `POST /api/agent/request` — send a comment to the configured agent command (requires `agent_cmd` config)
 - `GET  /api/commits` — list commits between base ref and HEAD (git mode only)
@@ -354,7 +354,7 @@ Sharing is opt-in. When `--share-url` (or `CRIT_SHARE_URL` env var, or `share_ur
 
 - The Share button appears in the header.
 - Clicking it POSTs the current document + comments to `{share_url}/api/reviews` (crit-web API).
-- The response `{url, delete_token}` is persisted to `.crit.json` via `POST /api/share-url`.
+- The response `{url, delete_token}` is persisted to the review file via `POST /api/share-url`.
 - A share-notice banner shows the URL with Copy / Unpublish actions.
 - Unpublish calls `DELETE {share_url}/api/reviews?delete_token=...` then clears local state.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [`integrations/`](integrations/) for all install methods and details.
 
 ### Plugin install (Claude Code)
 
-For the full experience - installs globally with a `/crit` command plus a `crit` skill that auto-activates when your agent works with `.crit.json`, `crit comment`, `crit pull/push`, etc:
+For the full experience - installs globally with a `/crit` command plus a `crit` skill that auto-activates when your agent works with review files, `crit comment`, `crit pull/push`, etc:
 
 ```
 /plugin marketplace add tomasz-tomczyk/crit
@@ -103,7 +103,7 @@ Select lines and use "Insert suggestion" to pre-fill the comment with the origin
 
 ### Finish review: agent notified automatically
 
-When you click "Finish Review", Crit writes `.crit.json` and notifies your agent If your agent was listening, it picks up the prompt automatically - no copy-paste needed.
+When you click "Finish Review", Crit writes the review file and notifies your agent If your agent was listening, it picks up the prompt automatically - no copy-paste needed.
 
 ### Programmatic comments
 
@@ -266,7 +266,7 @@ All keys are optional — omit any you don't need.
 | `output`               | string   | repo root or file dir      | Output directory for review files. Reviews are stored in `~/.crit/reviews/` by default.                                                                                                 |
 | `author`               | string   | `git config user.name`     | Author name shown on comments. Falls back to your git user name.                                                                                                                        |
 | `base_branch`          | string   | auto-detected              | Base branch to diff against (e.g. `"main"`, `"develop"`). Overrides auto-detection.                                                                                                     |
-| `ignore_patterns`      | string[] | `[".crit.json", ".crit/"]` | File patterns to exclude from git-mode file lists. Global and project patterns are merged.                                                                                              |
+| `ignore_patterns`      | string[] | `[".crit/"]` | File patterns to exclude from git-mode file lists. Global and project patterns are merged.                                                                                              |
 | `agent_cmd`            | string   | `""`                       | Shell command for "Send to agent" (e.g. `"claude -p"`). **Global config only** — project config cannot set this for security reasons. See [Send to agent](#send-to-agent-experimental). |
 | `auth_token`           | string   | `""`                       | Authentication token for crit.md. Set automatically by `crit auth login`. **Global config only.**                                                                                       |
 | `cleanup_on_approve`   | bool     | `true`                     | Automatically delete the review file when you approve with no unresolved comments. Set to `false` to preserve review history.                                                           |

--- a/config.go
+++ b/config.go
@@ -62,7 +62,6 @@ func defaultConfig() generatedConfig {
 			"*.lock",
 			"*.min.js",
 			"*.min.css",
-			".crit.json",
 			".crit/",
 		},
 		AgentCmd:         "",
@@ -215,7 +214,7 @@ func LoadConfig(projectDir string) Config {
 		merged.ShareURL = "https://crit.md"
 	}
 	if !globalPresence.IgnorePatterns && !projectPresence.IgnorePatterns {
-		merged.IgnorePatterns = []string{".crit.json", ".crit/"}
+		merged.IgnorePatterns = []string{".crit/"}
 	}
 
 	// 5. Fall back to git user.name if no author configured

--- a/config_test.go
+++ b/config_test.go
@@ -329,8 +329,8 @@ func TestLoadConfigRuntimeDefaults(t *testing.T) {
 	if cfg.ShareURL != "https://crit.md" {
 		t.Errorf("ShareURL = %q, want runtime default https://crit.md", cfg.ShareURL)
 	}
-	wantPatterns := []string{".crit.json", ".crit/"}
-	if len(cfg.IgnorePatterns) != len(wantPatterns) || cfg.IgnorePatterns[0] != wantPatterns[0] || cfg.IgnorePatterns[1] != wantPatterns[1] {
+	wantPatterns := []string{".crit/"}
+	if len(cfg.IgnorePatterns) != len(wantPatterns) || cfg.IgnorePatterns[0] != wantPatterns[0] {
 		t.Errorf("IgnorePatterns = %v, want %v", cfg.IgnorePatterns, wantPatterns)
 	}
 }
@@ -365,8 +365,8 @@ func TestLoadConfigRuntimeDefaultsOverriddenByGlobal(t *testing.T) {
 		t.Errorf("ShareURL = %q, want custom global value", cfg.ShareURL)
 	}
 	// ignore_patterns not set in any config — default applies
-	wantPatterns := []string{".crit.json", ".crit/"}
-	if len(cfg.IgnorePatterns) != len(wantPatterns) || cfg.IgnorePatterns[0] != wantPatterns[0] || cfg.IgnorePatterns[1] != wantPatterns[1] {
+	wantPatterns := []string{".crit/"}
+	if len(cfg.IgnorePatterns) != len(wantPatterns) || cfg.IgnorePatterns[0] != wantPatterns[0] {
 		t.Errorf("IgnorePatterns = %v, want %v", cfg.IgnorePatterns, wantPatterns)
 	}
 }

--- a/e2e/tests/comment-count-badge.spec.ts
+++ b/e2e/tests/comment-count-badge.spec.ts
@@ -10,7 +10,7 @@ async function waitForRound(request: APIRequestContext, previousRound: number) {
   }).toPass({ timeout: 5000 });
 }
 
-// Finish round, mark all comments as resolved in .crit.json, then complete the round.
+// Finish round, mark all comments as resolved in the review file, then complete the round.
 async function finishAndResolve(request: APIRequestContext) {
   const session = await request.get('/api/session').then(r => r.json());
   const currentRound = session.review_round;
@@ -71,7 +71,7 @@ test.describe('Comment Count Badge', () => {
     const countEl = page.locator('#commentCount');
     const badgeEl = page.locator('#commentCountNumber');
 
-    // Add a comment, resolve it via .crit.json, then complete the round
+    // Add a comment, resolve it via the review file, then complete the round
     await addComment(request, mdPath, 1, 'Will be resolved');
     await finishAndResolve(request);
 
@@ -178,7 +178,7 @@ test.describe('Comment Count Badge', () => {
     const countEl = page.locator('#commentCount');
     const badgeEl = page.locator('#commentCountNumber');
 
-    // Add a comment, resolve it via .crit.json, then complete the round
+    // Add a comment, resolve it via the review file, then complete the round
     await addComment(request, mdPath, 1, 'Will be resolved');
     await finishAndResolve(request);
 

--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -209,12 +209,12 @@ test.describe('Comments Panel — Git Mode', () => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Will be resolved');
 
-    // Finish to write .crit.json
+    // Finish to write the review file
     const finishRes = await request.post('/api/finish');
     const finishData = await finishRes.json();
     const critJsonPath = finishData.review_file;
 
-    // Mark comment as resolved in .crit.json
+    // Mark comment as resolved in the review file
     const critJson = JSON.parse(fs.readFileSync(critJsonPath, 'utf-8'));
     for (const fileKey of Object.keys(critJson.files)) {
       for (const comment of critJson.files[fileKey].comments) {
@@ -262,7 +262,7 @@ test.describe('Comments Panel — Git Mode', () => {
 
     await loadPage(page);
 
-    // After round-complete, .crit.json appears in session, so mdSection helper
+    // After round-complete, the review file appears in session, so mdSection helper
     // can match multiple sections. Use the plan.md section by ID directly.
     const mdSectionById = page.locator('#file-section-plan\\.md');
     const docBtn = mdSectionById.locator('.file-header-toggle .toggle-btn[data-mode="document"]');

--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -2,11 +2,11 @@ import { test, expect, type APIRequestContext } from '@playwright/test';
 import * as fs from 'fs';
 import { clearAllComments, loadPage } from './helpers';
 
-// Find a non-crit.json file path from the session
+// Find a file path from the session
 async function getTestFilePath(request: APIRequestContext): Promise<string> {
   const sessionRes = await request.get('/api/session');
   const session = await sessionRes.json();
-  const file = session.files.find((f: any) => f.path !== '.crit.json' && f.status !== 'deleted');
+  const file = session.files.find((f: any) => f.status !== 'deleted');
   return file?.path || session.files[0].path;
 }
 
@@ -118,11 +118,11 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
-    // Finish already wrote .crit.json; read the path from the finish response
+    // Finish already wrote the review file; read the path from the finish response
     const finishRes = await request.post('/api/finish');
     const finishData = await finishRes.json();
     const critJsonPath = finishData.review_file;
@@ -164,7 +164,7 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
@@ -207,7 +207,7 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
@@ -243,8 +243,8 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
   });
 
   test('file sections are re-rendered after round-complete', async ({ page, request }) => {
-    // Count non-.crit.json file sections before (its presence depends on disk state)
-    const sections = page.locator('.file-section').filter({ hasNotText: '.crit.json' });
+    // Count file sections before
+    const sections = page.locator('.file-section');
     const sectionsBefore = await sections.count();
 
     // Trigger round-complete

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -2,11 +2,11 @@ import { test, expect, type APIRequestContext } from '@playwright/test';
 import * as fs from 'fs';
 import { clearAllComments, loadPage, switchToDocumentView } from './helpers';
 
-// Find a non-crit.json file path from the session (e.g., plan.md or handler.js)
+// Find a file path from the session (e.g., plan.md or handler.js)
 async function getTestFilePath(request: APIRequestContext): Promise<string> {
   const sessionRes = await request.get('/api/session');
   const session = await sessionRes.json();
-  const file = session.files.find((f: any) => f.path !== '.crit.json' && f.status !== 'deleted');
+  const file = session.files.find((f: any) => f.status !== 'deleted');
   return file?.path || session.files[0].path;
 }
 
@@ -134,7 +134,7 @@ test.describe('Multi-Round — API', () => {
       data: { start_line: 1, end_line: 1, body: 'Unresolved comment' },
     });
 
-    // Finish to write .crit.json
+    // Finish to write the review file
     await request.post('/api/finish');
 
     // Signal round complete and wait for processing
@@ -157,12 +157,12 @@ test.describe('Multi-Round — API', () => {
       data: { start_line: 1, end_line: 1, body: 'Will be resolved' },
     });
 
-    // Finish to write .crit.json (get the path from response)
+    // Finish to write the review file (get the path from response)
     const finishRes = await request.post('/api/finish');
     const finishData = await finishRes.json();
     const critJsonPath = finishData.review_file;
 
-    // Simulate agent marking comment as resolved by editing .crit.json
+    // Simulate agent marking comment as resolved by editing the review file
     const critJson = JSON.parse(fs.readFileSync(critJsonPath, 'utf-8'));
     for (const fileKey of Object.keys(critJson.files)) {
       for (const comment of critJson.files[fileKey].comments) {
@@ -186,13 +186,13 @@ test.describe('Multi-Round — API', () => {
 
   test('file list is preserved after round-complete', async ({ request }) => {
     const before = await request.get('/api/session').then(r => r.json());
-    const filesBefore = before.files.map((f: any) => f.path).filter((p: string) => p !== '.crit.json').sort();
+    const filesBefore = before.files.map((f: any) => f.path).sort();
 
     await request.post('/api/round-complete');
     await waitForRound(request, before.review_round);
 
     const after = await request.get('/api/session').then(r => r.json());
-    const filesAfter = after.files.map((f: any) => f.path).filter((p: string) => p !== '.crit.json').sort();
+    const filesAfter = after.files.map((f: any) => f.path).sort();
 
     expect(filesAfter).toEqual(filesBefore);
   });
@@ -238,7 +238,7 @@ test.describe('Multi-Round — API', () => {
 test.describe('Multi-Round — Frontend', () => {
   test.beforeEach(async ({ page, request }) => {
     // Reset server to reviewing state in case a previous test left it in
-    // waiting/finished state. Without this, clearAllComments writes .crit.json,
+    // waiting/finished state. Without this, clearAllComments writes the review file,
     // the file watcher detects the change, and emits edit-detected SSE events
     // that can overwrite UI text in the next test.
     await request.post('/api/round-complete');
@@ -347,11 +347,11 @@ test.describe('Multi-Round — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
-    // Finish already wrote .crit.json; read the path from the finish response
+    // Finish already wrote the review file; read the path from the finish response
     const finishRes = await request.post('/api/finish');
     const finishData = await finishRes.json();
     const critJsonPath = finishData.review_file;
@@ -393,7 +393,7 @@ test.describe('Multi-Round — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
@@ -436,7 +436,7 @@ test.describe('Multi-Round — Frontend', () => {
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
-    // Click Finish to write .crit.json and enter waiting state
+    // Click Finish to write the review file and enter waiting state
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
@@ -472,8 +472,8 @@ test.describe('Multi-Round — Frontend', () => {
   });
 
   test('viewed state persists across round-complete', async ({ page, request }) => {
-    // Mark the first non-.crit.json file as viewed
-    const section = page.locator('.file-section').filter({ hasNotText: '.crit.json' }).first();
+    // Mark the first file as viewed
+    const section = page.locator('.file-section').first();
     const viewedCheckbox = section.locator('.file-header-viewed input');
     await viewedCheckbox.check();
     await expect(viewedCheckbox).toBeChecked();
@@ -489,8 +489,8 @@ test.describe('Multi-Round — Frontend', () => {
   });
 
   test('file sections are re-rendered after round-complete', async ({ page, request }) => {
-    // Count non-.crit.json file sections before (its presence depends on disk state)
-    const sections = page.locator('.file-section').filter({ hasNotText: '.crit.json' });
+    // Count file sections before
+    const sections = page.locator('.file-section');
     const sectionsBefore = await sections.count();
 
     // Trigger round-complete
@@ -517,11 +517,11 @@ test.describe('Multi-Round — Frontend', () => {
     // With an unresolved comment, button should say "Finish Review"
     await expect(page.locator('#finishBtn')).toHaveText('Finish Review');
 
-    // Click Finish to write .crit.json
+    // Click Finish to write the review file
     await page.locator('#finishBtn').click();
     await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
 
-    // Read .crit.json path and mark comment as resolved
+    // Read review file path and mark comment as resolved
     const finishRes = await request.post('/api/finish');
     const finishData = await finishRes.json();
     const critJsonPath = finishData.review_file;

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -58,10 +58,9 @@ test.describe('Scope Toggle', () => {
   test('switching to unstaged scope shows only unstaged files', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'unstaged');
-    // Unstaged: config.yaml (and possibly .crit.json which is also untracked)
-    const nonCritSections = page.locator('.file-section').filter({ hasNotText: '.crit.json' });
+    // Unstaged: config.yaml only
     await expect(async () => {
-      await expect(nonCritSections).toHaveCount(1);
+      await expect(page.locator('.file-section')).toHaveCount(1);
     }).toPass({ timeout: 5000 });
     await expect(page.locator('.file-section', { hasText: 'config.yaml' })).toBeVisible();
   });

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
             src = self;
             vendorHash = "sha256-n2yA86hAhSipIhQw9HSKubCVT4RrPdau+/Ve7ebrevc=";
             # Tests run in dedicated CI jobs (test + e2e); the Nix sandbox's
-            # /build TMPDIR cleanup races with the debounced .crit.json writer.
+            # /build TMPDIR cleanup races with the debounced review file writer.
             doCheck = false;
             ldflags = [ "-s" "-w" "-X main.version=${version}" ];
             meta = with nixpkgs.lib; {

--- a/github.go
+++ b/github.go
@@ -339,7 +339,6 @@ func mergeGHComments(cj *CritJSON, ghComments []ghComment) int {
 //  3. If one daemon matches, use its ReviewPath
 //  4. If multiple daemons match, use the one matching current branch
 //  5. If no daemon found, compute the centralized path: ~/.crit/reviews/<key>.json
-//  6. Fallback: repo root/.crit.json (legacy compat for old files)
 func resolveReviewPath(outputDir string) (string, error) {
 	if outputDir != "" {
 		abs, err := filepath.Abs(outputDir)
@@ -377,17 +376,6 @@ func resolveReviewPath(outputDir string) (string, error) {
 		return "", err
 	}
 
-	// If centralized file exists, use it.
-	if _, err := os.Stat(path); err == nil {
-		return path, nil
-	}
-
-	// Check legacy repo root (fallback for old .crit.json files).
-	if legacyPath, ok := findLegacyReviewPath(cwd); ok {
-		return legacyPath, nil
-	}
-
-	// Return centralized path (will be created on first write).
 	return path, nil
 }
 
@@ -406,25 +394,6 @@ func resolveReviewPathFromSessions(sessions []sessionEntry) string {
 		}
 	}
 	return ""
-}
-
-// findLegacyReviewPath checks for a .crit.json file at the repo root (git) or cwd (non-git).
-func findLegacyReviewPath(cwd string) (string, bool) {
-	if IsGitRepo() {
-		root, rootErr := RepoRoot()
-		if rootErr == nil {
-			legacyPath := filepath.Join(root, ".crit.json")
-			if _, err := os.Stat(legacyPath); err == nil {
-				return legacyPath, true
-			}
-		}
-	} else {
-		legacyPath := filepath.Join(cwd, ".crit.json")
-		if _, err := os.Stat(legacyPath); err == nil {
-			return legacyPath, true
-		}
-	}
-	return "", false
 }
 
 // writeCritJSON resolves the review path and writes a CritJSON via saveCritJSON.
@@ -491,7 +460,7 @@ func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
 	return resp.ID, nil
 }
 
-// critJSONToGHComments converts .crit.json comments to GitHub review comment format.
+// critJSONToGHComments converts review file comments to GitHub review comment format.
 // Returns the list of comments suitable for the GitHub "create review" API.
 func critJSONToGHComments(cj CritJSON) []map[string]any {
 	var result []map[string]any
@@ -612,7 +581,7 @@ type replyKey struct {
 	BodyPrefix string
 }
 
-// updateCritJSONWithGitHubIDs writes GitHub IDs back to .crit.json after a push.
+// updateCritJSONWithGitHubIDs writes GitHub IDs back to the review file after a push.
 // commentIDs maps "path:endLine" -> GitHubID for root comments.
 // replyIDs maps replyKey -> GitHubID for replies.
 func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, replyIDs map[replyKey]int64) error {
@@ -661,12 +630,12 @@ func truncateStr(s string, n int) string {
 	return string(r[:n])
 }
 
-// loadCritJSON reads .crit.json from disk, or returns a fresh CritJSON if the file doesn't exist.
+// loadCritJSON reads the review file from disk, or returns a fresh CritJSON if the file doesn't exist.
 func loadCritJSON(critPath string) (CritJSON, error) {
 	var cj CritJSON
 	if data, err := os.ReadFile(critPath); err == nil {
 		if err := json.Unmarshal(data, &cj); err != nil {
-			return cj, fmt.Errorf("invalid existing .crit.json: %w", err)
+			return cj, fmt.Errorf("invalid existing review file: %w", err)
 		}
 	} else if os.IsNotExist(err) {
 		branch := CurrentBranch()
@@ -683,7 +652,7 @@ func loadCritJSON(critPath string) (CritJSON, error) {
 			Files:       make(map[string]CritJSONFile),
 		}
 	} else {
-		return cj, fmt.Errorf("reading .crit.json: %w", err)
+		return cj, fmt.Errorf("reading review file: %w", err)
 	}
 	return cj, nil
 }
@@ -787,15 +756,15 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 	}
 	if !found {
 		if filterPath != "" {
-			return fmt.Errorf("comment %q not found in file %q in .crit.json", commentID, filterPath)
+			return fmt.Errorf("comment %q not found in file %q in review file", commentID, filterPath)
 		}
-		return fmt.Errorf("comment %q not found in .crit.json", commentID)
+		return fmt.Errorf("comment %q not found in review file", commentID)
 	}
 	return nil
 }
 
-// addCommentToCritJSON appends a comment to .crit.json for the given file and line range.
-// Creates .crit.json if it doesn't exist. Appends to existing comments if it does.
+// addCommentToCritJSON appends a comment to the review file for the given file and line range.
+// Creates the review file if it doesn't exist. Appends to existing comments if it does.
 // Works in both git repos and plain directories (file mode).
 // outputDir overrides the default location (repo root or CWD) when non-empty.
 func addCommentToCritJSON(filePath string, startLine, endLine int, body string, author string, outputDir string) error {
@@ -818,7 +787,7 @@ func addCommentToCritJSON(filePath string, startLine, endLine int, body string, 
 	return saveCritJSON(critPath, cj)
 }
 
-// addReplyToCritJSON adds a reply to an existing comment in .crit.json.
+// addReplyToCritJSON adds a reply to an existing comment in the review file.
 // It searches all files for the comment ID. If resolve is true, it also marks the comment as resolved.
 func addReplyToCritJSON(commentID, body, author string, resolve bool, outputDir string, filterPath string) error {
 	critPath, err := resolveReviewPath(outputDir)
@@ -902,7 +871,7 @@ func (e *BulkCommentEntry) UnmarshalJSON(data []byte) error {
 
 // bulkAddCommentsToCritJSON applies multiple comments and replies in a single load-save cycle.
 // globalAuthor is used when an entry doesn't specify its own author.
-// outputDir overrides the .crit.json location (empty = repo root or CWD).
+// outputDir overrides the review file location (empty = centralized storage).
 func processBulkEntry(cj *CritJSON, i int, e BulkCommentEntry, globalAuthor string) error {
 	if e.Body == "" {
 		return fmt.Errorf("entry %d: body is required", i)

--- a/integration_hashes_gen.go
+++ b/integration_hashes_gen.go
@@ -3,19 +3,19 @@
 package main
 
 var integrationHashes = map[string]string{
-	"integrations/aider/CONVENTIONS.md":                    "00191f3971e2e7b50f7911fbe55343a7ceea36fbb27a529856d5680d97e9aebb",
+	"integrations/aider/CONVENTIONS.md":                    "6216d823423d01803bd772b477e3d536fc31adf96b838c519a86660ed31ba9b5",
 	"integrations/claude-code/.claude-plugin/plugin.json":  "005dadcbce1bee1c5b80a50d7a2290932272489b2fdf2e85767d3a65810adf71",
 	"integrations/claude-code/hooks/hooks.json":            "beba2c8bd252637ff31b57ed868e4d56135e1a3f429f872befbd2d34b834512b",
-	"integrations/claude-code/skills/crit-cli/SKILL.md":    "5fb3460c3243a1b2faeb1c53c4566b5738c4ce912e4e4306a55260d55fefc734",
+	"integrations/claude-code/skills/crit-cli/SKILL.md":    "52ac121563590bb6ad79326857b91f30c03d9f5d67ee2abe0e691d2740eb376d",
 	"integrations/claude-code/skills/crit/SKILL.md":        "0f0a37418a7947b2088b8c279b83acc933f2e52bdacab6c9f7b60892403cce41",
-	"integrations/cline/crit.md":                           "883dbfc1e9954c1c360118908bb3f5b1968ce6c75e4bab38e45a7ce832f6ec9d",
-	"integrations/codex/skills/crit-cli/SKILL.md":          "1ec4ef95068615f9eac9008240abf0e1a1674275dc30f48b7300daacb31f5ee0",
+	"integrations/cline/crit.md":                           "bb35e99106f6009c9e2545f7b2a401323be1b5713bf50c45565349bfe02d3f03",
+	"integrations/codex/skills/crit-cli/SKILL.md":          "69f9af302514896d6053c1c6ea9b122b961b430e5c846d28d323217713be0cd6",
 	"integrations/codex/skills/crit/SKILL.md":              "b44e981ec31c3b3e6f246fbc6bf36636d1d4b0d8dadb7b0c6ab78aec17a4b5cd",
-	"integrations/cursor/skills/crit-cli/SKILL.md":         "83527f353bba57007c281d3c6853f8bc9701adad7aa16d3ecf87cefd0b5bfaa2",
+	"integrations/cursor/skills/crit-cli/SKILL.md":         "8922023b167d3fd0934b15dd371d3f40627f4557326cb783453e90d5a5ba7e49",
 	"integrations/cursor/skills/crit/SKILL.md":             "9d88c2d0dbd5a1dad4ba99bc60e04a515ec830e02a0af99ab4e7b2b2193e7644",
-	"integrations/github-copilot/skills/crit-cli/SKILL.md": "522f14e812f12a7550cc25295b5f9ab5c5dfbc8dcf0f1d87dd4bbd3b6b180932",
+	"integrations/github-copilot/skills/crit-cli/SKILL.md": "d1fcf9d6ae902766940c0bec10d273b5ad05b8100c566c48489030bf3c81b90c",
 	"integrations/github-copilot/skills/crit/SKILL.md":     "f61c61346c9f2e92b047bed1fdc2f2823ca925e38bc192d3087dc5badbfd937f",
-	"integrations/opencode/SKILL.md":                       "b5f199b9fba6dadae28c121f3a1759eb1ec587bf4830d03088ebf2cdbd8303e1",
+	"integrations/opencode/SKILL.md":                       "ed3d518fa116890278db68038d475f3972efbc7f2199db75be55e2a59086b2f0",
 	"integrations/opencode/crit.md":                        "2c9a9f348f3336e5d9f2cc071d7ea0a9653ee2c609b7ed39ea1d940a197a4ca7",
-	"integrations/windsurf/crit.md":                        "4caa2d5018efe51a326034aacd8780127f71b8df889ad5da8c4aa77aacd954e3",
+	"integrations/windsurf/crit.md":                        "8971143aab9f8e573d06902df46383089e725d3b176c41d723e9cf5ce1d59543",
 }

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -28,7 +28,7 @@ This installs integration files into your project. Safe to re-run — existing f
 
 For the full experience, install via the plugin marketplace. This gives you:
 - A `/crit` slash command for the review loop
-- A `crit` skill that auto-activates when working with `.crit.json`, `crit comment`, `crit pull/push`, etc.
+- A `crit` skill that auto-activates when working with review files, `crit comment`, `crit pull/push`, etc.
 
 ```
 /plugin marketplace add tomasz-tomczyk/crit
@@ -46,7 +46,7 @@ The marketplace manifest lives at the repo root (`.claude-plugin/marketplace.jso
 | **Good for** | Teams — everyone gets the integration | Individual users — works across all projects |
 | **Setup** | Run once per project | Install once, works everywhere |
 
-Both approaches give you the `/crit` slash command. The plugin marketplace additionally installs the `crit-cli` skill which auto-teaches the agent about `crit comment`, `.crit.json` format, `crit pull/push`, and resolution workflow.
+Both approaches give you the `/crit` slash command. The plugin marketplace additionally installs the `crit-cli` skill which auto-teaches the agent about `crit comment`, review file format, `crit pull/push`, and resolution workflow.
 
 ## What these do
 
@@ -54,10 +54,10 @@ All integrations follow the same pattern:
 
 1. **Plan first** — the agent writes an implementation plan as a markdown file before writing any code
 2. **Launch Crit** — the agent runs `crit $PLAN_FILE` to open the plan for review in your browser
-3. **Address feedback** — after review, the agent reads `.crit.json` to find your inline comments and revises the plan
+3. **Address feedback** — after review, the agent reads the review file to find your inline comments and revises the plan
 4. **Implement after approval** — only after you approve does the agent write code
 
 Each integration also teaches the agent about:
 - **`crit comment`** — leave inline review comments programmatically without opening the browser
-- **`.crit.json` format** — how to read comments, resolve them with threaded replies
+- **review file format** — how to read comments, resolve them with threaded replies
 - **`crit pull/push`** — sync reviews with GitHub PRs (push supports `--event approve|request-changes|comment`)

--- a/integrations/aider/CONVENTIONS.md
+++ b/integrations/aider/CONVENTIONS.md
@@ -30,7 +30,7 @@ Run `crit` (it starts the daemon if needed, opens the browser, and blocks until 
 crit
 ```
 
-**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
 
 ## After review
 
@@ -51,7 +51,7 @@ Only proceed after the user approves (finishes a round with zero comments).
 
 ## Leaving comments programmatically
 
-Use `crit comment` to add review comments to `.crit.json` without opening the browser:
+Use `crit comment` to add review comments to the review file without opening the browser:
 
 ```bash
 crit comment --author 'Aider' '<body>'                          # Review-level comment
@@ -62,7 +62,7 @@ crit comment --reply-to c_a1b2c3 --author 'Aider' '<body>'  # Reply to file comm
 crit comment --reply-to r_f1e2d3 --author 'Aider' '<body>'  # Reply to review comment
 ```
 
-Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates `.crit.json` automatically if it doesn't exist.
+Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates the review file automatically if it doesn't exist.
 
 ## Sharing Reviews
 
@@ -85,16 +85,16 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as PR review
+crit pull [pr-number]                                    # Fetch PR comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as PR review
 ```
 
 Requires `gh` CLI. PR number auto-detected from current branch. Event types for `--event`: `comment` (default), `approve`, `request-changes`.

--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crit-cli
-description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
+description: Use when working with crit CLI commands, review files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow.
 user-invocable: false
 ---
 
@@ -8,9 +8,9 @@ user-invocable: false
 
 > If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
-## .crit.json Format
+## Review File Format
 
-After a crit review session, comments are in `.crit.json`. Comments have three scopes:
+After a crit review session, comments are in the review file (see `crit status` for the path). Comments have three scopes:
 
 - **Line comments** (`scope: "line"`) — tied to specific lines in a file, stored in `files.<path>.comments`
 - **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
@@ -88,7 +88,7 @@ Review-level comment IDs (`r_XXXXXX`) are globally unique and never need disambi
 
 ### Plan mode comments
 
-When reviewing plans (via `crit plan` or the ExitPlanMode hook), `.crit.json` is stored in `~/.crit/plans/<slug>/` — not the project root. Use `--plan <slug>` so `crit comment` finds the right file:
+When reviewing plans (via `crit plan` or the ExitPlanMode hook), the review file is stored in `~/.crit/plans/<slug>/`. Use `--plan <slug>` so `crit comment` finds the right file:
 
 ```bash
 crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Claude Code' 'Updated the plan'
@@ -98,7 +98,7 @@ The `--plan` flag resolves to the plan storage directory automatically. The slug
 
 ## Leaving Comments with crit comment CLI
 
-Use `crit comment` to add review comments to `.crit.json` programmatically — no browser needed:
+Use `crit comment` to add review comments to the review file programmatically — no browser needed:
 
 ```bash
 # Review-level comment (general feedback, not tied to any file)
@@ -134,7 +134,7 @@ Rules:
 - **Paths** are relative to the current working directory
 - **Line numbers** reference the file as it exists on disk (1-indexed), not diff line numbers
 - **Comments are appended** — calling `crit comment` multiple times adds to the list, never replaces
-- **No setup needed** — `crit comment` creates `.crit.json` automatically if it doesn't exist
+- **No setup needed** — `crit comment` creates the review file automatically if it doesn't exist
 - **Do NOT run `crit` after leaving comments** — that triggers a new review round
 
 ### Bulk commenting (recommended for multiple comments)
@@ -173,15 +173,15 @@ Scope inference when `scope` is omitted:
 - Has `file`/`path` and `line` → line-level
 
 Benefits over individual `crit comment` calls:
-- **Atomic** — one write to `.crit.json`, no partial state
+- **Atomic** — one write to the review file, no partial state
 - **Faster** — single process invocation instead of N
 - **Safer** — no race conditions with concurrent crit processes
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR review comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
 ```
 
 Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch, or pass it explicitly.
@@ -209,7 +209,7 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review

--- a/integrations/cline/crit.md
+++ b/integrations/cline/crit.md
@@ -30,7 +30,7 @@ Run `crit` (it starts the daemon if needed, opens the browser, and blocks until 
 crit
 ```
 
-**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
 
 ## After review
 
@@ -51,7 +51,7 @@ Only proceed after the user approves (finishes a round with zero comments).
 
 ## Leaving comments programmatically
 
-Use `crit comment` to add review comments to `.crit.json` without opening the browser:
+Use `crit comment` to add review comments to the review file without opening the browser:
 
 ```bash
 crit comment --author 'Cline' '<body>'                          # Review-level comment
@@ -62,7 +62,7 @@ crit comment --reply-to c_a1b2c3 --author 'Cline' '<body>'  # Reply to file comm
 crit comment --reply-to r_f1e2d3 --author 'Cline' '<body>'  # Reply to review comment
 ```
 
-Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates `.crit.json` automatically if it doesn't exist.
+Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates the review file automatically if it doesn't exist.
 
 ## Sharing Reviews
 
@@ -85,16 +85,16 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as PR review
+crit pull [pr-number]                                    # Fetch PR comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as PR review
 ```
 
 Requires `gh` CLI. PR number auto-detected from current branch. Event types for `--event`: `comment` (default), `approve`, `request-changes`.

--- a/integrations/codex/skills/crit-cli/SKILL.md
+++ b/integrations/codex/skills/crit-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crit-cli
-description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
+description: Use when working with crit CLI commands, review files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow.
 user-invocable: false
 ---
 
@@ -8,9 +8,9 @@ user-invocable: false
 
 > If a plan was just written and the user said "crit" or "review", use the `$crit` skill instead — it covers the full review loop. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
-## .crit.json Format
+## Review File Format
 
-After a crit review session, comments are in `.crit.json`. Comments have three scopes:
+After a crit review session, comments are in the review file (see `crit status` for the path). Comments have three scopes:
 
 - **Line comments** (`scope: "line"`) — tied to specific lines in a file, stored in `files.<path>.comments`
 - **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
@@ -87,7 +87,7 @@ echo '[{"reply_to": "c_a1b2c3", "file": "src/auth.go", "body": "Fixed"}]' | crit
 Review-level comment IDs (`r_XXXXXX`) are globally unique and never need disambiguation.
 ### Plan mode comments
 
-When reviewing plans (via `crit plan` or the ExitPlanMode hook), `.crit.json` is stored in `~/.crit/plans/<slug>/` — not the project root. Use `--plan <slug>` so `crit comment` finds the right file:
+When reviewing plans (via `crit plan` or the ExitPlanMode hook), the review file is stored in `~/.crit/plans/<slug>/`. Use `--plan <slug>` so `crit comment` finds the right file:
 
 ```bash
 crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Claude Code' 'Updated the plan'
@@ -97,7 +97,7 @@ The `--plan` flag resolves to the plan storage directory automatically. The slug
 
 ## Leaving Comments with crit comment CLI
 
-Use `crit comment` to add review comments to `.crit.json` programmatically — no browser needed:
+Use `crit comment` to add review comments to the review file programmatically — no browser needed:
 
 ```bash
 # Review-level comment (general feedback, not tied to any file)
@@ -133,7 +133,7 @@ Rules:
 - **Paths** are relative to the current working directory
 - **Line numbers** reference the file as it exists on disk (1-indexed), not diff line numbers
 - **Comments are appended** — calling `crit comment` multiple times adds to the list, never replaces
-- **No setup needed** — `crit comment` creates `.crit.json` automatically if it doesn't exist
+- **No setup needed** — `crit comment` creates the review file automatically if it doesn't exist
 - **Do NOT run `crit` after leaving comments** — that triggers a new review round
 
 ### Bulk commenting (recommended for multiple comments)
@@ -172,15 +172,15 @@ Scope inference when `scope` is omitted:
 - Has `file`/`path` and `line` → line-level
 
 Benefits over individual `crit comment` calls:
-- **Atomic** — one write to `.crit.json`, no partial state
+- **Atomic** — one write to the review file, no partial state
 - **Faster** — single process invocation instead of N
 - **Safer** — no race conditions with concurrent crit processes
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR review comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
 ```
 
 Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch, or pass it explicitly.
@@ -199,6 +199,6 @@ crit unpublish                # Remove shared review
 
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL from the command output and include it directly in your response to the user
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **Unpublish reads the review file** — uses the stored delete token to remove the review

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crit-cli
-description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
+description: Use when working with crit CLI commands, review files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow.
 user-invocable: false
 ---
 
@@ -8,9 +8,9 @@ user-invocable: false
 
 > If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
-## .crit.json Format
+## Review File Format
 
-After a crit review session, comments are in `.crit.json`. Comments have three scopes:
+After a crit review session, comments are in the review file (see `crit status` for the path). Comments have three scopes:
 
 - **Line comments** (`scope: "line"`) — tied to specific lines in a file, stored in `files.<path>.comments`
 - **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
@@ -87,7 +87,7 @@ echo '[{"reply_to": "c_a1b2c3", "file": "src/auth.go", "body": "Fixed"}]' | crit
 Review-level comment IDs (`r_XXXXXX`) are globally unique and never need disambiguation.
 ### Plan mode comments
 
-When reviewing plans (via `crit plan` or the ExitPlanMode hook), `.crit.json` is stored in `~/.crit/plans/<slug>/` — not the project root. Use `--plan <slug>` so `crit comment` finds the right file:
+When reviewing plans (via `crit plan` or the ExitPlanMode hook), the review file is stored in `~/.crit/plans/<slug>/`. Use `--plan <slug>` so `crit comment` finds the right file:
 
 ```bash
 crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Claude Code' 'Updated the plan'
@@ -97,7 +97,7 @@ The `--plan` flag resolves to the plan storage directory automatically. The slug
 
 ## Leaving Comments with crit comment CLI
 
-Use `crit comment` to add review comments to `.crit.json` programmatically — no browser needed:
+Use `crit comment` to add review comments to the review file programmatically — no browser needed:
 
 ```bash
 # Review-level comment (general feedback, not tied to any file)
@@ -133,7 +133,7 @@ Rules:
 - **Paths** are relative to the current working directory
 - **Line numbers** reference the file as it exists on disk (1-indexed), not diff line numbers
 - **Comments are appended** — calling `crit comment` multiple times adds to the list, never replaces
-- **No setup needed** — `crit comment` creates `.crit.json` automatically if it doesn't exist
+- **No setup needed** — `crit comment` creates the review file automatically if it doesn't exist
 - **Do NOT run `crit` after leaving comments** — that triggers a new review round
 
 ### Bulk commenting (recommended for multiple comments)
@@ -172,15 +172,15 @@ Scope inference when `scope` is omitted:
 - Has `file`/`path` and `line` → line-level
 
 Benefits over individual `crit comment` calls:
-- **Atomic** — one write to `.crit.json`, no partial state
+- **Atomic** — one write to the review file, no partial state
 - **Faster** — single process invocation instead of N
 - **Safer** — no race conditions with concurrent crit processes
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR review comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
 ```
 
 Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch, or pass it explicitly.
@@ -208,7 +208,7 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crit-cli
-description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
+description: Use when working with crit CLI commands, review files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow.
 user-invocable: false
 ---
 
@@ -8,9 +8,9 @@ user-invocable: false
 
 > If a plan was just written and the user said `/crit` or `crit`, invoke the `/crit` command — do not use this reference skill. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
 
-## .crit.json Format
+## Review File Format
 
-After a crit review session, comments are in `.crit.json`. Comments have three scopes:
+After a crit review session, comments are in the review file (see `crit status` for the path). Comments have three scopes:
 
 - **Line comments** (`scope: "line"`) — tied to specific lines in a file, stored in `files.<path>.comments`
 - **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
@@ -87,7 +87,7 @@ echo '[{"reply_to": "c_a1b2c3", "file": "src/auth.go", "body": "Fixed"}]' | crit
 Review-level comment IDs (`r_XXXXXX`) are globally unique and never need disambiguation.
 ### Plan mode comments
 
-When reviewing plans (via `crit plan` or the ExitPlanMode hook), `.crit.json` is stored in `~/.crit/plans/<slug>/` — not the project root. Use `--plan <slug>` so `crit comment` finds the right file:
+When reviewing plans (via `crit plan` or the ExitPlanMode hook), the review file is stored in `~/.crit/plans/<slug>/`. Use `--plan <slug>` so `crit comment` finds the right file:
 
 ```bash
 crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Claude Code' 'Updated the plan'
@@ -97,7 +97,7 @@ The `--plan` flag resolves to the plan storage directory automatically. The slug
 
 ## Leaving Comments with crit comment CLI
 
-Use `crit comment` to add review comments to `.crit.json` programmatically — no browser needed:
+Use `crit comment` to add review comments to the review file programmatically — no browser needed:
 
 ```bash
 # Review-level comment (general feedback, not tied to any file)
@@ -133,7 +133,7 @@ Rules:
 - **Paths** are relative to the current working directory
 - **Line numbers** reference the file as it exists on disk (1-indexed), not diff line numbers
 - **Comments are appended** — calling `crit comment` multiple times adds to the list, never replaces
-- **No setup needed** — `crit comment` creates `.crit.json` automatically if it doesn't exist
+- **No setup needed** — `crit comment` creates the review file automatically if it doesn't exist
 - **Do NOT run `crit` after leaving comments** — that triggers a new review round
 
 ### Bulk commenting (recommended for multiple comments)
@@ -172,15 +172,15 @@ Scope inference when `scope` is omitted:
 - Has `file`/`path` and `line` → line-level
 
 Benefits over individual `crit comment` calls:
-- **Atomic** — one write to `.crit.json`, no partial state
+- **Atomic** — one write to the review file, no partial state
 - **Faster** — single process invocation instead of N
 - **Safer** — no race conditions with concurrent crit processes
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR review comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
 ```
 
 Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch, or pass it explicitly.
@@ -208,7 +208,7 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review

--- a/integrations/opencode/SKILL.md
+++ b/integrations/opencode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crit
-description: Use when working with crit CLI commands, .crit.json files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, .crit.json format, and resolution workflow.
+description: Use when working with crit CLI commands, review files, addressing review comments, leaving inline code review comments, sharing reviews via crit share/unpublish, pushing reviews to GitHub PRs, or pulling PR comments locally. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow.
 compatibility: opencode
 ---
 
@@ -8,7 +8,7 @@ compatibility: opencode
 
 - Launch Crit for a plan file or the current git diff.
 - Wait for the user to review changes in the browser.
-- Read `.crit.json` and address unresolved inline comments.
+- Read the review file and address unresolved inline comments.
 - Signal the next review round with `crit` when edits are done.
 - Leave inline review comments programmatically with `crit comment`.
 - Sync reviews with GitHub PRs via `crit pull` and `crit push`.
@@ -17,9 +17,9 @@ compatibility: opencode
 
 Use this when the user asks to review a plan, spec, or code changes in Crit, when project instructions require a Crit pass before accepting non-trivial changes, when leaving inline comments on code, or when syncing reviews with GitHub PRs.
 
-## .crit.json Format
+## Review File Format
 
-After a crit review session, comments are in `.crit.json`. Comments have three scopes:
+After a crit review session, comments are in the review file (see `crit status` for the path). Comments have three scopes:
 
 - **Line comments** (`scope: "line"`) — tied to specific lines in a file, stored in `files.<path>.comments`
 - **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
@@ -96,7 +96,7 @@ Review-level comment IDs (`r_XXXXXX`) are globally unique and never need disambi
 
 ## Leaving Comments with crit comment CLI
 
-Use `crit comment` to add review comments to `.crit.json` programmatically — no browser needed:
+Use `crit comment` to add review comments to the review file programmatically — no browser needed:
 
 ```bash
 # Review-level comment (general feedback, not tied to any file)
@@ -121,7 +121,7 @@ Rules:
 - **Paths** are relative to the current working directory
 - **Line numbers** reference the file as it exists on disk (1-indexed), not diff line numbers
 - **Comments are appended** — calling `crit comment` multiple times adds to the list, never replaces
-- **No setup needed** — `crit comment` creates `.crit.json` automatically if it doesn't exist
+- **No setup needed** — `crit comment` creates the review file automatically if it doesn't exist
 - **Do NOT run `crit` after leaving comments** — that triggers a new review round
 
 ### Bulk commenting (recommended for multiple comments)
@@ -160,15 +160,15 @@ Scope inference when `scope` is omitted:
 - Has `file`/`path` and `line` → line-level
 
 Benefits over individual `crit comment` calls:
-- **Atomic** — one write to `.crit.json`, no partial state
+- **Atomic** — one write to the review file, no partial state
 - **Faster** — single process invocation instead of N
 - **Safer** — no race conditions with concurrent crit processes
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR review comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as a GitHub PR review
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as a GitHub PR review
 ```
 
 Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch, or pass it explicitly.
@@ -196,13 +196,13 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review
 
 ## Guardrails
 
 - Do not continue past the review step until the user confirms they are done.
-- Treat `.crit.json` as the source of truth for line references and comment status.
+- Treat the review file as the source of truth for line references and comment status.
 - If there are no unresolved comments, tell the user no changes were requested and stop.

--- a/integrations/windsurf/crit.md
+++ b/integrations/windsurf/crit.md
@@ -30,7 +30,7 @@ Run `crit` (it starts the daemon if needed, opens the browser, and blocks until 
 crit
 ```
 
-**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read `.crit.json` early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. `crit` blocks until the user clicks Finish Review — that is how you know they are done.
 
 ## After review
 
@@ -51,7 +51,7 @@ Only proceed after the user approves (finishes a round with zero comments).
 
 ## Leaving comments programmatically
 
-Use `crit comment` to add review comments to `.crit.json` without opening the browser:
+Use `crit comment` to add review comments to the review file without opening the browser:
 
 ```bash
 crit comment --author 'Windsurf' '<body>'                          # Review-level comment
@@ -62,7 +62,7 @@ crit comment --reply-to c_a1b2c3 --author 'Windsurf' '<body>'  # Reply to file c
 crit comment --reply-to r_f1e2d3 --author 'Windsurf' '<body>'  # Reply to review comment
 ```
 
-Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates `.crit.json` automatically if it doesn't exist.
+Paths are relative, line numbers are 1-indexed, comments are appended (never replaced). Creates the review file automatically if it doesn't exist.
 
 ## Sharing Reviews
 
@@ -85,16 +85,16 @@ crit share --share-url https://crit.md <file>  # Explicit share URL
 Rules:
 - **No server needed** — `crit share` reads files directly from disk
 - **`--qr` is terminal-only** — only use when the user has a real terminal with monospace font rendering. Do not use in mobile apps (e.g. Claude Code mobile), web chat UIs, or any environment where Unicode block characters won't render correctly
-- **Comments included** — if `.crit.json` exists, comments for the shared files are included automatically
+- **Comments included** — if the review file exists, comments for the shared files are included automatically
 - **Relay the output** — always copy the URL (and QR code if `--qr` was used) from the command output and include it directly in your response to the user. Do not make them dig through tool output
-- **State persisted** — share URL and delete token are saved to `.crit.json`
-- **Unpublish reads `.crit.json`** — uses the stored delete token to remove the review
+- **State persisted** — share URL and delete token are saved to the review file
+- **Unpublish reads the review file** — uses the stored delete token to remove the review
 
 ## GitHub PR Integration
 
 ```bash
-crit pull [pr-number]                                    # Fetch PR comments into .crit.json
-crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post .crit.json comments as PR review
+crit pull [pr-number]                                    # Fetch PR comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]  # Post review comments as PR review
 ```
 
 Requires `gh` CLI. PR number auto-detected from current branch. Event types for `--event`: `comment` (default), `approve`, `request-changes`.

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func printShareUsage() {
 	fmt.Fprintln(os.Stderr, "Usage: crit share [--output <dir>] [--share-url <url>] [--qr] <file> [file...]")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Shares files to crit-web and prints the review URL.")
-	fmt.Fprintln(os.Stderr, "Comments from .crit.json are included automatically.")
+	fmt.Fprintln(os.Stderr, "Comments from the review file are included automatically.")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Examples:")
 	fmt.Fprintln(os.Stderr, "  crit share plan.md")
@@ -196,7 +196,7 @@ func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL,
 	}
 
 	if err := persistShareState(critPath, url, deleteToken, shareScope(filePaths)); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not save share state to .crit.json: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: could not save share state to review file: %v\n", err)
 	}
 
 	initialComments, _ := loadCommentsForUpsert(critPath, filePaths)
@@ -257,7 +257,7 @@ func parseFetchOutputDir(args []string) string {
 		default:
 			fmt.Fprintln(os.Stderr, "Usage: crit fetch [--output <dir>]")
 			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "Fetches comments added on crit-web into .crit.json.")
+			fmt.Fprintln(os.Stderr, "Fetches comments added on crit-web into the review file.")
 			fmt.Fprintln(os.Stderr, "Requires a prior `crit share` so a share URL is recorded.")
 			os.Exit(1)
 		}
@@ -266,7 +266,7 @@ func parseFetchOutputDir(args []string) string {
 }
 
 func printFetchedComments(webComments []webComment) {
-	fmt.Printf("Fetched %d new comment(s) into .crit.json\n", len(webComments))
+	fmt.Printf("Fetched %d new comment(s) into review file\n", len(webComments))
 	for _, wc := range webComments {
 		runes := []rune(wc.Body)
 		body := wc.Body
@@ -692,7 +692,7 @@ func runPush(args []string) {
 	replyIDs := postPushReplies(prNumber, allReplies)
 
 	if err := updateCritJSONWithGitHubIDs(critPath, commentIDs, replyIDs); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to update .crit.json with GitHub IDs: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: failed to update review file with GitHub IDs: %v\n", err)
 	}
 }
 
@@ -843,7 +843,7 @@ func runCommentClear(outputDir string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("Cleared .crit.json")
+	fmt.Println("Cleared review file")
 }
 
 func printCommentUsage() {
@@ -981,7 +981,7 @@ func looksLikeLineSpec(s string) bool {
 	return err == nil
 }
 
-// fileExistsOnDiskOrSession checks if a path exists as a file on disk or in .crit.json.
+// fileExistsOnDiskOrSession checks if a path exists as a file on disk or in the review file.
 func fileExistsOnDiskOrSession(path string, outputDir string) bool {
 	// Check disk first (relative to cwd)
 	if info, err := os.Stat(path); err == nil && !info.IsDir() {
@@ -996,7 +996,7 @@ func fileExistsOnDiskOrSession(path string, outputDir string) bool {
 			}
 		}
 	}
-	// Check if it exists in .crit.json
+	// Check if it exists in the review file
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return false
@@ -1587,8 +1587,8 @@ func parseServerFlags(args []string) serverFlagSet {
 	showVersion := fs.Bool("version", false, "Print version and exit")
 	fs.BoolVar(showVersion, "v", false, "Print version and exit (shorthand)")
 	shareURL := fs.String("share-url", "", "Base URL of hosted Crit service for sharing reviews (overrides CRIT_SHARE_URL env var)")
-	outputDir := fs.String("output", "", "Output directory for .crit.json (default: repo root or file directory)")
-	fs.StringVar(outputDir, "o", "", "Output directory for .crit.json (shorthand)")
+	outputDir := fs.String("output", "", "Output directory for review file (default: repo root or file directory)")
+	fs.StringVar(outputDir, "o", "", "Output directory for review file (shorthand)")
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status output (shorthand)")
 	noIgnore := fs.Bool("no-ignore", false, "Disable all ignore patterns from config files")
@@ -1710,7 +1710,7 @@ func createSession(sc *serverConfig) (*Session, error) {
 		return nil, err
 	}
 	// Set ReviewFilePath before loadCritJSON so it reads from the centralized
-	// review file, not the legacy repo-root .crit.json.
+	// review file.
 	if sc.reviewPath != "" {
 		session.ReviewFilePath = sc.reviewPath
 		session.loadCritJSON()
@@ -2269,15 +2269,15 @@ Usage:
   crit <file|dir> [...]                      Review specific files or directories
   crit stop [files...]                       Stop the daemon for current directory (and args)
   crit stop --all                            Stop all daemons for current directory
-  crit comment <path>:<line[-end]> <body>    Add a review comment to .crit.json
+  crit comment <path>:<line[-end]> <body>    Add a review comment
   crit comment --reply-to <id> [--resolve] [--author <name>] <body>  Reply to a comment
   crit comment --json [--author <name>] [--output <dir>]    Read comments from stdin as JSON
-  crit comment --clear                       Remove all comments from .crit.json
+  crit comment --clear                       Remove all comments from the review file
   crit share <file> [file...]                Share files to crit-web and print the URL
-  crit fetch [--output <dir>]               Fetch comments from crit-web into .crit.json
+  crit fetch [--output <dir>]               Fetch comments from crit-web into the review file
   crit unpublish                             Remove a shared review from crit-web
-  crit pull [--output <dir>] [pr-number]     Fetch GitHub PR comments to .crit.json
-  crit push [--dry-run] [--event <type>] [-m <msg>] [-o <dir>] [pr-number]  Post .crit.json comments to a GitHub PR
+  crit pull [--output <dir>] [pr-number]     Fetch GitHub PR comments into the review file
+  crit push [--dry-run] [--event <type>] [-m <msg>] [-o <dir>] [pr-number]  Post review comments to a GitHub PR
   crit plan --name <slug> <file>             Review a plan file (manages versioned copies)
   crit plan --name <slug>                    Read plan from stdin
   crit auth login                            Log in to crit-web via browser
@@ -2295,7 +2295,7 @@ Usage:
 
 Options:
   -p, --port <port>           Port to listen on (default: random)
-  -o, --output <dir>          Output directory for .crit.json
+  -o, --output <dir>          Output directory for review file
       --no-open               Don't auto-open browser
       --no-ignore             Disable all file ignore patterns
   -q, --quiet                 Suppress status output
@@ -2342,7 +2342,7 @@ Available keys:
   no_open           bool      Don't auto-open browser (default: false)
   share_url         string    Share service URL
   quiet             bool      Suppress status output (default: false)
-  output            string    Output directory for .crit.json
+  output            string    Output directory for review file
   author            string    Your name for comments (default: git config user.name)
   base_branch       string    Base branch to diff against (overrides auto-detection)
   ignore_patterns        []string  Gitignore-style patterns to exclude files from review

--- a/server.go
+++ b/server.go
@@ -860,7 +860,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	if totalComments > 0 && unresolvedComments > 0 {
 		if s.session.Mode == "plan" {
 			// Plan mode: concise feedback for the hook workflow.
-			// Claude revises the plan text directly — no need for crit comment or .crit.json instructions.
+			// Claude revises the plan text directly — no need for crit comment or review file instructions.
 			prompt = s.buildPlanFeedback(critJSON)
 		} else {
 			prompt = fmt.Sprintf(
@@ -908,7 +908,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 }
 
 // buildPlanFeedback formats review feedback for plan mode.
-// Points to .crit.json and hints at crit-cli skill, without inlining every comment.
+// Points to the review file and hints at crit-cli skill, without inlining every comment.
 func (s *Server) buildPlanFeedback(critJSON string) string {
 	// Extract slug from PlanDir (last path component)
 	slug := filepath.Base(s.session.PlanDir)

--- a/session.go
+++ b/session.go
@@ -153,7 +153,7 @@ type Session struct {
 	BaseRef        string
 	BaseBranchName string // display name of the base branch (e.g. "production", "master")
 	RepoRoot       string
-	OutputDir      string // custom output directory for .crit.json (empty = RepoRoot)
+	OutputDir      string // custom output directory for the review file (empty = RepoRoot)
 	ReviewFilePath string // centralized review file path (~/.crit/reviews/<key>.json)
 	PlanDir        string // managed storage dir for plan mode (empty for git/files)
 	ReviewRound    int
@@ -185,7 +185,7 @@ type Session struct {
 
 }
 
-// CritJSON is the on-disk format for .crit.json.
+// CritJSON is the on-disk format for review files.
 type CritJSON struct {
 	Branch         string                  `json:"branch"`
 	BaseRef        string                  `json:"base_ref"`
@@ -199,7 +199,7 @@ type CritJSON struct {
 	Files          map[string]CritJSONFile `json:"files"`
 }
 
-// CritJSONFile is the per-file section in .crit.json.
+// CritJSONFile is the per-file section in review files.
 type CritJSONFile struct {
 	Status   string    `json:"status"`
 	FileHash string    `json:"file_hash"`
@@ -1156,7 +1156,7 @@ func (s *Session) SetAwaitingFirstReview(v bool) {
 // comments and sending a signal to the watcher goroutine. The ReviewRound counter
 // is NOT incremented here — it is deferred to the watcher's handleRoundComplete*
 // handler, which increments it only after comments have been carried forward from
-// .crit.json. This prevents a TOCTOU race where GetSessionInfo could observe the
+// the review file. This prevents a TOCTOU race where GetSessionInfo could observe the
 // new round number before carry-forward is complete, returning empty comments.
 func (s *Session) SignalRoundComplete() {
 	s.mu.Lock()
@@ -1181,16 +1181,16 @@ func (s *Session) SignalRoundComplete() {
 
 // ClearAllComments removes all comments from all files and resets comment IDs and review round.
 // Used by the E2E test cleanup endpoint to return the server to a clean initial state.
-// It also removes .crit.json from s.Files and deletes the review file from disk
-// (centralized storage under ~/.crit/reviews/ or legacy repo-local .crit.json).
+// It also removes the review file entry from s.Files and deletes the review file from disk
+// (centralized storage under ~/.crit/reviews/).
 func (s *Session) ClearAllComments() {
 	s.mu.Lock()
-	// Cancel any pending debounced write so it cannot recreate .crit.json after we delete it.
+	// Cancel any pending debounced write so it cannot recreate the review file after we delete it.
 	if s.writeTimer != nil {
 		s.writeTimer.Stop()
 	}
 	s.writeGen++
-	// Reset all file state and drop the .crit.json entry from the file list.
+	// Reset all file state and drop the review file entry from the file list.
 	filtered := make([]*FileEntry, 0, len(s.Files))
 	for _, f := range s.Files {
 		if filepath.Base(f.Path) == ".crit.json" {
@@ -1330,7 +1330,7 @@ func (s *Session) scheduleWrite() {
 	})
 }
 
-// critJSONPath returns the path to the .crit.json file.
+// critJSONPath returns the path to the review file.
 func (s *Session) critJSONPath() string {
 	if s.OutputDir != "" {
 		return filepath.Join(s.OutputDir, ".crit.json")
@@ -1342,7 +1342,7 @@ func (s *Session) critJSONPath() string {
 	return filepath.Join(s.RepoRoot, ".crit.json")
 }
 
-// writeFilesSnapshot holds all session state needed to write .crit.json,
+// writeFilesSnapshot holds all session state needed to write the review file,
 // captured under lock so that disk I/O can happen without holding the lock.
 type writeFilesSnapshot struct {
 	critPath       string
@@ -1367,7 +1367,7 @@ type writeFileSnapshot struct {
 	deletedIDs map[string]struct{} // comment IDs deleted in-memory, skip during merge
 }
 
-// handleExternalDeletion checks if .crit.json was deleted externally and clears
+// handleExternalDeletion checks if the review file was deleted externally and clears
 // in-memory comments if so. Returns true if the file was deleted.
 func (s *Session) handleExternalDeletion(critPath string) bool {
 	s.mu.RLock()
@@ -1409,13 +1409,13 @@ func (s *Session) clearAllCommentData() {
 	}
 }
 
-// buildCritJSON loads existing .crit.json from disk, applies the snapshot metadata,
+// buildCritJSON loads the existing review file from disk, applies the snapshot metadata,
 // and merges per-file comments.
 func buildCritJSON(snap writeFilesSnapshot) CritJSON {
 	cj := CritJSON{Files: make(map[string]CritJSONFile)}
 	if data, err := os.ReadFile(snap.critPath); err == nil {
 		if unmarshalErr := json.Unmarshal(data, &cj); unmarshalErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: corrupt .crit.json, starting fresh: %v\n", unmarshalErr)
+			fmt.Fprintf(os.Stderr, "Warning: corrupt review file, starting fresh: %v\n", unmarshalErr)
 		}
 		if cj.Files == nil {
 			cj.Files = make(map[string]CritJSONFile)
@@ -1477,7 +1477,7 @@ func critJSONIsEmpty(cj CritJSON) bool {
 		cj.ShareURL == "" && cj.DeleteToken == "" && cj.ShareScope == ""
 }
 
-// WriteFiles writes the .crit.json file to disk.
+// WriteFiles writes the review file to disk.
 //
 // The implementation snapshots all needed session state under RLock, then
 // releases the lock before doing any disk I/O (ReadFile, Stat, WriteFile).
@@ -1509,11 +1509,11 @@ func (s *Session) WriteFiles() {
 
 	data, err := json.MarshalIndent(cj, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling .crit.json: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error marshaling review file: %v\n", err)
 		return
 	}
 	if err := atomicWriteFile(snap.critPath, data, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing .crit.json: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error writing review file: %v\n", err)
 		return
 	}
 	if info, err := os.Stat(snap.critPath); err == nil {
@@ -1567,7 +1567,7 @@ func (s *Session) snapshotForWrite(critPath string) writeFilesSnapshot {
 	return snap
 }
 
-// handleCritJSONDeleted clears all in-memory comment state when .crit.json
+// handleCritJSONDeleted clears all in-memory comment state when the review file
 // has been deleted. Returns true unconditionally to signal the deletion.
 func (s *Session) handleCritJSONDeleted() bool {
 	s.clearAllCommentData()
@@ -1772,7 +1772,7 @@ func (s *Session) mergeExternalCritJSON() bool {
 	return changed
 }
 
-// loadCritJSON loads comments and share state from an existing .crit.json.
+// loadCritJSON loads comments and share state from an existing review file.
 func (s *Session) loadCritJSON() {
 	data, err := os.ReadFile(s.critJSONPath())
 	if err != nil {
@@ -1794,8 +1794,8 @@ func (s *Session) loadCritJSON() {
 			s.deleteToken = cj.DeleteToken
 			s.shareScope = cj.ShareScope
 		}
-	} else {
-		// Legacy .crit.json without scope — load unconditionally for backwards compat.
+	} else if cj.ShareURL != "" {
+		// No scope recorded — load unconditionally.
 		s.sharedURL = cj.ShareURL
 		s.deleteToken = cj.DeleteToken
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -3532,10 +3532,10 @@ func TestLoadCritJSON_ShareScopeMismatch(t *testing.T) {
 	}
 }
 
-func TestLoadCritJSON_LegacyNoScope(t *testing.T) {
+func TestLoadCritJSON_NoScope(t *testing.T) {
 	s := newTestSession(t)
 
-	// Legacy .crit.json without ShareScope — should load unconditionally.
+	// Review file without ShareScope — should load unconditionally.
 	reviewPath := filepath.Join(s.RepoRoot, "review.json")
 	cj := CritJSON{
 		ShareURL:    "https://crit.example.com/review/legacy",

--- a/share.go
+++ b/share.go
@@ -32,7 +32,7 @@ func shareScope(paths []string) string {
 
 // computeShareHash returns a short stable hash of the current share state:
 // file contents (for change detection) and comment resolution states.
-// If the hash equals LastShareHash in .crit.json, nothing has changed since
+// If the hash equals LastShareHash in the review file, nothing has changed since
 // the last push and no new round is needed.
 func computeShareHash(files []shareFile, comments []shareComment) string {
 	sorted := make([]shareFile, len(files))
@@ -338,7 +338,7 @@ func buildLocalFingerprints(cj CritJSON) map[string]bool {
 // i.e., when the agent calls `crit share <files>` after applying changes from
 // the crit-web prompt. This captures any web-reviewer comments added after the
 // prompt was generated (e.g., a late-arriving review) so they appear in local
-// .crit.json before the next round is pushed.
+// the review file before the next round is pushed.
 //
 // shareURL is the full review URL, e.g. "https://crit.md/r/abc123".
 func fetchNewWebComments(shareURL string, localIDs map[string]bool, localFingerprints map[string]bool, authToken string) ([]webComment, error) {
@@ -545,7 +545,7 @@ func mergeWebComments(critPath string, newComments []webComment) error {
 	}
 
 	// Find the highest existing web-N index so new IDs are globally unique
-	// even if earlier ones were deleted from .crit.json.
+	// even if earlier ones were deleted from the review file.
 	webCount := highestWebIndex(cj)
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -616,11 +616,11 @@ func persistShareState(critPath string, shareURL string, deleteToken string, sco
 func clearShareState(critPath string) error {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
-		return nil //nolint:nilerr // no .crit.json file means nothing to clear
+		return nil //nolint:nilerr // no review file means nothing to clear
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
-		return fmt.Errorf("invalid .crit.json: %w", err)
+		return fmt.Errorf("invalid review file: %w", err)
 	}
 	cj.ShareURL = ""
 	cj.DeleteToken = ""

--- a/share_test.go
+++ b/share_test.go
@@ -828,7 +828,7 @@ func TestLoadExistingShareCfg(t *testing.T) {
 	dir := t.TempDir()
 	critPath := filepath.Join(dir, ".crit.json")
 
-	// Legacy .crit.json without scope — loads unconditionally
+	// Review file without scope — loads unconditionally
 	cj := CritJSON{
 		ShareURL:    "https://crit.md/r/existing",
 		DeleteToken: "del-token-123",

--- a/test/test-diff.sh
+++ b/test/test-diff.sh
@@ -8,7 +8,7 @@
 #   2. Seeds 4 review comments + 4 threaded replies via the API
 #   3. Waits for you to press Enter (browse the comments + replies first)
 #   4. Swaps in test-plan-v2.md to simulate agent edits
-#   5. Marks some comments as resolved in .crit.json
+#   5. Marks some comments as resolved in the review file
 #   6. Signals round-complete so the diff + resolved comments appear
 #
 # Threading coverage:
@@ -239,7 +239,7 @@ curl -sf -X POST "http://127.0.0.1:$PORT/api/comment/c4/replies?path=$ENCODED_PA
     "author": "reviewer"
   }' > /dev/null
 
-# Finish the review to write .crit.json
+# Finish the review to write the review file
 REVIEW_FILE=$(curl -sf -X POST "http://127.0.0.1:$PORT/api/finish" | python3 -c "import json, sys; print(json.load(sys.stdin)['review_file'])")
 
 echo ""
@@ -253,7 +253,7 @@ cp test/test-plan-v2.md "$FILE"
 # Give the file watcher one tick to detect the change (polls every 1s).
 sleep 1.5
 
-# Mark 3 of 4 comments as resolved in .crit.json (comment #4 stays open)
+# Mark 3 of 4 comments as resolved in the review file (comment #4 stays open)
 python3 - "$REVIEW_FILE" <<'PYEOF'
 import json, sys
 path = sys.argv[1]

--- a/watch.go
+++ b/watch.go
@@ -166,7 +166,7 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 		case <-stop:
 			return
 		case <-ticker.C:
-			// Check for external .crit.json changes (e.g. crit comment).
+			// Check for external review file changes (e.g. crit comment).
 			s.mergeExternalCritJSON()
 
 			fp := WorkingTreeFingerprint()
@@ -200,7 +200,7 @@ func (s *Session) watchFileMtimes(stop <-chan struct{}) {
 		case <-stop:
 			return
 		case <-ticker.C:
-			// Check for external .crit.json changes (e.g. crit comment).
+			// Check for external review file changes (e.g. crit comment).
 			s.mergeExternalCritJSON()
 
 			s.mu.RLock()
@@ -399,13 +399,13 @@ func (s *Session) emitRoundStatus(edits int) {
 	s.status.RoundReady(round, resolved, open)
 }
 
-// loadResolvedComments reads .crit.json to pick up resolved fields the agent wrote.
+// loadResolvedComments reads the review file to pick up resolved fields the agent wrote.
 func (s *Session) loadResolvedComments() {
 	critPath := s.critJSONPath()
 	info, statErr := os.Stat(critPath)
 	data, err := os.ReadFile(critPath)
 	if err != nil {
-		// No .crit.json — clear all PreviousComments
+		// No review file — clear all PreviousComments
 		s.mu.Lock()
 		for _, f := range s.Files {
 			f.PreviousComments = nil
@@ -431,7 +431,7 @@ func (s *Session) loadResolvedComments() {
 	s.reviewComments = cj.ReviewComments
 	// Record the current mtime so mergeExternalCritJSON does not re-process
 	// this same file. Without this, the file watcher could detect the
-	// externally-written .crit.json (e.g. from a test or crit comment) as a
+	// externally-written review file (e.g. from a test or crit comment) as a
 	// new change and wipe comments that were added via the API after the
 	// round completed.
 	if statErr == nil {


### PR DESCRIPTION
## Summary

- Replace all stale `.crit.json` references with "review file" terminology across Go source, docs, and integration files (PR #256 moved storage to `~/.crit/reviews/<key>.json`)
- Remove legacy compatibility code: `findLegacyReviewPath()` function and its fallback in `resolveReviewPath()`
- Remove `.crit.json` from default `ignore_patterns` and `.gitignore`
- Clean up E2E test filters that excluded `.crit.json` from file list assertions

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `gofmt -l .` — clean
- [x] Expert Go review — no bugs or risks found

🤖 Generated with [Claude Code](https://claude.com/claude-code)