### PR TITLE
feat: tab-ready title indicator for background review rounds

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/e2e/tests/tab-badge.spec.ts
+++ b/e2e/tests/tab-badge.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+// The bullet prefix the app prepends to document.title when the badge is active.
+const BADGE_PREFIX = '\u25CF ';
+
+// Override document.visibilityState / document.hidden in the page context so
+// the app sees the tab as hidden or visible on demand, then dispatch
+// visibilitychange so listeners (the badge-clearing one) fire.
+async function setVisibility(page: Page, visible: boolean) {
+  await page.evaluate((isVisible) => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => (isVisible ? 'visible' : 'hidden'),
+    });
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => !isVisible,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }, visible);
+}
+
+// Wait until the page has exposed the tab-badge test hook (script loaded).
+async function waitForBadgeReady(page: Page) {
+  await page.waitForFunction(() => !!(window as unknown as { __critTabBadge?: unknown }).__critTabBadge);
+}
+
+test.describe('Tab-Ready Indicator', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('title prefixed on file-changed when tab hidden', async ({ page, request }) => {
+    await loadPage(page);
+    await waitForBadgeReady(page);
+    const originalTitle = await page.title();
+    expect(originalTitle.startsWith(BADGE_PREFIX)).toBe(false);
+
+    // Simulate user tabbing away.
+    await setVisibility(page, false);
+
+    // Trigger a round-complete — the server emits file-changed via SSE.
+    await request.post('/api/round-complete');
+
+    await expect.poll(() => page.title(), { timeout: 5000 }).toMatch(new RegExp('^' + BADGE_PREFIX));
+  });
+
+  test('no prefix when tab visible during round-complete', async ({ page, request }) => {
+    await loadPage(page);
+    await waitForBadgeReady(page);
+
+    // Force visible state so test behaves identically in headed and headless runs.
+    await setVisibility(page, true);
+
+    await request.post('/api/round-complete');
+
+    // Wait for the round-complete side effect (overlay deactivates) then assert.
+    await expect(page.locator('#waitingOverlay')).not.toHaveClass(/active/, { timeout: 5000 });
+
+    expect((await page.title()).startsWith(BADGE_PREFIX)).toBe(false);
+  });
+
+  test('prefix clears when visibility returns to visible', async ({ page, request }) => {
+    await loadPage(page);
+    await waitForBadgeReady(page);
+
+    await setVisibility(page, false);
+    await request.post('/api/round-complete');
+    await expect.poll(() => page.title(), { timeout: 5000 }).toMatch(new RegExp('^' + BADGE_PREFIX));
+
+    await setVisibility(page, true);
+
+    await expect.poll(() => page.title(), { timeout: 2000 }).not.toMatch(new RegExp('^' + BADGE_PREFIX));
+  });
+
+  test('rapid set/clear cycles end in the correct state', async ({ page }) => {
+    await loadPage(page);
+    await waitForBadgeReady(page);
+
+    // Direct helper calls — exercises idempotency without SSE races.
+    await page.evaluate(() => {
+      const api = (window as unknown as { __critTabBadge: { set: () => void; clear: () => void } }).__critTabBadge;
+      api.set();
+      api.set(); // idempotent
+      api.clear();
+      api.clear(); // idempotent
+      api.set();
+      api.clear();
+    });
+    expect((await page.title()).startsWith(BADGE_PREFIX)).toBe(false);
+
+    await page.evaluate(() => {
+      (window as unknown as { __critTabBadge: { set: () => void } }).__critTabBadge.set();
+    });
+    await expect.poll(() => page.title(), { timeout: 2000 }).toMatch(new RegExp('^' + BADGE_PREFIX));
+
+    await page.evaluate(() => {
+      (window as unknown as { __critTabBadge: { clear: () => void } }).__critTabBadge.clear();
+    });
+    await expect.poll(() => page.title(), { timeout: 2000 }).not.toMatch(new RegExp('^' + BADGE_PREFIX));
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -81,6 +81,44 @@
     return html;
   }
 
+  // ===== Tab-Ready Indicator =====
+  // Prepends a bullet to document.title when a review round completes while
+  // the tab is hidden. Clears on visibilitychange → visible.
+  const BADGE_PREFIX = '\u25CF ';
+  let baseTitle = document.title;
+  let badgeActive = false;
+
+  // Set the page title, preserving the badge prefix if currently active.
+  function setDocumentTitle(nextBase) {
+    baseTitle = nextBase;
+    document.title = badgeActive ? BADGE_PREFIX + baseTitle : baseTitle;
+  }
+
+  function setTabBadge() {
+    if (badgeActive) return;
+    badgeActive = true;
+    if (!document.title.startsWith(BADGE_PREFIX)) {
+      document.title = BADGE_PREFIX + baseTitle;
+    }
+  }
+
+  function clearTabBadge() {
+    if (!badgeActive) return;
+    badgeActive = false;
+    document.title = baseTitle;
+  }
+
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'visible') clearTabBadge();
+  });
+
+  // Expose for tests (kept minimal — E2E may use these directly per spec fallback).
+  window.__critTabBadge = {
+    set: setTabBadge,
+    clear: clearTabBadge,
+    isActive: function() { return badgeActive; },
+  };
+
   (function() {
     const defaultFence = commentMd.renderer.rules.fence;
     commentMd.renderer.rules.fence = function(tokens, idx, options, env, self) {
@@ -613,9 +651,9 @@
     }
 
     updateHeaderRound();
-    document.title = session.mode === 'git'
+    setDocumentTitle(session.mode === 'git'
       ? 'Crit — ' + (session.branch || 'review')
-      : 'Crit — ' + (session.files || []).map(f => f.path).join(', ');
+      : 'Crit — ' + (session.files || []).map(f => f.path).join(', '));
 
     files = await loadAllFileData(session.files || [], diffScope);
 
@@ -5841,6 +5879,9 @@
         updateViewedCount();
         updateTreeViewedState();
         setUIState('reviewing');
+        // Signal "ready" in the tab bar if the user has tabbed away.
+        // Cleared by the visibilitychange listener when they return.
+        if (document.visibilityState !== 'visible') setTabBadge();
       } catch (err) {
         console.error('Error handling file-changed:', err);
       }


### PR DESCRIPTION
## Summary

- Prepends `● ` to `document.title` when a review round completes while the tab is hidden. Clears on `visibilitychange` → visible.
- Helps reviewers notice a round is ready when they've tabbed away to their terminal/editor while the agent edits.

## Why a bullet, not a count

Gmail/Slack/Discord/X all use `(N)` in the title, but those are unread *counts*. Crit's state is binary — ready or not — so `(1) Crit` would imply "one unread" rather than "round done." A leading bullet is cleaner and matches the binary state.

## Design decisions

Design doc explored favicon badging too, but it's dropped: the SVG favicon overrides PNG mutations (requires extra DOM-swap complexity), and a 30%-of-favicon dot felt visually loud for a dev tool. Title prefix alone catches attention in the OS taskbar, browser tab list, and window switcher — which is where users actually glance while waiting.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build` passes
- [x] `go test ./...` passes
- [x] New E2E suite `e2e/tests/tab-badge.spec.ts` (git-mode, 4 tests) passes
- [ ] CI full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)