### PR TITLE
fix: serialize debounced review-file writes with ClearAllComments

### DIFF
--- a/session.go
+++ b/session.go
@@ -170,11 +170,17 @@ type Session struct {
 	// prevents mergeFileSnapshotIntoCritJSON from re-adding them from disk.
 	deletedCommentIDs map[string]map[string]struct{}
 
-	mu                  sync.RWMutex
-	subscribers         map[chan SSEEvent]struct{}
-	subMu               sync.Mutex
-	writeTimer          *time.Timer
-	writeGen            int
+	mu          sync.RWMutex
+	subscribers map[chan SSEEvent]struct{}
+	subMu       sync.Mutex
+	writeTimer  *time.Timer
+	writeGen    int
+	// writeMu serializes debounced WriteFiles() calls with ClearAllComments
+	// so a stale in-flight write cannot recreate the review file after it has
+	// been deleted. time.Timer.Stop() does not wait for callbacks already
+	// executing, so the writeGen check alone is not sufficient to prevent a
+	// snapshot-taken-before-clear from resurrecting the file.
+	writeMu             sync.Mutex
 	pendingWrite        bool
 	sharedURL           string
 	deleteToken         string
@@ -1204,6 +1210,12 @@ func (s *Session) SignalRoundComplete() {
 // It also removes the review file entry from s.Files and deletes the review file from disk
 // (centralized storage under ~/.crit/reviews/).
 func (s *Session) ClearAllComments() {
+	// Hold writeMu for the duration so any in-flight debounced write must
+	// finish (and observe the new writeGen) before we proceed. Without this,
+	// a WriteFiles() call that passed the gen check a moment ago could
+	// atomicWriteFile the old snapshot back onto disk after os.Remove below.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 	s.mu.Lock()
 	// Cancel any pending debounced write so it cannot recreate the review file after we delete it.
 	if s.writeTimer != nil {
@@ -1341,6 +1353,12 @@ func (s *Session) scheduleWrite() {
 	}
 	gen := s.writeGen
 	s.writeTimer = time.AfterFunc(200*time.Millisecond, func() {
+		// Serialize debounced writes with ClearAllComments so a stale
+		// in-flight write cannot recreate the review file after we've
+		// deleted it. ClearAllComments bumps writeGen under writeMu, so
+		// once we hold the mutex the gen check reflects the final state.
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
 		s.mu.RLock()
 		if s.writeGen != gen {
 			s.mu.RUnlock()


### PR DESCRIPTION
## Summary

Fixes a race between the 200ms debounced `WriteFiles()` and `ClearAllComments()` that was causing flakiness in the `file-mode` E2E project (PR #285 CI, `rendered-diff.filemode.spec.ts` "can add comment in unified diff view"). The symptom was a stale `carried-forward` comment from a preceding test showing up alongside the new comment, violating a single-element locator assertion.

## Root cause

`ClearAllComments` called `time.Timer.Stop()` and `os.Remove(critPath)`, but `Stop()` does not wait for `AfterFunc` callbacks that have already started. The debounced callback in `scheduleWrite` checked `writeGen` under RLock, released the lock, then called `WriteFiles()` which snapshots state and calls `atomicWriteFile`. If `ClearAllComments` ran between the snapshot and the disk write, it would delete the file, and the in-flight `atomicWriteFile` would resurrect it with the prior test's comment. The next test's `round-complete` then ran `loadResolvedComments` against the resurrected file and carried the stale comment forward.

## Fix

Add a `writeMu sync.Mutex` held across:

- the scheduled-write callback (from `writeGen` check through the actual disk write), and
- the whole of `ClearAllComments`.

Any in-flight debounced write now blocks `ClearAllComments` until the write completes, and any newly scheduled write observes the bumped `writeGen` under the mutex and bails cleanly. `ReadFiles` / direct `WriteFiles` call sites are unaffected — `writeMu` only serializes the debounced and clear-all paths.

## Test plan

- [x] `go test ./...` — all Go tests pass (29.5s)
- [x] `gofmt -l .` clean, `golangci-lint run ./...` clean
- [x] `cd e2e && npx playwright test --project=file-mode --reporter=line` — 118/118 passing, ran twice
- [x] `cd e2e && npx playwright test --project=file-mode tests/rendered-diff.filemode.spec.ts` — ran 3 consecutive passes to stress the previously flaky file
- [x] `cd e2e && npx playwright test --project=git-mode --reporter=line` — 376/376 passing (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)