### PR TITLE
fix: preserve context lines in unified-diff selection after deletion-anchored drag

### DIFF
--- a/e2e/tests/drag-selection.spec.ts
+++ b/e2e/tests/drag-selection.spec.ts
@@ -314,4 +314,57 @@ test.describe('Diff Drag Selection — Unified Mode', () => {
     const count = await selectedLines.count();
     expect(count).toBeGreaterThanOrEqual(1);
   });
+
+  test('unified drag from deletion spans across context lines after release', async ({ page }) => {
+    // Regression: dragging from a deletion anchor across context + another deletion
+    // should keep the full old-side range highlighted after mouseup, not collapse
+    // to only the deletion lines.
+    const section = goSection(page);
+    await expect(section).toBeVisible();
+
+    // Find two deletion lines separated by at least one context line in between.
+    const pair = await section.evaluate((sec) => {
+      const lines = Array.from(sec.querySelectorAll('.diff-container.unified .diff-line'));
+      let firstDel = -1;
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].classList.contains('deletion')) {
+          if (firstDel === -1) { firstDel = i; continue; }
+          // Check at least one context line between firstDel and i
+          for (let j = firstDel + 1; j < i; j++) {
+            const cls = lines[j].classList;
+            if (!cls.contains('deletion') && !cls.contains('addition')) {
+              return { first: firstDel, last: i };
+            }
+          }
+        }
+      }
+      return null;
+    });
+    if (!pair) test.skip(true, 'fixture needs two deletions with context between');
+
+    const allLines = section.locator('.diff-container.unified .diff-line');
+    const firstDel = allLines.nth(pair!.first);
+    const lastDel = allLines.nth(pair!.last);
+
+    await firstDel.scrollIntoViewIfNeeded();
+    await firstDel.hover();
+    const firstBtn = firstDel.locator('.diff-comment-btn');
+    await expect(firstBtn).toBeAttached();
+    const secondBtn = lastDel.locator('.diff-comment-btn');
+
+    await dragBetween(page, firstBtn, secondBtn);
+
+    await expect(page.locator('.comment-form')).toBeVisible();
+
+    // After mouseup, context lines between the deletions should still be highlighted
+    // (not just the deletion endpoints). Before the fix, inCurrentForm filtered by
+    // side so only deletion lines kept the .selected class after the drag released.
+    const selectedContext = section.locator(
+      '.diff-container.unified .diff-line.selected:not(.deletion):not(.addition)'
+    );
+    await expect(async () => {
+      const n = await selectedContext.count();
+      expect(n).toBeGreaterThan(0);
+    }).toPass();
+  });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2954,11 +2954,16 @@
             const inCurrentDrag = diffDragState && unifiedVisualStart !== null && unifiedVisualEnd !== null &&
                 visualIdx >= unifiedVisualStart && visualIdx <= unifiedVisualEnd;
             const formSide = activeForms.length > 0 ? (activeForms[activeForms.length - 1].side || '') : '';
+            // Match against the line's number in the form's space (OldNum for old-side, NewNum otherwise)
+            // so context lines participate in old-side range selections.
+            const relevantNum = formSide === 'old' ? line.OldNum : line.NewNum;
             const inCurrentForm = !diffDragState && selectionStart !== null && selectionEnd !== null &&
-                lineSide === formSide && commentLineNum >= selectionStart && commentLineNum <= selectionEnd;
+                relevantNum > 0 && relevantNum >= selectionStart && relevantNum <= selectionEnd;
             const inCurrentSelUnified = inCurrentDrag || inCurrentForm;
             const hasFormUnified = getFormsForFile(file.path).some(function(f) {
-              return !f.editingId && commentLineNum >= f.startLine && commentLineNum <= f.endLine && (f.side || '') === lineSide;
+              const fSide = f.side || '';
+              const fNum = fSide === 'old' ? line.OldNum : line.NewNum;
+              return !f.editingId && fNum > 0 && fNum >= f.startLine && fNum <= f.endLine;
             });
             if (inCurrentSelUnified) { lineEl.classList.add('selected'); }
             if (hasFormUnified && !inCurrentSelUnified) { lineEl.classList.add('form-selected'); }

--- a/test/test-diff.sh
+++ b/test/test-diff.sh
@@ -97,6 +97,39 @@ defmodule MyApp.Accounts do
 end
 EXEOF
 
+# Scheduler file — exercises unified-diff gutter drag starting from a deletion line.
+# v1 → v2 produces three deletion/addition pairs separated by context lines; drag
+# the + gutter from the first deletion to the last to verify the selection spans
+# context lines (not collapsed to deletions only).
+cat > "$WORD_DIFF_DIR/scheduler.ex" << 'EXEOF'
+defmodule Vetspire.DistributedWorker.Scheduler do
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    {:ok, %{dynamic_supervisor: opts[:sup], owned: %{}}}
+  end
+
+  def handle_call({:schedule, task_id, child_spec}, _from, state) do
+    owned = state.owned
+
+    case DynamicSupervisor.start_child(state.dynamic_supervisor, child_spec) do
+      {:ok, pid} ->
+        Map.put(owned, task_id, {pid, Process.monitor(pid)})
+
+      {:ok, pid, _info} ->
+        Map.put(owned, task_id, {pid, Process.monitor(pid)})
+
+      {:error, {:already_started, pid}} ->
+        Map.put(owned, task_id, {pid, Process.monitor(pid)})
+    end
+  end
+end
+EXEOF
+
 git -C "$WORD_DIFF_DIR" add -A && git -C "$WORD_DIFF_DIR" commit -q -m "initial"
 
 # Modify the file to produce good word-level diff pairs
@@ -148,6 +181,37 @@ defmodule MyApp.Accounts do
         |> validate_required([:password, :password_confirmation])
         |> validate_length(:password, min: 8)
         |> validate_confirmation(:password)
+  end
+end
+EXEOF
+
+# Modify scheduler.ex — Map.put → track/3, producing three paired del/add blocks
+# separated by context lines. This is the target for the unified-diff gutter drag test.
+cat > "$WORD_DIFF_DIR/scheduler.ex" << 'EXEOF'
+defmodule Vetspire.DistributedWorker.Scheduler do
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    {:ok, %{dynamic_supervisor: opts[:sup], owned: %{}}}
+  end
+
+  def handle_call({:schedule, task_id, child_spec}, _from, state) do
+    owned = state.owned
+
+    case DynamicSupervisor.start_child(state.dynamic_supervisor, child_spec) do
+      {:ok, pid} ->
+        track(owned, task_id, pid)
+
+      {:ok, pid, _info} ->
+        track(owned, task_id, pid)
+
+      {:error, {:already_started, pid}} ->
+        track(owned, task_id, pid)
+    end
   end
 end
 EXEOF


### PR DESCRIPTION
## Summary

In unified diff view, dragging from a deletion line's + gutter to another deletion line collapsed the post-release selection to only the deletion lines — context in between lost its `.selected` class, making it look like the drag had stopped working.

Root cause: `renderDiffUnified`'s post-drag range check compared `commentLineNum` (NewNum for context/additions, OldNum for deletions) against `selectionStart/End` with a `lineSide === formSide` filter. For an old-side form, context lines have `lineSide=''` and their `commentLineNum` is a NewNum outside the old-side range, so they dropped out. `buildUnifiedCommentVisualSet` already handled this correctly for saved comments — the active-form path just wasn't updated the same way.

Fix: pick the line's relevant number for the form's space (`line.OldNum` for old-side, `line.NewNum` otherwise) and use that in the range check — same treatment for both `inCurrentForm` and `hasFormUnified`.

## Test plan

- [x] Added regression test `unified drag from deletion spans across context lines after release` in `e2e/tests/drag-selection.spec.ts` — fails without the fix, passes with it
- [x] Full drag-selection + comments + expanded-comments + old-side-suggest + unstaged-comments suites pass (56 tests)
- [x] Added a `scheduler.ex` fixture to `test-diff.sh` instance 2 that reproduces the three-del/add-pair pattern from the original report — `make test-diff`, open the word-diff port, switch to unified, drag first deletion → last deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)