### PR TITLE
feat: add Sapling SCM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ node_modules/
 
 # Playwright test artifacts
 test-results/
+
+# Agents: Codex, Claude etc
+.codex
+.agents
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ All keys are optional — omit any you don't need.
 | `cleanup_on_approve`   | bool     | `true`                     | Automatically delete the review file when you approve with no unresolved comments. Set to `false` to preserve review history.                                                           |
 | `no_update_check`      | bool     | `false`                    | Don't check for new versions on startup.                                                                                                                                                |
 | `no_integration_check` | bool     | `false`                    | Skip the integration config freshness check on startup.                                                                                                                                 |
+| `vcs`                  | string   | auto-detected              | Preferred VCS backend: `"git"`, `"sl"`. When set, crit uses this VCS instead of auto-detecting. Falls back to git if the configured VCS isn't available. Can also be set via `--vcs` CLI flag (flag takes precedence over config). |
 
 ### CLI flags
 
@@ -283,6 +284,7 @@ All keys are optional — omit any you don't need.
 | `--output`      | `-o`  | `output`              | Output directory for review files      |
 | `--quiet`       | `-q`  | `quiet`               | Suppress status output                 |
 | `--base-branch` |       | `base_branch`         | Base branch to diff against            |
+| `--vcs`         |       | `vcs`                 | VCS backend (`git` or `sl`)            |
 | `--no-ignore`   |       |                       | Temporarily bypass all ignore patterns |
 | `--version`     | `-v`  |                       | Print version and exit                 |
 

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	AuthUserName       string   `json:"auth_user_name,omitempty"`
 	AuthUserEmail      string   `json:"auth_user_email,omitempty"`
 	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
+	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl"
 }
 
 // CleanupOnApproveEnabled returns whether review files should be cleaned up

--- a/config.go
+++ b/config.go
@@ -67,6 +67,7 @@ func defaultConfig() generatedConfig {
 		},
 		AgentCmd:         "",
 		CleanupOnApprove: true,
+		VCS:              "",
 	}
 }
 
@@ -86,6 +87,7 @@ type generatedConfig struct {
 	NoUpdateCheck      bool     `json:"no_update_check"`
 	AgentCmd           string   `json:"agent_cmd"`
 	CleanupOnApprove   bool     `json:"cleanup_on_approve"`
+	VCS                string   `json:"vcs"`
 }
 
 func (c generatedConfig) String() string {
@@ -167,6 +169,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if project.BaseBranch != "" {
 		merged.BaseBranch = project.BaseBranch
 	}
+	if project.VCS != "" {
+		merged.VCS = project.VCS
+	}
 	if projectPresence.NoIntegrationCheck {
 		merged.NoIntegrationCheck = project.NoIntegrationCheck
 	}
@@ -221,10 +226,20 @@ func LoadConfig(projectDir string) Config {
 		merged.IgnorePatterns = []string{".crit/"}
 	}
 
-	// 5. Fall back to git user.name if no author configured
+	// 5. Fall back to VCS user name if no author configured.
+	// Try the configured VCS first, then fall back to the other.
 	if merged.Author == "" {
-		if out, err := exec.Command("git", "config", "user.name").Output(); err == nil {
-			merged.Author = strings.TrimSpace(string(out))
+		switch merged.VCS {
+		case "sl", "sapling":
+			merged.Author = slUserName()
+			if merged.Author == "" {
+				merged.Author = gitUserName()
+			}
+		default:
+			merged.Author = gitUserName()
+			if merged.Author == "" {
+				merged.Author = slUserName()
+			}
 		}
 	}
 
@@ -269,6 +284,29 @@ func saveGlobalConfig(apply func(m map[string]json.RawMessage) error) error {
 	}
 	data = append(data, '\n')
 	return os.WriteFile(path, data, 0o600)
+}
+
+// gitUserName returns the git-configured user name, or empty string on error.
+func gitUserName() string {
+	out, err := exec.Command("git", "config", "user.name").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// slUserName returns the Sapling-configured user name, or empty string on error.
+// Strips the email suffix ("Name <email>" -> "Name").
+func slUserName() string {
+	out, err := exec.Command("sl", "config", "ui.username").Output()
+	if err != nil {
+		return ""
+	}
+	name := strings.TrimSpace(string(out))
+	if idx := strings.Index(name, " <"); idx >= 0 {
+		name = name[:idx]
+	}
+	return name
 }
 
 // matchPattern checks if a file path matches an ignore pattern.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7287,7 +7287,7 @@
       { label: 'Review', shortcuts: [
         { key: '<kbd>Shift</kbd>+<kbd>F</kbd>', action: 'Finish review' },
         { key: '<kbd>Shift</kbd>+<kbd>C</kbd>', action: 'Toggle comments panel' },
-        { key: '<kbd>Shift</kbd>+<kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd>/<kbd>4</kbd>', action: 'Switch scope', mode: 'git mode' },
+        { key: '<kbd>Shift</kbd>+<kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd>/<kbd>4</kbd>', action: 'Switch scope', mode: 'vcs mode' },
       ]},
       { label: 'View', shortcuts: [
         { key: '<kbd>t</kbd>', action: 'Toggle table of contents', mode: 'file mode' },
@@ -7330,7 +7330,7 @@
     // Session info
     html += '<div class="settings-section-label">Current Session</div>';
     html += '<div class="about-session"><div class="about-session-grid">';
-    html += '<span class="about-session-label">Mode</span><span class="about-session-value">' + (session.mode || 'unknown') + '</span>';
+    html += '<span class="about-session-label">Mode</span><span class="about-session-value">' + (session.vcs_name || session.mode || 'unknown') + '</span>';
     if (session.mode === 'git' && session.branch) {
       html += '<span class="about-session-label">Branch</span><span class="about-session-value">' + escapeHtml(session.branch) + '</span>';
     }

--- a/git.go
+++ b/git.go
@@ -534,6 +534,7 @@ var skipDirs = map[string]bool{
 	"vendor":       true,
 	"__pycache__":  true,
 	".git":         true,
+	".sl":          true,
 	"dist":         true,
 	"build":        true,
 	"_build":       true,

--- a/git_vcs.go
+++ b/git_vcs.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GitVCS implements VCS for git repositories. Each method delegates to the
+// existing package-level function in git.go.
+type GitVCS struct{}
+
+func (g *GitVCS) Name() string { return "git" }
+
+func (g *GitVCS) RepoRoot() (string, error) { return RepoRoot() }
+
+func (g *GitVCS) CurrentBranch() string { return CurrentBranch() }
+
+func (g *GitVCS) DefaultBranch() string { return DefaultBranch() }
+
+func (g *GitVCS) SetDefaultBranchOverride(branch string) { setDefaultBranchOverride(branch) }
+
+func (g *GitVCS) GetDefaultBranchOverride() string { return getDefaultBranchOverride() }
+
+func (g *GitVCS) MergeBase(ref string) (string, error) { return MergeBase(ref) }
+
+func (g *GitVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
+	return changedFilesOnDefaultInDir(dir)
+}
+
+func (g *GitVCS) ChangedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error) {
+	return changedFilesFromBaseInDir(baseRef, dir)
+}
+
+func (g *GitVCS) ChangedFilesScoped(scope, baseRef string) ([]FileChange, error) {
+	return ChangedFilesScoped(scope, baseRef)
+}
+
+func (g *GitVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
+	return ChangedFilesForCommit(sha, dir)
+}
+
+func (g *GitVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
+	return fileDiffUnified(path, baseRef, dir)
+}
+
+func (g *GitVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
+	return fileDiffUnifiedCtx(ctx, path, baseRef, dir)
+}
+
+func (g *GitVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+	return FileDiffScoped(path, scope, baseRef, dir)
+}
+
+func (g *GitVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
+	return FileDiffForCommit(path, sha, dir)
+}
+
+func (g *GitVCS) FileDiffUnifiedNewFile(path string) ([]DiffHunk, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return FileDiffUnifiedNewFile(string(data)), nil
+}
+
+func (g *GitVCS) CommitLog(baseRef, dir string) ([]CommitInfo, error) {
+	return CommitLog(baseRef, dir)
+}
+
+func (g *GitVCS) WorkingTreeFingerprint() string { return WorkingTreeFingerprint() }
+
+func (g *GitVCS) UntrackedFiles(dir string) ([]FileChange, error) {
+	return untrackedFilesInDir(dir)
+}
+
+func (g *GitVCS) AllTrackedFiles(dir string) ([]string, error) {
+	return AllTrackedFiles(dir)
+}
+
+func (g *GitVCS) RemoteBranches(dir string) ([]string, error) {
+	return RemoteBranches(dir)
+}
+
+func (g *GitVCS) DiffNumstat(baseRef, dir string) (map[string]NumstatEntry, error) {
+	return DiffNumstatDir(baseRef, dir)
+}
+
+func (g *GitVCS) UserName() string {
+	out, err := exec.Command("git", "config", "user.name").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func (g *GitVCS) FileStatusInRepo(path, baseRef, repoRoot string) string {
+	return fileStatusInRepo(path, repoRoot, baseRef)
+}
+
+func (g *GitVCS) HasStagingArea() bool { return true }
+
+func (g *GitVCS) SkipDirNames() []string { return []string{".git"} }

--- a/git_vcs.go
+++ b/git_vcs.go
@@ -95,6 +95,9 @@ func (g *GitVCS) UserName() string {
 	return strings.TrimSpace(string(out))
 }
 
+// FileStatusInRepo returns the status of a single file relative to baseRef.
+// Note: the VCS interface uses (path, baseRef, dir) order while the underlying
+// fileStatusInRepo uses (path, repoRoot, baseRef) — arguments are reordered here.
 func (g *GitVCS) FileStatusInRepo(path, baseRef, repoRoot string) string {
 	return fileStatusInRepo(path, repoRoot, baseRef)
 }

--- a/git_vcs.go
+++ b/git_vcs.go
@@ -95,6 +95,12 @@ func (g *GitVCS) UserName() string {
 	return strings.TrimSpace(string(out))
 }
 
+// FileContentAtRef returns the content of a file at the given git ref.
+func (g *GitVCS) FileContentAtRef(path, ref, dir string) (string, error) {
+	content := fileContentAtRef(path, ref, dir)
+	return content, nil
+}
+
 // FileStatusInRepo returns the status of a single file relative to baseRef.
 // Note: the VCS interface uses (path, baseRef, dir) order while the underlying
 // fileStatusInRepo uses (path, repoRoot, baseRef) — arguments are reordered here.

--- a/git_vcs_test.go
+++ b/git_vcs_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+// Compile-time interface compliance check.
+var _ VCS = &GitVCS{}
+
+func TestGitVCS_Name(t *testing.T) {
+	g := &GitVCS{}
+	if got := g.Name(); got != "git" {
+		t.Errorf("Name() = %q, want %q", got, "git")
+	}
+}
+
+func TestGitVCS_HasStagingArea(t *testing.T) {
+	g := &GitVCS{}
+	if !g.HasStagingArea() {
+		t.Error("HasStagingArea() = false, want true")
+	}
+}
+
+func TestGitVCS_SkipDirNames(t *testing.T) {
+	g := &GitVCS{}
+	dirs := g.SkipDirNames()
+	if len(dirs) != 1 || dirs[0] != ".git" {
+		t.Errorf("SkipDirNames() = %v, want [.git]", dirs)
+	}
+}

--- a/git_vcs_test.go
+++ b/git_vcs_test.go
@@ -26,3 +26,10 @@ func TestGitVCS_SkipDirNames(t *testing.T) {
 		t.Errorf("SkipDirNames() = %v, want [.git]", dirs)
 	}
 }
+
+func TestDetectVCS_GitOverride(t *testing.T) {
+	vcs := DetectVCS("git")
+	if vcs == nil || vcs.Name() != "git" {
+		t.Errorf("DetectVCS(\"git\") should return GitVCS, got %v", vcs)
+	}
+}

--- a/github.go
+++ b/github.go
@@ -436,8 +436,8 @@ func resolveReviewPath(outputDir string) (string, error) {
 
 	// No daemon — compute centralized path.
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(""); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 	key := sessionKey(cwd, branch, nil)
 	path, err := reviewFilePath(key)
@@ -458,9 +458,13 @@ func resolveReviewPathFromDaemon(cwd string) string {
 		return path
 	}
 
-	// Fallback: match by git repo root.
-	if len(sessions) == 0 && IsGitRepo() {
-		if repoRoot, err := RepoRoot(); err == nil && repoRoot != cwd {
+	// Fallback: match by VCS repo root.
+	if len(sessions) == 0 {
+		vcs := DetectVCS("")
+		if vcs == nil {
+			return ""
+		}
+		if repoRoot, err := vcs.RepoRoot(); err == nil && repoRoot != cwd {
 			repoSessions, _ := listSessionsForRepoRoot(repoRoot)
 			if path := pickReviewPath(repoSessions); path != "" {
 				return path

--- a/main.go
+++ b/main.go
@@ -1500,6 +1500,9 @@ func runReviewClient(entry sessionEntry) (approved bool) {
 	return false
 }
 
+// TODO: runStop, runStatus, and other subcommands use DetectVCS("") for auto-detection.
+// The --vcs flag from the main server command is not threaded through to these subcommands yet.
+// This is acceptable for v1 since subcommands primarily need to locate the daemon, not run VCS ops.
 func runStop(args []string) {
 	all := false
 	var fileArgs []string
@@ -1741,7 +1744,7 @@ func createSession(sc *serverConfig) (*Session, error) {
 	if len(sc.files) == 0 {
 		vcs := DetectVCS(sc.vcsOverride)
 		if vcs == nil {
-			return nil, fmt.Errorf("not in a git repository and no files specified")
+			return nil, fmt.Errorf("not in a version-controlled repository and no files specified")
 		}
 		session, err = NewSessionFromVCS(vcs, sc.ignorePatterns)
 	} else {

--- a/main.go
+++ b/main.go
@@ -1591,6 +1591,7 @@ type serverConfig struct {
 	authToken          string
 	outputDir          string
 	author             string
+	baseBranch         string   // --base-branch override for diff base
 	ignorePatterns     []string
 	files              []string // explicit file arguments (empty = git mode)
 	noIntegrationCheck bool
@@ -1726,6 +1727,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		authToken:          cfg.AuthToken,
 		outputDir:          sf.outputDir,
 		author:             cfg.Author,
+		baseBranch:         sf.baseBranch,
 		ignorePatterns:     ignorePatterns,
 		noIntegrationCheck: cfg.NoIntegrationCheck,
 		noUpdateCheck:      cfg.NoUpdateCheck,
@@ -1746,12 +1748,21 @@ func createSession(sc *serverConfig) (*Session, error) {
 		if vcs == nil {
 			return nil, fmt.Errorf("not in a version-controlled repository and no files specified")
 		}
+		if sc.baseBranch != "" {
+			vcs.SetDefaultBranchOverride(sc.baseBranch)
+		}
 		session, err = NewSessionFromVCS(vcs, sc.ignorePatterns)
 	} else {
 		session, err = NewSessionFromFiles(sc.files, sc.ignorePatterns)
 	}
 	if err != nil {
 		return nil, err
+	}
+	// Apply --base-branch override to the session's VCS instance. This covers
+	// files mode where resolveGitContext creates a fresh VCS that doesn't have
+	// the override yet. For Sapling, the instance-level field must be set.
+	if sc.baseBranch != "" && session.VCS != nil {
+		session.VCS.SetDefaultBranchOverride(sc.baseBranch)
 	}
 	// Set ReviewFilePath before loadCritJSON so it reads from the centralized
 	// review file.

--- a/main.go
+++ b/main.go
@@ -1591,7 +1591,7 @@ type serverConfig struct {
 	authToken          string
 	outputDir          string
 	author             string
-	baseBranch         string   // --base-branch override for diff base
+	baseBranch         string // --base-branch override for diff base
 	ignorePatterns     []string
 	files              []string // explicit file arguments (empty = git mode)
 	noIntegrationCheck bool

--- a/main.go
+++ b/main.go
@@ -432,8 +432,8 @@ func runConfig(args []string) {
 		}
 	}
 	configDir := ""
-	if IsGitRepo() {
-		configDir, _ = RepoRoot()
+	if vcs := DetectVCS(""); vcs != nil {
+		configDir, _ = vcs.RepoRoot()
 	}
 	if configDir == "" {
 		configDir, _ = os.Getwd()
@@ -773,11 +773,11 @@ func resolveCommentFlags(f *commentFlags) {
 		}
 	}
 
-	// Resolve author: --author flag > config > git user.name
+	// Resolve author: --author flag > config > VCS user.name
 	if f.author == "" {
 		cfgDir, _ := os.Getwd()
-		if IsGitRepo() {
-			cfgDir, _ = RepoRoot()
+		if vcs := DetectVCS(""); vcs != nil {
+			cfgDir, _ = vcs.RepoRoot()
 		}
 		cfg := LoadConfig(cfgDir)
 		f.author = cfg.Author
@@ -987,9 +987,9 @@ func fileExistsOnDiskOrSession(path string, outputDir string) bool {
 	if info, err := os.Stat(path); err == nil && !info.IsDir() {
 		return true
 	}
-	// Check in repo root if we're in a git repo
-	if IsGitRepo() {
-		if root, err := RepoRoot(); err == nil {
+	// Check in repo root if we're in a VCS repo
+	if vcs := DetectVCS(""); vcs != nil {
+		if root, err := vcs.RepoRoot(); err == nil {
 			absPath := filepath.Join(root, path)
 			if info, err := os.Stat(absPath); err == nil && !info.IsDir() {
 				return true
@@ -1394,8 +1394,8 @@ func runReview(args []string) {
 
 	cwd, _ := resolvedCWD()
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(sc.vcsOverride); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 	key := sessionKey(cwd, branch, sc.files)
 
@@ -1520,8 +1520,8 @@ func runStop(args []string) {
 	}
 
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(""); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 
 	// If file args were given, use the exact key (user knows which session).
@@ -1596,6 +1596,7 @@ type serverConfig struct {
 	planDir            string // managed storage directory for plan mode
 	planName           string // display name for plan content
 	reviewPath         string // centralized review file path (~/.crit/reviews/<key>.json)
+	vcsOverride        string // "git", "sl"/"sapling", or "" for auto-detect
 	cfg                Config // full resolved config for the settings panel
 }
 
@@ -1609,6 +1610,7 @@ type serverFlagSet struct {
 	quiet       bool
 	noIgnore    bool
 	baseBranch  string
+	vcsOverride string
 	planDir     string
 	planName    string
 	fileArgs    []string
@@ -1628,6 +1630,7 @@ func parseServerFlags(args []string) serverFlagSet {
 	fs.BoolVar(quiet, "q", false, "Suppress status output (shorthand)")
 	noIgnore := fs.Bool("no-ignore", false, "Disable all ignore patterns from config files")
 	baseBranch := fs.String("base-branch", "", "Base branch to diff against (overrides auto-detection)")
+	vcsFlag := fs.String("vcs", "", "VCS backend to use: git, sl/sapling (default: auto-detect)")
 	planDir := fs.String("plan-dir", "", "")
 	planName := fs.String("name", "", "")
 	fs.Usage = func() {
@@ -1644,6 +1647,7 @@ func parseServerFlags(args []string) serverFlagSet {
 		quiet:       *quiet,
 		noIgnore:    *noIgnore,
 		baseBranch:  *baseBranch,
+		vcsOverride: *vcsFlag,
 		planDir:     *planDir,
 		planName:    *planName,
 		fileArgs:    fs.Args(),
@@ -1696,8 +1700,8 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 	}
 
 	configDir := ""
-	if IsGitRepo() {
-		configDir, _ = RepoRoot()
+	if vcs := DetectVCS(sf.vcsOverride); vcs != nil {
+		configDir, _ = vcs.RepoRoot()
 	}
 	if configDir == "" {
 		configDir, _ = os.Getwd()
@@ -1726,6 +1730,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		files:              sf.fileArgs,
 		planDir:            sf.planDir,
 		planName:           sf.planName,
+		vcsOverride:        sf.vcsOverride,
 		cfg:                cfg,
 	}, nil
 }
@@ -1734,10 +1739,11 @@ func createSession(sc *serverConfig) (*Session, error) {
 	var session *Session
 	var err error
 	if len(sc.files) == 0 {
-		if !IsGitRepo() {
+		vcs := DetectVCS(sc.vcsOverride)
+		if vcs == nil {
 			return nil, fmt.Errorf("not in a git repository and no files specified")
 		}
-		session, err = NewSessionFromGit(sc.ignorePatterns)
+		session, err = NewSessionFromVCS(vcs, sc.ignorePatterns)
 	} else {
 		session, err = NewSessionFromFiles(sc.files, sc.ignorePatterns)
 	}
@@ -1790,8 +1796,8 @@ func serveSessionKey(sc *serverConfig) string {
 		return planSessionKey(cwd, sc.planName)
 	}
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(sc.vcsOverride); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 	return sessionKey(cwd, branch, sc.files)
 }
@@ -1861,8 +1867,8 @@ func runServe(args []string) {
 	}
 	key := serveSessionKey(sc)
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(sc.vcsOverride); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 	if sc.outputDir != "" {
 		abs, _ := filepath.Abs(sc.outputDir)
@@ -2002,8 +2008,8 @@ func runStatus(args []string) {
 	}
 
 	branch := ""
-	if IsGitRepo() {
-		branch = CurrentBranch()
+	if vcs := DetectVCS(""); vcs != nil {
+		branch = vcs.CurrentBranch()
 	}
 
 	sessions, keys := listSessionsForCWD(cwd)

--- a/main.go
+++ b/main.go
@@ -1735,9 +1735,18 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		files:              sf.fileArgs,
 		planDir:            sf.planDir,
 		planName:           sf.planName,
-		vcsOverride:        sf.vcsOverride,
+		vcsOverride:        resolveVCSOverride(sf.vcsOverride, cfg.VCS),
 		cfg:                cfg,
 	}, nil
+}
+
+// resolveVCSOverride returns the effective VCS override.
+// --vcs flag takes precedence over config "vcs" field.
+func resolveVCSOverride(flag, config string) string {
+	if flag != "" {
+		return flag
+	}
+	return config
 }
 
 func createSession(sc *serverConfig) (*Session, error) {
@@ -2021,8 +2030,10 @@ func runStatus(args []string) {
 		os.Exit(1)
 	}
 
+	vcsName := ""
 	branch := ""
 	if vcs := DetectVCS(""); vcs != nil {
+		vcsName = vcs.Name()
 		branch = vcs.CurrentBranch()
 	}
 
@@ -2050,15 +2061,16 @@ func runStatus(args []string) {
 	}
 
 	if jsonOutput {
-		printStatusJSON(branch, revPath, revExists, matchedSession)
+		printStatusJSON(vcsName, branch, revPath, revExists, matchedSession)
 		return
 	}
 
-	printStatusHuman(branch, revPath, revExists, matchedSession)
+	printStatusHuman(vcsName, branch, revPath, revExists, matchedSession)
 }
 
-func printStatusJSON(branch, revPath string, revExists bool, session *sessionEntry) {
+func printStatusJSON(vcsName, branch, revPath string, revExists bool, session *sessionEntry) {
 	result := map[string]interface{}{
+		"vcs":                vcsName,
 		"branch":             branch,
 		"review_file":        revPath,
 		"review_file_exists": revExists,
@@ -2096,7 +2108,10 @@ func addReviewStats(result map[string]interface{}, revPath string) {
 	}
 }
 
-func printStatusHuman(branch, revPath string, revExists bool, session *sessionEntry) {
+func printStatusHuman(vcsName, branch, revPath string, revExists bool, session *sessionEntry) {
+	if vcsName != "" {
+		fmt.Printf("VCS:         %s\n", vcsName)
+	}
 	if branch != "" {
 		fmt.Printf("Branch:      %s\n", branch)
 	}

--- a/sapling.go
+++ b/sapling.go
@@ -158,9 +158,9 @@ func (s *SaplingVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHun
 }
 
 // FileDiffForCommit returns diff hunks for a file in a single commit.
+// Uses --change which handles initial commits (no parent) correctly.
 func (s *SaplingVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	parentRev := sha + "~1"
-	cmd := exec.Command("sl", "diff", "-r", parentRev, "-r", sha, path)
+	cmd := exec.Command("sl", "diff", "--change", sha, path)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -275,8 +275,27 @@ func (s *SaplingVCS) UserName() string {
 	return name
 }
 
+// FileContentAtRef returns the content of a file at the given Sapling revision.
+func (s *SaplingVCS) FileContentAtRef(path, ref, dir string) (string, error) {
+	if ref == "" {
+		return "", nil
+	}
+	cmd := exec.Command("sl", "cat", "-r", ref, path)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("sl cat -r %s %s: %w", ref, path, err)
+	}
+	return string(out), nil
+}
+
 // FileStatusInRepo returns the status of a single file relative to baseRef.
 func (s *SaplingVCS) FileStatusInRepo(path, baseRef, dir string) string {
+	if baseRef == "" {
+		return "modified"
+	}
 	out, err := slCommandInDir(dir, "status", "--rev", baseRef, path)
 	if err != nil {
 		return ""

--- a/sapling.go
+++ b/sapling.go
@@ -6,11 +6,14 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 // SaplingVCS implements VCS for Sapling SCM repositories.
 type SaplingVCS struct {
-	defaultBranch string
+	defaultBranchOnce sync.Once
+	defaultBranch     string
+	defaultBranchMu   sync.RWMutex // protects defaultBranch when set via override
 }
 
 func (s *SaplingVCS) Name() string { return "sl" }
@@ -40,21 +43,38 @@ func (s *SaplingVCS) CurrentBranch() string {
 }
 
 // DefaultBranch returns the cached default branch, detecting it on first call.
+// If an override is set, it is returned immediately without caching.
 func (s *SaplingVCS) DefaultBranch() string {
-	if s.defaultBranch != "" {
-		return s.defaultBranch
+	s.defaultBranchMu.RLock()
+	override := s.defaultBranch
+	s.defaultBranchMu.RUnlock()
+	if override != "" {
+		return override
 	}
-	s.defaultBranch = detectSaplingDefaultBranch()
+	s.defaultBranchOnce.Do(func() {
+		s.defaultBranchMu.Lock()
+		// Double-check: an override may have been set between RUnlock and Do.
+		if s.defaultBranch == "" {
+			s.defaultBranch = detectSaplingDefaultBranch()
+		}
+		s.defaultBranchMu.Unlock()
+	})
+	s.defaultBranchMu.RLock()
+	defer s.defaultBranchMu.RUnlock()
 	return s.defaultBranch
 }
 
 // SetDefaultBranchOverride overrides the default branch detection.
 func (s *SaplingVCS) SetDefaultBranchOverride(branch string) {
+	s.defaultBranchMu.Lock()
 	s.defaultBranch = branch
+	s.defaultBranchMu.Unlock()
 }
 
 // GetDefaultBranchOverride returns the current default branch override, if any.
 func (s *SaplingVCS) GetDefaultBranchOverride() string {
+	s.defaultBranchMu.RLock()
+	defer s.defaultBranchMu.RUnlock()
 	return s.defaultBranch
 }
 
@@ -139,7 +159,7 @@ func (s *SaplingVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHun
 
 // FileDiffForCommit returns diff hunks for a file in a single commit.
 func (s *SaplingVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	parentRev := sha + "^"
+	parentRev := sha + "~1"
 	cmd := exec.Command("sl", "diff", "-r", parentRev, "-r", sha, path)
 	if dir != "" {
 		cmd.Dir = dir
@@ -169,6 +189,8 @@ func (s *SaplingVCS) CommitLog(baseRef, dir string) ([]CommitInfo, error) {
 		return nil, nil
 	}
 	revset := fmt.Sprintf("%s::. - %s", baseRef, baseRef)
+	// The \\n in Go string literals produce literal \n characters, which Sapling's
+	// template engine interprets as newlines (field separators in the output).
 	tpl := "{node}\\n{node|short}\\n{desc|firstline}\\n{author|user}\\n{date|isodate}\\n---\\n"
 	args := []string{"log", "-r", revset, "-T", tpl}
 	out, err := slCommandInDir(dir, args...)
@@ -179,6 +201,9 @@ func (s *SaplingVCS) CommitLog(baseRef, dir string) ([]CommitInfo, error) {
 }
 
 // WorkingTreeFingerprint returns a string representing the current working tree state.
+// Note: `sl status` output may vary with locale settings on some systems.
+// This is acceptable for change-detection (comparing consecutive calls) but
+// should not be used as a stable hash key.
 func (s *SaplingVCS) WorkingTreeFingerprint() string {
 	out, err := exec.Command("sl", "status").Output()
 	if err != nil {
@@ -226,6 +251,9 @@ func (s *SaplingVCS) RemoteBranches(dir string) ([]string, error) {
 
 // DiffNumstat returns per-file addition/deletion counts.
 func (s *SaplingVCS) DiffNumstat(baseRef, dir string) (map[string]NumstatEntry, error) {
+	if baseRef == "" {
+		return nil, nil
+	}
 	out, err := slCommandInDir(dir, "diff", "--stat", "-r", baseRef)
 	if err != nil {
 		return nil, err
@@ -322,7 +350,11 @@ func parseRemoteBookmarks(output string) []string {
 	var names []string
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimRight(line, "\r")
-		name := strings.TrimSpace(strings.Fields(line)[0])
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
 		if name != "" {
 			names = append(names, name)
 		}

--- a/sapling.go
+++ b/sapling.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// SaplingVCS implements VCS for Sapling SCM repositories.
+type SaplingVCS struct {
+	defaultBranch string
+}
+
+func (s *SaplingVCS) Name() string { return "sl" }
+
+// RepoRoot returns the absolute path to the Sapling repository root.
+func (s *SaplingVCS) RepoRoot() (string, error) {
+	out, err := exec.Command("sl", "root").Output()
+	if err != nil {
+		return "", fmt.Errorf("sl root: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentBranch returns the active bookmark or short node hash.
+func (s *SaplingVCS) CurrentBranch() string {
+	out, err := exec.Command("sl", "log", "-r", ".", "-T", "{activebookmark}").Output()
+	if err == nil {
+		if b := strings.TrimSpace(string(out)); b != "" {
+			return b
+		}
+	}
+	out, err = exec.Command("sl", "log", "-r", ".", "-T", "{node|short}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// DefaultBranch returns the cached default branch, detecting it on first call.
+func (s *SaplingVCS) DefaultBranch() string {
+	if s.defaultBranch != "" {
+		return s.defaultBranch
+	}
+	s.defaultBranch = detectSaplingDefaultBranch()
+	return s.defaultBranch
+}
+
+// SetDefaultBranchOverride overrides the default branch detection.
+func (s *SaplingVCS) SetDefaultBranchOverride(branch string) {
+	s.defaultBranch = branch
+}
+
+// GetDefaultBranchOverride returns the current default branch override, if any.
+func (s *SaplingVCS) GetDefaultBranchOverride() string {
+	return s.defaultBranch
+}
+
+// MergeBase returns the common ancestor between the working copy and ref.
+func (s *SaplingVCS) MergeBase(ref string) (string, error) {
+	revset := fmt.Sprintf("ancestor(., %s)", ref)
+	out, err := exec.Command("sl", "log", "-r", revset, "-T", "{node}").Output()
+	if err != nil {
+		return "", fmt.Errorf("sl ancestor: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ChangedFilesOnDefaultInDir returns changed files when on the default branch.
+func (s *SaplingVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
+	out, err := slCommandInDir(dir, "status")
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingStatus(out), nil
+}
+
+// ChangedFilesFromBaseInDir returns files changed between baseRef and the working copy.
+func (s *SaplingVCS) ChangedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error) {
+	out, err := slCommandInDir(dir, "status", "--rev", baseRef)
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingStatus(out), nil
+}
+
+// ChangedFilesScoped returns changed files for a scope. Sapling has no staging area,
+// so "staged" and "unstaged" return nil.
+func (s *SaplingVCS) ChangedFilesScoped(scope, baseRef string) ([]FileChange, error) {
+	if scope == "branch" {
+		return s.ChangedFilesFromBaseInDir(baseRef, "")
+	}
+	// Sapling has no staging area.
+	return nil, nil
+}
+
+// ChangedFilesForCommit returns the files changed in a single commit.
+func (s *SaplingVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
+	out, err := slCommandInDir(dir, "status", "--change", sha)
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingStatus(out), nil
+}
+
+// FileDiffUnified returns parsed diff hunks for a file against a base ref.
+func (s *SaplingVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
+	return s.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir)
+}
+
+// FileDiffUnifiedCtx is like FileDiffUnified but accepts a context for cancellation.
+func (s *SaplingVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
+	args := buildDiffArgs(baseRef, path)
+	cmd := exec.CommandContext(ctx, "sl", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		// sl diff exits 1 when there is a diff; check for actual errors.
+		if len(out) > 0 {
+			return ParseUnifiedDiff(string(out)), nil
+		}
+		return nil, nil
+	}
+	return ParseUnifiedDiff(string(out)), nil
+}
+
+// FileDiffScoped returns diff hunks for a file using a scope-appropriate diff.
+// Sapling has no staging area, so "staged" and "unstaged" return nil.
+func (s *SaplingVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+	if scope == "branch" {
+		return s.FileDiffUnified(path, baseRef, dir)
+	}
+	return nil, nil
+}
+
+// FileDiffForCommit returns diff hunks for a file in a single commit.
+func (s *SaplingVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
+	parentRev := sha + "^"
+	cmd := exec.Command("sl", "diff", "-r", parentRev, "-r", sha, path)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		if len(out) > 0 {
+			return ParseUnifiedDiff(string(out)), nil
+		}
+		return nil, nil
+	}
+	return ParseUnifiedDiff(string(out)), nil
+}
+
+// FileDiffUnifiedNewFile returns diff hunks showing an entire file as added.
+func (s *SaplingVCS) FileDiffUnifiedNewFile(path string) ([]DiffHunk, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return FileDiffUnifiedNewFile(string(data)), nil
+}
+
+// CommitLog returns the commits between baseRef and HEAD.
+func (s *SaplingVCS) CommitLog(baseRef, dir string) ([]CommitInfo, error) {
+	if baseRef == "" {
+		return nil, nil
+	}
+	revset := fmt.Sprintf("%s::. - %s", baseRef, baseRef)
+	tpl := "{node}\\n{node|short}\\n{desc|firstline}\\n{author|user}\\n{date|isodate}\\n---\\n"
+	args := []string{"log", "-r", revset, "-T", tpl}
+	out, err := slCommandInDir(dir, args...)
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingCommitLog(out), nil
+}
+
+// WorkingTreeFingerprint returns a string representing the current working tree state.
+func (s *SaplingVCS) WorkingTreeFingerprint() string {
+	out, err := exec.Command("sl", "status").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// UntrackedFiles returns untracked files in the given directory.
+func (s *SaplingVCS) UntrackedFiles(dir string) ([]FileChange, error) {
+	out, err := slCommandInDir(dir, "status", "-u")
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingStatus(out), nil
+}
+
+// AllTrackedFiles returns all tracked files plus untracked non-ignored files.
+func (s *SaplingVCS) AllTrackedFiles(dir string) ([]string, error) {
+	trackedOut, err := slCommandInDir(dir, "files")
+	if err != nil {
+		return nil, err
+	}
+	files := splitNonEmpty(trackedOut)
+
+	untrackedOut, err := slCommandInDir(dir, "status", "-u")
+	if err != nil {
+		return files, nil
+	}
+	for _, fc := range parseSaplingStatus(untrackedOut) {
+		files = append(files, fc.Path)
+	}
+	return files, nil
+}
+
+// RemoteBranches returns remote bookmark names. Returns nil on error
+// since remote bookmarks may not be available.
+func (s *SaplingVCS) RemoteBranches(dir string) ([]string, error) {
+	out, err := slCommandInDir(dir, "bookmark", "--list", "--remote")
+	if err != nil {
+		return nil, nil
+	}
+	return parseRemoteBookmarks(out), nil
+}
+
+// DiffNumstat returns per-file addition/deletion counts.
+func (s *SaplingVCS) DiffNumstat(baseRef, dir string) (map[string]NumstatEntry, error) {
+	out, err := slCommandInDir(dir, "diff", "--stat", "-r", baseRef)
+	if err != nil {
+		return nil, err
+	}
+	return parseSaplingDiffStat(out), nil
+}
+
+// UserName returns the Sapling-configured user name.
+func (s *SaplingVCS) UserName() string {
+	out, err := exec.Command("sl", "config", "ui.username").Output()
+	if err != nil {
+		return ""
+	}
+	name := strings.TrimSpace(string(out))
+	// Strip email suffix: "Name <email>" -> "Name"
+	if idx := strings.Index(name, " <"); idx >= 0 {
+		name = name[:idx]
+	}
+	return name
+}
+
+// FileStatusInRepo returns the status of a single file relative to baseRef.
+func (s *SaplingVCS) FileStatusInRepo(path, baseRef, dir string) string {
+	out, err := slCommandInDir(dir, "status", "--rev", baseRef, path)
+	if err != nil {
+		return ""
+	}
+	changes := parseSaplingStatus(out)
+	if len(changes) == 0 {
+		return ""
+	}
+	return changes[0].Status
+}
+
+// HasStagingArea returns false because Sapling has no staging area.
+func (s *SaplingVCS) HasStagingArea() bool { return false }
+
+// SkipDirNames returns directory names to skip during walks.
+// Includes .git because Sapling often operates on git-backed repos.
+func (s *SaplingVCS) SkipDirNames() []string { return []string{".sl", ".git"} }
+
+// detectSaplingDefaultBranch probes for "main" then "master" bookmarks.
+func detectSaplingDefaultBranch() string {
+	for _, branch := range []string{"main", "master"} {
+		err := exec.Command("sl", "log", "-r", branch, "-T", "{node|short}").Run()
+		if err == nil {
+			return branch
+		}
+	}
+	return "main"
+}
+
+// slCommandInDir runs an sl subcommand in the given directory and returns stdout.
+func slCommandInDir(dir string, args ...string) (string, error) {
+	cmd := exec.Command("sl", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("sl %s: %w", strings.Join(args, " "), err)
+	}
+	return string(out), nil
+}
+
+// buildDiffArgs constructs arguments for sl diff.
+func buildDiffArgs(baseRef, path string) []string {
+	args := []string{"diff"}
+	if baseRef != "" {
+		args = append(args, "-r", baseRef)
+	}
+	args = append(args, path)
+	return args
+}
+
+// splitNonEmpty splits output by newline and returns non-empty lines.
+func splitNonEmpty(output string) []string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
+	var result []string
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line != "" {
+			result = append(result, line)
+		}
+	}
+	return result
+}
+
+// parseRemoteBookmarks extracts bookmark names from `sl bookmark --list --remote` output.
+func parseRemoteBookmarks(output string) []string {
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimRight(line, "\r")
+		name := strings.TrimSpace(strings.Fields(line)[0])
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// parseSaplingCommitLog parses the templated output from sl log into CommitInfo slices.
+// The template produces blocks separated by "---\n", each containing:
+// node, short_node, first_line_of_description, author, isodate.
+func parseSaplingCommitLog(output string) []CommitInfo {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
+	blocks := strings.Split(trimmed, "---")
+	var commits []CommitInfo
+	for _, block := range blocks {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		lines := strings.SplitN(block, "\n", 5)
+		if len(lines) < 5 {
+			continue
+		}
+		commits = append(commits, CommitInfo{
+			SHA:      strings.TrimSpace(lines[0]),
+			ShortSHA: strings.TrimSpace(lines[1]),
+			Message:  strings.TrimSpace(lines[2]),
+			Author:   strings.TrimSpace(lines[3]),
+			Date:     strings.TrimSpace(lines[4]),
+		})
+	}
+	return commits
+}

--- a/sapling.go
+++ b/sapling.go
@@ -231,7 +231,7 @@ func (s *SaplingVCS) AllTrackedFiles(dir string) ([]string, error) {
 
 	untrackedOut, err := slCommandInDir(dir, "status", "-u")
 	if err != nil {
-		return files, nil
+		return files, nil //nolint:nilerr // graceful: return tracked files even if untracked listing fails
 	}
 	for _, fc := range parseSaplingStatus(untrackedOut) {
 		files = append(files, fc.Path)
@@ -244,7 +244,7 @@ func (s *SaplingVCS) AllTrackedFiles(dir string) ([]string, error) {
 func (s *SaplingVCS) RemoteBranches(dir string) ([]string, error) {
 	out, err := slCommandInDir(dir, "bookmark", "--list", "--remote")
 	if err != nil {
-		return nil, nil
+		return nil, nil //nolint:nilerr // graceful: remote bookmarks may not be available
 	}
 	return parseRemoteBookmarks(out), nil
 }

--- a/sapling_parse.go
+++ b/sapling_parse.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"strings"
+)
+
+// saplingStatusMap maps Sapling/Mercurial status characters to crit status strings.
+var saplingStatusMap = map[byte]string{
+	'M': "modified",
+	'A': "added",
+	'R': "deleted",
+	'?': "untracked",
+	'!': "deleted",
+}
+
+// parseSaplingStatus parses `sl status` output (Mercurial format).
+// Each line is: <status-char> <space> <path>
+// Maps: M->"modified", A->"added", R->"deleted", ?->"untracked", !->"deleted"
+// Skips: I (ignored), C (clean), and any unrecognized status characters.
+func parseSaplingStatus(output string) []FileChange {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	var changes []FileChange
+	for _, line := range lines {
+		line = strings.TrimRight(line, "\r")
+		if len(line) < 3 || line[1] != ' ' {
+			continue
+		}
+		status, ok := saplingStatusMap[line[0]]
+		if !ok {
+			continue
+		}
+		path := line[2:]
+		changes = append(changes, FileChange{Path: path, Status: status})
+	}
+	return changes
+}
+
+// parseSaplingDiffStat parses `sl diff --stat` output.
+// Each file line has the format: " path | N +++--"
+// The summary line ("N files changed, ...") is skipped.
+// The function counts '+' and '-' characters in the visual bar
+// to determine additions and deletions.
+func parseSaplingDiffStat(output string) map[string]NumstatEntry {
+	result := make(map[string]NumstatEntry)
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return result
+	}
+
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if isSummaryLine(line) {
+			continue
+		}
+		path, entry, ok := parseDiffStatLine(line)
+		if !ok {
+			continue
+		}
+		result[path] = entry
+	}
+	return result
+}
+
+// isSummaryLine returns true if the line is a diff-stat summary
+// (e.g., " 3 files changed, 10 insertions(+), 2 deletions(-)").
+func isSummaryLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.Contains(trimmed, "files changed") ||
+		strings.Contains(trimmed, "file changed")
+}
+
+// parseDiffStatLine parses a single diff --stat file line.
+// Format: " path | N +++--"
+// Returns the path, a NumstatEntry, and whether parsing succeeded.
+func parseDiffStatLine(line string) (string, NumstatEntry, bool) {
+	pipeIdx := strings.LastIndex(line, "|")
+	if pipeIdx < 0 {
+		return "", NumstatEntry{}, false
+	}
+	path := strings.TrimSpace(line[:pipeIdx])
+	if path == "" {
+		return "", NumstatEntry{}, false
+	}
+
+	right := line[pipeIdx+1:]
+	adds, dels := countPlusMinus(right)
+	return path, NumstatEntry{Additions: adds, Deletions: dels}, true
+}
+
+// countPlusMinus counts '+' and '-' characters in a diff-stat bar segment.
+func countPlusMinus(s string) (int, int) {
+	var adds, dels int
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '+':
+			adds++
+		case '-':
+			dels++
+		}
+	}
+	return adds, dels
+}

--- a/sapling_parse_test.go
+++ b/sapling_parse_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseSaplingStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want []FileChange
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single modified file",
+			input: "M foo.go",
+			want:  []FileChange{{Path: "foo.go", Status: "modified"}},
+		},
+		{
+			name:  "single added file",
+			input: "A new_file.go",
+			want:  []FileChange{{Path: "new_file.go", Status: "added"}},
+		},
+		{
+			name:  "single removed file",
+			input: "R old_file.go",
+			want:  []FileChange{{Path: "old_file.go", Status: "deleted"}},
+		},
+		{
+			name:  "single untracked file",
+			input: "? scratch.txt",
+			want:  []FileChange{{Path: "scratch.txt", Status: "untracked"}},
+		},
+		{
+			name:  "missing file treated as deleted",
+			input: "! gone.go",
+			want:  []FileChange{{Path: "gone.go", Status: "deleted"}},
+		},
+		{
+			name:  "ignored file skipped",
+			input: "I build/output.o",
+			want:  nil,
+		},
+		{
+			name:  "clean file skipped",
+			input: "C lib/util.go",
+			want:  nil,
+		},
+		{
+			name: "multiple files mixed statuses",
+			input: "M src/main.go\nA src/new.go\nR src/old.go\n? notes.txt\n! vanished.go",
+			want: []FileChange{
+				{Path: "src/main.go", Status: "modified"},
+				{Path: "src/new.go", Status: "added"},
+				{Path: "src/old.go", Status: "deleted"},
+				{Path: "notes.txt", Status: "untracked"},
+				{Path: "vanished.go", Status: "deleted"},
+			},
+		},
+		{
+			name: "ignored and clean files filtered from mixed input",
+			input: "M keep.go\nI skip.o\nC clean.go\nA also_keep.go",
+			want: []FileChange{
+				{Path: "keep.go", Status: "modified"},
+				{Path: "also_keep.go", Status: "added"},
+			},
+		},
+		{
+			name:  "path with spaces",
+			input: "M path with spaces/file name.go",
+			want:  []FileChange{{Path: "path with spaces/file name.go", Status: "modified"}},
+		},
+		{
+			name:  "windows line endings",
+			input: "M foo.go\r\nA bar.go\r\n",
+			want: []FileChange{
+				{Path: "foo.go", Status: "modified"},
+				{Path: "bar.go", Status: "added"},
+			},
+		},
+		{
+			name:  "whitespace only input",
+			input: "   \n  \n",
+			want:  nil,
+		},
+		{
+			name:  "malformed line too short",
+			input: "M",
+			want:  nil,
+		},
+		{
+			name:  "malformed line no space separator",
+			input: "MXfoo.go",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSaplingStatus(tt.input)
+			assertFileChangesEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseSaplingDiffStat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]NumstatEntry
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  map[string]NumstatEntry{},
+		},
+		{
+			name:  "typical mixed output",
+			input: " src/main.go | 10 ++++------\n src/util.go | 3 +++\n 2 files changed, 7 insertions(+), 6 deletions(-)",
+			want: map[string]NumstatEntry{
+				"src/main.go": {Additions: 4, Deletions: 6},
+				"src/util.go": {Additions: 3, Deletions: 0},
+			},
+		},
+		{
+			name:  "file with only additions",
+			input: " new.go | 5 +++++\n 1 file changed, 5 insertions(+)",
+			want: map[string]NumstatEntry{
+				"new.go": {Additions: 5, Deletions: 0},
+			},
+		},
+		{
+			name:  "file with only deletions",
+			input: " old.go | 3 ---\n 1 file changed, 3 deletions(-)",
+			want: map[string]NumstatEntry{
+				"old.go": {Additions: 0, Deletions: 3},
+			},
+		},
+		{
+			name:  "summary line is skipped",
+			input: " 5 files changed, 20 insertions(+), 10 deletions(-)",
+			want:  map[string]NumstatEntry{},
+		},
+		{
+			name:  "path with spaces",
+			input: " path with spaces/file.go | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)",
+			want: map[string]NumstatEntry{
+				"path with spaces/file.go": {Additions: 1, Deletions: 1},
+			},
+		},
+		{
+			name:  "windows line endings",
+			input: " a.go | 3 +++\r\n b.go | 2 --\r\n 2 files changed, 3 insertions(+), 2 deletions(-)\r\n",
+			want: map[string]NumstatEntry{
+				"a.go": {Additions: 3, Deletions: 0},
+				"b.go": {Additions: 0, Deletions: 2},
+			},
+		},
+		{
+			name:  "no summary line",
+			input: " config.yaml | 4 ++--",
+			want: map[string]NumstatEntry{
+				"config.yaml": {Additions: 2, Deletions: 2},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSaplingDiffStat(tt.input)
+			assertNumstatEqual(t, got, tt.want)
+		})
+	}
+}
+
+func assertFileChangesEqual(t *testing.T, got, want []FileChange) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d changes, want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("change[%d]: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertNumstatEqual(t *testing.T, got, want map[string]NumstatEntry) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	}
+	for path, wantEntry := range want {
+		gotEntry, ok := got[path]
+		if !ok {
+			t.Errorf("missing entry for %q", path)
+			continue
+		}
+		if gotEntry != wantEntry {
+			t.Errorf("entry[%q]: got %+v, want %+v", path, gotEntry, wantEntry)
+		}
+	}
+}

--- a/sapling_parse_test.go
+++ b/sapling_parse_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestParseSaplingStatus(t *testing.T) {
 	tests := []struct {
-		name string
+		name  string
 		input string
-		want []FileChange
+		want  []FileChange
 	}{
 		{
 			name:  "empty input",
@@ -51,7 +51,7 @@ func TestParseSaplingStatus(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name: "multiple files mixed statuses",
+			name:  "multiple files mixed statuses",
 			input: "M src/main.go\nA src/new.go\nR src/old.go\n? notes.txt\n! vanished.go",
 			want: []FileChange{
 				{Path: "src/main.go", Status: "modified"},
@@ -62,7 +62,7 @@ func TestParseSaplingStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "ignored and clean files filtered from mixed input",
+			name:  "ignored and clean files filtered from mixed input",
 			input: "M keep.go\nI skip.o\nC clean.go\nA also_keep.go",
 			want: []FileChange{
 				{Path: "keep.go", Status: "modified"},

--- a/sapling_test.go
+++ b/sapling_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
 
 // Compile-time interface compliance check.
 var _ VCS = &SaplingVCS{}
@@ -178,10 +183,44 @@ func TestDetectVCS_SaplingOverride(t *testing.T) {
 	for _, override := range []string{"sl", "sapling"} {
 		v := DetectVCS(override)
 		if v == nil {
-			t.Fatalf("DetectVCS(%q) = nil, want *SaplingVCS", override)
+			// Falls back to git if sl not in PATH — that's fine
+			t.Skipf("DetectVCS(%q) returned nil (sl likely not in PATH)", override)
 		}
-		if _, ok := v.(*SaplingVCS); !ok {
-			t.Errorf("DetectVCS(%q) returned %T, want *SaplingVCS", override, v)
+		// If sl is in PATH, should return SaplingVCS; otherwise GitVCS fallback
+		if _, hasSL := exec.LookPath("sl"); hasSL == nil {
+			if _, ok := v.(*SaplingVCS); !ok {
+				t.Errorf("DetectVCS(%q) returned %T, want *SaplingVCS", override, v)
+			}
 		}
+	}
+}
+
+func TestHasSLDirFrom_DetectsDotSL(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "nested", "repo")
+	if err := os.MkdirAll(filepath.Join(root, ".sl"), 0o755); err != nil {
+		t.Fatalf("mkdir .sl: %v", err)
+	}
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	if !hasSLDirFrom(child) {
+		t.Fatal("expected hasSLDirFrom to detect .sl metadata")
+	}
+}
+
+func TestHasSLDirFrom_DoesNotDetectDotGitSL(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "nested", "repo")
+	if err := os.MkdirAll(filepath.Join(root, ".git", "sl"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/sl: %v", err)
+	}
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	// .git/sl should NOT trigger hasSLDirFrom — it's handled separately
+	// as a hint, not as auto-detection
+	if hasSLDirFrom(child) {
+		t.Fatal("hasSLDirFrom should not detect .git/sl as Sapling metadata")
 	}
 }

--- a/sapling_test.go
+++ b/sapling_test.go
@@ -126,6 +126,54 @@ func TestParseSaplingCommitLog(t *testing.T) {
 	}
 }
 
+func TestParseRemoteBookmarks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single bookmark",
+			input: "main   abc123def456",
+			want:  []string{"main"},
+		},
+		{
+			name:  "multiple bookmarks",
+			input: "main   abc123\nrelease   def456\ndev   789abc",
+			want:  []string{"main", "release", "dev"},
+		},
+		{
+			name:  "empty lines",
+			input: "main   abc123\n\n\nrelease   def456\n",
+			want:  []string{"main", "release"},
+		},
+		{
+			name:  "whitespace only lines",
+			input: "main   abc123\n   \nrelease   def456",
+			want:  []string{"main", "release"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRemoteBookmarks(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d bookmarks, want %d\ngot:  %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("bookmark[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestDetectVCS_SaplingOverride(t *testing.T) {
 	for _, override := range []string{"sl", "sapling"} {
 		v := DetectVCS(override)

--- a/sapling_test.go
+++ b/sapling_test.go
@@ -1,0 +1,139 @@
+package main
+
+import "testing"
+
+// Compile-time interface compliance check.
+var _ VCS = &SaplingVCS{}
+
+func TestSaplingVCS_Name(t *testing.T) {
+	s := &SaplingVCS{}
+	if got := s.Name(); got != "sl" {
+		t.Errorf("Name() = %q, want %q", got, "sl")
+	}
+}
+
+func TestSaplingVCS_HasStagingArea(t *testing.T) {
+	s := &SaplingVCS{}
+	if s.HasStagingArea() {
+		t.Error("HasStagingArea() = true, want false")
+	}
+}
+
+func TestSaplingVCS_SkipDirNames(t *testing.T) {
+	s := &SaplingVCS{}
+	dirs := s.SkipDirNames()
+	want := map[string]bool{".sl": true, ".git": true}
+	if len(dirs) != len(want) {
+		t.Fatalf("SkipDirNames() = %v, want keys of %v", dirs, want)
+	}
+	for _, d := range dirs {
+		if !want[d] {
+			t.Errorf("unexpected dir name %q in SkipDirNames()", d)
+		}
+	}
+}
+
+func TestSaplingVCS_ChangedFilesScoped_Staged(t *testing.T) {
+	s := &SaplingVCS{}
+	got, err := s.ChangedFilesScoped("staged", "")
+	if err != nil {
+		t.Fatalf("ChangedFilesScoped(staged) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ChangedFilesScoped(staged) = %v, want nil", got)
+	}
+}
+
+func TestSaplingVCS_ChangedFilesScoped_Unstaged(t *testing.T) {
+	s := &SaplingVCS{}
+	got, err := s.ChangedFilesScoped("unstaged", "")
+	if err != nil {
+		t.Fatalf("ChangedFilesScoped(unstaged) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ChangedFilesScoped(unstaged) = %v, want nil", got)
+	}
+}
+
+func TestSaplingVCS_DefaultBranchOverride(t *testing.T) {
+	s := &SaplingVCS{}
+	s.SetDefaultBranchOverride("develop")
+	if got := s.GetDefaultBranchOverride(); got != "develop" {
+		t.Errorf("GetDefaultBranchOverride() = %q, want %q", got, "develop")
+	}
+	if got := s.DefaultBranch(); got != "develop" {
+		t.Errorf("DefaultBranch() = %q after override, want %q", got, "develop")
+	}
+}
+
+func TestParseSaplingCommitLog(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []CommitInfo
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name: "single commit",
+			input: "abc123def456abc123def456abc123def456abcdef\n" +
+				"abc123d\n" +
+				"Fix the widget\n" +
+				"alice\n" +
+				"2024-03-15 10:30 +0000\n" +
+				"---\n",
+			want: []CommitInfo{
+				{
+					SHA:      "abc123def456abc123def456abc123def456abcdef",
+					ShortSHA: "abc123d",
+					Message:  "Fix the widget",
+					Author:   "alice",
+					Date:     "2024-03-15 10:30 +0000",
+				},
+			},
+		},
+		{
+			name: "multiple commits",
+			input: "aaaa\naa\nFirst commit\nalice\n2024-01-01 00:00 +0000\n---\n" +
+				"bbbb\nbb\nSecond commit\nbob\n2024-01-02 00:00 +0000\n---\n",
+			want: []CommitInfo{
+				{SHA: "aaaa", ShortSHA: "aa", Message: "First commit", Author: "alice", Date: "2024-01-01 00:00 +0000"},
+				{SHA: "bbbb", ShortSHA: "bb", Message: "Second commit", Author: "bob", Date: "2024-01-02 00:00 +0000"},
+			},
+		},
+		{
+			name:  "incomplete block is skipped",
+			input: "abc\nshort\n---\n",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSaplingCommitLog(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d commits, want %d\ngot:  %+v\nwant: %+v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("commit[%d]: got %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDetectVCS_SaplingOverride(t *testing.T) {
+	for _, override := range []string{"sl", "sapling"} {
+		v := DetectVCS(override)
+		if v == nil {
+			t.Fatalf("DetectVCS(%q) = nil, want *SaplingVCS", override)
+		}
+		if _, ok := v.(*SaplingVCS); !ok {
+			t.Errorf("DetectVCS(%q) returned %T, want *SaplingVCS", override, v)
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -616,8 +616,13 @@ func (s *Server) handleBranches(w http.ResponseWriter, r *http.Request) {
 	sess := s.session.Load()
 	sess.mu.RLock()
 	repoRoot := sess.RepoRoot
+	vcs := sess.VCS
 	sess.mu.RUnlock()
-	branches, err := RemoteBranches(repoRoot)
+	if vcs == nil {
+		writeJSON(w, []string{})
+		return
+	}
+	branches, err := vcs.RemoteBranches(repoRoot)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1140,9 +1145,13 @@ func (s *Server) handleFilesList(w http.ResponseWriter, r *http.Request) {
 	var paths []string
 	var err error
 
-	// Try git first (works in both "git" and "files" mode when inside a repo),
-	// fall back to filesystem walk for non-git directories.
-	paths, err = AllTrackedFiles(sess.RepoRoot)
+	// Try VCS first (works in both "git" and "files" mode when inside a repo),
+	// fall back to filesystem walk for non-VCS directories.
+	if sess.VCS != nil {
+		paths, err = sess.VCS.AllTrackedFiles(sess.RepoRoot)
+	} else {
+		err = fmt.Errorf("no VCS")
+	}
 	if err != nil {
 		paths, err = WalkFiles(sess.RepoRoot)
 	}

--- a/session.go
+++ b/session.go
@@ -1397,7 +1397,7 @@ func (s *Session) ClearAllComments() {
 // ChangeBaseBranch changes the diff base to the given branch, recomputes merge-base,
 // rebuilds the file list with new diffs, and notifies connected browsers via SSE.
 // Comments are preserved for files that still appear in the new diff.
-func (s *Session) ChangeBaseBranch(branch string) error {
+func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // inherent complexity: rollback, recompute diffs, preserve comments
 	s.mu.RLock()
 	mode := s.Mode
 	vcs := s.VCS

--- a/session.go
+++ b/session.go
@@ -455,19 +455,20 @@ func expandAndDedupPaths(paths []string, ignorePatterns []string) ([]string, err
 	return unique, nil
 }
 
-// resolveGitContext returns git repo state for file-mode sessions.
-func resolveGitContext() (root, branch, baseRef, baseBranchName string) {
-	if !IsGitRepo() {
-		return "", "", "", ""
+// resolveGitContext returns VCS repo state for file-mode sessions.
+func resolveGitContext() (root, branch, baseRef, baseBranchName string, vcs VCS) {
+	vcs = DetectVCS("")
+	if vcs == nil {
+		return "", "", "", "", nil
 	}
-	root, _ = RepoRoot()
-	branch = CurrentBranch()
-	resolvedBase := DefaultBranch()
+	root, _ = vcs.RepoRoot()
+	branch = vcs.CurrentBranch()
+	resolvedBase := vcs.DefaultBranch()
 	baseBranchName = resolvedBase
 	if branch != resolvedBase {
-		baseRef, _ = MergeBase(resolvedBase)
+		baseRef, _ = vcs.MergeBase(resolvedBase)
 	}
-	return root, branch, baseRef, baseBranchName
+	return root, branch, baseRef, baseBranchName, vcs
 }
 
 // NewSessionFromFiles creates a session from explicitly provided file or directory paths.
@@ -487,12 +488,13 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 		return nil, fmt.Errorf("no files found")
 	}
 
-	root, branch, baseRef, baseBranchName := resolveGitContext()
+	root, branch, baseRef, baseBranchName, vcs := resolveGitContext()
 	if root == "" {
 		root = filepath.Dir(expandedPaths[0])
 	}
 
 	s := &Session{
+		VCS:                 vcs,
 		Mode:                "files",
 		Branch:              branch,
 		BaseRef:             baseRef,
@@ -528,10 +530,10 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 			Comments: []Comment{},
 		}
 
-		if IsGitRepo() {
-			hunks, diffErr := fileDiffUnified(relPath, baseRef, root)
+		if vcs != nil {
+			hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, root)
 			if diffErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", relPath, diffErr)
+				fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", relPath, diffErr)
 			} else {
 				fe.DiffHunks = hunks
 			}
@@ -1160,6 +1162,7 @@ func (s *Session) EnsureFileEntry(path string) bool {
 	}
 	repoRoot := s.RepoRoot
 	baseRef := s.BaseRef
+	vcs := s.VCS
 	s.mu.RUnlock()
 
 	if repoRoot == "" {
@@ -1172,9 +1175,12 @@ func (s *Session) EnsureFileEntry(path string) bool {
 		return false
 	}
 
-	// Determine the file's git status via a single-file diff against baseRef
+	// Determine the file's VCS status via a single-file diff against baseRef
 	// (avoids running full ChangedFiles which diffs ALL files).
-	status := fileStatusInRepo(path, repoRoot, baseRef)
+	status := "modified"
+	if vcs != nil {
+		status = vcs.FileStatusInRepo(path, baseRef, repoRoot)
+	}
 
 	fe := &FileEntry{
 		Path:     path,
@@ -1189,8 +1195,8 @@ func (s *Session) EnsureFileEntry(path string) bool {
 	// Generate diff hunks
 	if status == "added" || status == "untracked" {
 		fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
-	} else if status != "deleted" {
-		if hunks, err := fileDiffUnified(path, baseRef, repoRoot); err == nil {
+	} else if status != "deleted" && vcs != nil {
+		if hunks, err := vcs.FileDiffUnified(path, baseRef, repoRoot); err == nil {
 			fe.DiffHunks = hunks
 		}
 	}
@@ -1429,25 +1435,29 @@ func (s *Session) ClearAllComments() {
 func (s *Session) ChangeBaseBranch(branch string) error {
 	s.mu.RLock()
 	mode := s.Mode
+	vcs := s.VCS
 	s.mu.RUnlock()
 	if mode != "git" {
 		return fmt.Errorf("base branch can only be changed in git mode")
 	}
+	if vcs == nil {
+		return fmt.Errorf("no VCS available")
+	}
 
 	// Compute merge-base with the new branch (try both local and remote ref)
-	mb, err := MergeBase(branch)
+	mb, err := vcs.MergeBase(branch)
 	if err != nil {
-		mb, err = MergeBase("origin/" + branch)
+		mb, err = vcs.MergeBase("origin/" + branch)
 		if err != nil {
 			return fmt.Errorf("cannot compute merge-base with %s: %w", branch, err)
 		}
 	}
 
 	// Save old state for rollback
-	oldOverride := getDefaultBranchOverride()
+	oldOverride := vcs.GetDefaultBranchOverride()
 
-	// Update the global override so ChangedFiles() uses the new base
-	setDefaultBranchOverride(branch)
+	// Update the override so ChangedFiles() uses the new base
+	vcs.SetDefaultBranchOverride(branch)
 
 	s.mu.Lock()
 	oldBaseRef := s.BaseRef
@@ -1470,13 +1480,13 @@ func (s *Session) ChangeBaseBranch(branch string) error {
 	// Re-detect changed files with new base
 	var changes []FileChange
 	if currentBranch != branch {
-		changes, err = changedFilesFromBaseInDir(mb, repoRoot)
+		changes, err = vcs.ChangedFilesFromBaseInDir(mb, repoRoot)
 	} else {
-		changes, err = changedFilesOnDefaultInDir(repoRoot)
+		changes, err = vcs.ChangedFilesOnDefaultInDir(repoRoot)
 	}
 	if err != nil {
 		// Rollback all state
-		setDefaultBranchOverride(oldOverride)
+		vcs.SetDefaultBranchOverride(oldOverride)
 		s.mu.Lock()
 		s.BaseRef = oldBaseRef
 		s.BaseBranchName = oldBaseBranchName
@@ -1506,7 +1516,7 @@ func (s *Session) ChangeBaseBranch(branch string) error {
 			}
 		}
 		if fc.Status != "added" && fc.Status != "untracked" {
-			if hunks, diffErr := fileDiffUnified(fc.Path, mb, repoRoot); diffErr == nil {
+			if hunks, diffErr := vcs.FileDiffUnified(fc.Path, mb, repoRoot); diffErr == nil {
 				fe.DiffHunks = hunks
 			}
 		} else {
@@ -2391,16 +2401,16 @@ func availableScopes(baseRef string) []string {
 }
 
 // GetCommits returns the list of commits between the base ref and HEAD.
-// Returns nil for non-git sessions or when no base ref is set.
+// Returns nil for non-VCS sessions or when no base ref is set.
 func (s *Session) GetCommits() []CommitInfo {
 	s.mu.RLock()
-	if s.Mode != "git" || s.BaseRef == "" {
+	if s.Mode != "git" || s.BaseRef == "" || s.VCS == nil {
 		s.mu.RUnlock()
 		return nil
 	}
-	baseRef, repoRoot := s.BaseRef, s.RepoRoot
+	baseRef, repoRoot, vcs := s.BaseRef, s.RepoRoot, s.VCS
 	s.mu.RUnlock()
-	commits, err := CommitLog(baseRef, repoRoot)
+	commits, err := vcs.CommitLog(baseRef, repoRoot)
 	if err != nil {
 		return nil
 	}

--- a/session.go
+++ b/session.go
@@ -221,30 +221,6 @@ type CritJSONFile struct {
 	Comments []Comment `json:"comments"`
 }
 
-// detectGitChanges resolves the base ref and returns the list of changed files.
-func detectGitChanges(root string, ignorePatterns []string) (branch, baseRef, resolvedBase string, changes []FileChange, err error) {
-	branch = CurrentBranch()
-	resolvedBase = DefaultBranch()
-	if branch != resolvedBase {
-		baseRef, _ = MergeBase(resolvedBase)
-	}
-
-	if baseRef != "" {
-		changes, err = changedFilesFromBaseInDir(baseRef, root)
-	} else {
-		changes, err = changedFilesOnDefaultInDir(root)
-	}
-	if err != nil {
-		return "", "", "", nil, fmt.Errorf("detecting changes: %w", err)
-	}
-	changes = filterIgnored(changes, ignorePatterns)
-
-	if len(changes) == 0 {
-		return "", "", "", nil, fmt.Errorf("no changed files detected (after applying ignore patterns)")
-	}
-	return branch, baseRef, resolvedBase, changes, nil
-}
-
 // populateLazyFile fills stats for a file that will be loaded on demand.
 func populateLazyFile(fe *FileEntry, fc FileChange, numstats map[string]NumstatEntry) {
 	fe.Lazy = true
@@ -291,58 +267,10 @@ func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string) bool 
 }
 
 // NewSessionFromGit creates a session by auto-detecting changed files via git.
-// The base branch is read from DefaultBranch(), which respects the package-level
-// defaultBranchOverride set by resolveServerConfig() when --base-branch is given.
-// We use the global rather than a parameter so that RefreshFileList() during
-// multi-round reviews picks up the same override automatically.
+// It delegates to NewSessionFromVCS with a GitVCS backend.
+// Retained for test compatibility; production code uses NewSessionFromVCS directly.
 func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
-	root, err := RepoRoot()
-	if err != nil {
-		return nil, fmt.Errorf("not a git repository: %w", err)
-	}
-
-	branch, baseRef, resolvedBase, changes, err := detectGitChanges(root, ignorePatterns)
-	if err != nil {
-		return nil, err
-	}
-
-	s := &Session{
-		VCS:                 &GitVCS{},
-		Mode:                "git",
-		Branch:              branch,
-		BaseRef:             baseRef,
-		BaseBranchName:      resolvedBase,
-		RepoRoot:            root,
-		ReviewRound:         1,
-		IgnorePatterns:      ignorePatterns,
-		subscribers:         make(map[chan SSEEvent]struct{}),
-		roundComplete:       make(chan struct{}, 1),
-		awaitingFirstReview: true,
-	}
-
-	var numstats map[string]NumstatEntry
-	if len(changes) > lazyFileThreshold && baseRef != "" {
-		numstats, _ = DiffNumstatDir(baseRef, root)
-	}
-
-	for i, fc := range changes {
-		absPath := filepath.Join(root, fc.Path)
-		fe := &FileEntry{
-			Path:     fc.Path,
-			AbsPath:  absPath,
-			Status:   fc.Status,
-			FileType: detectFileType(fc.Path),
-		}
-
-		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
-			populateLazyFile(fe, fc, numstats)
-		} else if !populateEagerFile(fe, fc, baseRef, root) {
-			continue
-		}
-		s.Files = append(s.Files, fe)
-	}
-
-	return s, nil
+	return NewSessionFromVCS(&GitVCS{}, ignorePatterns)
 }
 
 // detectVCSChanges resolves the base ref and returns the list of changed files using the VCS interface.

--- a/session.go
+++ b/session.go
@@ -116,7 +116,9 @@ type FileEntry struct {
 
 // ensureLoaded loads content and diff hunks for a lazy file on first access.
 // For non-lazy files, this is an immediate no-op.
-func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string) error {
+// The vcs parameter is used for computing diffs; pass nil to fall back to
+// the git package-level functions (backward compat for tests).
+func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string, vcs VCS) error {
 	if !fe.Lazy {
 		return nil
 	}
@@ -137,18 +139,32 @@ func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string) error {
 			} else {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
-				hunks, err := fileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fe.Path, err)
-				} else {
-					fe.DiffHunks = hunks
-				}
+				fe.loadDiff(ctx, repoRoot, baseRef, vcs)
 			}
 		}
 
 		fe.Lazy = false
 	})
 	return fe.loadErr
+}
+
+// loadDiff computes diff hunks via the VCS interface or git package-level fallback.
+func (fe *FileEntry) loadDiff(ctx context.Context, repoRoot, baseRef string, vcs VCS) {
+	if vcs != nil {
+		hunks, err := vcs.FileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fe.Path, err)
+		} else {
+			fe.DiffHunks = hunks
+		}
+		return
+	}
+	hunks, err := fileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fe.Path, err)
+	} else {
+		fe.DiffHunks = hunks
+	}
 }
 
 // Session is the top-level state manager for a multi-file review.
@@ -239,7 +255,9 @@ func populateLazyFile(fe *FileEntry, fc FileChange, numstats map[string]NumstatE
 }
 
 // populateEagerFile reads content and computes diffs for a file loaded at startup.
-func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string) bool {
+// The vcs parameter is used for computing diffs; pass nil to fall back to
+// the git package-level functions.
+func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string, vcs VCS) bool {
 	if fc.Status != "deleted" {
 		data, err := os.ReadFile(fe.AbsPath)
 		if err != nil {
@@ -253,17 +271,31 @@ func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string) bool 
 		if fc.Status == "added" || fc.Status == "untracked" {
 			fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
 		} else {
-			hunks, err := fileDiffUnified(fc.Path, baseRef, root)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fc.Path, err)
-			} else {
-				fe.DiffHunks = hunks
-			}
+			populateEagerFileDiff(fe, fc, baseRef, root, vcs)
 		}
 	}
 
 	fe.Comments = []Comment{}
 	return true
+}
+
+// populateEagerFileDiff computes diff hunks for an eager-loaded file.
+func populateEagerFileDiff(fe *FileEntry, fc FileChange, baseRef, root string, vcs VCS) {
+	if vcs != nil {
+		hunks, err := vcs.FileDiffUnified(fc.Path, baseRef, root)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fc.Path, err)
+		} else {
+			fe.DiffHunks = hunks
+		}
+		return
+	}
+	hunks, err := fileDiffUnified(fc.Path, baseRef, root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fc.Path, err)
+	} else {
+		fe.DiffHunks = hunks
+	}
 }
 
 // NewSessionFromGit creates a session by auto-detecting changed files via git.
@@ -340,7 +372,7 @@ func NewSessionFromVCS(vcs VCS, ignorePatterns []string) (*Session, error) {
 
 		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
 			populateLazyFile(fe, fc, numstats)
-		} else if !populateEagerFile(fe, fc, baseRef, root) {
+		} else if !populateEagerFile(fe, fc, baseRef, root, vcs) {
 			continue
 		}
 		s.Files = append(s.Files, fe)
@@ -2102,10 +2134,11 @@ func (s *Session) GetFileSnapshot(path string) (map[string]any, bool) {
 	}
 	repoRoot := s.RepoRoot
 	baseRef := s.BaseRef
+	vcs := s.VCS
 	s.mu.RUnlock()
 
 	// Load content on demand for lazy files
-	if err := f.ensureLoaded(repoRoot, baseRef); err != nil {
+	if err := f.ensureLoaded(repoRoot, baseRef, vcs); err != nil {
 		return nil, false
 	}
 
@@ -2159,10 +2192,11 @@ func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
 	}
 	repoRoot := s.RepoRoot
 	baseRef := s.BaseRef
+	vcs := s.VCS
 	s.mu.RUnlock()
 
 	// Load content + diffs on demand for lazy files
-	if err := f.ensureLoaded(repoRoot, baseRef); err != nil {
+	if err := f.ensureLoaded(repoRoot, baseRef, vcs); err != nil {
 		return nil, false
 	}
 
@@ -2231,6 +2265,8 @@ func (s *Session) GetSessionInfo() SessionInfo {
 		vcsName = s.VCS.Name()
 	}
 
+	vcs := s.VCS
+
 	info := SessionInfo{
 		Mode:           s.Mode,
 		VCSName:        vcsName,
@@ -2242,7 +2278,7 @@ func (s *Session) GetSessionInfo() SessionInfo {
 		Cwd:            s.RepoRoot,
 	}
 
-	info.AvailableScopes = cachedAvailableScopes(info.BaseRef)
+	info.AvailableScopes = cachedAvailableScopes(info.BaseRef, vcs)
 
 	for _, f := range s.Files {
 		fi := SessionFileInfo{
@@ -2288,8 +2324,8 @@ var (
 const scopeCacheTTL = 2 * time.Second
 
 // cachedAvailableScopes returns availableScopes results, using a 2-second cache
-// to avoid running git commands on every /api/session poll.
-func cachedAvailableScopes(baseRef string) []string {
+// to avoid running VCS commands on every /api/session poll.
+func cachedAvailableScopes(baseRef string, vcs VCS) []string {
 	scopeCacheMu.Lock()
 	defer scopeCacheMu.Unlock()
 
@@ -2300,7 +2336,7 @@ func cachedAvailableScopes(baseRef string) []string {
 		return result
 	}
 
-	scopes := availableScopes(baseRef)
+	scopes := availableScopes(baseRef, vcs)
 	scopeCacheBaseRef = baseRef
 	scopeCacheResult = scopes
 	scopeCacheExpiry = now.Add(scopeCacheTTL)
@@ -2311,19 +2347,24 @@ func cachedAvailableScopes(baseRef string) []string {
 }
 
 // availableScopes returns the list of scopes that have files.
-// Only includes a scope if git reports changes for it.
-func availableScopes(baseRef string) []string {
+// Only includes a scope if the VCS reports changes for it.
+func availableScopes(baseRef string, vcs VCS) []string {
 	scopes := []string{"all"}
+	if vcs == nil {
+		return scopes
+	}
 	if baseRef != "" {
-		if files, err := changedFilesBranch(baseRef); err == nil && len(files) > 0 {
+		if files, err := vcs.ChangedFilesScoped("branch", baseRef); err == nil && len(files) > 0 {
 			scopes = append(scopes, "branch")
 		}
 	}
-	if files, err := changedFilesStaged(); err == nil && len(files) > 0 {
-		scopes = append(scopes, "staged")
-	}
-	if files, err := changedFilesUnstaged(); err == nil && len(files) > 0 {
-		scopes = append(scopes, "unstaged")
+	if vcs.HasStagingArea() {
+		if files, err := vcs.ChangedFilesScoped("staged", baseRef); err == nil && len(files) > 0 {
+			scopes = append(scopes, "staged")
+		}
+		if files, err := vcs.ChangedFilesScoped("unstaged", baseRef); err == nil && len(files) > 0 {
+			scopes = append(scopes, "unstaged")
+		}
 	}
 	return scopes
 }
@@ -2347,6 +2388,7 @@ func (s *Session) GetCommits() []CommitInfo {
 
 // scopedSessionSnapshot holds session state read under lock for scoped queries.
 type scopedSessionSnapshot struct {
+	vcs            VCS
 	baseRef        string
 	baseBranchName string
 	repoRoot       string
@@ -2375,6 +2417,7 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	copy(rc, s.reviewComments)
 
 	return scopedSessionSnapshot{
+		vcs:            s.VCS,
 		baseRef:        s.BaseRef,
 		baseBranchName: s.BaseBranchName,
 		repoRoot:       s.RepoRoot,
@@ -2388,9 +2431,12 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	}
 }
 
-func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string) []DiffHunk {
+func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+	if vcs == nil {
+		return nil
+	}
 	if commit != "" {
-		h, err := FileDiffForCommit(fc.Path, commit, repoRoot)
+		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot)
 		if err == nil {
 			return h
 		}
@@ -2403,7 +2449,7 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string) []DiffH
 		}
 		return nil
 	}
-	h, err := FileDiffScoped(fc.Path, scope, baseRef, repoRoot)
+	h, err := vcs.FileDiffScoped(fc.Path, scope, baseRef, repoRoot)
 	if err == nil {
 		return h
 	}
@@ -2441,16 +2487,20 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 		BaseRef:         snap.baseRef,
 		BaseBranchName:  snap.baseBranchName,
 		ReviewRound:     snap.reviewRound,
-		AvailableScopes: availableScopes(snap.baseRef),
+		AvailableScopes: availableScopes(snap.baseRef, snap.vcs),
 		ReviewComments:  snap.reviewComments,
+	}
+
+	if snap.vcs == nil {
+		return info
 	}
 
 	var changes []FileChange
 	var err error
 	if commit != "" {
-		changes, err = ChangedFilesForCommit(commit, snap.repoRoot)
+		changes, err = snap.vcs.ChangedFilesForCommit(commit, snap.repoRoot)
 	} else {
-		changes, err = ChangedFilesScoped(scope, snap.baseRef)
+		changes, err = snap.vcs.ChangedFilesScoped(scope, snap.baseRef)
 	}
 	if err != nil || len(changes) == 0 {
 		return info
@@ -2474,7 +2524,7 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 			continue
 		}
 
-		hunks := scopedHunks(fc, scope, commit, snap.baseRef, snap.repoRoot)
+		hunks := scopedHunks(fc, scope, commit, snap.baseRef, snap.repoRoot, snap.vcs)
 		fi.Additions, fi.Deletions = countHunkStats(hunks)
 		info.Files = append(info.Files, fi)
 	}
@@ -2488,13 +2538,14 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 	f := s.fileByPathLocked(path)
 	baseRef = s.BaseRef
 	repoRoot = s.RepoRoot
+	vcs := s.VCS
 	if f != nil {
 		status = f.Status
 	}
 	s.mu.RUnlock()
 
 	if f != nil {
-		if err := f.ensureLoaded(repoRoot, baseRef); err == nil {
+		if err := f.ensureLoaded(repoRoot, baseRef, vcs); err == nil {
 			s.mu.RLock()
 			content = f.Content
 			s.mu.RUnlock()
@@ -2508,11 +2559,13 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 	absPath := filepath.Join(repoRoot, path)
 	if data, err := os.ReadFile(absPath); err == nil {
 		content = string(data)
-		if changes, err := ChangedFilesScoped(scope, baseRef); err == nil {
-			for _, fc := range changes {
-				if fc.Path == path {
-					status = fc.Status
-					break
+		if vcs != nil {
+			if changes, err := vcs.ChangedFilesScoped(scope, baseRef); err == nil {
+				for _, fc := range changes {
+					if fc.Path == path {
+						status = fc.Status
+						break
+					}
 				}
 			}
 		}
@@ -2520,21 +2573,25 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 	return status, content, baseRef, repoRoot
 }
 
-func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot string) []DiffHunk {
-	if commit != "" {
-		h, err := FileDiffForCommit(path, commit, repoRoot)
-		if err == nil {
-			return h
-		}
-		return nil
-	}
+func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+	// Pure content-based diffs don't need VCS.
 	if status == "untracked" && (scope == "unstaged" || scope == "all" || scope == "") {
 		return FileDiffUnifiedNewFile(content)
 	}
 	if status == "added" && scope != "unstaged" {
 		return FileDiffUnifiedNewFile(content)
 	}
-	h, err := FileDiffScoped(path, scope, baseRef, repoRoot)
+	if vcs == nil {
+		return nil
+	}
+	if commit != "" {
+		h, err := vcs.FileDiffForCommit(path, commit, repoRoot)
+		if err == nil {
+			return h
+		}
+		return nil
+	}
+	h, err := vcs.FileDiffScoped(path, scope, baseRef, repoRoot)
 	if err == nil {
 		return h
 	}
@@ -2551,7 +2608,11 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string) (map[str
 
 	status, content, baseRef, repoRoot := s.loadScopedFileState(path, scope)
 
-	hunks := computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot)
+	s.mu.RLock()
+	vcs := s.VCS
+	s.mu.RUnlock()
+
+	hunks := computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot, vcs)
 	if hunks == nil {
 		hunks = []DiffHunk{}
 	}

--- a/session.go
+++ b/session.go
@@ -621,7 +621,12 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 	// not the working tree. Extract anchor from the base ref content.
 	var anchor string
 	if side == "old" && s.BaseRef != "" {
-		baseContent := fileContentAtRef(filePath, s.BaseRef, s.RepoRoot)
+		var baseContent string
+		if s.VCS != nil {
+			baseContent, _ = s.VCS.FileContentAtRef(filePath, s.BaseRef, s.RepoRoot)
+		} else {
+			baseContent = fileContentAtRef(filePath, s.BaseRef, s.RepoRoot)
+		}
 		anchor = extractAnchor(baseContent, startLine, endLine)
 	} else {
 		anchor = extractAnchor(f.Content, startLine, endLine)

--- a/session.go
+++ b/session.go
@@ -153,6 +153,7 @@ func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string) error {
 
 // Session is the top-level state manager for a multi-file review.
 type Session struct {
+	VCS            VCS // nil for non-VCS sessions (e.g. files mode without a repo)
 	Files          []*FileEntry
 	Mode           string   // "files" (explicit markdown files) or "git" (auto-detected from git)
 	CLIArgs        []string // original file arguments passed on the command line (empty for git mode)
@@ -306,6 +307,7 @@ func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 	}
 
 	s := &Session{
+		VCS:                 &GitVCS{},
 		Mode:                "git",
 		Branch:              branch,
 		BaseRef:             baseRef,
@@ -321,6 +323,82 @@ func NewSessionFromGit(ignorePatterns []string) (*Session, error) {
 	var numstats map[string]NumstatEntry
 	if len(changes) > lazyFileThreshold && baseRef != "" {
 		numstats, _ = DiffNumstatDir(baseRef, root)
+	}
+
+	for i, fc := range changes {
+		absPath := filepath.Join(root, fc.Path)
+		fe := &FileEntry{
+			Path:     fc.Path,
+			AbsPath:  absPath,
+			Status:   fc.Status,
+			FileType: detectFileType(fc.Path),
+		}
+
+		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
+			populateLazyFile(fe, fc, numstats)
+		} else if !populateEagerFile(fe, fc, baseRef, root) {
+			continue
+		}
+		s.Files = append(s.Files, fe)
+	}
+
+	return s, nil
+}
+
+// detectVCSChanges resolves the base ref and returns the list of changed files using the VCS interface.
+func detectVCSChanges(vcs VCS, root string, ignorePatterns []string) (branch, baseRef, resolvedBase string, changes []FileChange, err error) {
+	branch = vcs.CurrentBranch()
+	resolvedBase = vcs.DefaultBranch()
+	if branch != resolvedBase {
+		baseRef, _ = vcs.MergeBase(resolvedBase)
+	}
+
+	if baseRef != "" {
+		changes, err = vcs.ChangedFilesFromBaseInDir(baseRef, root)
+	} else {
+		changes, err = vcs.ChangedFilesOnDefaultInDir(root)
+	}
+	if err != nil {
+		return "", "", "", nil, fmt.Errorf("detecting changes: %w", err)
+	}
+	changes = filterIgnored(changes, ignorePatterns)
+
+	if len(changes) == 0 {
+		return "", "", "", nil, fmt.Errorf("no changed files detected (after applying ignore patterns)")
+	}
+	return branch, baseRef, resolvedBase, changes, nil
+}
+
+// NewSessionFromVCS creates a session by auto-detecting changed files using the given VCS backend.
+// This is the VCS-agnostic equivalent of NewSessionFromGit.
+func NewSessionFromVCS(vcs VCS, ignorePatterns []string) (*Session, error) {
+	root, err := vcs.RepoRoot()
+	if err != nil {
+		return nil, fmt.Errorf("not a %s repository: %w", vcs.Name(), err)
+	}
+
+	branch, baseRef, resolvedBase, changes, err := detectVCSChanges(vcs, root, ignorePatterns)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Session{
+		VCS:                 vcs,
+		Mode:                "git",
+		Branch:              branch,
+		BaseRef:             baseRef,
+		BaseBranchName:      resolvedBase,
+		RepoRoot:            root,
+		ReviewRound:         1,
+		IgnorePatterns:      ignorePatterns,
+		subscribers:         make(map[chan SSEEvent]struct{}),
+		roundComplete:       make(chan struct{}, 1),
+		awaitingFirstReview: true,
+	}
+
+	var numstats map[string]NumstatEntry
+	if len(changes) > lazyFileThreshold && baseRef != "" {
+		numstats, _ = vcs.DiffNumstat(baseRef, root)
 	}
 
 	for i, fc := range changes {
@@ -2179,6 +2257,7 @@ func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
 // SessionInfo returns metadata about the session for the API.
 type SessionInfo struct {
 	Mode            string            `json:"mode"` // "files" or "git"
+	VCSName         string            `json:"vcs_name,omitempty"`
 	Branch          string            `json:"branch"`
 	BaseRef         string            `json:"base_ref"`
 	BaseBranchName  string            `json:"base_branch_name,omitempty"`
@@ -2209,8 +2288,14 @@ func (s *Session) GetSessionInfo() SessionInfo {
 	reviewComments := make([]Comment, len(s.reviewComments))
 	copy(reviewComments, s.reviewComments)
 
+	var vcsName string
+	if s.VCS != nil {
+		vcsName = s.VCS.Name()
+	}
+
 	info := SessionInfo{
 		Mode:           s.Mode,
+		VCSName:        vcsName,
 		Branch:         s.Branch,
 		BaseRef:        s.BaseRef,
 		BaseBranchName: s.BaseBranchName,

--- a/session_test.go
+++ b/session_test.go
@@ -2639,7 +2639,7 @@ func TestEnsureLoaded(t *testing.T) {
 		t.Fatal("expected no diff hunks before ensureLoaded")
 	}
 
-	err := fe.ensureLoaded(dir, base)
+	err := fe.ensureLoaded(dir, base, nil)
 	if err != nil {
 		t.Fatalf("ensureLoaded failed: %v", err)
 	}
@@ -2658,7 +2658,7 @@ func TestEnsureLoaded(t *testing.T) {
 	}
 
 	// Second call is a no-op (sync.Once)
-	err = fe.ensureLoaded(dir, base)
+	err = fe.ensureLoaded(dir, base, nil)
 	if err != nil {
 		t.Fatalf("second ensureLoaded should not fail: %v", err)
 	}
@@ -2670,7 +2670,7 @@ func TestEnsureLoadedNotLazy(t *testing.T) {
 		Content: "already loaded",
 		Lazy:    false,
 	}
-	err := fe.ensureLoaded("/tmp", "abc123")
+	err := fe.ensureLoaded("/tmp", "abc123", nil)
 	if err != nil {
 		t.Fatalf("ensureLoaded on non-lazy file should be no-op, got: %v", err)
 	}

--- a/share.go
+++ b/share.go
@@ -612,8 +612,8 @@ func clearShareState(critPath string) error {
 // Used by share/fetch/unpublish commands to avoid redundant config parsing.
 func loadShareConfig() Config {
 	cfgDir := ""
-	if IsGitRepo() {
-		cfgDir, _ = RepoRoot()
+	if vcs := DetectVCS(""); vcs != nil {
+		cfgDir, _ = vcs.RepoRoot()
 	}
 	if cfgDir == "" {
 		cfgDir, _ = os.Getwd()

--- a/vcs.go
+++ b/vcs.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// VCS abstracts version control operations so crit can support multiple backends
+// (git, Sapling, etc.). Each method corresponds to an existing package-level
+// function in git.go; the interface lets callers work with any VCS uniformly.
+type VCS interface {
+	// Name returns the VCS identifier ("git", "sl", etc.).
+	Name() string
+
+	// RepoRoot returns the absolute path to the repository root.
+	RepoRoot() (string, error)
+
+	// CurrentBranch returns the name of the current branch.
+	CurrentBranch() string
+
+	// DefaultBranch returns the name of the default branch (e.g. "main", "master").
+	DefaultBranch() string
+
+	// SetDefaultBranchOverride overrides the default branch detection.
+	SetDefaultBranchOverride(branch string)
+
+	// GetDefaultBranchOverride returns the current default branch override, if any.
+	GetDefaultBranchOverride() string
+
+	// MergeBase returns the merge-base commit between HEAD and the given ref.
+	MergeBase(ref string) (string, error)
+
+	// ChangedFilesOnDefaultInDir returns changed files when on the default branch.
+	ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error)
+
+	// ChangedFilesFromBaseInDir returns files changed between baseRef and the working tree.
+	ChangedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error)
+
+	// ChangedFilesScoped returns changed files for a specific scope (branch, staged, unstaged).
+	ChangedFilesScoped(scope, baseRef string) ([]FileChange, error)
+
+	// ChangedFilesForCommit returns the files changed in a single commit.
+	ChangedFilesForCommit(sha, dir string) ([]FileChange, error)
+
+	// FileDiffUnified returns parsed diff hunks for a file against a base ref.
+	FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error)
+
+	// FileDiffUnifiedCtx is like FileDiffUnified but accepts a context for timeout control.
+	FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error)
+
+	// FileDiffScoped returns diff hunks for a file using a scope-appropriate diff command.
+	FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error)
+
+	// FileDiffForCommit returns diff hunks for a file in a single commit.
+	FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error)
+
+	// FileDiffUnifiedNewFile returns diff hunks showing an entire file as added.
+	FileDiffUnifiedNewFile(path string) ([]DiffHunk, error)
+
+	// CommitLog returns the commits between baseRef and HEAD.
+	CommitLog(baseRef, dir string) ([]CommitInfo, error)
+
+	// WorkingTreeFingerprint returns a string representing the current working tree state.
+	WorkingTreeFingerprint() string
+
+	// UntrackedFiles returns untracked files, running from the specified directory.
+	UntrackedFiles(dir string) ([]FileChange, error)
+
+	// AllTrackedFiles returns all tracked files plus untracked non-ignored files.
+	AllTrackedFiles(dir string) ([]string, error)
+
+	// RemoteBranches returns the names of all remote branches.
+	RemoteBranches(dir string) ([]string, error)
+
+	// DiffNumstat returns per-file addition/deletion counts.
+	DiffNumstat(baseRef, dir string) (map[string]NumstatEntry, error)
+
+	// UserName returns the VCS-configured user name.
+	UserName() string
+
+	// FileStatusInRepo returns the status of a single file relative to baseRef.
+	FileStatusInRepo(path, baseRef, dir string) string
+
+	// HasStagingArea returns true if the VCS has a staging area (e.g. git index).
+	HasStagingArea() bool
+
+	// SkipDirNames returns directory names that should be skipped during walks
+	// (e.g. ".git", ".sl").
+	SkipDirNames() []string
+}
+
+// DetectVCS returns the appropriate VCS backend for the current directory.
+// If vcsOverride is set ("git", "sl", or "sapling"), that backend is used directly.
+// Otherwise, auto-detection checks for .sl/ first (Sapling on git repos has both),
+// then falls back to git. Returns nil if no VCS is detected.
+func DetectVCS(vcsOverride string) VCS {
+	switch vcsOverride {
+	case "git":
+		return &GitVCS{}
+	case "sl", "sapling":
+		// TODO: return &SaplingVCS{} once implemented
+		return nil
+	}
+
+	// Auto-detect: check for .sl/ first since Sapling repos on top of git have both.
+	if hasSLDir() {
+		// TODO: return &SaplingVCS{} once implemented
+		return nil
+	}
+
+	if IsGitRepo() {
+		return &GitVCS{}
+	}
+
+	return nil
+}
+
+// hasSLDir checks whether a .sl/ directory exists at or above the current directory.
+func hasSLDir() bool {
+	dir, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".sl")); err == nil && info.IsDir() {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return false
+}

--- a/vcs.go
+++ b/vcs.go
@@ -99,14 +99,12 @@ func DetectVCS(vcsOverride string) VCS {
 	case "git":
 		return &GitVCS{}
 	case "sl", "sapling":
-		// TODO: return &SaplingVCS{} once implemented
-		return nil
+		return &SaplingVCS{}
 	}
 
 	// Auto-detect: check for .sl/ first since Sapling repos on top of git have both.
 	if hasSLDir() {
-		// TODO: return &SaplingVCS{} once implemented
-		return nil
+		return &SaplingVCS{}
 	}
 
 	if IsGitRepo() {

--- a/vcs.go
+++ b/vcs.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -91,7 +93,8 @@ type VCS interface {
 }
 
 // DetectVCS returns the appropriate VCS backend for the current directory.
-// If vcsOverride is set ("git", "sl", or "sapling"), that backend is used directly.
+// If vcsOverride is set ("git", "sl", or "sapling"), that backend is preferred
+// but falls back to git if the requested backend isn't available.
 // Otherwise, auto-detection checks for .sl/ first (Sapling on git repos has both),
 // then falls back to git. Returns nil if no VCS is detected.
 func DetectVCS(vcsOverride string) VCS {
@@ -99,15 +102,29 @@ func DetectVCS(vcsOverride string) VCS {
 	case "git":
 		return &GitVCS{}
 	case "sl", "sapling":
-		return &SaplingVCS{}
+		if _, err := exec.LookPath("sl"); err == nil {
+			return &SaplingVCS{}
+		}
+		fmt.Fprintf(os.Stderr, "Warning: vcs=%q requested but sl not in PATH, falling back to git\n", vcsOverride)
+		if IsGitRepo() {
+			return &GitVCS{}
+		}
+		return nil
 	}
 
 	// Auto-detect: check for .sl/ first since Sapling repos on top of git have both.
 	if hasSLDir() {
-		return &SaplingVCS{}
+		if _, err := exec.LookPath("sl"); err == nil {
+			return &SaplingVCS{}
+		}
 	}
 
 	if IsGitRepo() {
+		// Check if Sapling metadata exists under .git/sl — this means sl was used
+		// here but it's primarily a git repo. Hint but don't switch automatically.
+		if hasGitSLDir() {
+			fmt.Fprintf(os.Stderr, "Hint: Sapling detected. Use --vcs sl or set \"vcs\": \"sl\" in config to use Sapling.\n")
+		}
 		return &GitVCS{}
 	}
 
@@ -120,8 +137,33 @@ func hasSLDir() bool {
 	if err != nil {
 		return false
 	}
+	return hasSLDirFrom(dir)
+}
+
+// hasSLDirFrom checks whether a .sl/ directory exists at or above the given directory.
+func hasSLDirFrom(dir string) bool {
 	for {
 		if info, err := os.Stat(filepath.Join(dir, ".sl")); err == nil && info.IsDir() {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return false
+}
+
+// hasGitSLDir checks whether .git/sl/ exists at or above the current directory,
+// indicating Sapling has been used in a git repo.
+func hasGitSLDir() bool {
+	dir, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".git", "sl")); err == nil && info.IsDir() {
 			return true
 		}
 		parent := filepath.Dir(dir)

--- a/vcs.go
+++ b/vcs.go
@@ -81,6 +81,9 @@ type VCS interface {
 	// UserName returns the VCS-configured user name.
 	UserName() string
 
+	// FileContentAtRef returns the content of a file at a given ref/revision.
+	FileContentAtRef(path, ref, dir string) (string, error)
+
 	// FileStatusInRepo returns the status of a single file relative to baseRef.
 	FileStatusInRepo(path, baseRef, dir string) string
 

--- a/watch.go
+++ b/watch.go
@@ -76,8 +76,19 @@ func (s *Session) RefreshFileList() {
 		return
 	}
 
-	// ChangedFiles shells out to VCS — no lock needed
-	changes, err := ChangedFiles()
+	// Shell out to VCS for changed files — no lock held.
+	s.mu.RLock()
+	baseRef := s.BaseRef
+	repoRoot := s.RepoRoot
+	s.mu.RUnlock()
+
+	var changes []FileChange
+	var err error
+	if vcs.CurrentBranch() == vcs.DefaultBranch() {
+		changes, err = vcs.ChangedFilesOnDefaultInDir(repoRoot)
+	} else {
+		changes, err = vcs.ChangedFilesFromBaseInDir(baseRef, repoRoot)
+	}
 	if err != nil {
 		return
 	}
@@ -91,8 +102,6 @@ func (s *Session) RefreshFileList() {
 	for _, f := range s.Files {
 		existing[f.Path] = f
 	}
-	repoRoot := s.RepoRoot
-	baseRef := s.BaseRef
 	s.mu.RUnlock()
 
 	// Fetch numstats if we might need them for lazy files
@@ -173,6 +182,11 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
+	// Read VCS once under lock — it doesn't change after session init.
+	s.mu.RLock()
+	vcs := s.VCS
+	s.mu.RUnlock()
+
 	var lastFP string
 	wasWaiting := false
 
@@ -191,8 +205,8 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 			}
 
 			var fp string
-			if s.VCS != nil {
-				fp = s.VCS.WorkingTreeFingerprint()
+			if vcs != nil {
+				fp = vcs.WorkingTreeFingerprint()
 			} else {
 				fp = WorkingTreeFingerprint()
 			}

--- a/watch.go
+++ b/watch.go
@@ -33,6 +33,7 @@ func (s *Session) RefreshDiffs() {
 	}
 	baseRef := s.BaseRef
 	repoRoot := s.RepoRoot
+	vcs := s.VCS
 	s.mu.RUnlock()
 
 	// Compute diffs without holding any lock
@@ -45,10 +46,10 @@ func (s *Session) RefreshDiffs() {
 		var hunks []DiffHunk
 		if snap.status == "added" || snap.status == "untracked" {
 			hunks = FileDiffUnifiedNewFile(snap.content)
-		} else {
-			h, err := fileDiffUnified(snap.path, baseRef, repoRoot)
+		} else if vcs != nil {
+			h, err := vcs.FileDiffUnified(snap.path, baseRef, repoRoot)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", snap.path, err)
+				fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", snap.path, err)
 			} else {
 				hunks = h
 			}
@@ -67,7 +68,15 @@ func (s *Session) RefreshDiffs() {
 // RefreshFileList re-runs ChangedFiles and updates the session's file list.
 // New files are added, removed files are dropped.
 func (s *Session) RefreshFileList() {
-	// ChangedFiles shells out to git — no lock needed
+	s.mu.RLock()
+	vcs := s.VCS
+	s.mu.RUnlock()
+
+	if vcs == nil {
+		return
+	}
+
+	// ChangedFiles shells out to VCS — no lock needed
 	changes, err := ChangedFiles()
 	if err != nil {
 		return
@@ -90,7 +99,7 @@ func (s *Session) RefreshFileList() {
 	var numstats map[string]NumstatEntry
 	if len(changes) > lazyFileThreshold {
 		if baseRef != "" {
-			numstats, _ = DiffNumstatDir(baseRef, repoRoot)
+			numstats, _ = vcs.DiffNumstat(baseRef, repoRoot)
 		}
 	}
 
@@ -175,13 +184,18 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 			// Check for external review file changes (e.g. crit comment).
 			s.mergeExternalCritJSON()
 
-			// Only poll git status while waiting for the agent to make edits.
+			// Only poll VCS status while waiting for the agent to make edits.
 			if !s.isWaitingForAgent() {
 				wasWaiting = false
 				continue
 			}
 
-			fp := WorkingTreeFingerprint()
+			var fp string
+			if s.VCS != nil {
+				fp = s.VCS.WorkingTreeFingerprint()
+			} else {
+				fp = WorkingTreeFingerprint()
+			}
 			if !wasWaiting {
 				// Just entered waiting state — establish baseline.
 				lastFP = fp


### PR DESCRIPTION
## Summary

- Extract a `VCS` interface from git-specific code, implement `GitVCS` (zero behavior change for git users)
- Implement `SaplingVCS` backend using `sl` CLI for all operations
- Auto-detect Sapling repos (`.sl/` directory) with `--vcs` flag override
- Handle Sapling's lack of staging area (staged/unstaged scopes hidden automatically)
- Generalize frontend labels ("vcs mode" instead of "git mode")

Closes #288

## Known limitations

- **No staging area**: Sapling has no index — staged/unstaged scopes are hidden
- **Stacked diffs**: Per-stack review is out of scope for v1
- **`--vcs` flag**: Only applies to the serve command, not `crit stop`/`crit status` (tracked as TODO)

## Test plan

- [ ] All existing tests pass (git behavior unchanged)
- [ ] Sapling parser unit tests pass (status + diff-stat formats)
- [ ] SaplingVCS unit tests pass (interface compliance, scope hiding, commit log parsing)
- [ ] Manual: `crit` in a Sapling repo detects and opens review UI
- [ ] Manual: `crit --vcs git` forces git backend in colocated repos