### PR TITLE
fix: audit cleanup — session files, type safety, config docs

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,6 +175,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if projectPresence.CleanupOnApprove {
 		merged.CleanupOnApprove = project.CleanupOnApprove
 	}
+	// Security: agent_cmd is intentionally NOT merged from project config.
+	// It must remain global-only to prevent untrusted project configs from
+	// overriding the agent command.
 	// auth_token is global-only (like agent_cmd) — project config cannot override
 	// Union ignore patterns
 	merged.IgnorePatterns = append(merged.IgnorePatterns, project.IgnorePatterns...)

--- a/daemon.go
+++ b/daemon.go
@@ -232,9 +232,7 @@ func listSessionsForCWD(cwd string) ([]sessionEntry, []string) {
 			alive = append(alive, entry)
 			keys = append(keys, key)
 		} else {
-			os.Remove(filepath.Join(dir, de.Name()))
-			os.Remove(filepath.Join(dir, key+".log"))
-			os.Remove(filepath.Join(dir, key+".lock"))
+			removeSessionFile(key)
 		}
 	}
 	return alive, keys
@@ -695,6 +693,9 @@ func cleanOrphanedSessions() {
 		}
 		if !isDaemonAlive(entry) {
 			os.Remove(path)
+			key := strings.TrimSuffix(de.Name(), ".json")
+			os.Remove(filepath.Join(sessDir, key+".log"))
+			os.Remove(filepath.Join(sessDir, key+".lock"))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -589,11 +589,11 @@ func displayPushDryRun(ghComments []map[string]interface{}, allReplies []ghReply
 		fmt.Printf("  Review body: %s\n\n", message)
 	}
 	for _, c := range ghComments {
-		path := c["path"].(string)
-		line := c["line"].(int)
-		body := c["body"].(string)
-		if sl, ok := c["start_line"]; ok {
-			fmt.Printf("  %s:%d-%d\n", path, sl.(int), line)
+		path, _ := c["path"].(string)
+		line, _ := c["line"].(int)
+		body, _ := c["body"].(string)
+		if sl, ok := c["start_line"].(int); ok {
+			fmt.Printf("  %s:%d-%d\n", path, sl, line)
 		} else {
 			fmt.Printf("  %s:%d\n", path, line)
 		}


### PR DESCRIPTION
## Summary

Pre-release audit fixes for v0.9.1..HEAD (Go backend).

- **P0**: `cleanOrphanedSessions` now removes `.log`/`.lock` alongside `.json` — previously leaked these files when daemon PID was dead
- **P1**: `displayPushDryRun` uses comma-ok type assertions instead of bare assertions that could panic
- **P1**: Explicit security comment on `agent_cmd` global-only invariant in `mergeConfigs` (enforced by omission, now documented)
- **P2**: `listSessionsForCWD` calls `removeSessionFile()` instead of duplicating the 3-file cleanup pattern

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)