### PR TITLE
fix: resolve crit comment --reply-to failing from different subdirectory

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -252,6 +252,46 @@ func findSessionForCWDBranch(cwd, branch string) (entry sessionEntry, key string
 	return sessionEntry{}, "", len(matched)
 }
 
+// listSessionsForRepoRoot returns alive sessions whose CWD is within the given
+// git repository root. This handles the case where `crit` was started from a
+// subdirectory (e.g. repo/api) but `crit comment` is run from a different
+// subdirectory or the repo root itself.
+func listSessionsForRepoRoot(repoRoot string) ([]sessionEntry, []string) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return nil, nil
+	}
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil
+	}
+	prefix := repoRoot + string(filepath.Separator)
+	var alive []sessionEntry
+	var keys []string
+	for _, de := range dirEntries {
+		if !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		key := strings.TrimSuffix(de.Name(), ".json")
+		data, err := os.ReadFile(filepath.Join(dir, de.Name()))
+		if err != nil {
+			continue
+		}
+		var entry sessionEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			continue
+		}
+		if entry.CWD != repoRoot && !strings.HasPrefix(entry.CWD, prefix) {
+			continue
+		}
+		if isDaemonAlive(entry) {
+			alive = append(alive, entry)
+			keys = append(keys, key)
+		}
+	}
+	return alive, keys
+}
+
 // isDaemonAlive checks if the daemon process is running AND responding to HTTP.
 // After PID recycling, a different process could listen on the same port,
 // so we validate that the response body contains {"status":"ok"}.

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -483,3 +483,74 @@ func TestFindSessionForCWDBranch_MultipleMatches(t *testing.T) {
 		t.Errorf("expected matchCount 2 for ambiguous case, got %d", matchCount)
 	}
 }
+
+func TestListSessionsForRepoRoot_MatchesSubdirectories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := "/tmp/myrepo"
+
+	// Create mock HTTP servers for alive sessions
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts1.Close()
+	port1, _ := strconv.Atoi(ts1.URL[strings.LastIndex(ts1.URL, ":")+1:])
+
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts2.Close()
+	port2, _ := strconv.Atoi(ts2.URL[strings.LastIndex(ts2.URL, ":")+1:])
+
+	ts3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts3.Close()
+	port3, _ := strconv.Atoi(ts3.URL[strings.LastIndex(ts3.URL, ":")+1:])
+
+	pid := os.Getpid()
+
+	// Session started from repo/api subdirectory
+	writeSessionFile("sub1", sessionEntry{PID: pid, Port: port1, CWD: repoRoot + "/api", Branch: "feat", ReviewPath: "/reviews/sub1.json"})
+	// Session started from repo root
+	writeSessionFile("sub2", sessionEntry{PID: pid, Port: port2, CWD: repoRoot, Branch: "main", ReviewPath: "/reviews/sub2.json"})
+	// Session from a completely different repo
+	writeSessionFile("other", sessionEntry{PID: pid, Port: port3, CWD: "/tmp/other-repo", Branch: "main", ReviewPath: "/reviews/other.json"})
+
+	entries, keys := listSessionsForRepoRoot(repoRoot)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 sessions for repo root, got %d", len(entries))
+	}
+
+	// Verify both repo sessions found, other excluded
+	foundKeys := map[string]bool{}
+	for _, k := range keys {
+		foundKeys[k] = true
+	}
+	if !foundKeys["sub1"] || !foundKeys["sub2"] {
+		t.Errorf("expected keys sub1 and sub2, got %v", keys)
+	}
+	if foundKeys["other"] {
+		t.Error("should not include session from different repo")
+	}
+}
+
+func TestListSessionsForRepoRoot_NoPartialMatch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+	port, _ := strconv.Atoi(ts.URL[strings.LastIndex(ts.URL, ":")+1:])
+
+	// /tmp/myrepo-extended should NOT match /tmp/myrepo
+	writeSessionFile("extended", sessionEntry{PID: os.Getpid(), Port: port, CWD: "/tmp/myrepo-extended", Branch: "main"})
+
+	entries, _ := listSessionsForRepoRoot("/tmp/myrepo")
+	if len(entries) != 0 {
+		t.Errorf("expected 0 sessions (no partial match), got %d", len(entries))
+	}
+}

--- a/github.go
+++ b/github.go
@@ -353,33 +353,8 @@ func resolveReviewPath(outputDir string) (string, error) {
 		return "", err
 	}
 
-	// Check daemon registry for running sessions — exact CWD match.
-	sessions, _ := listSessionsForCWD(cwd)
-	if len(sessions) == 1 && sessions[0].ReviewPath != "" {
-		return sessions[0].ReviewPath, nil
-	}
-	if len(sessions) > 1 {
-		path := resolveReviewPathFromSessions(sessions)
-		if path != "" {
-			return path, nil
-		}
-	}
-
-	// Fallback: match by git repo root (handles subdirectory mismatch —
-	// e.g. daemon started from repo/api but crit comment run from repo/).
-	if len(sessions) == 0 && IsGitRepo() {
-		if repoRoot, rootErr := RepoRoot(); rootErr == nil && repoRoot != cwd {
-			repoSessions, _ := listSessionsForRepoRoot(repoRoot)
-			if len(repoSessions) == 1 && repoSessions[0].ReviewPath != "" {
-				return repoSessions[0].ReviewPath, nil
-			}
-			if len(repoSessions) > 1 {
-				path := resolveReviewPathFromSessions(repoSessions)
-				if path != "" {
-					return path, nil
-				}
-			}
-		}
+	if path := resolveReviewPathFromDaemon(cwd); path != "" {
+		return path, nil
 	}
 
 	// No daemon — compute centralized path.
@@ -394,6 +369,40 @@ func resolveReviewPath(outputDir string) (string, error) {
 	}
 
 	return path, nil
+}
+
+// resolveReviewPathFromDaemon checks the daemon registry for a running session
+// and returns its review path. Tries exact CWD match first, then falls back to
+// matching by git repo root (handles subdirectory mismatch — e.g. daemon started
+// from repo/api but crit comment run from repo/).
+func resolveReviewPathFromDaemon(cwd string) string {
+	sessions, _ := listSessionsForCWD(cwd)
+	if path := pickReviewPath(sessions); path != "" {
+		return path
+	}
+
+	// Fallback: match by git repo root.
+	if len(sessions) == 0 && IsGitRepo() {
+		if repoRoot, err := RepoRoot(); err == nil && repoRoot != cwd {
+			repoSessions, _ := listSessionsForRepoRoot(repoRoot)
+			if path := pickReviewPath(repoSessions); path != "" {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+// pickReviewPath selects a review path from a list of sessions.
+// Returns the path if exactly one session has one, or defers to branch matching for multiple.
+func pickReviewPath(sessions []sessionEntry) string {
+	if len(sessions) == 1 && sessions[0].ReviewPath != "" {
+		return sessions[0].ReviewPath
+	}
+	if len(sessions) > 1 {
+		return resolveReviewPathFromSessions(sessions)
+	}
+	return ""
 }
 
 // resolveReviewPathFromSessions picks the best ReviewPath from multiple daemon sessions.

--- a/github.go
+++ b/github.go
@@ -353,7 +353,7 @@ func resolveReviewPath(outputDir string) (string, error) {
 		return "", err
 	}
 
-	// Check daemon registry for running sessions.
+	// Check daemon registry for running sessions — exact CWD match.
 	sessions, _ := listSessionsForCWD(cwd)
 	if len(sessions) == 1 && sessions[0].ReviewPath != "" {
 		return sessions[0].ReviewPath, nil
@@ -362,6 +362,23 @@ func resolveReviewPath(outputDir string) (string, error) {
 		path := resolveReviewPathFromSessions(sessions)
 		if path != "" {
 			return path, nil
+		}
+	}
+
+	// Fallback: match by git repo root (handles subdirectory mismatch —
+	// e.g. daemon started from repo/api but crit comment run from repo/).
+	if len(sessions) == 0 && IsGitRepo() {
+		if repoRoot, rootErr := RepoRoot(); rootErr == nil && repoRoot != cwd {
+			repoSessions, _ := listSessionsForRepoRoot(repoRoot)
+			if len(repoSessions) == 1 && repoSessions[0].ReviewPath != "" {
+				return repoSessions[0].ReviewPath, nil
+			}
+			if len(repoSessions) > 1 {
+				path := resolveReviewPathFromSessions(repoSessions)
+				if path != "" {
+					return path, nil
+				}
+			}
 		}
 	}
 
@@ -801,9 +818,89 @@ func addReplyToCritJSON(commentID, body, author string, resolve bool, outputDir 
 	}
 
 	if err := appendReply(&cj, commentID, body, author, resolve, filterPath); err != nil {
+		// Only fall back to scanning when the comment genuinely wasn't found.
+		// Don't fall back for ambiguity errors ("found in multiple files").
+		if strings.Contains(err.Error(), "not found") {
+			if altPath, err2 := findReviewFileByCommentID(commentID, critPath); err2 == nil {
+				altCJ, loadErr := loadCritJSON(altPath)
+				if loadErr != nil {
+					return err // return original error
+				}
+				if replyErr := appendReply(&altCJ, commentID, body, author, resolve, filterPath); replyErr != nil {
+					return err // return original error
+				}
+				fmt.Fprintf(os.Stderr, "Note: comment %s found in %s (not the resolved review file)\n", commentID, filepath.Base(altPath))
+				return saveCritJSON(altPath, altCJ)
+			}
+		}
 		return err
 	}
 	return saveCritJSON(critPath, cj)
+}
+
+// findReviewFileByCommentID scans all review files in ~/.crit/reviews/ for the given
+// comment ID, skipping excludePath. Returns the path if found in exactly one file.
+func findReviewFileByCommentID(commentID string, excludePath string) (string, error) {
+	dir, err := reviewsDir()
+	if err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var matchPath string
+	for _, de := range entries {
+		if !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, de.Name())
+		if path == excludePath {
+			continue
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		if reviewFileContainsComment(data, commentID) {
+			if matchPath != "" {
+				return "", fmt.Errorf("comment %q found in multiple review files", commentID)
+			}
+			matchPath = path
+		}
+	}
+	if matchPath == "" {
+		return "", fmt.Errorf("comment %q not found in any review file", commentID)
+	}
+	return matchPath, nil
+}
+
+// reviewFileContainsComment does a quick check if a review JSON file contains
+// a comment with the given ID. Uses string search first as a fast path to
+// avoid parsing files that definitely don't contain the ID.
+func reviewFileContainsComment(data []byte, commentID string) bool {
+	// Fast path: if the ID string doesn't appear at all, skip JSON parsing.
+	if !bytes.Contains(data, []byte(commentID)) {
+		return false
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return false
+	}
+	for _, c := range cj.ReviewComments {
+		if c.ID == commentID {
+			return true
+		}
+	}
+	for _, cf := range cj.Files {
+		for _, c := range cf.Comments {
+			if c.ID == commentID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // clearCritJSON removes the review file from the resolved path or outputDir.

--- a/github_test.go
+++ b/github_test.go
@@ -972,6 +972,106 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 	}
 }
 
+func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create the reviews directory with a review file containing the target comment.
+	reviewDir := filepath.Join(home, ".crit", "reviews")
+	os.MkdirAll(reviewDir, 0755)
+	targetCJ := CritJSON{
+		Branch:      "feat",
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c_target", StartLine: 10, EndLine: 10, Body: "Fix this", CreatedAt: "2025-01-01T00:00:00Z", UpdatedAt: "2025-01-01T00:00:00Z"},
+				},
+			},
+		},
+	}
+	targetData, _ := json.MarshalIndent(targetCJ, "", "  ")
+	os.WriteFile(filepath.Join(reviewDir, "correct.json"), targetData, 0644)
+
+	// Create a local outputDir with a different review file that does NOT contain the comment.
+	localDir := t.TempDir()
+	localCJ := CritJSON{Branch: "other", ReviewRound: 1, Files: map[string]CritJSONFile{}}
+	localData, _ := json.MarshalIndent(localCJ, "", "  ")
+	os.WriteFile(filepath.Join(localDir, ".crit.json"), localData, 0644)
+
+	// Reply should fall back to the review file containing c_target.
+	err := addReplyToCritJSON("c_target", "Done, fixed", "agent", false, localDir, "")
+	if err != nil {
+		t.Fatalf("expected fallback to find comment, got error: %v", err)
+	}
+
+	// Verify reply was written to the correct review file.
+	data, _ := os.ReadFile(filepath.Join(reviewDir, "correct.json"))
+	var result CritJSON
+	json.Unmarshal(data, &result)
+	comments := result.Files["main.go"].Comments
+	if len(comments[0].Replies) != 1 {
+		t.Fatalf("expected 1 reply in fallback file, got %d", len(comments[0].Replies))
+	}
+	if comments[0].Replies[0].Body != "Done, fixed" {
+		t.Errorf("reply body = %q", comments[0].Replies[0].Body)
+	}
+
+	// Verify the local file was NOT modified.
+	localData2, _ := os.ReadFile(filepath.Join(localDir, ".crit.json"))
+	var localResult CritJSON
+	json.Unmarshal(localData2, &localResult)
+	if len(localResult.Files) != 0 {
+		t.Error("local review file should not have been modified")
+	}
+}
+
+func TestFindReviewFileByCommentID_NotInAnyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	reviewDir := filepath.Join(home, ".crit", "reviews")
+	os.MkdirAll(reviewDir, 0755)
+
+	cj := CritJSON{Files: map[string]CritJSONFile{
+		"test.md": {Comments: []Comment{{ID: "c_abc", StartLine: 1, EndLine: 1, Body: "x"}}},
+	}}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(filepath.Join(reviewDir, "review1.json"), data, 0644)
+
+	_, err := findReviewFileByCommentID("c_nonexistent", "/excluded.json")
+	if err == nil {
+		t.Fatal("expected error for comment not in any file")
+	}
+	if !strings.Contains(err.Error(), "not found in any") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestFindReviewFileByCommentID_InReviewComments(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	reviewDir := filepath.Join(home, ".crit", "reviews")
+	os.MkdirAll(reviewDir, 0755)
+
+	cj := CritJSON{
+		ReviewComments: []Comment{{ID: "r_review1", Body: "General feedback"}},
+		Files:          map[string]CritJSONFile{},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(filepath.Join(reviewDir, "review1.json"), data, 0644)
+
+	path, err := findReviewFileByCommentID("r_review1", "/excluded.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filepath.Base(path) != "review1.json" {
+		t.Errorf("expected review1.json, got %s", filepath.Base(path))
+	}
+}
+
 func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
 	cj := CritJSON{
 		Files: map[string]CritJSONFile{


### PR DESCRIPTION
## Summary

- When a `crit` daemon was started from a subdirectory (e.g. `repo/api`) but `crit comment --reply-to` was run from a different directory in the same repo (e.g. `repo/`), the exact CWD match in session lookup would fail, causing replies to silently target the wrong (empty) review file
- Adds **repo root session matching** as a fallback — when no session matches the exact CWD, matches sessions whose CWD is within the same git repo root
- Adds **comment ID fallback** — when a reply target isn't found in the resolved review file, scans all `~/.crit/reviews/*.json` for the comment ID (only on "not found" errors, not ambiguity)

## Test plan

- [x] New tests for `listSessionsForRepoRoot` (subdirectory matching, partial name exclusion)
- [x] New tests for `findReviewFileByCommentID` (not found, review comments, fallback success)
- [x] Full test suite passes (`go test ./...`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)