### PR TITLE
fix: add --no-ext-diff to git diff commands to support external diff tools

### DIFF
--- a/git.go
+++ b/git.go
@@ -243,11 +243,11 @@ func FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
 		if baseRef == "" {
 			return nil, nil
 		}
-		cmd = exec.Command("git", "diff", "--no-color", baseRef+"..HEAD", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--no-ext-diff", baseRef+"..HEAD", "--", path)
 	case "staged":
-		cmd = exec.Command("git", "diff", "--no-color", "--cached", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--no-ext-diff", "--cached", "--", path)
 	case "unstaged":
-		cmd = exec.Command("git", "diff", "--no-color", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--no-ext-diff", "--", path)
 	default:
 		return fileDiffUnified(path, baseRef, dir)
 	}
@@ -331,7 +331,7 @@ func ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
 // The dir parameter sets the working directory for the git command.
 // For the initial (root) commit, sha^ is undefined so we diff against the empty tree.
 func FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	cmd := exec.Command("git", "diff", "--no-color", sha+"^.."+sha, "--", path)
+	cmd := exec.Command("git", "diff", "--no-color", "--no-ext-diff", sha+"^.."+sha, "--", path)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -344,7 +344,7 @@ func FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
 		case errors.As(err, &exitErr) && exitErr.ExitCode() == 128:
 			// sha^ failed (root commit) — diff against the empty tree
 			emptyTree := "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-			cmd2 := exec.Command("git", "diff", "--no-color", emptyTree+".."+sha, "--", path)
+			cmd2 := exec.Command("git", "diff", "--no-color", "--no-ext-diff", emptyTree+".."+sha, "--", path)
 			if dir != "" {
 				cmd2.Dir = dir
 			}
@@ -640,9 +640,9 @@ func dedup(changes []FileChange) []FileChange {
 func fileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
 	var cmd *exec.Cmd
 	if baseRef == "" {
-		cmd = exec.Command("git", "diff", "--no-color", "HEAD", "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--no-ext-diff", "HEAD", "--", path)
 	} else {
-		cmd = exec.Command("git", "diff", "--no-color", baseRef, "--", path)
+		cmd = exec.Command("git", "diff", "--no-color", "--no-ext-diff", baseRef, "--", path)
 	}
 	if dir != "" {
 		cmd.Dir = dir
@@ -664,9 +664,9 @@ func fileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
 func fileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
 	var cmd *exec.Cmd
 	if baseRef == "" {
-		cmd = exec.CommandContext(ctx, "git", "diff", "--no-color", "HEAD", "--", path)
+		cmd = exec.CommandContext(ctx, "git", "diff", "--no-color", "--no-ext-diff", "HEAD", "--", path)
 	} else {
-		cmd = exec.CommandContext(ctx, "git", "diff", "--no-color", baseRef, "--", path)
+		cmd = exec.CommandContext(ctx, "git", "diff", "--no-color", "--no-ext-diff", baseRef, "--", path)
 	}
 	if dir != "" {
 		cmd.Dir = dir

--- a/git.go
+++ b/git.go
@@ -721,7 +721,7 @@ type NumstatEntry struct {
 // DiffNumstatDir runs git diff --numstat against the given base ref and returns per-file stats.
 // If dir is non-empty, git runs in that directory.
 func DiffNumstatDir(baseRef, dir string) (map[string]NumstatEntry, error) {
-	cmd := exec.Command("git", "diff", "--numstat", baseRef)
+	cmd := exec.Command("git", "diff", "--no-ext-diff", "--numstat", baseRef)
 	if dir != "" {
 		cmd.Dir = dir
 	}


### PR DESCRIPTION
## Problem

When a user has an external diff tool configured (e.g. **difftastic**, **delta**, or any tool set via `GIT_EXTERNAL_DIFF` or `diff.external` in gitconfig), `git diff` outputs in the tool's custom format rather than standard unified diff. Crit's `ParseUnifiedDiff` cannot parse these formats, so it returns 0 hunks — causing the diff view to appear completely blank even though the file is correctly detected as modified.

This is a silent failure: the file appears in the file list with a modified status icon, but clicking it shows no content. There is no error message to indicate why.

### Example

With difftastic configured, `git diff AGENTS.md` outputs:
```
AGENTS.md --- Text
17 17
18 18 ## Microservices
19 19
.. 20 this is a test input
.. 21
20 22 ### a title
```

`ParseUnifiedDiff` expects lines starting with `+`, `-`, ` ` and `@@` hunk headers — none of which appear in this output. Result: 0 hunks, blank UI.

### Why detection still worked

The file list detection uses `git diff --name-status`, which only outputs filenames and status letters (`M`, `A`, `D`). External diff drivers are not invoked for `--name-status` output, so detection correctly identifies the file as modified. Only the content diff fetch is broken.

## Fix

Add `--no-ext-diff` to all `git diff` invocations that produce diff content for parsing:

- `fileDiffUnified` — default diff (vs HEAD or merge base)
- `fileDiffUnifiedCtx` — same, with context cancellation for lazy loading
- `FileDiffScoped` — branch/staged/unstaged scope diffs
- `FileDiffForCommit` — per-commit diffs in the commit selector sidebar

`--no-ext-diff` tells git to always use its built-in unified diff driver, regardless of any external diff configuration. This is the correct approach for programmatic diff consumption — external diff tools are designed for human-readable terminal output, not machine parsing.

The `--name-status` detection commands are unchanged since they are unaffected by external diff drivers.

## Testing

All 12 existing `TestFileDiff*` tests pass. These tests run against real git repos and cover all modified code paths.


# Screenshots

### Before
<img width="438" height="154" alt="Screenshot 2026-04-20 at 16 55 56" src="https://github.com/user-attachments/assets/38aca654-dff0-42c3-ad31-9bc96d28c852" />


### After
(Actual diff cutt off here, to hide sensitive info)
<img width="376" height="224" alt="Screenshot 2026-04-20 at 16 56 47" src="https://github.com/user-attachments/assets/79611a05-4549-497c-afd4-64f7273d51e9" />
