### PR TITLE
fix: hide share button entirely in git mode

### DIFF
--- a/e2e/tests/share.spec.ts
+++ b/e2e/tests/share.spec.ts
@@ -2,16 +2,14 @@ import { test, expect } from '@playwright/test';
 import { loadPage } from './helpers';
 
 // ============================================================
-// Share Feature — Git Mode (share button disabled in git mode with tooltip)
+// Share Feature — Git Mode (share button hidden in git mode)
 // ============================================================
 test.describe('Share — Git Mode', () => {
-  test('share button is disabled in git mode', async ({ page }) => {
+  test('share button is hidden in git mode', async ({ page }) => {
     await loadPage(page);
 
     const shareBtn = page.locator('#shareBtn');
-    await expect(shareBtn).toBeVisible();
-    await expect(shareBtn).toBeDisabled();
-    await expect(shareBtn).toHaveAttribute('title', /not available in git mode/i);
+    await expect(shareBtn).toBeHidden();
   });
 
   test('config API returns default share_url', async ({ request }) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -547,13 +547,10 @@
     agentEnabled = configRes.agent_cmd_enabled || false;
     agentName = configRes.agent_name || 'agent';
 
-    if (shareURL) {
+    if (shareURL && session.mode !== 'git') {
       const shareBtn = document.getElementById('shareBtn');
       shareBtn.style.display = '';
-      if (session.mode === 'git') {
-        shareBtn.disabled = true;
-        shareBtn.title = 'Sharing is not available in git mode';
-      } else if (hostedURL) {
+      if (hostedURL) {
         setShareButtonState('shared');
       }
     }


### PR DESCRIPTION
## Summary
- Git mode used to render the Share button visible-but-disabled with a tooltip. Hide it outright instead — a dead affordance for an unsupported mode is worse than nothing.
- Introduced in #271; restoring the original hidden behavior.

## Test plan
- [x] Updated \`e2e/tests/share.spec.ts\` to assert the button is hidden in git mode
- [ ] Full Playwright suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)