### PR TITLE
refactor: unify CLI and browser share code paths

### DIFF
--- a/server.go
+++ b/server.go
@@ -339,11 +339,23 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files, comments, reviewRound := buildShareFromSession(s.session)
+	// Read file content from disk and comments from the review file.
+	// This uses the same disk-based path as `crit share` (CLI), ensuring
+	// a single source of truth for the share payload. The review file is
+	// kept current by saveCritJSON (200ms debounce on every comment change).
+	files := s.session.LoadShareFilesFromDisk()
 	if len(files) == 0 {
 		http.Error(w, "no files in session", http.StatusBadRequest)
 		return
 	}
+
+	filePaths := make([]string, len(files))
+	for i, f := range files {
+		filePaths[i] = f.Path
+	}
+
+	critPath := s.session.critJSONPath()
+	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
 
 	url, deleteToken, err := shareFilesToWeb(files, comments, s.shareURL, reviewRound, s.authToken)
 	if err != nil {
@@ -353,12 +365,8 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	paths := make([]string, len(files))
-	for i, f := range files {
-		paths[i] = f.Path
-	}
 	s.session.SetSharedURLAndToken(url, deleteToken)
-	s.session.SetShareScope(shareScope(paths))
+	s.session.SetShareScope(shareScope(filePaths))
 	writeJSON(w, map[string]any{"url": url, "delete_token": deleteToken})
 }
 

--- a/session.go
+++ b/session.go
@@ -1134,6 +1134,36 @@ func (s *Session) GetShareState() (string, string) {
 	return s.sharedURL, s.deleteToken
 }
 
+// LoadShareFilesFromDisk reads file content from disk for all session files,
+// returning share-ready file entries. Deleted files are skipped since they
+// have no on-disk content to share.
+func (s *Session) LoadShareFilesFromDisk() []shareFile {
+	s.mu.RLock()
+	type fileInfo struct {
+		path    string
+		absPath string
+		status  string
+	}
+	infos := make([]fileInfo, len(s.Files))
+	for i, f := range s.Files {
+		infos[i] = fileInfo{path: f.Path, absPath: f.AbsPath, status: f.Status}
+	}
+	s.mu.RUnlock()
+
+	var files []shareFile
+	for _, fi := range infos {
+		if fi.status == "deleted" {
+			continue
+		}
+		data, err := os.ReadFile(fi.absPath)
+		if err != nil {
+			continue // file may have been removed since session started
+		}
+		files = append(files, shareFile{Path: fi.path, Content: string(data)})
+	}
+	return files
+}
+
 // GetDeleteToken returns the stored delete token.
 func (s *Session) GetDeleteToken() string {
 	s.mu.RLock()

--- a/share.go
+++ b/share.go
@@ -179,40 +179,6 @@ func setBearer(req *http.Request, token string) {
 	}
 }
 
-// buildShareFromSession extracts files and unresolved comments from a live session.
-func buildShareFromSession(s *Session) ([]shareFile, []shareComment, int) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var files []shareFile
-	var comments []shareComment
-	for _, f := range s.Files {
-		files = append(files, shareFile{Path: f.Path, Content: f.Content})
-		for _, c := range f.Comments {
-			if c.Resolved {
-				continue
-			}
-			sc := shareComment{
-				File:      f.Path,
-				StartLine: c.StartLine,
-				EndLine:   c.EndLine,
-				Body:      c.Body,
-				Quote:     c.Quote,
-				Author:    c.Author,
-				Scope:     c.Scope,
-			}
-			if c.ReviewRound >= 1 {
-				sc.ReviewRound = c.ReviewRound
-			}
-			for _, r := range c.Replies {
-				sc.Replies = append(sc.Replies, shareReply{Body: r.Body, Author: r.Author})
-			}
-			comments = append(comments, sc)
-		}
-	}
-	return files, comments, s.ReviewRound
-}
-
 // loadCommentsForShare reads the review file at critPath and returns shareComment entries
 // for the given file paths, plus the review round. Resolved comments are excluded.
 func loadCommentsForShare(critPath string, filePaths []string) ([]shareComment, int) {

--- a/share_test.go
+++ b/share_test.go
@@ -601,75 +601,25 @@ func TestClearShareState(t *testing.T) {
 	}
 }
 
-func TestBuildShareFromSession(t *testing.T) {
-	s := &Session{
-		ReviewRound: 3,
-		Files: []*FileEntry{
-			{
-				Path:    "plan.md",
-				Content: "# Plan",
-				Comments: []Comment{
-					{ID: "c1", StartLine: 1, EndLine: 1, Body: "Open comment", Author: "Alice", Quote: "# Plan"},
-					{ID: "c2", StartLine: 2, EndLine: 2, Body: "Resolved comment", Author: "Bob", Resolved: true},
-					{ID: "c3", StartLine: 3, EndLine: 3, Body: "Another open", Author: "Alice", ReviewRound: 2},
-				},
-			},
-			{
-				Path:    "src/main.go",
-				Content: "package main",
-				Comments: []Comment{
-					{ID: "c4", StartLine: 10, EndLine: 15, Body: "All resolved", Resolved: true},
-				},
-			},
-		},
-	}
-
-	files, comments, round := buildShareFromSession(s)
-	if round != 3 {
-		t.Errorf("expected round 3, got %d", round)
-	}
-	if len(files) != 2 {
-		t.Fatalf("expected 2 files, got %d", len(files))
-	}
-	if files[0].Path != "plan.md" || files[0].Content != "# Plan" {
-		t.Errorf("unexpected first file: %+v", files[0])
-	}
-	// Only unresolved comments: c1 and c3
-	if len(comments) != 2 {
-		t.Fatalf("expected 2 unresolved comments, got %d", len(comments))
-	}
-	if comments[0].Body != "Open comment" {
-		t.Errorf("expected first comment body 'Open comment', got %s", comments[0].Body)
-	}
-	if comments[0].Quote != "# Plan" {
-		t.Errorf("expected first comment quote '# Plan', got %s", comments[0].Quote)
-	}
-	if comments[1].ReviewRound != 2 {
-		t.Errorf("expected review_round 2 on second comment, got %d", comments[1].ReviewRound)
-	}
-}
-
-func TestBuildShareFromSession_NoComments(t *testing.T) {
-	s := &Session{
-		ReviewRound: 1,
-		Files: []*FileEntry{
-			{Path: "readme.md", Content: "# Hello"},
-		},
-	}
-
-	files, comments, round := buildShareFromSession(s)
-	if round != 1 {
-		t.Errorf("expected round 1, got %d", round)
-	}
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file, got %d", len(files))
-	}
-	if len(comments) != 0 {
-		t.Errorf("expected 0 comments, got %d", len(comments))
-	}
-}
-
 func TestHandleShare_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write file on disk
+	os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan"), 0644)
+
+	// Write review file with comments (one unresolved, one resolved)
+	cj := CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{
+				{ID: "c1", StartLine: 1, EndLine: 1, Body: "Fix this"},
+				{ID: "c2", StartLine: 2, EndLine: 2, Body: "Done", Resolved: true},
+			}},
+		},
+	}
+	data, _ := json.Marshal(cj)
+	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+
 	// Mock crit-web server
 	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
@@ -690,15 +640,12 @@ func TestHandleShare_Success(t *testing.T) {
 	defer critWeb.Close()
 
 	sess := &Session{
+		OutputDir:   dir,
 		ReviewRound: 1,
 		Files: []*FileEntry{
 			{
 				Path:    "plan.md",
-				Content: "# Plan",
-				Comments: []Comment{
-					{ID: "c1", StartLine: 1, EndLine: 1, Body: "Fix this"},
-					{ID: "c2", StartLine: 2, EndLine: 2, Body: "Done", Resolved: true},
-				},
+				AbsPath: filepath.Join(dir, "plan.md"),
 			},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
@@ -726,6 +673,11 @@ func TestHandleShare_Success(t *testing.T) {
 }
 
 func TestHandleShare_ShareServiceError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write file on disk
+	os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan"), 0644)
+
 	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
@@ -733,9 +685,10 @@ func TestHandleShare_ShareServiceError(t *testing.T) {
 	defer critWeb.Close()
 
 	sess := &Session{
+		OutputDir:   dir,
 		ReviewRound: 1,
 		Files: []*FileEntry{
-			{Path: "plan.md", Content: "# Plan"},
+			{Path: "plan.md", AbsPath: filepath.Join(dir, "plan.md")},
 		},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
@@ -989,52 +942,6 @@ func TestBuildSharePayload_WithReplies(t *testing.T) {
 	}
 	if cs[0].Replies[1].Author != "Alice" {
 		t.Errorf("expected reply author 'Alice', got %q", cs[0].Replies[1].Author)
-	}
-}
-
-func TestBuildShareFromSession_WithReplies(t *testing.T) {
-	s := &Session{
-		Files: []*FileEntry{{
-			Path:    "f.md",
-			Content: "hello",
-			Comments: []Comment{{
-				ID: "c1", StartLine: 1, EndLine: 1, Body: "fix",
-				Author: "Alice",
-				Replies: []Reply{
-					{ID: "c1-r1", Body: "done", Author: "Bob"},
-				},
-			}},
-		}},
-		ReviewRound: 1,
-	}
-	_, comments, _ := buildShareFromSession(s)
-	if len(comments) != 1 {
-		t.Fatalf("expected 1 comment, got %d", len(comments))
-	}
-	if len(comments[0].Replies) != 1 {
-		t.Fatalf("expected 1 reply, got %d", len(comments[0].Replies))
-	}
-	if comments[0].Replies[0].Body != "done" {
-		t.Errorf("expected reply body 'done', got %q", comments[0].Replies[0].Body)
-	}
-}
-
-func TestBuildShareFromSession_SkipsResolvedWithReplies(t *testing.T) {
-	s := &Session{
-		Files: []*FileEntry{{
-			Path:    "f.md",
-			Content: "hello",
-			Comments: []Comment{{
-				ID: "c1", StartLine: 1, EndLine: 1, Body: "old issue",
-				Resolved: true,
-				Replies:  []Reply{{ID: "c1-r1", Body: "fixed"}},
-			}},
-		}},
-		ReviewRound: 1,
-	}
-	_, comments, _ := buildShareFromSession(s)
-	if len(comments) != 0 {
-		t.Fatalf("expected 0 comments (resolved should be skipped), got %d", len(comments))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes `buildShareFromSession` (the browser-only share path that read from in-memory session state)
- `handleShare` now reads files from disk via new `LoadShareFilesFromDisk()` and comments from the review file via `loadCommentsForShare()` — the same disk-based path the CLI uses
- Fixes #297 (review-level comments dropped when sharing from browser) as a side effect of unification
- Future share payload changes (#291 orphaned files) only need updating in one place

## What changed

- **`share.go`**: Removed `buildShareFromSession` (-34 lines)
- **`session.go`**: Added `LoadShareFilesFromDisk()` — copies file paths under read lock, reads content from disk outside the lock
- **`server.go`**: `handleShare` now uses `loadCommentsForShare` + `LoadShareFilesFromDisk` instead of the removed function
- **`share_test.go`**: Updated `TestHandleShare_*` tests to set up real files on disk and a `.crit.json` review file

Net: -89 lines.

## Test plan

- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `make e2e-share` — all 18 share integration tests pass (including `TestShareSyncReviewLevelComments` and `TestShareSyncFullLifecycle`)

Closes #302