### PR TITLE
fix: match reply form font size to comment form

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1394,7 +1394,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   background: var(--comment-bg);
   color: var(--fg-primary);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: 14px;
   resize: vertical;
 }
 


### PR DESCRIPTION
## Summary
- Reply form textarea was 13px while comment form textarea was 14px
- Bumped reply textarea to 14px to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)