### PR TITLE
feat: only poll git status while waiting for agent edits

### DIFF
--- a/server.go
+++ b/server.go
@@ -878,6 +878,9 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	approved := unresolvedComments == 0
+	if !approved {
+		s.session.setWaitingForAgent(true)
+	}
 
 	writeJSON(w, map[string]any{
 		"status":      "finished",

--- a/session.go
+++ b/session.go
@@ -185,6 +185,7 @@ type Session struct {
 	lastRoundEdits      int
 	lastCritJSONMtime   time.Time // mtime after our last WriteFiles(); used to detect external changes
 	awaitingFirstReview bool      // true until first review-cycle completes
+	waitingForAgent     bool      // true between finish (with unresolved comments) and round-complete
 	browserClients      int32     // number of connected SSE browser clients (atomic)
 
 }
@@ -1156,6 +1157,20 @@ func (s *Session) SetAwaitingFirstReview(v bool) {
 	s.awaitingFirstReview = v
 }
 
+// setWaitingForAgent marks whether the session is in the "waiting for agent edits" phase.
+func (s *Session) setWaitingForAgent(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.waitingForAgent = v
+}
+
+// isWaitingForAgent returns true if the session is waiting for agent edits.
+func (s *Session) isWaitingForAgent() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.waitingForAgent
+}
+
 // SignalRoundComplete prepares the session for a new round by clearing current
 // comments and sending a signal to the watcher goroutine. The ReviewRound counter
 // is NOT incremented here — it is deferred to the watcher's handleRoundComplete*
@@ -1171,6 +1186,7 @@ func (s *Session) SignalRoundComplete() {
 	s.pendingWrite = false
 	s.lastRoundEdits = s.pendingEdits
 	s.pendingEdits = 0
+	s.waitingForAgent = false
 	// Clear comments on all files.
 	// ReviewRound is incremented later by the watcher after carry-forward.
 	for _, f := range s.Files {

--- a/session.go
+++ b/session.go
@@ -1226,6 +1226,7 @@ func (s *Session) ClearAllComments() {
 	s.ReviewRound = 1
 	s.lastCritJSONMtime = time.Time{}
 	s.pendingWrite = false
+	s.waitingForAgent = false
 	critPath := s.critJSONPath()
 	s.mu.Unlock()
 	// Delete the review file from disk (centralized or legacy path).

--- a/watch.go
+++ b/watch.go
@@ -155,11 +155,16 @@ func (s *Session) Watch(stop <-chan struct{}) {
 
 // watchGit polls `git status --porcelain` for working tree changes.
 // Used in git mode (no-args invocation).
+//
+// Git status polling only runs during the "waiting for agent" phase (between
+// POST /api/finish and POST /api/round-complete). mergeExternalCritJSON runs
+// on every tick since it only uses os.Stat.
 func (s *Session) watchGit(stop <-chan struct{}) {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	lastFP := WorkingTreeFingerprint()
+	var lastFP string
+	wasWaiting := false
 
 	for {
 		select {
@@ -169,7 +174,19 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 			// Check for external review file changes (e.g. crit comment).
 			s.mergeExternalCritJSON()
 
+			// Only poll git status while waiting for the agent to make edits.
+			if !s.isWaitingForAgent() {
+				wasWaiting = false
+				continue
+			}
+
 			fp := WorkingTreeFingerprint()
+			if !wasWaiting {
+				// Just entered waiting state — establish baseline.
+				lastFP = fp
+				wasWaiting = true
+				continue
+			}
 			if fp == lastFP {
 				continue
 			}

--- a/watch_test.go
+++ b/watch_test.go
@@ -374,6 +374,70 @@ func TestCarryForwardComment_PreservesQuote(t *testing.T) {
 	}
 }
 
+// TestWatchGit_SkipsGitStatusWhenNotWaiting verifies that watchGit does not
+// detect edits when waitingForAgent is false, and does detect them once
+// waitingForAgent is set to true.
+func TestWatchGit_SkipsGitStatusWhenNotWaiting(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Create a feature branch so we have a known base
+	runGit(t, dir, "checkout", "-b", "feat")
+	writeFile(t, filepath.Join(dir, "file.go"), "package main\n")
+	runGit(t, dir, "add", "file.go")
+	runGit(t, dir, "commit", "-m", "add file")
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feat",
+		BaseRef:     "main",
+		ReviewRound: 1,
+		Files: []*FileEntry{
+			{
+				Path:     "file.go",
+				AbsPath:  filepath.Join(dir, "file.go"),
+				Status:   "modified",
+				FileType: "code",
+				Comments: []Comment{},
+			},
+		},
+		subscribers:   make(map[chan SSEEvent]struct{}),
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Start watchGit with waitingForAgent = false (default).
+	// WorkingTreeFingerprint uses cwd, so chdir before starting.
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+	go s.watchGit(stop)
+
+	// Create an untracked file — this changes git status --porcelain output.
+	time.Sleep(500 * time.Millisecond) // let watcher start
+	writeFile(t, filepath.Join(dir, "untracked1.txt"), "hello\n")
+
+	// Wait for a couple of watcher ticks — should NOT detect edits.
+	time.Sleep(2500 * time.Millisecond)
+	if edits := s.GetPendingEdits(); edits != 0 {
+		t.Errorf("expected 0 edits while not waiting for agent, got %d", edits)
+	}
+
+	// Now set waitingForAgent = true and wait for the baseline tick.
+	s.setWaitingForAgent(true)
+	time.Sleep(1500 * time.Millisecond) // baseline tick
+
+	// Create another new file to change the fingerprint from the baseline.
+	writeFile(t, filepath.Join(dir, "untracked2.txt"), "world\n")
+	time.Sleep(2500 * time.Millisecond)
+
+	if edits := s.GetPendingEdits(); edits == 0 {
+		t.Error("expected edits > 0 after setting waitingForAgent = true")
+	}
+}
+
 func TestRestoreOrphanedComments(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Gate `WorkingTreeFingerprint()` (git status) polling behind a `waitingForAgent` state flag
- Only poll between `POST /api/finish` (with unresolved comments) and `POST /api/round-complete`
- `mergeExternalCritJSON` continues on every tick (just `os.Stat`)
- Fresh baseline taken when entering the waiting state to avoid spurious edit detection

Closes #282

## Reproduction
- N/A — optimization, not a bug fix

## Review
- [x] Expert code review: passed (1 warning found and fixed)
- [x] Test suite: passing

## Test plan
- New test `TestWatchGit_SkipsGitStatusWhenNotWaiting` verifies edits are NOT detected while browsing, and ARE detected once `waitingForAgent` is set
- Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)