### PR TITLE
fix: support crit pull across gh CLI versions

### DIFF
--- a/github.go
+++ b/github.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -136,9 +137,58 @@ func detectPRInfo() *PRInfo {
 
 // fetchPRComments fetches all review comments for a PR.
 func fetchPRComments(prNumber int) ([]ghComment, error) {
-	// Use --paginate --slurp to collect all pages into a single JSON structure.
-	// --slurp wraps each page into an outer array: [[page1...], [page2...], ...]
-	// So we unmarshal into [][]ghComment and flatten.
+	if ghSupportsAPISlurp() {
+		return fetchPRCommentsWithSlurp(prNumber)
+	}
+	// TODO: Remove this compatibility path once Crit requires gh v2.48.0+,
+	// which added `gh api --slurp`.
+	return fetchPRCommentsWithoutSlurp(prNumber)
+}
+
+func ghSupportsAPISlurp() bool {
+	out, err := exec.Command("gh", "version").Output()
+	if err != nil {
+		return false
+	}
+	return ghVersionSupportsSlurp(string(out))
+}
+
+func ghVersionSupportsSlurp(versionOutput string) bool {
+	fields := strings.Fields(versionOutput)
+	if len(fields) < 3 || fields[0] != "gh" || fields[1] != "version" {
+		return false
+	}
+	return versionAtLeast(fields[2], 2, 48, 0)
+}
+
+func versionAtLeast(version string, wantMajor, wantMinor, wantPatch int) bool {
+	core := strings.SplitN(strings.TrimPrefix(version, "v"), "-", 2)[0]
+	parts := strings.Split(core, ".")
+	if len(parts) < 3 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return false
+	}
+	if major != wantMajor {
+		return major > wantMajor
+	}
+	if minor != wantMinor {
+		return minor > wantMinor
+	}
+	return patch >= wantPatch
+}
+
+func fetchPRCommentsWithSlurp(prNumber int) ([]ghComment, error) {
 	out, err := exec.Command("gh", "api",
 		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
 		"--paginate",
@@ -152,11 +202,37 @@ func fetchPRComments(prNumber int) ([]ghComment, error) {
 	if err := json.Unmarshal(out, &pages); err != nil {
 		return nil, fmt.Errorf("parsing PR comments: %w", err)
 	}
+
 	var comments []ghComment
 	for _, page := range pages {
 		comments = append(comments, page...)
 	}
 	return comments, nil
+}
+
+func fetchPRCommentsWithoutSlurp(prNumber int) ([]ghComment, error) {
+	out, err := exec.Command("gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
+		"--paginate",
+		"--jq",
+		".[]",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR comments: %w", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(out))
+	var comments []ghComment
+	for {
+		var c ghComment
+		if err := dec.Decode(&c); err != nil {
+			if err == io.EOF {
+				return comments, nil
+			}
+			return nil, fmt.Errorf("parsing PR comments: %w", err)
+		}
+		comments = append(comments, c)
+	}
 }
 
 // isDuplicateGHComment checks if a GitHub comment already exists in the comment list.

--- a/github.go
+++ b/github.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -226,7 +227,7 @@ func fetchPRCommentsWithoutSlurp(prNumber int) ([]ghComment, error) {
 	for {
 		var c ghComment
 		if err := dec.Decode(&c); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return comments, nil
 			}
 			return nil, fmt.Errorf("parsing PR comments: %w", err)

--- a/github_test.go
+++ b/github_test.go
@@ -78,6 +78,30 @@ func TestMergeGHComments_BasicConversion(t *testing.T) {
 	}
 }
 
+func TestGHVersionSupportsSlurp(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "older than 2.48.0", version: "gh version 2.47.0 (2025-01-01)\n", want: false},
+		{name: "exactly 2.48.0", version: "gh version 2.48.0 (2025-01-01)\n", want: true},
+		{name: "newer patch release", version: "gh version 2.48.1 (2025-01-01)\n", want: true},
+		{name: "newer minor release", version: "gh version 2.49.0 (2025-01-01)\n", want: true},
+		{name: "prefixed version", version: "gh version v2.48.0 (2025-01-01)\n", want: true},
+		{name: "prerelease", version: "gh version 2.48.0-rc1 (2025-01-01)\n", want: true},
+		{name: "invalid output", version: "not a gh version", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ghVersionSupportsSlurp(tt.version); got != tt.want {
+				t.Fatalf("ghVersionSupportsSlurp(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeGHComments_FiltersLeftSide(t *testing.T) {
 	comments := []ghComment{
 		{ID: 1, Path: "old.go", Line: 5, Side: "LEFT", Body: "old code comment"},


### PR DESCRIPTION

GitHub CLI added `gh api --slurp` in v2.48.0, but older installs
still need to fetch paginated PR comments successfully.

Detect whether the local `gh` supports `--slurp` and use the native
`--paginate --slurp` path when available. For older gh versions, fall
back to `--paginate --jq .[]` and decode the streamed JSON objects.

This keeps `crit pull` working on both pre-2.48.0 and newer gh releases,
with a TODO to remove the compatibility branch once Crit requires
`gh v2.48.0+`.
