### PR TITLE
fix: preserve leading unchanged context before the first diff hunk

### DIFF
--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loadPage } from './helpers';
+import { goSection, loadPage } from './helpers';
 
 test.describe('Diff Rendering — Split Mode (default)', () => {
   test('shows split diff by default', async ({ page }) => {
@@ -72,6 +72,26 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     await expect(spacer).toContainText('unchanged line');
   });
 
+  test('shows a spacer before the first hunk when the file has leading unchanged lines', async ({ page }) => {
+    await loadPage(page);
+
+    const serverSection = goSection(page);
+    await expect(serverSection).toBeVisible();
+
+    const firstSpacer = serverSection.locator('.diff-spacer').first();
+    await expect(firstSpacer).toBeVisible();
+
+    const firstHeader = serverSection.locator('.diff-hunk-header').first();
+    await expect(firstHeader).toBeVisible();
+
+    await expect.poll(async () => {
+      return firstHeader.evaluate((el) => el.previousElementSibling?.className || '');
+    }).toContain('diff-spacer');
+
+    await firstSpacer.click();
+    await expect(firstHeader.locator('.hunk-text')).toContainText('@@ -1,');
+  });
+
   test('clicking spacer expands context lines', async ({ page }) => {
     await loadPage(page);
 
@@ -81,10 +101,10 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
 
     // Count spacers before click
     const spacersBefore = serverSection.locator('.diff-spacer');
-    const spacerCountBefore = await spacersBefore.count();
-    expect(spacerCountBefore).toBeGreaterThan(0);
+    await expect(spacersBefore).not.toHaveCount(0);
 
     // Count diff rows before expansion
+    const spacerCountBefore = await spacersBefore.count();
     const rowsBefore = await serverSection.locator('.diff-split-row').count();
 
     // Click the first spacer
@@ -92,8 +112,7 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     await firstSpacer.click();
 
     // After clicking, the spacer count should decrease by 1 (it gets merged)
-    const spacerCountAfter = await serverSection.locator('.diff-spacer').count();
-    expect(spacerCountAfter).toBeLessThan(spacerCountBefore);
+    await expect(serverSection.locator('.diff-spacer')).toHaveCount(spacerCountBefore - 1);
 
     // More rows should be visible after expansion
     const rowsAfter = await serverSection.locator('.diff-split-row').count();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2858,11 +2858,43 @@
   }
 
   // Helper: render hunk spacer
-  // prevIdx/nextIdx are indices into file.diffHunks so we can merge on expand
+  // prevIdx/nextIdx are indices into file.diffHunks so we can merge on expand.
+  // When prevHunk is null, this renders the leading unchanged block before the first hunk.
+  function buildMergedHunkHeader(oldStart, oldCount, newStart, newCount, originalHeader) {
+    const suffixMatch = originalHeader && originalHeader.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/);
+    const suffix = suffixMatch ? suffixMatch[1] : '';
+    return '@@ -' + oldStart + ',' + oldCount + ' +' + newStart + ',' + newCount + ' @@' + suffix;
+  }
+
+  function mergeDiffHunks(leftHunk, rightHunk, contextLines) {
+    const oldStart = leftHunk ? leftHunk.OldStart : 1;
+    const newStart = leftHunk ? leftHunk.NewStart : 1;
+    const mergedLines = (leftHunk ? leftHunk.Lines : []).concat(contextLines, rightHunk.Lines);
+    const maxOldNum = mergedLines.reduce(function(max, line) {
+      return line.OldNum > max ? line.OldNum : max;
+    }, 0);
+    const maxNewNum = mergedLines.reduce(function(max, line) {
+      return line.NewNum > max ? line.NewNum : max;
+    }, 0);
+    const oldCount = oldStart > 0 && maxOldNum >= oldStart ? (maxOldNum - oldStart + 1) : 0;
+    const newCount = newStart > 0 && maxNewNum >= newStart ? (maxNewNum - newStart + 1) : 0;
+    const headerSource = leftHunk ? leftHunk.Header : rightHunk.Header;
+    return {
+      OldStart: oldStart,
+      OldCount: oldCount,
+      NewStart: newStart,
+      NewCount: newCount,
+      Header: buildMergedHunkHeader(oldStart, oldCount, newStart, newCount, headerSource),
+      Lines: mergedLines,
+    };
+  }
+
   function renderDiffSpacer(prevHunk, nextHunk, file, prevIdx, nextIdx) {
-    const prevNewEnd = prevHunk.NewStart + prevHunk.NewCount;
-    const prevOldEnd = prevHunk.OldStart + prevHunk.OldCount;
-    const gap = nextHunk.NewStart - prevNewEnd;
+    const gapStartNew = prevHunk ? prevHunk.NewStart + prevHunk.NewCount : 1;
+    const gapStartOld = prevHunk ? prevHunk.OldStart + prevHunk.OldCount : 1;
+    const gap = prevHunk
+      ? nextHunk.NewStart - gapStartNew
+      : Math.max(nextHunk.NewStart, nextHunk.OldStart) - 1;
     if (gap <= 0) return null;
     const spacer = document.createElement('div');
     spacer.className = 'diff-spacer';
@@ -2877,25 +2909,17 @@
       // Build context lines to bridge the gap
       const contextLines = [];
       for (let i = 0; i < gap; i++) {
-        const newLineNum = prevNewEnd + i;
-        const oldLineNum = prevOldEnd + i;
+        const newLineNum = gapStartNew + i;
+        const oldLineNum = gapStartOld + i;
         const text = newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
         contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
       }
 
-      // Merge: prev hunk + context lines + next hunk → single hunk
       const hunks = file.diffHunks;
-      const merged = {
-        OldStart: hunks[prevIdx].OldStart,
-        NewStart: hunks[prevIdx].NewStart,
-        Header: hunks[prevIdx].Header,
-        Lines: hunks[prevIdx].Lines.concat(contextLines, hunks[nextIdx].Lines)
-      };
-      merged.OldCount = (hunks[nextIdx].OldStart + hunks[nextIdx].OldCount) - merged.OldStart;
-      merged.NewCount = (hunks[nextIdx].NewStart + hunks[nextIdx].NewCount) - merged.NewStart;
-
-      // Replace prevIdx with merged, remove nextIdx
-      hunks.splice(prevIdx, 2, merged);
+      const merged = mergeDiffHunks(prevHunk, hunks[nextIdx], contextLines);
+      const spliceStart = prevHunk ? prevIdx : nextIdx;
+      const spliceCount = prevHunk ? 2 : 1;
+      hunks.splice(spliceStart, spliceCount, merged);
 
       // Re-render from data model so all lines get proper interaction
       renderFileByPath(file.path);
@@ -2959,10 +2983,10 @@
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
 
-      if (hi > 0) {
-        const spacer = renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
-        if (spacer) container.appendChild(spacer);
-      }
+      const spacer = hi === 0
+        ? renderDiffSpacer(null, hunk, file, -1, hi)
+        : renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
+      if (spacer) container.appendChild(spacer);
 
       container.appendChild(renderDiffHunkHeader(hunk));
 
@@ -3060,10 +3084,10 @@
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
 
-      if (hi > 0) {
-        const spacer = renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
-        if (spacer) container.appendChild(spacer);
-      }
+      const spacer = hi === 0
+        ? renderDiffSpacer(null, hunk, file, -1, hi)
+        : renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
+      if (spacer) container.appendChild(spacer);
 
       container.appendChild(renderDiffHunkHeader(hunk));
 


### PR DESCRIPTION
- Show an expandable spacer before the first diff hunk when a file begins with unchanged lines.
- Fix leading-context handling for zero-count unified diff hunks, including pure insertions and deletions.
- Recompute merged hunk ranges from merged line numbers so expanded hunk headers stay accurate.
- Tighten the Playwright diff-rendering coverage by using the shared server.go helper and retryable spacer-count assertions.

Updated UI:
<img width="1120" height="553" alt="image" src="https://github.com/user-attachments/assets/d903a709-e765-41a7-bd13-5a2c402ce887" />

Fixes #319 