### PR TITLE
fix: preserve reply form state when opening new comment forms

### DIFF
--- a/e2e/tests/threading.spec.ts
+++ b/e2e/tests/threading.spec.ts
@@ -282,4 +282,34 @@ test.describe('Comment Threading', () => {
     // After resolving, card should collapse even though it was a live thread
     await expect(section.locator('.comment-card.collapsed')).toHaveCount(1);
   });
+
+  test('reply form persists expanded state and text when opening a new comment form on same file', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Review this');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Expand reply input and type text
+    await card.locator('.reply-input').click();
+    await expect(card.locator('.reply-textarea')).toBeFocused();
+    await card.locator('.reply-textarea').fill('draft reply text');
+    await expect(card.locator('.reply-form-buttons')).toBeVisible();
+
+    // Open a new comment form on a different line of the SAME file to trigger re-render
+    const thirdLineBlock = section.locator('.line-block').nth(2);
+    await thirdLineBlock.hover();
+    await section.locator('.line-comment-gutter').nth(2).click();
+
+    // Verify the new comment form opened
+    await expect(section.locator('.comment-form')).toBeVisible();
+
+    // Verify reply form survived the re-render
+    await expect(card.locator('.reply-form.expanded')).toBeVisible();
+    await expect(card.locator('.reply-textarea')).toHaveValue('draft reply text');
+    await expect(card.locator('.reply-form-buttons')).toBeVisible();
+  });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -195,6 +195,9 @@
   let agentName = 'agent';
   const pendingAgentRequests = new Set();
 
+  // Track active reply form state so it survives DOM re-renders (commentId → { text })
+  const activeReplyForms = new Map();
+
   // Track manually toggled collapse state (comment ID → boolean, true = collapsed)
   const commentCollapseOverrides = {};
 
@@ -1653,6 +1656,18 @@
     for (let i = 0; i < fileForms.length; i++) {
       const ta = document.querySelector('.comment-form[data-form-key="' + fileForms[i].formKey + '"] textarea');
       if (ta) fileForms[i].draftBody = ta.value;
+    }
+    // Save expanded reply form state before DOM re-render
+    const section = document.getElementById('file-section-' + filePath);
+    if (section) {
+      const expandedForms = section.querySelectorAll('.reply-form.expanded');
+      for (let i = 0; i < expandedForms.length; i++) {
+        const card = expandedForms[i].closest('.comment-card');
+        if (card && card.dataset.commentId) {
+          const ta = expandedForms[i].querySelector('.reply-textarea');
+          activeReplyForms.set(card.dataset.commentId, { text: ta ? ta.value : '' });
+        }
+      }
     }
   }
 
@@ -5205,6 +5220,7 @@
       input.replaceWith(textarea);
       form.appendChild(buttons);
       textarea.focus();
+      activeReplyForms.set(commentId, { text: textarea.value });
     }
 
     function collapse() {
@@ -5213,9 +5229,15 @@
       textarea.replaceWith(input);
       input.value = '';
       if (buttons.parentNode) buttons.remove();
+      activeReplyForms.delete(commentId);
     }
 
     input.addEventListener('focus', expand);
+
+    // Keep reply form state in sync for surviving re-renders
+    textarea.addEventListener('input', function() {
+      activeReplyForms.set(commentId, { text: textarea.value });
+    });
 
     cancelBtn.addEventListener('click', collapse);
 
@@ -5259,6 +5281,7 @@
           });
         }
 
+        activeReplyForms.delete(commentId);
         refreshFileComments(filePath);
       } catch (err) {
         console.error('Failed to add reply:', err);
@@ -5281,6 +5304,15 @@
         }
       }
     });
+
+    // Restore saved reply form state after DOM re-render
+    const saved = activeReplyForms.get(commentId);
+    if (saved && saved.text) {
+      form.classList.add('expanded');
+      textarea.value = saved.text;
+      input.replaceWith(textarea);
+      form.appendChild(buttons);
+    }
 
     return form;
   }
@@ -5929,6 +5961,7 @@
         files.sort(fileSortComparator);
 
         activeForms = [];
+        activeReplyForms.clear();
         activeFilePath = null;
         selectionStart = null;
         selectionEnd = null;
@@ -6573,6 +6606,7 @@
     if (reloadInFlight) return reloadInFlight;
     reloadInFlight = (async function() {
       try {
+        activeReplyForms.clear();
         document.getElementById('filesContainer').innerHTML =
           '<div class="loading" style="padding: 40px; text-align: center; color: var(--fg-muted);">Loading...</div>';
 


### PR DESCRIPTION
## Summary
- Reply forms now preserve their expanded state and text content when a new comment form is opened (which triggers a DOM re-render)
- Added `activeReplyForms` Map to track reply state across re-renders, analogous to how `activeForms` preserves comment form state
- State is cleared on scope changes, session reloads, cancel, and submit

## Test plan
- New E2E test: "reply form persists expanded state and text when opening a new comment form on same file"
- All 13 threading tests pass
- All 9 multi-form tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)