### PR TITLE
fix: audit cleanup — comment index perf, CSS fixes, test isolation

### DIFF
--- a/e2e/tests/tab-badge.spec.ts
+++ b/e2e/tests/tab-badge.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { clearAllComments, loadPage } from './helpers';
+import { clearAllComments } from './helpers';
 
 // The bullet prefix the app prepends to document.title when the badge is active.
 const BADGE_PREFIX = '\u25CF ';
@@ -21,8 +21,10 @@ async function setVisibility(page: Page, visible: boolean) {
   }, visible);
 }
 
-// Wait until the page has exposed the tab-badge test hook (script loaded).
-async function waitForBadgeReady(page: Page) {
+// Load the page with ?test query param so the tab-badge test hook is exposed.
+async function loadPageWithTestParam(page: Page) {
+  await page.goto('/?test');
+  await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
   await page.waitForFunction(() => !!(window as unknown as { __critTabBadge?: unknown }).__critTabBadge);
 }
 
@@ -32,8 +34,7 @@ test.describe('Tab-Ready Indicator', () => {
   });
 
   test('title prefixed on file-changed when tab hidden', async ({ page, request }) => {
-    await loadPage(page);
-    await waitForBadgeReady(page);
+    await loadPageWithTestParam(page);
     const originalTitle = await page.title();
     expect(originalTitle.startsWith(BADGE_PREFIX)).toBe(false);
 
@@ -47,8 +48,7 @@ test.describe('Tab-Ready Indicator', () => {
   });
 
   test('no prefix when tab visible during round-complete', async ({ page, request }) => {
-    await loadPage(page);
-    await waitForBadgeReady(page);
+    await loadPageWithTestParam(page);
 
     // Force visible state so test behaves identically in headed and headless runs.
     await setVisibility(page, true);
@@ -62,8 +62,7 @@ test.describe('Tab-Ready Indicator', () => {
   });
 
   test('prefix clears when visibility returns to visible', async ({ page, request }) => {
-    await loadPage(page);
-    await waitForBadgeReady(page);
+    await loadPageWithTestParam(page);
 
     await setVisibility(page, false);
     await request.post('/api/round-complete');
@@ -75,8 +74,7 @@ test.describe('Tab-Ready Indicator', () => {
   });
 
   test('rapid set/clear cycles end in the correct state', async ({ page }) => {
-    await loadPage(page);
-    await waitForBadgeReady(page);
+    await loadPageWithTestParam(page);
 
     // Direct helper calls — exercises idempotency without SSE races.
     await page.evaluate(() => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3287,19 +3287,6 @@
     return { commentsMap: commentsMap, diffCommentsMap: diffCommentsMap, rangeSet: rangeSet };
   }
 
-  // Convenience wrappers that maintain the existing call-site API
-  function buildCommentsMap(comments) {
-    return buildCommentIndices(comments).commentsMap;
-  }
-
-  function buildDiffCommentsMap(comments) {
-    return buildCommentIndices(comments).diffCommentsMap;
-  }
-
-  function buildCommentedRangeSet(comments) {
-    return buildCommentIndices(comments).rangeSet;
-  }
-
   // For unified diff: build a Set of visual indices that should have has-comment.
   // This handles interleaved add/del lines correctly by using sequential position.
   function buildUnifiedCommentVisualSet(hunks, comments) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -112,12 +112,14 @@
     if (document.visibilityState === 'visible') clearTabBadge();
   });
 
-  // Expose for tests (kept minimal — E2E may use these directly per spec fallback).
-  window.__critTabBadge = {
-    set: setTabBadge,
-    clear: clearTabBadge,
-    isActive: function() { return badgeActive; },
-  };
+  // Expose for tests — only when ?test query param is present.
+  if (location.search.includes('test')) {
+    window.__critTabBadge = {
+      set: setTabBadge,
+      clear: clearTabBadge,
+      isActive: function() { return badgeActive; },
+    };
+  }
 
   (function() {
     const defaultFence = commentMd.renderer.rules.fence;
@@ -2011,8 +2013,7 @@
     container.appendChild(rightLabel);
 
     // Two-pointer merge for horizontal alignment
-    const commentsMap = buildCommentsMap(file.comments);
-    const commentRangeSet = buildCommentedRangeSet(file.comments);
+    const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
     let oldIdx = 0, newIdx = 0;
 
     while (oldIdx < prevBlocks.length || newIdx < currBlocks.length) {
@@ -2157,8 +2158,7 @@
     const oldBlocks = file.previousLineBlocks;
     const newBlocks = file.lineBlocks;
 
-    const commentsMap = buildCommentsMap(file.comments);
-    const commentRangeSet = buildCommentedRangeSet(file.comments);
+    const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 
     // Two-pointer merge: walk both block lists simultaneously
     let oldIdx = 0;
@@ -2271,9 +2271,7 @@
     container.className = 'document-wrapper' + (file.fileType === 'code' ? ' code-document' : '');
     if (!file.lineBlocks) return container;
 
-    const commentsMap = buildCommentsMap(file.comments);
-
-    const commentRangeSet = buildCommentedRangeSet(file.comments);
+    const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 
     const changeInfo = (file.viewMode === 'document' && session.mode !== 'git') ? getChangeInfo(file) : null;
     // Build a map of afterLine -> deletion marker for quick lookup
@@ -3060,8 +3058,7 @@
       return container;
     }
 
-    const commentsMap = buildDiffCommentsMap(file.comments);
-    const commentRangeSet = buildCommentedRangeSet(file.comments);
+    const { diffCommentsMap: commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2955,7 +2955,7 @@
       return container;
     }
 
-    const commentsMap = buildDiffCommentsMap(file.comments);
+    const { diffCommentsMap: commentsMap } = buildCommentIndices(file.comments);
     const commentVisualSet = buildUnifiedCommentVisualSet(hunks, file.comments);
     let visualIdx = 0; // sequential index for unified drag (old/new nums are different spaces)
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -405,11 +405,6 @@ body {
   from { opacity: 1; transform: translateY(0) scale(1); }
   to { opacity: 0; transform: translateY(8px) scale(0.98); }
 }
-.toast.success {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  color: var(--fg-secondary);
-}
 .toast.error {
   background: var(--toast-error-bg);
   border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
@@ -436,10 +431,6 @@ body {
 .toast-btn-filled {
   color: var(--bg-primary);
 }
-.toast.success .toast-btn-filled {
-  background: var(--green);
-}
-.toast.success .toast-btn-filled:hover { filter: brightness(1.1); }
 .toast.error .toast-btn-filled {
   background: var(--red);
 }
@@ -2067,7 +2058,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .config-card-cmd-label {
   color: var(--fg-muted);
-  font-family: var(--font-sans);
+  font-family: var(--font-body);
   font-size: 11px;
   margin-right: 8px;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Pre-release audit fixes for v0.9.1..HEAD (frontend).

- **P1**: Render functions call `buildCommentIndices` once and destructure, instead of 2-3 separate wrapper calls that each re-iterate all comments
- **P1**: Fix undefined `--font-sans` CSS variable → `--font-body` in `.config-card-cmd-label`
- **P1**: Gate `window.__critTabBadge` test helpers behind `?test` query param (no longer pollutes production global scope)
- **P2**: Remove dead `.toast.success` CSS rules (never used — `showToast` only called with `'error'`)

## Test plan

- [x] `tab-badge.spec.ts` updated to use `?test` param
- [ ] E2E suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)