### PR TITLE
fix: resolved live threads now collapse correctly

### DIFF
--- a/e2e/tests/threading.spec.ts
+++ b/e2e/tests/threading.spec.ts
@@ -252,4 +252,31 @@ test.describe('Comment Threading', () => {
     await expect(card.locator('.reply-body')).toContainText('Fixed it');
     await expect(card.locator('.reply-input')).toBeVisible();
   });
+
+  test('resolving a live thread collapses it', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    const comment = await addComment(request, mdPath, 1, 'Fix this bug');
+
+    // Add an agent reply to make it a "live thread" (agent_cmd is "echo", so agent name is "echo")
+    await request.post(`/api/comment/${comment.id}/replies?path=${encodeURIComponent(mdPath)}`, {
+      data: { body: 'Fixed it', author: 'echo' },
+    });
+
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Live thread should be expanded (not collapsed)
+    await expect(card).not.toHaveClass(/collapsed/);
+
+    // Hover and resolve
+    await card.hover();
+    await card.locator('.comment-actions button[title="Resolve"]').click();
+
+    // After resolving, card should collapse even though it was a live thread
+    await expect(section.locator('.comment-card.collapsed')).toHaveCount(1);
+  });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4424,8 +4424,8 @@
     card.className = cardClass;
     card.dataset.commentId = comment.id;
 
-    // Collapse state — live threads never auto-collapse
-    const liveOrPending = isLiveThread(comment) || pendingAgentRequests.has(comment.id);
+    // Collapse state — live threads stay expanded unless resolved
+    const liveOrPending = !comment.resolved && (isLiveThread(comment) || pendingAgentRequests.has(comment.id));
     const isCollapsed = liveOrPending ? false
       : opts.collapseDefault
         ? (commentCollapseOverrides[comment.id] !== undefined ? commentCollapseOverrides[comment.id] : true)


### PR DESCRIPTION
## Summary

- `isLiveThread()` was overriding `collapseDefault` for resolved comments, keeping them expanded even after clicking Resolve
- Gate the live-thread expansion check on `!comment.resolved` so resolved threads collapse like any other resolved comment
- Added E2E test: create a live thread (agent reply), resolve it, assert it collapses

## Test plan

- [x] New test `resolving a live thread collapses it` passes
- [x] All 12 threading tests pass
- [x] Agent-request tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)