### PR TITLE
feat: opportunistic background cleanup of stale reviews and sessions

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -663,3 +663,33 @@ func stopAllDaemonsForCWD(cwd string) {
 		stopDaemon(key)
 	}
 }
+
+// cleanOrphanedSessions removes session files whose daemon PID is dead.
+// It silently ignores all errors — intended for best-effort background use.
+func cleanOrphanedSessions() {
+	sessDir, err := sessionsDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(sessDir)
+	if err != nil {
+		return
+	}
+	for _, de := range entries {
+		if !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(sessDir, de.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var entry sessionEntry
+		if json.Unmarshal(data, &entry) != nil {
+			continue
+		}
+		if !isDaemonAlive(entry) {
+			os.Remove(path)
+		}
+	}
+}

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -554,3 +554,42 @@ func TestListSessionsForRepoRoot_NoPartialMatch(t *testing.T) {
 		t.Errorf("expected 0 sessions (no partial match), got %d", len(entries))
 	}
 }
+
+func TestCleanOrphanedSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sessDir := filepath.Join(home, ".crit", "sessions")
+
+	// Create a session file with a dead PID (PID that cannot exist).
+	deadEntry := sessionEntry{PID: 999999999, Port: 12345, CWD: "/tmp/repo"}
+	if err := writeSessionFile("deadpid12345", deadEntry); err != nil {
+		t.Fatalf("writeSessionFile: %v", err)
+	}
+
+	// Create a session file with a live PID (our own process).
+	// isDaemonAlive also checks HTTP, so this will fail the HTTP probe and
+	// be treated as dead. Use an httptest server to keep it alive.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+	port, _ := strconv.Atoi(ts.URL[strings.LastIndex(ts.URL, ":")+1:])
+
+	liveEntry := sessionEntry{PID: os.Getpid(), Port: port, CWD: "/tmp/repo"}
+	if err := writeSessionFile("livepid12345", liveEntry); err != nil {
+		t.Fatalf("writeSessionFile: %v", err)
+	}
+
+	cleanOrphanedSessions()
+
+	// Dead PID session should be removed.
+	if _, err := os.Stat(filepath.Join(sessDir, "deadpid12345.json")); !os.IsNotExist(err) {
+		t.Error("expected dead PID session file to be removed")
+	}
+
+	// Live PID session should still exist.
+	if _, err := os.Stat(filepath.Join(sessDir, "livepid12345.json")); err != nil {
+		t.Error("expected live PID session file to still exist")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1129,6 +1129,35 @@ func killDaemonOnApproval(approved bool, pid int) {
 	}
 }
 
+// backgroundCleanup silently removes stale review files and orphaned session
+// files. It is intended to be called as a goroutine from review entry points
+// so it adds zero perceived latency. All errors are swallowed — no output is
+// written to stdout or stderr.
+func backgroundCleanup() {
+	revDir, err := reviewsDir()
+	if err == nil {
+		stale := findStaleReviews(revDir, 14)
+		deleteStaleReviewsSilent(stale)
+	}
+	cleanOrphanedSessions()
+}
+
+// deleteStaleReviewsSilent is like deleteStaleReviews but swallows all errors.
+// Used by backgroundCleanup to avoid any output to stderr.
+func deleteStaleReviewsSilent(stale []staleReview) {
+	sessDir, _ := sessionsDir()
+	for _, s := range stale {
+		if os.Remove(s.path) != nil {
+			continue
+		}
+		if sessDir != "" {
+			os.Remove(filepath.Join(sessDir, s.key+".json"))
+			os.Remove(filepath.Join(sessDir, s.key+".lock"))
+			os.Remove(filepath.Join(sessDir, s.key+".log"))
+		}
+	}
+}
+
 // cleanupOnApproval deletes the review file when the review is approved
 // and cleanup is enabled.
 func cleanupOnApproval(approved bool, reviewPath string, cleanupEnabled bool) {
@@ -1138,6 +1167,8 @@ func cleanupOnApproval(approved bool, reviewPath string, cleanupEnabled bool) {
 }
 
 func runPlan(args []string) {
+	go backgroundCleanup()
+
 	pc := resolvePlanConfig(args)
 	content := readPlanContent(pc)
 
@@ -1224,6 +1255,8 @@ func emitHookDecision(approved bool, prompt string) {
 // opens a crit review session, and writes a hookSpecificOutput JSON
 // decision (allow/deny) to stdout.
 func runPlanHook() {
+	go backgroundCleanup()
+
 	var event planHookEvent
 	if err := json.NewDecoder(os.Stdin).Decode(&event); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: could not parse stdin: %v\n", err)
@@ -1346,6 +1379,8 @@ func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 }
 
 func runReview(args []string) {
+	go backgroundCleanup()
+
 	// Parse args to extract file args (stripping flags like --port, --no-open).
 	// The session key must use only file args to match what runServe computes.
 	sc, err := resolveServerConfig(args)


### PR DESCRIPTION
## Summary

- Every `crit` invocation now launches a background goroutine that silently cleans up `~/.crit/reviews/` (files >14 days old with no active daemon) and `~/.crit/sessions/` (dead daemon PIDs)
- Zero latency impact — runs concurrently with daemon startup/browser opening
- All errors swallowed — degrades gracefully to status quo if anything fails

## Test plan

- [ ] `TestCleanOrphanedSessions` — creates dead/live session files, verifies only dead ones are removed
- [ ] Existing `TestCleanupOnApproval_*` tests still pass
- [ ] Full CI suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)