### PR TITLE
test: add e2e share integration tests for crit ↔ crit-web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,16 @@ Sharing is opt-in. When `--share-url` (or `CRIT_SHARE_URL` env var, or `share_ur
 - A share-notice banner shows the URL with Copy / Unpublish actions.
 - Unpublish calls `DELETE {share_url}/api/reviews?delete_token=...` then clears local state.
 
+### Share Integration Tests
+
+`share_integration_test.go` contains end-to-end tests for the crit ↔ crit-web share flow (build tag: `integration`). When modifying share logic, the share payload, comment sync, or any crit-web interaction:
+
+1. **Run the tests**: `make e2e-share` (or `./scripts/e2e-share.sh`)
+2. **Add new test cases** for any new share functionality — name them `TestShareSync*`
+3. **Verify on web**: tests log review URLs; use `./scripts/e2e-share.sh --serve` to start crit-web and inspect reviews in browser
+
+Requires a local crit-web checkout at `../crit-web` and PostgreSQL. See `scripts/AGENTS.md` for full details.
+
 ## Multi-Round Review
 
 When the agent runs `crit` (or calls `POST /api/round-complete`):

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ test-diff:
 	./test/test-diff.sh
 
 test-share-sync: build
-	go test -tags integration -run TestShareSyncIntegration -v -count=1 ./...
+	go test -tags integration -run TestShareSync -v -count=1 ./...
+
+e2e-share:
+	./scripts/e2e-share.sh
 
 test-daemon:
 	./test/test-daemon-reuse.sh
@@ -55,4 +58,4 @@ e2e-failed:
 e2e-report:
 	cd e2e && npx playwright show-report
 
-.PHONY: build build-all generate verify-generate update-deps test setup-hooks clean test-diff test-share-sync test-daemon test-plan-daemon e2e e2e-failed e2e-report
+.PHONY: build build-all generate verify-generate update-deps test setup-hooks clean test-diff test-share-sync e2e-share test-daemon test-plan-daemon e2e e2e-failed e2e-report

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,84 @@
+# Scripts
+
+## e2e-share.sh
+
+End-to-end integration tests for the crit CLI to crit-web share flow. Tests the full round-trip: sharing reviews, fetching web comments, re-sharing without duplicates, and unpublishing.
+
+### Prerequisites
+
+- A local crit-web checkout as a sibling directory (`../crit-web` relative to the crit repo root, or set `CRIT_WEB_DIR`)
+- PostgreSQL running locally (the script creates a `crit_e2e` database)
+- mise (for Go and Elixir toolchain management)
+
+### Usage
+
+```bash
+# Full run: build crit, start crit-web on :4001, run tests, tear down
+make e2e-share
+# or directly:
+./scripts/e2e-share.sh
+
+# Start crit-web for manual testing (Ctrl+C to stop)
+./scripts/e2e-share.sh --serve
+
+# Run tests against an already-running crit-web
+./scripts/e2e-share.sh --skip-web
+
+# Run a specific test
+./scripts/e2e-share.sh -run TestShareSyncFullLifecycle
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CRIT_WEB_PORT` | `4001` | Port for the test crit-web instance |
+| `CRIT_WEB_DIR` | `../crit-web` | Path to crit-web checkout |
+| `DB_NAME` | `crit_e2e` | PostgreSQL database name (separate from dev) |
+
+### What the script does
+
+1. Builds crit via `make build`
+2. Creates/resets the `crit_e2e` database
+3. Starts crit-web with `SELFHOSTED=true` on the test port (no OAuth)
+4. Waits for `GET /health` to return 200
+5. Runs all `TestShareSync*` integration tests with `CRIT_AUTH_TOKEN=""` to bypass any local auth config
+6. Tears down crit-web on exit
+
+### Test file: `share_integration_test.go`
+
+Build tag: `//go:build integration` — these tests are excluded from `go test ./...` and only run via `go test -tags integration`.
+
+Tests use `--output <dir>` to write `.crit.json` to a temp directory (not `~/.crit/reviews/`), and `--share-url` to point at the local crit-web instance.
+
+Every test logs its review URL (`t.Logf("  -> Review: ...")`) so you can open them in a browser for visual inspection. Reviews persist on crit-web after tests run (except the unpublish test).
+
+#### Test cases
+
+| Test | What it covers |
+|---|---|
+| `TestShareSyncIntegration` | Original: share, seed web comment, re-share, verify content + export |
+| `TestShareSyncNoComments` | Share with zero comments, verify document on web |
+| `TestShareSyncLineComments` | Line-scoped comments: body, position, scope verified on web |
+| `TestShareSyncFileComment` | File-scoped comment: body, scope, file_path verified on web |
+| `TestShareSyncReviewLevelComments` | Review-level comments shared (tests #297 fix for CLI path) |
+| `TestShareSyncMixedCommentTypes` | All 3 scopes together, each verified on web |
+| `TestShareSyncResolvedExcluded` | Resolved comments filtered out of share payload |
+| `TestShareSyncReshareNoDuplicates` | Re-share preserves comments without duplication |
+| `TestShareSyncReshareNoChanges` | No-op when content unchanged (round stays same) |
+| `TestShareSyncFetchWebComments` | Web-authored comments pulled into local .crit.json |
+| `TestShareSyncFetchWebCommentsNoDuplicates` | Repeated syncs don't duplicate web comments |
+| `TestShareSyncMultipleFiles` | Multi-file share with per-file comment association |
+| `TestShareSyncMultipleRounds` | Round progression across 3 share cycles, content verified |
+| `TestShareSyncCommentWithReplies` | Threaded replies included in share |
+| `TestShareSyncUnpublish` | Full unpublish: web deletion + local state cleared |
+| `TestShareSyncExport` | Export endpoint returns .crit.json-compatible shape |
+| `TestShareSyncFetchReviewLevelWebComment` | Review-level web comments merged into local ReviewComments |
+| `TestShareSyncFullLifecycle` | Complete round-trip: local comments with threads, share, web comments added, fetch, re-share (preserved), fetch again (no duplicates) |
+
+#### Adding new tests
+
+- Name test functions `TestShareSync*` so they're picked up by the `-run TestShareSync` filter
+- Use the helpers: `critShareCmd`, `critUnpublishCmd`, `writeTestCritJSON`, `readCritJSON`, `commentsFromAPI`, `documentFromAPI`, `seedComment`, `seedCommentAt`, `seedReviewComment`, `logReview`, `extractToken`
+- Always call `logReview(t, output)` after sharing so the URL is visible in test output
+- Use `writeTestCritJSON` (not `writeCritJSON` — that name conflicts with `github.go`)

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/e2e-share.sh
+++ b/scripts/e2e-share.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# End-to-end integration test runner for crit ↔ crit-web share flow.
+# Builds crit, starts a local crit-web, runs share integration tests, tears down.
+#
+# Usage:
+#   ./scripts/e2e-share.sh              # run all share integration tests
+#   ./scripts/e2e-share.sh -run TestFoo # pass extra args to go test
+#   ./scripts/e2e-share.sh --skip-web   # assume crit-web already running
+#   ./scripts/e2e-share.sh --serve     # start crit-web and keep it running (no tests)
+set -euo pipefail
+
+CRIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WEB_DIR="${CRIT_WEB_DIR:-$(cd "$CRIT_DIR/../crit-web" && pwd)}"
+
+# Activate mise so go/mix/etc are available
+if command -v /opt/homebrew/bin/mise >/dev/null 2>&1; then
+  eval "$(/opt/homebrew/bin/mise env -s bash -C "$CRIT_DIR" 2>/dev/null)" || true
+  eval "$(/opt/homebrew/bin/mise env -s bash -C "$WEB_DIR" 2>/dev/null)" || true
+fi
+WEB_PORT="${CRIT_WEB_PORT:-4001}"
+WEB_URL="http://localhost:$WEB_PORT"
+WEB_PID=""
+SKIP_WEB=false
+SERVE_ONLY=false
+GO_TEST_ARGS=()
+
+# Parse our flags vs go test args
+for arg in "$@"; do
+  case "$arg" in
+    --skip-web) SKIP_WEB=true ;;
+    --serve) SERVE_ONLY=true ;;
+    *) GO_TEST_ARGS+=("$arg") ;;
+  esac
+done
+
+cleanup() {
+  if [ -n "$WEB_PID" ]; then
+    echo "→ Stopping crit-web (pid $WEB_PID)..."
+    kill "$WEB_PID" 2>/dev/null || true
+    wait "$WEB_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# 1. Build crit
+echo "→ Building crit..."
+make -C "$CRIT_DIR" build -j
+
+# 2. Start crit-web (unless --skip-web)
+if [ "$SKIP_WEB" = false ]; then
+  # Check if something is already on the port
+  if lsof -ti tcp:"$WEB_PORT" >/dev/null 2>&1; then
+    echo "✗ Port $WEB_PORT already in use. Use --skip-web if crit-web is already running."
+    exit 1
+  fi
+
+  echo "→ Starting crit-web on :$WEB_PORT..."
+  cd "$WEB_DIR"
+  # Use a separate DB so we don't trash the dev database
+  export DB_NAME="${DB_NAME:-crit_e2e}"
+  # Reset DB to clean state
+  MIX_ENV=dev mix ecto.reset --quiet 2>/dev/null || mix ecto.setup --quiet
+  # Start Phoenix in background on the test port
+  PORT=$WEB_PORT SELFHOSTED=true ADMIN_PASSWORD=test mix phx.server &
+  WEB_PID=$!
+  cd "$CRIT_DIR"
+
+  # Wait for health
+  echo "→ Waiting for crit-web..."
+  for i in $(seq 1 30); do
+    if curl -sf "$WEB_URL/health" >/dev/null 2>&1; then
+      echo "→ crit-web ready"
+      break
+    fi
+    if ! kill -0 "$WEB_PID" 2>/dev/null; then
+      echo "✗ crit-web process died"
+      exit 1
+    fi
+    if [ "$i" -eq 30 ]; then
+      echo "✗ crit-web failed to start within 30s"
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+# 3. Serve-only mode: keep running for manual testing
+if [ "$SERVE_ONLY" = true ]; then
+  echo "✓ crit-web running at $WEB_URL (Ctrl+C to stop)"
+  echo "  crit binary: $CRIT_DIR/crit"
+  echo "  Usage: CRIT_SHARE_URL=$WEB_URL CRIT_AUTH_TOKEN='' $CRIT_DIR/crit share -o /tmp/test plan.md"
+  wait "$WEB_PID"
+  exit 0
+fi
+
+# 3. Run integration tests
+echo "→ Running share integration tests..."
+cd "$CRIT_DIR"
+CRIT_SHARE_URL="$WEB_URL" \
+CRIT_WEB_URL="$WEB_URL" \
+CRIT_BINARY="$CRIT_DIR/crit" \
+CRIT_AUTH_TOKEN="" \
+  go test -tags integration -run TestShareSync -v -count=1 "${GO_TEST_ARGS[@]}" ./...
+
+echo "✓ All share integration tests passed"

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -69,7 +69,7 @@ func TestShareSyncIntegration(t *testing.T) {
 	}
 
 	// b) Share to local crit-web (first share = POST, creates review)
-	cmd := exec.Command(binary, "share", "--share-url", baseURL, "plan.md")
+	cmd := exec.Command(binary, "share", "--share-url", baseURL, "--output", dir, "plan.md")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -110,7 +110,7 @@ func TestShareSyncIntegration(t *testing.T) {
 	}
 
 	// e) Re-share: crit share should pull web comment, push new round
-	cmd2 := exec.Command(binary, "share", "--share-url", baseURL, "plan.md")
+	cmd2 := exec.Command(binary, "share", "--share-url", baseURL, "--output", dir, "plan.md")
 	cmd2.Dir = dir
 	out2, err := cmd2.CombinedOutput()
 	if err != nil {
@@ -205,11 +205,19 @@ func TestShareSyncIntegration(t *testing.T) {
 	t.Logf("Share sync integration test passed. Review URL: %s", shareURL)
 }
 
+// --- Helpers ---
+
 // seedComment is a helper for integration tests to simulate a web reviewer comment.
 func seedComment(t *testing.T, baseURL, token, file, body string) {
 	t.Helper()
+	seedCommentAt(t, baseURL, token, file, body, 1, 1)
+}
+
+// seedCommentAt seeds a comment at a specific line range.
+func seedCommentAt(t *testing.T, baseURL, token, file, body string, startLine, endLine int) {
+	t.Helper()
 	payload, _ := json.Marshal(map[string]any{
-		"file": file, "start_line": 1, "end_line": 1, "body": body,
+		"file": file, "start_line": startLine, "end_line": endLine, "body": body,
 	})
 	resp, err := http.Post(baseURL+"/api/reviews/"+token+"/seed-comment", "application/json", bytes.NewReader(payload))
 	if err != nil {
@@ -218,6 +226,22 @@ func seedComment(t *testing.T, baseURL, token, file, body string) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("seed-comment returned %d", resp.StatusCode)
+	}
+}
+
+// seedReviewComment seeds a review-level (file-agnostic) comment on crit-web.
+func seedReviewComment(t *testing.T, baseURL, token, body string) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]any{
+		"body": body, "scope": "review",
+	})
+	resp, err := http.Post(baseURL+"/api/reviews/"+token+"/seed-comment", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("seed-review-comment failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed-review-comment returned %d", resp.StatusCode)
 	}
 }
 
@@ -236,4 +260,1036 @@ func reviewRoundFromAPI(t *testing.T, baseURL, token string) int {
 		t.Fatalf("decoding document: %v", err)
 	}
 	return body.ReviewRound
+}
+
+// writeTestCritJSON writes a CritJSON to .crit.json in dir.
+// NOTE: readCritJSON is defined in github_test.go and shared across test files.
+func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
+	t.Helper()
+	d, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), d, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// critShareCmd runs `crit share` and returns stdout. Fails the test on error.
+// Uses --output to point at the temp dir so crit reads/writes .crit.json there.
+func critShareCmd(t *testing.T, binary, baseURL, dir string, files ...string) string {
+	t.Helper()
+	args := append([]string{"share", "--share-url", baseURL, "--output", dir}, files...)
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crit share failed: %s\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// critUnpublishCmd runs `crit unpublish` and returns stdout.
+func critUnpublishCmd(t *testing.T, binary, baseURL, dir string) string {
+	t.Helper()
+	cmd := exec.Command(binary, "unpublish", "--share-url", baseURL, "--output", dir)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crit unpublish failed: %s\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// extractToken extracts the review token from a share URL or output containing one.
+func extractToken(t *testing.T, output string) string {
+	t.Helper()
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(lines[i], "/r/") {
+			return path.Base(lines[i])
+		}
+	}
+	t.Fatalf("no review URL found in output: %s", output)
+	return ""
+}
+
+// extractURL extracts the full review URL from share output.
+func extractURL(t *testing.T, output string) string {
+	t.Helper()
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(lines[i], "/r/") {
+			return strings.TrimSpace(lines[i])
+		}
+	}
+	t.Fatalf("no review URL found in output: %s", output)
+	return ""
+}
+
+// logReview logs the review URL for manual inspection.
+func logReview(t *testing.T, output string) {
+	t.Helper()
+	t.Logf("  → Review: %s", extractURL(t, output))
+}
+
+// commentsFromAPI fetches all comments for a review from crit-web.
+func commentsFromAPI(t *testing.T, baseURL, token string) []webComment {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/comments", baseURL, token))
+	if err != nil {
+		t.Fatalf("comments request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("comments returned %d", resp.StatusCode)
+	}
+	var comments []webComment
+	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+		t.Fatalf("decoding comments: %v", err)
+	}
+	return comments
+}
+
+// documentFromAPI fetches the review document files from crit-web.
+func documentFromAPI(t *testing.T, baseURL, token string) []map[string]any {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/document", baseURL, token))
+	if err != nil {
+		t.Fatalf("document request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("document returned %d", resp.StatusCode)
+	}
+	var body struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding document: %v", err)
+	}
+	return body.Files
+}
+
+// --- New test cases ---
+
+// TestShareSyncNoComments verifies sharing a file with no comments.
+func TestShareSyncNoComments(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# Hello\n\nWorld\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"readme.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "readme.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Verify document content on crit-web
+	files := documentFromAPI(t, baseURL, token)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0]["path"] != "readme.md" {
+		t.Errorf("expected path readme.md, got %v", files[0]["path"])
+	}
+	if content, _ := files[0]["content"].(string); !strings.Contains(content, "# Hello") {
+		t.Errorf("expected file content '# Hello', got %q", content)
+	}
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 0 {
+		t.Errorf("expected 0 comments, got %d", len(comments))
+	}
+}
+
+// TestShareSyncLineComments verifies line-scoped comments with correct body, position, and scope on web.
+func TestShareSyncLineComments(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n\nStep 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "clarify this step", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+					{ID: "c2", StartLine: 5, EndLine: 5, Body: "needs more detail", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+
+	bodies := map[string]webComment{}
+	for _, c := range comments {
+		bodies[c.Body] = c
+	}
+	for _, want := range []struct {
+		body  string
+		line  int
+		scope string
+		file  string
+	}{
+		{"clarify this step", 3, "line", "plan.md"},
+		{"needs more detail", 5, "line", "plan.md"},
+	} {
+		got, ok := bodies[want.body]
+		if !ok {
+			t.Errorf("missing comment %q on crit-web", want.body)
+			continue
+		}
+		if got.StartLine != want.line {
+			t.Errorf("comment %q: start_line = %d, want %d", want.body, got.StartLine, want.line)
+		}
+		if got.Scope != want.scope {
+			t.Errorf("comment %q: scope = %q, want %q", want.body, got.Scope, want.scope)
+		}
+		if got.FilePath != want.file {
+			t.Errorf("comment %q: file_path = %q, want %q", want.body, got.FilePath, want.file)
+		}
+	}
+}
+
+// TestShareSyncFileComment verifies file-scoped comments appear correctly on web.
+func TestShareSyncFileComment(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("# Notes\n\nSome content\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"notes.md": {
+				Comments: []Comment{
+					{ID: "fc1", Body: "this file needs restructuring", Scope: "file",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "notes.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].Scope != "file" {
+		t.Errorf("scope = %q, want 'file'", comments[0].Scope)
+	}
+	if comments[0].Body != "this file needs restructuring" {
+		t.Errorf("body = %q, want 'this file needs restructuring'", comments[0].Body)
+	}
+	if comments[0].FilePath != "notes.md" {
+		t.Errorf("file_path = %q, want 'notes.md'", comments[0].FilePath)
+	}
+}
+
+// TestShareSyncReviewLevelComments verifies that review-level comments are shared.
+// This is the fix for https://github.com/tomasz-tomczyk/crit/issues/297.
+func TestShareSyncReviewLevelComments(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		ReviewComments: []Comment{
+			{ID: "rc1", Body: "overall this plan needs work", Scope: "review",
+				CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+			{ID: "rc2", Body: "consider adding a timeline", Scope: "review",
+				CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+		},
+		Files: map[string]CritJSONFile{"plan.md": {}},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	reviewBodies := map[string]bool{}
+	for _, c := range comments {
+		if c.Scope == "review" {
+			reviewBodies[c.Body] = true
+		}
+	}
+	if len(reviewBodies) != 2 {
+		t.Fatalf("expected 2 review-level comments, got %d (total: %d)", len(reviewBodies), len(comments))
+	}
+	if !reviewBodies["overall this plan needs work"] {
+		t.Error("missing review comment 'overall this plan needs work' on crit-web")
+	}
+	if !reviewBodies["consider adding a timeline"] {
+		t.Error("missing review comment 'consider adding a timeline' on crit-web")
+	}
+}
+
+// TestShareSyncMixedCommentTypes verifies all 3 comment scopes appear correctly on web.
+func TestShareSyncMixedCommentTypes(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		ReviewComments: []Comment{
+			{ID: "rc1", Body: "review-level comment", Scope: "review",
+				CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+		},
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "lc1", StartLine: 3, EndLine: 3, Body: "line-level comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+					{ID: "fc1", Body: "file-level comment", Scope: "file",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 3 {
+		t.Fatalf("expected 3 comments, got %d", len(comments))
+	}
+
+	byScope := map[string]webComment{}
+	for _, c := range comments {
+		byScope[c.Scope] = c
+	}
+	if len(byScope) != 3 {
+		t.Fatalf("expected 3 distinct scopes, got: %v", byScope)
+	}
+	if byScope["review"].Body != "review-level comment" {
+		t.Errorf("review comment body = %q, want 'review-level comment'", byScope["review"].Body)
+	}
+	if byScope["line"].Body != "line-level comment" {
+		t.Errorf("line comment body = %q, want 'line-level comment'", byScope["line"].Body)
+	}
+	if byScope["line"].StartLine != 3 || byScope["line"].EndLine != 3 {
+		t.Errorf("line comment position = %d-%d, want 3-3", byScope["line"].StartLine, byScope["line"].EndLine)
+	}
+	if byScope["file"].Body != "file-level comment" {
+		t.Errorf("file comment body = %q, want 'file-level comment'", byScope["file"].Body)
+	}
+}
+
+// TestShareSyncResolvedExcluded verifies resolved comments are NOT shared.
+func TestShareSyncResolvedExcluded(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nDone\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "resolved comment", Scope: "line",
+						Resolved: true, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+					{ID: "c2", StartLine: 3, EndLine: 3, Body: "unresolved comment", Scope: "line",
+						Resolved: false, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment (resolved excluded), got %d", len(comments))
+	}
+	if comments[0].Body != "unresolved comment" {
+		t.Errorf("body = %q, want 'unresolved comment'", comments[0].Body)
+	}
+	if comments[0].StartLine != 3 || comments[0].EndLine != 3 {
+		t.Errorf("position = %d-%d, want 3-3", comments[0].StartLine, comments[0].EndLine)
+	}
+}
+
+// TestShareSyncReshareNoDuplicates verifies re-sharing preserves comments without duplication.
+func TestShareSyncReshareNoDuplicates(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "original comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output1 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output1)
+	token := extractToken(t, output1)
+
+	// Update content to force a change
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (revised)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	output2 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	if !strings.Contains(output2, "Updated (round 2)") {
+		t.Errorf("expected 'Updated (round 2)', got: %s", output2)
+	}
+	token2 := extractToken(t, output2)
+	if token != token2 {
+		t.Errorf("re-share should use same token: %s vs %s", token, token2)
+	}
+
+	// Verify comment content on web: no duplicates, correct body and position
+	comments := commentsFromAPI(t, baseURL, token)
+	origCount := 0
+	for _, c := range comments {
+		if c.Body == "original comment" {
+			origCount++
+			if c.StartLine != 3 || c.EndLine != 3 {
+				t.Errorf("comment position changed: %d-%d", c.StartLine, c.EndLine)
+			}
+		}
+	}
+	if origCount != 1 {
+		t.Errorf("expected exactly 1 'original comment', got %d (total: %d)", origCount, len(comments))
+	}
+
+	// Verify updated content is on web
+	files := documentFromAPI(t, baseURL, token)
+	if len(files) == 0 {
+		t.Fatal("no files in document after re-share")
+	}
+	if content, _ := files[0]["content"].(string); !strings.Contains(content, "Step 1 (revised)") {
+		t.Errorf("expected revised content on web, got %q", content)
+	}
+}
+
+// TestShareSyncReshareNoChanges verifies re-sharing with no changes is a no-op.
+func TestShareSyncReshareNoChanges(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output1 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output1)
+	_ = extractToken(t, output1)
+	round1 := readCritJSON(t, dir).ReviewRound
+
+	output2 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	if strings.Contains(output2, "Updated") {
+		t.Errorf("expected no update for unchanged content, got: %s", output2)
+	}
+
+	round2 := readCritJSON(t, dir).ReviewRound
+	if round2 != round1 {
+		t.Errorf("round should not increment: %d → %d", round1, round2)
+	}
+}
+
+// TestShareSyncFetchWebComments verifies web-authored comments are pulled back locally
+// and verifies they appear correctly on both web and local.
+func TestShareSyncFetchWebComments(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n\nStep 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Seed two web comments at different lines
+	seedCommentAt(t, baseURL, token, "plan.md", "web comment on step 1", 3, 3)
+	seedCommentAt(t, baseURL, token, "plan.md", "web comment on step 2", 5, 5)
+
+	// Verify web comments exist on crit-web before sync
+	webComments := commentsFromAPI(t, baseURL, token)
+	if len(webComments) != 2 {
+		t.Fatalf("expected 2 web comments, got %d", len(webComments))
+	}
+	for _, wc := range webComments {
+		if wc.FilePath != "plan.md" {
+			t.Errorf("web comment file = %q, want plan.md", wc.FilePath)
+		}
+	}
+
+	// Update content so re-share triggers a PUT
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (done)\n\nStep 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-share — should pull web comments into local .crit.json
+	critShareCmd(t, binary, baseURL, dir, "plan.md")
+
+	cj := readCritJSON(t, dir)
+	localComments := cj.Files["plan.md"].Comments
+	webCount := 0
+	for _, c := range localComments {
+		if strings.HasPrefix(c.ID, "web-") {
+			webCount++
+			// Verify the bodies match what we seeded
+			if c.Body != "web comment on step 1" && c.Body != "web comment on step 2" {
+				t.Errorf("unexpected web comment body: %q", c.Body)
+			}
+		}
+	}
+	if webCount != 2 {
+		t.Errorf("expected 2 web comments merged locally, got %d (total: %d)", webCount, len(localComments))
+	}
+}
+
+// TestShareSyncFetchWebCommentsNoDuplicates verifies repeated syncs don't duplicate web comments.
+func TestShareSyncFetchWebCommentsNoDuplicates(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	seedComment(t, baseURL, token, "plan.md", "web reviewer says hi")
+
+	// Re-share twice with content changes each time
+	for i := 2; i <= 3; i++ {
+		content := fmt.Sprintf("# Plan\n\nContent v%d\n", i)
+		if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		critShareCmd(t, binary, baseURL, dir, "plan.md")
+	}
+
+	// Count — should be exactly 1
+	cj := readCritJSON(t, dir)
+	webCount := 0
+	for _, c := range cj.Files["plan.md"].Comments {
+		if c.Body == "web reviewer says hi" {
+			webCount++
+		}
+	}
+	if webCount != 1 {
+		t.Errorf("expected 1 web comment after 2 re-shares, got %d", webCount)
+	}
+}
+
+// TestShareSyncMultipleFiles verifies sharing multiple files with per-file comments.
+func TestShareSyncMultipleFiles(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("# Notes\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md":  {Comments: []Comment{{ID: "c1", StartLine: 1, EndLine: 1, Body: "plan comment", Scope: "line", CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"}}},
+			"notes.md": {Comments: []Comment{{ID: "c2", StartLine: 1, EndLine: 1, Body: "notes comment", Scope: "line", CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"}}},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md", "notes.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	files := documentFromAPI(t, baseURL, token)
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+
+	// Verify comments are associated with correct files on web
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+	byFile := map[string]string{}
+	for _, c := range comments {
+		byFile[c.FilePath] = c.Body
+	}
+	if byFile["plan.md"] != "plan comment" {
+		t.Errorf("plan.md comment = %q, want 'plan comment'", byFile["plan.md"])
+	}
+	if byFile["notes.md"] != "notes comment" {
+		t.Errorf("notes.md comment = %q, want 'notes comment'", byFile["notes.md"])
+	}
+}
+
+// TestShareSyncMultipleRounds verifies round progression and content updates across 3 cycles.
+func TestShareSyncMultipleRounds(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan v1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	for round := 2; round <= 3; round++ {
+		content := fmt.Sprintf("# Plan v%d\n", round)
+		if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		out := critShareCmd(t, binary, baseURL, dir, "plan.md")
+		expected := fmt.Sprintf("Updated (round %d)", round)
+		if !strings.Contains(out, expected) {
+			t.Errorf("round %d: expected %q, got: %s", round, expected, out)
+		}
+	}
+
+	finalRound := readCritJSON(t, dir).ReviewRound
+	if finalRound != 3 {
+		t.Errorf("expected round 3, got %d", finalRound)
+	}
+
+	// Verify latest content on web
+	files := documentFromAPI(t, baseURL, token)
+	if len(files) == 0 {
+		t.Fatal("no files")
+	}
+	if content, _ := files[0]["content"].(string); !strings.Contains(content, "Plan v3") {
+		t.Errorf("expected 'Plan v3' on web, got %q", content)
+	}
+}
+
+// TestShareSyncCommentWithReplies verifies comments with reply threads on web.
+func TestShareSyncCommentWithReplies(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{
+						ID: "c1", StartLine: 3, EndLine: 3, Body: "parent comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z",
+						Replies: []Reply{
+							{ID: "r1", Body: "first reply", Author: "agent"},
+							{ID: "r2", Body: "second reply", Author: "reviewer"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].Body != "parent comment" {
+		t.Errorf("body = %q, want 'parent comment'", comments[0].Body)
+	}
+	if comments[0].StartLine != 3 {
+		t.Errorf("start_line = %d, want 3", comments[0].StartLine)
+	}
+}
+
+// TestShareSyncUnpublish verifies the full unpublish flow clears web and local state.
+func TestShareSyncUnpublish(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Verify review exists on web
+	resp, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/document", baseURL, token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("review should exist, got %d", resp.StatusCode)
+	}
+
+	unpubOut := critUnpublishCmd(t, binary, baseURL, dir)
+	if !strings.Contains(unpubOut, "unpublished") {
+		t.Errorf("expected 'unpublished', got: %s", unpubOut)
+	}
+
+	// Verify review gone from web
+	resp2, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/document", baseURL, token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 after unpublish, got %d", resp2.StatusCode)
+	}
+
+	// Verify local state cleared
+	cj := readCritJSON(t, dir)
+	if cj.ShareURL != "" {
+		t.Errorf("ShareURL should be cleared, got %q", cj.ShareURL)
+	}
+	if cj.DeleteToken != "" {
+		t.Errorf("DeleteToken should be cleared, got %q", cj.DeleteToken)
+	}
+}
+
+// TestShareSyncExport verifies the export endpoint returns correct .crit.json-compatible data.
+func TestShareSyncExport(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		ReviewComments: []Comment{
+			{ID: "rc1", Body: "review comment for export", Scope: "review",
+				CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+		},
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "lc1", StartLine: 3, EndLine: 3, Body: "line comment for export", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	exportResp, err := http.Get(baseURL + "/api/export/" + token + "/comments")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer exportResp.Body.Close()
+	if exportResp.StatusCode != http.StatusOK {
+		t.Fatalf("export returned %d", exportResp.StatusCode)
+	}
+
+	var exportBody map[string]any
+	if err := json.NewDecoder(exportResp.Body).Decode(&exportBody); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{"review_round", "share_url", "delete_token"} {
+		if exportBody[key] == nil {
+			t.Errorf("export missing %q", key)
+		}
+	}
+
+	// Verify comment shape uses "author" not internal fields
+	expFiles, _ := exportBody["files"].(map[string]any)
+	for _, fileEntry := range expFiles {
+		entry, _ := fileEntry.(map[string]any)
+		comments, _ := entry["comments"].([]any)
+		for _, raw := range comments {
+			c, _ := raw.(map[string]any)
+			if _, has := c["author_display_name"]; has {
+				t.Error("export comment must not have author_display_name")
+			}
+			if _, has := c["author_identity"]; has {
+				t.Error("export comment must not have author_identity")
+			}
+		}
+	}
+}
+
+// TestShareSyncFetchReviewLevelWebComment verifies review-level web comments
+// are pulled back into local ReviewComments.
+func TestShareSyncFetchReviewLevelWebComment(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Seed a review-level comment on crit-web
+	seedReviewComment(t, baseURL, token, "overall feedback from web")
+
+	// Verify it exists on web
+	webComments := commentsFromAPI(t, baseURL, token)
+	reviewFound := false
+	for _, c := range webComments {
+		if c.Body == "overall feedback from web" && c.Scope == "review" {
+			reviewFound = true
+		}
+	}
+	if !reviewFound {
+		t.Fatal("review-level comment not found on crit-web after seeding")
+	}
+
+	// Change content and re-share to trigger fetch
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nContent v2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	critShareCmd(t, binary, baseURL, dir, "plan.md")
+
+	// Verify review-level comment was merged locally
+	cj := readCritJSON(t, dir)
+	found := false
+	for _, c := range cj.ReviewComments {
+		if c.Body == "overall feedback from web" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected review-level web comment in local ReviewComments, got: %+v", cj.ReviewComments)
+	}
+}
+
+// TestShareSyncFullLifecycle exercises the complete round-trip:
+//
+//	local comments (with replies) → share → web comments added → fetch →
+//	re-share (web comments preserved) → fetch again (no duplicates)
+func TestShareSyncFullLifecycle(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	// --- Round 1: local review with threaded comments ---
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n\nStep 2\n\nStep 3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		ReviewComments: []Comment{
+			{ID: "rc1", Body: "overall looks good but needs detail", Scope: "review",
+				CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z",
+				Replies: []Reply{
+					{ID: "rr1", Body: "agreed, will expand step 2", Author: "agent"},
+				}},
+		},
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "clarify what step 1 means", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z",
+						Replies: []Reply{
+							{ID: "cr1", Body: "it means the first thing", Author: "agent"},
+							{ID: "cr2", Body: "ok that makes sense", Author: "reviewer"},
+						}},
+					{ID: "c2", StartLine: 5, EndLine: 5, Body: "step 2 is too vague", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	// Share
+	output1 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output1)
+	token := extractToken(t, output1)
+
+	// Verify all comments on web
+	webComments := commentsFromAPI(t, baseURL, token)
+	if len(webComments) != 3 {
+		t.Fatalf("round 1: expected 3 comments on web (1 review + 2 line), got %d", len(webComments))
+	}
+	webBodies := map[string]bool{}
+	for _, c := range webComments {
+		webBodies[c.Body] = true
+	}
+	for _, want := range []string{"overall looks good but needs detail", "clarify what step 1 means", "step 2 is too vague"} {
+		if !webBodies[want] {
+			t.Errorf("round 1: missing comment %q on web", want)
+		}
+	}
+
+	// --- Round 2: web reviewer adds comments ---
+	seedCommentAt(t, baseURL, token, "plan.md", "web: step 3 needs acceptance criteria", 7, 7)
+	seedReviewComment(t, baseURL, token, "web: overall timeline is missing")
+
+	// Update content locally and re-share — should fetch web comments
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (clarified)\n\nStep 2 (expanded)\n\nStep 3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	output2 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	if !strings.Contains(output2, "Updated") {
+		t.Errorf("round 2: expected update, got: %s", output2)
+	}
+
+	// Verify web comments were pulled locally
+	cj2 := readCritJSON(t, dir)
+	localWebCount := 0
+	for _, c := range cj2.Files["plan.md"].Comments {
+		if strings.HasPrefix(c.ID, "web-") {
+			localWebCount++
+			if c.Body != "web: step 3 needs acceptance criteria" {
+				t.Errorf("unexpected web file comment: %q", c.Body)
+			}
+		}
+	}
+	if localWebCount != 1 {
+		t.Errorf("round 2: expected 1 web file comment locally, got %d", localWebCount)
+	}
+	localWebReviewCount := 0
+	for _, c := range cj2.ReviewComments {
+		if strings.HasPrefix(c.ID, "web-") {
+			localWebReviewCount++
+			if c.Body != "web: overall timeline is missing" {
+				t.Errorf("unexpected web review comment: %q", c.Body)
+			}
+		}
+	}
+	if localWebReviewCount != 1 {
+		t.Errorf("round 2: expected 1 web review comment locally, got %d", localWebReviewCount)
+	}
+
+	// Verify original web comments still exist on web (not overwritten by re-share)
+	webComments2 := commentsFromAPI(t, baseURL, token)
+	webBodies2 := map[string]int{}
+	for _, c := range webComments2 {
+		webBodies2[c.Body]++
+	}
+	if webBodies2["web: step 3 needs acceptance criteria"] != 1 {
+		t.Errorf("round 2: web comment 'step 3 needs acceptance criteria' count = %d, want 1", webBodies2["web: step 3 needs acceptance criteria"])
+	}
+	if webBodies2["web: overall timeline is missing"] != 1 {
+		t.Errorf("round 2: web review comment 'timeline is missing' count = %d, want 1", webBodies2["web: overall timeline is missing"])
+	}
+
+	// --- Round 3: re-share again with more local changes (no new web comments) ---
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (done)\n\nStep 2 (done)\n\nStep 3 (done)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	output3 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	if !strings.Contains(output3, "Updated") {
+		t.Errorf("round 3: expected update, got: %s", output3)
+	}
+
+	// Verify NO duplicate web comments locally
+	cj3 := readCritJSON(t, dir)
+	localWebFileCount := 0
+	for _, c := range cj3.Files["plan.md"].Comments {
+		if strings.HasPrefix(c.ID, "web-") {
+			localWebFileCount++
+		}
+	}
+	if localWebFileCount != 1 {
+		t.Errorf("round 3: expected 1 web file comment locally (no dup), got %d", localWebFileCount)
+	}
+	localWebRevCount := 0
+	for _, c := range cj3.ReviewComments {
+		if strings.HasPrefix(c.ID, "web-") {
+			localWebRevCount++
+		}
+	}
+	if localWebRevCount != 1 {
+		t.Errorf("round 3: expected 1 web review comment locally (no dup), got %d", localWebRevCount)
+	}
+
+	// Verify NO duplicates on web either
+	webComments3 := commentsFromAPI(t, baseURL, token)
+	webBodies3 := map[string]int{}
+	for _, c := range webComments3 {
+		webBodies3[c.Body]++
+	}
+	for body, count := range webBodies3 {
+		if count > 1 {
+			t.Errorf("round 3: duplicate on web: %q appears %d times", body, count)
+		}
+	}
+
+	// Original local comments should still be on web
+	for _, want := range []string{"clarify what step 1 means", "step 2 is too vague"} {
+		if webBodies3[want] != 1 {
+			t.Errorf("round 3: original comment %q count = %d, want 1", want, webBodies3[want])
+		}
+	}
+
+	t.Logf("Full lifecycle passed across 3 rounds. Review: %s", extractURL(t, output1))
 }


### PR DESCRIPTION
## Summary

- 18 integration test cases covering the full crit → crit-web share lifecycle
- Orchestration script (`scripts/e2e-share.sh`) that builds crit, starts a local crit-web, runs tests, tears down
- Fixed `--output` flag missing from the original `TestShareSyncIntegration`

## Test coverage

| Test | What it covers |
|---|---|
| `TestShareSyncIntegration` | Original: share, seed web comment, re-share, verify content + export |
| `TestShareSyncNoComments` | Share with zero comments |
| `TestShareSyncLineComments` | Line-scoped comments: body, position, scope on web |
| `TestShareSyncFileComment` | File-scoped comment on web |
| `TestShareSyncReviewLevelComments` | Review-level comments shared (#297 CLI path) |
| `TestShareSyncMixedCommentTypes` | All 3 scopes together |
| `TestShareSyncResolvedExcluded` | Resolved comments filtered out |
| `TestShareSyncReshareNoDuplicates` | Re-share without duplication |
| `TestShareSyncReshareNoChanges` | No-op when content unchanged |
| `TestShareSyncFetchWebComments` | Web comments pulled into local .crit.json |
| `TestShareSyncFetchWebCommentsNoDuplicates` | No duplicates after repeated syncs |
| `TestShareSyncMultipleFiles` | Multi-file share |
| `TestShareSyncMultipleRounds` | 3 rounds of share |
| `TestShareSyncCommentWithReplies` | Threaded replies |
| `TestShareSyncUnpublish` | Full unpublish + cleanup |
| `TestShareSyncExport` | Export endpoint shape |
| `TestShareSyncFetchReviewLevelWebComment` | Review-level web comments synced locally |
| `TestShareSyncFullLifecycle` | Complete round-trip: local threads → share → web comments → fetch → re-share (preserved) → no duplicates |

## Usage

```bash
# Full automated run (builds crit, starts crit-web on :4001, runs tests, tears down)
make e2e-share

# Start crit-web for manual inspection
./scripts/e2e-share.sh --serve

# Run against already-running crit-web
./scripts/e2e-share.sh --skip-web

# Single test
./scripts/e2e-share.sh -run TestShareSyncFullLifecycle
```

Requires a local crit-web checkout at `../crit-web` and PostgreSQL. Uses separate DB (`crit_e2e`) and port (4001) to avoid conflicting with dev setup.

## Related

- #297 — review-level comments dropped (browser path, not tested here — CLI path works)
- #291 — orphaned file support (not yet implemented)
- #302 — unify CLI/browser share code paths