### PR TITLE
fix: prevent flaky round-complete E2E test

### DIFF
--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -793,14 +793,13 @@ test.describe('No-Changes Confirmation', () => {
     const round1 = (await request.get('/api/session').then(r => r.json())).review_round;
     await request.post('/api/round-complete');
     await waitForRound(request, round1);
+    await loadPage(page);
 
     // Resolve only the first comment via API
     const comments = await request.get(`/api/file/comments?path=${encodeURIComponent(filePath)}`).then(r => r.json());
     await request.put(`/api/comment/${comments[0].id}/resolve?path=${encodeURIComponent(filePath)}`, {
       data: { resolved: true },
     });
-
-    await loadPage(page);
 
     // Click finish — one comment still unresolved, no new feedback → confirmation
     await page.locator('#finishBtn').click();


### PR DESCRIPTION
## Summary

- Move `loadPage(page)` before the comment API read in "shows confirmation when user resolved some but not all comments" test
- This was the only test in the No-Changes Confirmation block that read comments immediately after `waitForRound` without a `loadPage` buffer, making it vulnerable to a stale `roundComplete` signal race from `beforeEach`

## Test plan

- [x] The fix matches the pattern used by every other test in the describe block
- [x] CI should pass consistently (this test was flaky before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)