### PR TITLE
fix: reset viewed state when file content changes between rounds

### DIFF
--- a/e2e/tests/viewed.spec.ts
+++ b/e2e/tests/viewed.spec.ts
@@ -1,5 +1,23 @@
 import { test, expect } from '@playwright/test';
-import { loadPage } from './helpers';
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+import { clearAllComments, loadPage } from './helpers';
+
+// Read fixture state written by setup-fixtures.sh
+function readFixtureState(): { fixtureDir: string } {
+  const raw = fs.readFileSync('/tmp/crit-e2e-state-3123', 'utf8');
+  const env: Record<string, string> = {};
+  for (const line of raw.trim().split('\n')) {
+    const eq = line.indexOf('=');
+    if (eq >= 0) {
+      env[line.slice(0, eq)] = line.slice(eq + 1);
+    }
+  }
+  if (!env['CRIT_FIXTURE_DIR']) {
+    throw new Error('CRIT_FIXTURE_DIR not set in state file');
+  }
+  return { fixtureDir: env['CRIT_FIXTURE_DIR'] };
+}
 
 // ============================================================
 // Viewed Checkbox — Git Mode
@@ -115,6 +133,46 @@ test.describe('Viewed Checkbox — Git Mode', () => {
 
     const reloadedCheckbox = page.locator('#file-section-plan\\.md .file-header-viewed input[type="checkbox"]');
     await expect(reloadedCheckbox).toBeChecked();
+  });
+  test('viewed state resets when file content changes between rounds', async ({ page, request }) => {
+    // Reset server state
+    await request.post('/api/round-complete');
+    await clearAllComments(request);
+    await loadPage(page);
+
+    const { fixtureDir } = readFixtureState();
+
+    // Mark plan.md as viewed
+    const section = page.locator('#file-section-plan\\.md');
+    const checkbox = section.locator('.file-header-viewed input[type="checkbox"]');
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+    await expect(section).not.toHaveAttribute('open', '');
+
+    // Verify tree indicator shows viewed
+    const treeFile = page.locator('.tree-file', {
+      has: page.locator('.tree-file-name', { hasText: 'plan.md' }),
+    });
+    await expect(treeFile).toHaveClass(/viewed/);
+
+    // Modify plan.md on disk and commit the change
+    const planPath = `${fixtureDir}/plan.md`;
+    const original = fs.readFileSync(planPath, 'utf8');
+    fs.writeFileSync(planPath, original + '\n## Added by test\n\nNew content.\n');
+    execSync('git add plan.md && git commit -q -m "test: modify plan.md"', { cwd: fixtureDir });
+
+    // Trigger round-complete so the server picks up the file change
+    await request.post('/api/round-complete');
+
+    // Wait for UI to refresh — the viewed checkbox should be unchecked
+    await expect(checkbox).not.toBeChecked({ timeout: 5_000 });
+
+    // File section should be open (uncollapsed)
+    await expect(section).toHaveAttribute('open', '');
+
+    // Tree view should no longer show the viewed indicator
+    await expect(treeFile).not.toHaveClass(/viewed/);
+    await expect(treeFile.locator('.tree-viewed-check')).toHaveCount(0);
   });
 });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -314,6 +314,7 @@
         lazy: true,
         diffTooLarge: false,
         diffLoaded: false,
+        fileHash: '',
       };
     });
 
@@ -346,6 +347,7 @@
         orphaned: true,
         diffTooLarge: false,
         diffLoaded: false,
+        fileHash: '',
       };
     }
     let diffUrl = '/api/file/diff?path=' + enc(fi.path);
@@ -378,6 +380,7 @@
       deletions: fi.deletions || 0,
       lazy: false,
       orphaned: false,
+      fileHash: fileRes.file_hash || '',
     };
 
     // Mark large diffs for deferred rendering
@@ -5895,6 +5898,7 @@
             collapsed: files[pi].collapsed,
             diffLoaded: files[pi].diffLoaded,
             viewed: files[pi].viewed,
+            fileHash: files[pi].fileHash,
           };
         }
 
@@ -5913,11 +5917,12 @@
         for (let fi = 0; fi < files.length; fi++) {
           const prev = prevState[files[fi].path];
           if (prev) {
+            const contentChanged = prev.fileHash && files[fi].fileHash && prev.fileHash !== files[fi].fileHash;
             files[fi].viewMode = prev.viewMode;
             // Lazy files must stay collapsed — they have no content to render
-            if (!files[fi].lazy) files[fi].collapsed = prev.collapsed;
+            if (!files[fi].lazy && !contentChanged) files[fi].collapsed = prev.collapsed;
             if (prev.diffLoaded) files[fi].diffLoaded = prev.diffLoaded;
-            if (prev.viewed) files[fi].viewed = true;
+            if (prev.viewed && !contentChanged) files[fi].viewed = true;
           }
         }
 

--- a/session.go
+++ b/session.go
@@ -2070,6 +2070,7 @@ func (s *Session) GetFileSnapshot(path string) (map[string]any, bool) {
 		"status":    f.Status,
 		"file_type": f.FileType,
 		"content":   f.Content,
+		"file_hash": f.FileHash,
 	}, true
 }
 
@@ -2098,6 +2099,7 @@ func (s *Session) GetFileSnapshotFromDisk(path string) (map[string]any, bool) {
 		"status":    "modified",
 		"file_type": detectFileType(path),
 		"content":   string(data),
+		"file_hash": fileHash(data),
 	}, true
 }
 


### PR DESCRIPTION
## Summary
- Expose `file_hash` in `/api/file` response so the frontend can detect content changes
- Reset "viewed" checkbox and collapsed state when a file's content changes between rounds
- Previously both states persisted incorrectly, hiding changed files from the reviewer

## Review
- [x] Code review: passed (go-expert + frontend-expert)
- [x] Parity audit: N/A (viewed state is crit-only)

## Test plan
- [x] Go tests pass (`go test ./...`)
- [x] E2E test confirms failure without fix, pass with fix (TDD)
- [x] All 12 viewed.spec.ts tests pass

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)