### PR TITLE
fix: use --no-optional-locks for git status polling

### DIFF
--- a/git.go
+++ b/git.go
@@ -850,7 +850,7 @@ func ParseUnifiedDiff(diff string) []DiffHunk {
 // WorkingTreeFingerprint returns a string representing the current working tree state.
 // Compare consecutive calls to detect changes.
 func WorkingTreeFingerprint() string {
-	cmd := exec.Command("git", "status", "--porcelain")
+	cmd := exec.Command("git", "--no-optional-locks", "status", "--porcelain")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""


### PR DESCRIPTION
## Summary

- Add `--no-optional-locks` flag to the `git status --porcelain` call in `WorkingTreeFingerprint()`, which is polled every 1 second by the file watcher
- Without this flag, `git status` opportunistically refreshes the index's cached stat data, acquiring `index.lock` in the process
- In large repos where `git status` takes multiple seconds, this creates lock contention that blocks concurrent git operations — `git commit`, `git add`, `git reset`, `git checkout`, `git stash`, and any other command that writes to the index
- Affected operations fail with:
  ```
  fatal: Unable to create '<repo>/.git/index.lock': File exists.
  
  Another git process seems to be running in this repository, e.g.
  an editor opened by 'git commit'. Please make sure all processes
  are terminated then try again.
  ```

### Why this matters in large repos

The lock contention window is proportional to how long `git status` takes. In a small repo it completes in milliseconds, so the lock is held for a tiny fraction of each 1-second poll cycle. In a large monorepo, `git status` can take multiple seconds — if it takes longer than the 1-second poll interval, the lock is held continuously with no gap for other git processes to acquire it.

### The fix

The `--no-optional-locks` flag (added in git 2.15) tells git to skip the opportunistic index refresh. The output is identical — the only cost is that the next git command can't rely on cached stat data being fresh, which is irrelevant for crit's use case of polling for changes and discarding the output a second later.

## Test plan

- [ ] Verified by running looping commits in a large monorepo while crit daemon was active — no `index.lock` errors
- [ ] Existing `TestWorkingTreeFingerprint_RealRepo` passes