### PR TITLE
fix: omit branch from file-mode session key to prevent duplicate daemons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ crit/
 15. **Headless CLI comment** — `crit comment` writes directly to the review file without starting the server; SSE notifies any running server
 16. **Comment threading** — comments support nested replies and a `resolved` boolean. Agents reply with `crit comment --reply-to <id> --resolve`. The review file schema nests replies inside each comment's `replies` array.
 17. **Commit selection** — in git mode, a sidebar lists individual commits. Selecting one scopes the file list and diffs to that commit only.
-18. **Centralized review storage** — review data stored in `~/.crit/reviews/<key>.json` (keyed by cwd + branch + args). `crit status` shows the review file path; `crit cleanup` removes stale reviews.
+18. **Centralized review storage** — review data stored in `~/.crit/reviews/<key>.json` (keyed by cwd + branch for git mode, cwd + args for file mode). `crit status` shows the review file path; `crit cleanup` removes stale reviews.
 
 ## Build & Run
 
@@ -387,7 +387,7 @@ The daemon signals readiness (via the OS pipe) as soon as the HTTP port is bound
 
 ### Session Registry
 
-Daemon state lives in `~/.crit/sessions/` with one file per session, keyed by `sha256(cwd + "\0" + branch + "\0" + sorted(args))[:12]`:
+Daemon state lives in `~/.crit/sessions/` with one file per session. Git mode (no args): `sha256(cwd + "\0" + branch)[:12]`. File mode (args present): `sha256(cwd + "\0" + args...)[:12]` — branch is excluded because file reviews are not branch-dependent:
 
 ```
 ~/.crit/sessions/

--- a/daemon.go
+++ b/daemon.go
@@ -50,8 +50,10 @@ func resolvedCWD() (string, error) {
 	return resolved, nil
 }
 
-// sessionKey returns a deterministic hash for cwd + branch + args, used as the session filename.
-// Format: sha256(cwd + "\0" + branch + "\0" + arg1 + "\0" + arg2 + ...)[:12]
+// sessionKey returns a deterministic hash used as the session filename.
+// Git mode (no args): sha256(cwd + "\0" + branch)[:12] — branch-scoped because diffs depend on it.
+// File mode (args present): sha256(cwd + "\0" + arg1 + "\0" + arg2 + ...)[:12] — branch-independent
+// because file reviews are not tied to a specific branch.
 func sessionKey(cwd string, branch string, args []string) string {
 	sorted := make([]string, len(args))
 	copy(sorted, args)
@@ -59,7 +61,10 @@ func sessionKey(cwd string, branch string, args []string) string {
 	h := sha256.New()
 	h.Write([]byte(cwd))
 	h.Write([]byte{0})
-	h.Write([]byte(branch))
+	if len(sorted) == 0 {
+		// Git mode: include branch so different branches get separate sessions.
+		h.Write([]byte(branch))
+	}
 	for _, a := range sorted {
 		h.Write([]byte{0})
 		h.Write([]byte(a))

--- a/daemon.go
+++ b/daemon.go
@@ -500,7 +500,7 @@ func handleDaemonPipeError(key string, readErr error, readEnd *os.File, cmd *exe
 }
 
 // startDaemon spawns a crit _serve process in the background and waits for it to be ready.
-// The key must match what the daemon computes in runServe (sessionKey(cwd, fileArgs)).
+// The key must match what the daemon computes in runServe (sessionKey(cwd, branch, fileArgs)).
 // Raw args (including flags) are passed through to _serve which parses them itself.
 // Uses an OS pipe (FD 3) for the daemon to signal readiness by writing its port number.
 func startDaemon(key string, args []string) (sessionEntry, error) {

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -52,6 +52,22 @@ func TestSessionKey_NilVsEmpty(t *testing.T) {
 	}
 }
 
+func TestSessionKey_FileMode_BranchIndependent(t *testing.T) {
+	k1 := sessionKey("/tmp/repo", "main", []string{"plan.md"})
+	k2 := sessionKey("/tmp/repo", "feature-x", []string{"plan.md"})
+	if k1 != k2 {
+		t.Errorf("file-mode key should be branch-independent: %s vs %s", k1, k2)
+	}
+}
+
+func TestSessionKey_GitMode_BranchDependent(t *testing.T) {
+	k1 := sessionKey("/tmp/repo", "main", nil)
+	k2 := sessionKey("/tmp/repo", "feature-x", nil)
+	if k1 == k2 {
+		t.Errorf("git-mode key should differ by branch: %s", k1)
+	}
+}
+
 func TestSessionKey_Length(t *testing.T) {
 	k := sessionKey("/tmp/repo", "main", nil)
 	if len(k) != 12 {


### PR DESCRIPTION
## Summary
- File-mode reviews (`crit <file>`) included the git branch in the session key, so switching branches between invocations spawned a new daemon and split review data across two files
- Now file-mode keys hash `cwd + args` only (branch excluded), matching the existing `planSessionKey` precedent
- Git-mode (`crit` with no args) still includes branch, since diffs are branch-scoped

## Review
- [x] Code review: passed (go-expert agent, no blockers)
- [x] Parity audit: N/A (backend only)

## Test plan
- [x] New unit tests: `TestSessionKey_FileMode_BranchIndependent`, `TestSessionKey_GitMode_BranchDependent`
- [x] Full test suite: `go test ./...` passes

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)