### PR TITLE
feat: extend comment carry-forward to code files

### DIFF
--- a/git.go
+++ b/git.go
@@ -165,6 +165,21 @@ func MergeBase(base string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// fileContentAtRef returns the content of a file at the given git ref.
+// Returns empty string on any error (file doesn't exist at ref, not a git repo, etc.).
+func fileContentAtRef(path, ref, dir string) string {
+	if ref == "" {
+		return ""
+	}
+	cmd := exec.Command("git", "show", ref+":"+path)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
 // ChangedFiles returns the list of files changed in the current working state.
 // On the default branch: staged + unstaged + untracked files.
 // On a feature branch: all changes since the merge base with the default branch + untracked.

--- a/session.go
+++ b/session.go
@@ -576,6 +576,17 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 	if f == nil {
 		return Comment{}, false
 	}
+
+	// For old-side comments, line numbers reference the base version of the file,
+	// not the working tree. Extract anchor from the base ref content.
+	var anchor string
+	if side == "old" && s.BaseRef != "" {
+		baseContent := fileContentAtRef(filePath, s.BaseRef, s.RepoRoot)
+		anchor = extractAnchor(baseContent, startLine, endLine)
+	} else {
+		anchor = extractAnchor(f.Content, startLine, endLine)
+	}
+
 	now := time.Now().UTC().Format(time.RFC3339)
 	c := Comment{
 		ID:          randomCommentID(),
@@ -584,7 +595,7 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 		Side:        side,
 		Body:        body,
 		Quote:       quote,
-		Anchor:      extractAnchor(f.Content, startLine, endLine),
+		Anchor:      anchor,
 		Author:      author,
 		Scope:       "line",
 		CreatedAt:   now,

--- a/session_test.go
+++ b/session_test.go
@@ -3878,6 +3878,57 @@ func TestAddComment_NoAnchorForReviewComment(t *testing.T) {
 	}
 }
 
+func TestAddComment_OldSideAnchorFromBase(t *testing.T) {
+	// Old-side comments reference the base version's line numbers.
+	// extractAnchor should fall back to git show <baseRef>:<path> for the anchor.
+	dir := initTestRepo(t)
+
+	// Create a file on the base branch with known content.
+	goPath := filepath.Join(dir, "main.go")
+	writeFile(t, goPath, "package main\n\nfunc deleted() {\n\t// old code\n}\n")
+	runGit(t, dir, "add", "main.go")
+	runGit(t, dir, "commit", "-m", "add main.go")
+	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+
+	// Create feature branch and modify the file (removing the old function).
+	runGit(t, dir, "checkout", "-b", "feat")
+	writeFile(t, goPath, "package main\n\nfunc newFunc() {\n\t// new code\n}\n")
+	runGit(t, dir, "add", "main.go")
+	runGit(t, dir, "commit", "-m", "replace function")
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     baseRef,
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{
+			{
+				Path:     "main.go",
+				AbsPath:  goPath,
+				Status:   "modified",
+				FileType: "code",
+				Content:  "package main\n\nfunc newFunc() {\n\t// new code\n}\n",
+				Comments: []Comment{},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	// Comment on old-side line 3 ("func deleted() {") — this line doesn't exist
+	// in the working tree, so anchor must come from the base ref.
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+	c, ok := s.AddComment("main.go", 3, 3, "old", "Why was this removed?", "", "reviewer")
+	if !ok {
+		t.Fatal("AddComment failed")
+	}
+	if c.Anchor != "func deleted() {" {
+		t.Errorf("old-side Anchor = %q, want %q", c.Anchor, "func deleted() {")
+	}
+}
+
 func TestExtractAnchor(t *testing.T) {
 	content := "line1\nline2\nline3\nline4\nline5"
 

--- a/watch.go
+++ b/watch.go
@@ -360,18 +360,18 @@ func (s *Session) handleRoundCompleteGit() {
 	// Refresh file list (agent may have created/deleted files)
 	s.RefreshFileList()
 
-	// Snapshot markdown PreviousContent before re-reading, then carry forward
-	// with LCS + anchor verification (same as files mode).
+	// Snapshot PreviousContent before re-reading for all files with comments.
+	// Markdown uses LCS + anchor verification; code files use anchor-only search.
 	s.mu.Lock()
 	for _, f := range s.Files {
-		if f.FileType == "markdown" && f.PreviousContent == "" {
+		if f.PreviousContent == "" && len(f.PreviousComments) > 0 {
 			f.PreviousContent = f.Content
 		}
 	}
 	s.rereadFileContents(false)
 	s.mu.Unlock()
 
-	// Run LCS-based carry-forward for markdown files (with anchor verification).
+	// Run carry-forward: LCS + anchor for markdown, anchor-only for code files.
 	s.carryForwardComments()
 
 	// Carry forward remaining files (code files, or markdown files without PreviousContent).
@@ -579,69 +579,71 @@ func remapLines(lineMap map[int]int, oldStart, oldEnd, maxLine int) (int, int) {
 	return s, e
 }
 
-// carryForwardComments maps comments from the previous round
-// to the new document positions for markdown files.
+// carryForwardComments maps comments from the previous round to new document
+// positions using LCS line mapping + anchor verification. Works for all file
+// types (markdown and code) that have PreviousContent and PreviousComments.
+// Files without PreviousContent are left for carryForwardAllComments.
 func (s *Session) carryForwardComments() {
 	s.mu.RLock()
 	var toProcess []*FileEntry
 	for _, f := range s.Files {
-		if f.FileType == "markdown" && f.PreviousContent != "" {
+		if f.PreviousContent != "" && len(f.PreviousComments) > 0 {
 			toProcess = append(toProcess, f)
 		}
 	}
 	s.mu.RUnlock()
 
 	for _, f := range toProcess {
-		s.mu.RLock()
-		prevContent := f.PreviousContent
-		currContent := f.Content
-		prevComments := make([]Comment, len(f.PreviousComments))
-		copy(prevComments, f.PreviousComments)
-		s.mu.RUnlock()
+		s.carryForwardFileComments(f)
+	}
+}
 
-		if len(prevComments) == 0 {
+// carryForwardFileComments remaps comments for a single file using LCS line
+// mapping with anchor-based verification and correction.
+func (s *Session) carryForwardFileComments(f *FileEntry) {
+	s.mu.RLock()
+	prevContent := f.PreviousContent
+	currContent := f.Content
+	prevComments := make([]Comment, len(f.PreviousComments))
+	copy(prevComments, f.PreviousComments)
+	s.mu.RUnlock()
+
+	if len(prevComments) == 0 {
+		return
+	}
+
+	entries := ComputeLineDiff(prevContent, currContent)
+	lineMap := MapOldLineToNew(entries)
+
+	newLines := splitLines(currContent)
+	newLineCount := len(newLines)
+	if newLineCount == 0 {
+		newLineCount = 1
+	}
+
+	s.mu.Lock()
+	f.Comments = nil // Clear before carry-forward to prevent duplicates
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, c := range prevComments {
+		s.trackDeletedComment(f.Path, c.ID)
+
+		if c.Scope == "file" {
+			f.Comments = append(f.Comments, carryForwardComment(c, randomCommentID(), now))
 			continue
 		}
+		newStart, newEnd := remapLines(lineMap, c.StartLine, c.EndLine, newLineCount)
+		carried := carryForwardComment(c, randomCommentID(), now)
+		carried.StartLine = newStart
+		carried.EndLine = newEnd
 
-		entries := ComputeLineDiff(prevContent, currContent)
-		lineMap := MapOldLineToNew(entries)
-
-		newLines := splitLines(currContent)
-		newLineCount := len(newLines)
-		if newLineCount == 0 {
-			newLineCount = 1
+		if c.Anchor != "" {
+			corrStart, corrEnd, drift := verifyAndCorrectPosition(newLines, c.Anchor, newStart, newEnd)
+			carried.StartLine = corrStart
+			carried.EndLine = corrEnd
+			carried.Drifted = drift != 0
 		}
 
-		s.mu.Lock()
-		f.Comments = nil // Clear before carry-forward to prevent duplicates
-		now := time.Now().UTC().Format(time.RFC3339)
-		for _, c := range prevComments {
-			// Track the old ID as deleted so mergeFileSnapshotIntoCritJSON
-			// won't re-add the original from disk alongside the carried-forward copy.
-			s.trackDeletedComment(f.Path, c.ID)
-
-			// File-level comments have no line references — carry forward as-is.
-			if c.Scope == "file" {
-				carried := carryForwardComment(c, randomCommentID(), now)
-
-				f.Comments = append(f.Comments, carried)
-				continue
-			}
-			newStart, newEnd := remapLines(lineMap, c.StartLine, c.EndLine, newLineCount)
-			carried := carryForwardComment(c, randomCommentID(), now)
-			carried.StartLine = newStart
-			carried.EndLine = newEnd
-
-			// Anchor-based verification and correction.
-			if c.Anchor != "" {
-				corrStart, corrEnd, drift := verifyAndCorrectPosition(newLines, c.Anchor, newStart, newEnd)
-				carried.StartLine = corrStart
-				carried.EndLine = corrEnd
-				carried.Drifted = drift != 0
-			}
-
-			f.Comments = append(f.Comments, carried)
-		}
-		s.mu.Unlock()
+		f.Comments = append(f.Comments, carried)
 	}
+	s.mu.Unlock()
 }

--- a/watch.go
+++ b/watch.go
@@ -361,7 +361,7 @@ func (s *Session) handleRoundCompleteGit() {
 	s.RefreshFileList()
 
 	// Snapshot PreviousContent before re-reading for all files with comments.
-	// Markdown uses LCS + anchor verification; code files use anchor-only search.
+	// LCS + anchor verification is used for all file types.
 	s.mu.Lock()
 	for _, f := range s.Files {
 		if f.PreviousContent == "" && len(f.PreviousComments) > 0 {
@@ -371,7 +371,7 @@ func (s *Session) handleRoundCompleteGit() {
 	s.rereadFileContents(false)
 	s.mu.Unlock()
 
-	// Run carry-forward: LCS + anchor for markdown, anchor-only for code files.
+	// Run LCS-based carry-forward with anchor verification for all file types.
 	s.carryForwardComments()
 
 	// Carry forward remaining files (code files, or markdown files without PreviousContent).
@@ -600,6 +600,11 @@ func (s *Session) carryForwardComments() {
 
 // carryForwardFileComments remaps comments for a single file using LCS line
 // mapping with anchor-based verification and correction.
+//
+// Old-side comments (c.Side == "old") reference the base ref, not the working
+// tree. Their line numbers and anchor text are stable across rounds (the base
+// ref doesn't change), so they are carried forward at their original positions
+// without LCS remapping or anchor search.
 func (s *Session) carryForwardFileComments(f *FileEntry) {
 	s.mu.RLock()
 	prevContent := f.PreviousContent
@@ -627,7 +632,10 @@ func (s *Session) carryForwardFileComments(f *FileEntry) {
 	for _, c := range prevComments {
 		s.trackDeletedComment(f.Path, c.ID)
 
-		if c.Scope == "file" {
+		// File-level and old-side comments keep their original positions.
+		// File-level comments have no line references. Old-side comments
+		// reference the base ref which doesn't change between rounds.
+		if c.Scope == "file" || c.Side == "old" {
 			f.Comments = append(f.Comments, carryForwardComment(c, randomCommentID(), now))
 			continue
 		}

--- a/watch_test.go
+++ b/watch_test.go
@@ -856,3 +856,293 @@ func TestCarryForward_AnchorLenFromAnchorNotLCS(t *testing.T) {
 		t.Error("expected Drifted=false — anchor found in file")
 	}
 }
+
+func TestCarryForwardComments_CodeFileAnchorMoves(t *testing.T) {
+	// Code file with anchor text that moves to a different line between rounds.
+	// carryForwardComments should find the anchor in the new content and remap.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	newContent := "package main\n\nimport \"fmt\"\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n"
+	writeFile(t, goPath, newContent)
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:     "main.go",
+				AbsPath:  goPath,
+				Status:   "modified",
+				FileType: "code",
+				// Content already updated to new version (simulating post-reread)
+				Content: newContent,
+				// PreviousContent: old version before agent edits
+				PreviousContent: "package main\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n",
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_code1",
+						StartLine: 4,
+						EndLine:   4,
+						Body:      "Use log instead of fmt",
+						Anchor:    "\tfmt.Println(\"hello\")",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	// The anchor text "\tfmt.Println(\"hello\")" is now on line 6
+	if carried.StartLine != 6 || carried.EndLine != 6 {
+		t.Errorf("expected line 6 (where anchor moved to), got start=%d end=%d", carried.StartLine, carried.EndLine)
+	}
+	if carried.Drifted {
+		t.Error("expected Drifted=false since anchor was found")
+	}
+	if !carried.CarriedForward {
+		t.Error("expected CarriedForward=true")
+	}
+}
+
+func TestCarryForwardComments_CodeFileAnchorDeleted(t *testing.T) {
+	// Code file where the anchor text was deleted between rounds.
+	// The comment should be marked Drifted=true.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	newContent := "package main\n\nfunc hello() {\n\t// refactored\n}\n"
+	writeFile(t, goPath, newContent)
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:            "main.go",
+				AbsPath:         goPath,
+				Status:          "modified",
+				FileType:        "code",
+				Content:         newContent,
+				PreviousContent: "package main\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n",
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_code2",
+						StartLine: 4,
+						EndLine:   4,
+						Body:      "Use log instead",
+						Anchor:    "\tfmt.Println(\"hello\")",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if !carried.Drifted {
+		t.Error("expected Drifted=true when anchor text was deleted")
+	}
+	if !carried.CarriedForward {
+		t.Error("expected CarriedForward=true")
+	}
+}
+
+func TestCarryForwardComments_CodeFileNoAnchorUsesLCS(t *testing.T) {
+	// Code file with a comment that has no Anchor (old comment before anchors existed).
+	// With PreviousContent available, carryForwardComments uses LCS to remap
+	// the line position, same as markdown files.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	oldContent := "package main\n\nfunc hello() {}\n"
+	// New content: line inserted before the function
+	newContent := "package main\n\n// greeting\nfunc hello() {}\n"
+	writeFile(t, goPath, newContent)
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:            "main.go",
+				AbsPath:         goPath,
+				Status:          "modified",
+				FileType:        "code",
+				Content:         newContent,
+				PreviousContent: oldContent,
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_code3",
+						StartLine: 3,
+						EndLine:   3,
+						Body:      "Add docs",
+						// No Anchor — old comment, but LCS still remaps correctly
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	// LCS remaps line 3 ("func hello() {}") to line 4 in the new content.
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if carried.StartLine != 4 || carried.EndLine != 4 {
+		t.Errorf("expected LCS remap to line 4, got start=%d end=%d", carried.StartLine, carried.EndLine)
+	}
+	if !carried.CarriedForward {
+		t.Error("expected CarriedForward=true")
+	}
+}
+
+func TestCarryForwardComments_CodeFileWithPreviousContent(t *testing.T) {
+	// Code file where PreviousContent is set before carryForwardComments runs.
+	// This simulates the handleRoundCompleteGit flow where we snapshot Content
+	// before re-reading. The carry-forward should use anchor search on the
+	// new Content to find the comment's new position.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	newContent := "package main\n\n// Added comment\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n"
+	writeFile(t, goPath, newContent)
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:     "main.go",
+				AbsPath:  goPath,
+				Status:   "modified",
+				FileType: "code",
+				Content:  newContent,
+				// PreviousContent = old version (before the agent's edits)
+				PreviousContent: "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n",
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_code4",
+						StartLine: 3,
+						EndLine:   3,
+						Body:      "Use a constant",
+						Anchor:    "import \"fmt\"",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+					{
+						ID:        "c_code5",
+						StartLine: 6,
+						EndLine:   6,
+						Body:      "Add error handling",
+						Anchor:    "\tfmt.Println(\"hello\")",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(s.Files[0].Comments))
+	}
+
+	// Find comments by body
+	var importComment, printComment Comment
+	for _, c := range s.Files[0].Comments {
+		switch c.Body {
+		case "Use a constant":
+			importComment = c
+		case "Add error handling":
+			printComment = c
+		}
+	}
+
+	// "import \"fmt\"" moved from line 3 to line 4
+	if importComment.StartLine != 4 || importComment.EndLine != 4 {
+		t.Errorf("import comment: expected line 4, got start=%d end=%d", importComment.StartLine, importComment.EndLine)
+	}
+
+	// "\tfmt.Println(\"hello\")" moved from line 6 to line 7
+	if printComment.StartLine != 7 || printComment.EndLine != 7 {
+		t.Errorf("print comment: expected line 7, got start=%d end=%d", printComment.StartLine, printComment.EndLine)
+	}
+}
+
+func TestCarryForwardComments_CodeFileFileLevelComment(t *testing.T) {
+	// File-level comments (scope=file) on code files should be carried forward as-is.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	writeFile(t, goPath, "package main\n")
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:            "main.go",
+				AbsPath:         goPath,
+				Status:          "modified",
+				FileType:        "code",
+				Content:         "package main\n",
+				PreviousContent: "package main\n",
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_file1",
+						Body:      "This file needs refactoring",
+						Scope:     "file",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if carried.Scope != "file" {
+		t.Errorf("expected scope=file, got %q", carried.Scope)
+	}
+	if carried.Body != "This file needs refactoring" {
+		t.Errorf("body not preserved: got %q", carried.Body)
+	}
+	if !carried.CarriedForward {
+		t.Error("expected CarriedForward=true")
+	}
+}

--- a/watch_test.go
+++ b/watch_test.go
@@ -1146,3 +1146,65 @@ func TestCarryForwardComments_CodeFileFileLevelComment(t *testing.T) {
 		t.Error("expected CarriedForward=true")
 	}
 }
+
+func TestCarryForwardComments_CodeFileOldSidePreservesPosition(t *testing.T) {
+	// Old-side comments have line numbers referencing the base ref, not the
+	// working tree. Their anchor text comes from deleted lines that don't exist
+	// in the working tree. LCS remapping and anchor search against the working
+	// tree would corrupt these comments. They must be carried forward at their
+	// original positions unchanged.
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "main.go")
+	// Working tree: the old function was replaced.
+	oldContent := "package main\n\nfunc old() {\n\t// legacy\n}\n\nfunc helper() {}\n"
+	newContent := "package main\n\nimport \"fmt\"\n\nfunc new() {\n\tfmt.Println(\"new\")\n}\n\nfunc helper() {}\n"
+	writeFile(t, goPath, newContent)
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:            "main.go",
+				AbsPath:         goPath,
+				Status:          "modified",
+				FileType:        "code",
+				Content:         newContent,
+				PreviousContent: oldContent,
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_old_side",
+						StartLine: 3,
+						EndLine:   3,
+						Side:      "old",
+						Body:      "Why was this removed?",
+						Anchor:    "func old() {",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	// Old-side comment must keep its original position (line 3 in the base ref).
+	if carried.StartLine != 3 || carried.EndLine != 3 {
+		t.Errorf("old-side comment should stay at original position: expected line 3, got start=%d end=%d",
+			carried.StartLine, carried.EndLine)
+	}
+	if carried.Drifted {
+		t.Error("old-side comment should not be marked Drifted")
+	}
+	if carried.Side != "old" {
+		t.Errorf("Side should be preserved as %q, got %q", "old", carried.Side)
+	}
+}


### PR DESCRIPTION
## Summary
- `carryForwardComments()` only processed markdown files — code files fell through to `carryForwardAllComments()` which copied at original positions with zero remapping
- Unified `carryForwardFileComments` now handles all file types with LCS + anchor verification
- Old-side comments (referencing base ref) are preserved at original positions (base ref is stable across rounds)
- Fixed `AddComment` to extract anchor from base ref for old-side comments via `git show`

## Review
- [x] Code review: passed (old-side comment corruption bug caught and fixed)
- [x] TDD verified: all 7 new tests fail without fix, pass with fix

## Test plan
- 7 new Go unit tests: anchor moves, anchor deleted, no-anchor LCS fallback, multi-comment files, file-level comments, old-side preservation, old-side anchor extraction
- Full `go test ./...` passes
- See also: #325 for the frontend complement (outdated inline comment rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)