### PR TITLE
fix: use server-side Live field for live badge instead of reply author heuristic

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4388,8 +4388,8 @@
 
   // ===== Agent Button =====
   function isLiveThread(comment) {
-    if (!agentEnabled || !comment.replies) return false;
-    return comment.replies.some(function(r) { return r.author === agentName; });
+    if (!agentEnabled) return false;
+    return !!comment.live;
   }
 
   function checkAgentReplies(comments) {

--- a/server.go
+++ b/server.go
@@ -1275,6 +1275,8 @@ func (s *Server) handleAgentRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.session.SetCommentLive(filePath, comment.ID)
+
 	prompt := buildAgentPrompt(comment, filePath)
 
 	// Run agent command asynchronously

--- a/server_agent_test.go
+++ b/server_agent_test.go
@@ -69,6 +69,15 @@ func TestHandleAgentRequest_Success(t *testing.T) {
 	if resp["status"] != "accepted" {
 		t.Errorf("status = %v, want accepted", resp["status"])
 	}
+
+	// Verify the comment is marked as live
+	comments := session.GetComments("test.md")
+	if len(comments) == 0 {
+		t.Fatal("expected comment to exist")
+	}
+	if !comments[0].Live {
+		t.Error("expected comment Live to be true after agent request")
+	}
 }
 
 func TestAgentName_Codex(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -2332,27 +2332,3 @@ func TestHandleAgentRequest_MethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405, got %d", w.Code)
 	}
 }
-
-func TestHandleAgentRequest_SetsLive(t *testing.T) {
-	srv, session := newTestServer(t)
-	srv.agentCmd = "echo test"
-
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
-
-	body := strings.NewReader(`{"comment_id": "` + c.ID + `"}`)
-	req := httptest.NewRequest("POST", "/api/agent/request", body)
-	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
-
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
-	}
-
-	comments := session.GetComments("test.md")
-	if len(comments) == 0 {
-		t.Fatal("expected comment to exist")
-	}
-	if !comments[0].Live {
-		t.Error("expected comment Live to be true after agent request")
-	}
-}

--- a/server_test.go
+++ b/server_test.go
@@ -2332,3 +2332,27 @@ func TestHandleAgentRequest_MethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405, got %d", w.Code)
 	}
 }
+
+func TestHandleAgentRequest_SetsLive(t *testing.T) {
+	srv, session := newTestServer(t)
+	srv.agentCmd = "echo test"
+
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+
+	body := strings.NewReader(`{"comment_id": "` + c.ID + `"}`)
+	req := httptest.NewRequest("POST", "/api/agent/request", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	comments := session.GetComments("test.md")
+	if len(comments) == 0 {
+		t.Fatal("expected comment to exist")
+	}
+	if !comments[0].Live {
+		t.Error("expected comment Live to be true after agent request")
+	}
+}

--- a/session.go
+++ b/session.go
@@ -68,6 +68,7 @@ type Comment struct {
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
 	Resolved       bool    `json:"resolved,omitempty"`
+	Live           bool    `json:"live,omitempty"`
 	CarriedForward bool    `json:"carried_forward,omitempty"`
 	ReviewRound    int     `json:"review_round,omitempty"`
 	Replies        []Reply `json:"replies,omitempty"`
@@ -789,6 +790,24 @@ func (s *Session) SetCommentResolved(filePath, id string, resolved bool) (Commen
 		}
 	}
 	return Comment{}, false
+}
+
+// SetCommentLive marks a comment as live (sent to an agent).
+func (s *Session) SetCommentLive(filePath, id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f := s.fileByPathLocked(filePath)
+	if f == nil {
+		return false
+	}
+	for i, c := range f.Comments {
+		if c.ID == id {
+			f.Comments[i].Live = true
+			s.scheduleWrite()
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteComment deletes a comment from a specific file.

--- a/watch.go
+++ b/watch.go
@@ -293,6 +293,7 @@ func carryForwardComment(old Comment, newID string, now string) Comment {
 		UpdatedAt:      now,
 		Resolved:       old.Resolved,
 		CarriedForward: true,
+		Live:           old.Live,
 		ReviewRound:    old.ReviewRound,
 		Replies:        old.Replies,
 	}


### PR DESCRIPTION
## Summary
- Add `Live` bool field to `Comment` struct, set server-side when `POST /api/agent/request` is called
- Update `isLiveThread()` in frontend to check `comment.live` instead of scanning reply authors
- Preserve `Live` field across round transitions in `carryForwardComment`
- Fixes false-positive live badges on threads with CLI-authored agent replies

Closes #262

## Review
- [x] Code review: passed (go-expert + frontend-expert)
- [x] Parity audit: N/A (agent features not in crit-web)

## Test plan
- [x] `go test ./...` — all pass
- [x] TestHandleAgentRequest_Success verifies Live is set to true
- [x] carryForwardComment preserves Live field

🤖 Generated with [Claude Code](https://claude.com/claude-code)