### PR TITLE
feat: render outdated comments inline when lines leave diff hunks

### DIFF
--- a/e2e/tests/outdated-diff-comments.spec.ts
+++ b/e2e/tests/outdated-diff-comments.spec.ts
@@ -48,7 +48,6 @@ async function findNonHunkLine(request: APIRequestContext, filePath: string): Pr
 // ============================================================
 test.describe('Outdated Diff Comments', () => {
   test.beforeEach(async ({ request }) => {
-    await request.post('/api/round-complete');
     await clearAllComments(request);
   });
 

--- a/e2e/tests/outdated-diff-comments.spec.ts
+++ b/e2e/tests/outdated-diff-comments.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { clearAllComments, loadPage, goSection } from './helpers';
+
+// Get the server.go file path from the session
+async function getServerGoPath(request: APIRequestContext): Promise<string> {
+  const session = await (await request.get('/api/session')).json();
+  const goFile = session.files.find((f: { path: string }) => f.path === 'server.go');
+  expect(goFile).toBeTruthy();
+  return goFile.path;
+}
+
+// Collect all line:side keys present in a file's diff hunks
+async function getRenderedDiffKeys(request: APIRequestContext, filePath: string): Promise<Set<string>> {
+  const diffResp = await request.get(`/api/file/diff?path=${encodeURIComponent(filePath)}`);
+  const diffData = await diffResp.json();
+  const hunks = diffData.hunks || [];
+  const keys = new Set<string>();
+  for (const hunk of hunks) {
+    for (const line of hunk.Lines) {
+      if (line.Type === 'del' && line.OldNum) keys.add(line.OldNum + ':old');
+      if (line.Type === 'add' && line.NewNum) keys.add(line.NewNum + ':');
+      if (line.Type === 'context') {
+        if (line.OldNum) keys.add(line.OldNum + ':old');
+        if (line.NewNum) keys.add(line.NewNum + ':');
+      }
+    }
+  }
+  return keys;
+}
+
+// Find a new-side line number that is NOT in any diff hunk for the file
+async function findNonHunkLine(request: APIRequestContext, filePath: string): Promise<number> {
+  const keys = await getRenderedDiffKeys(request, filePath);
+  // Pick a line number that's not in any hunk. Start from 1000.
+  for (let n = 1000; n < 2000; n++) {
+    if (!keys.has(n + ':')) return n;
+  }
+  throw new Error('Could not find a non-hunk line number');
+}
+
+// ============================================================
+// Outdated Diff Comments — lines no longer in diff hunks
+//
+// When a comment's end_line:side key doesn't match any line rendered
+// in the current diff hunks, the comment should still appear inline
+// with an "Outdated" badge. This covers the scenario where an agent
+// undoes a code change after the reviewer commented on it.
+// ============================================================
+test.describe('Outdated Diff Comments', () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post('/api/round-complete');
+    await clearAllComments(request);
+  });
+
+  test('comment on non-hunk line renders with Outdated badge', async ({ page, request }) => {
+    const filePath = await getServerGoPath(request);
+
+    // Create a comment at a line number that doesn't appear in any diff hunk.
+    // This simulates what happens when a comment was on a line that existed in
+    // a previous round's diff but the agent removed that change.
+    const nonHunkLine = await findNonHunkLine(request, filePath);
+    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'This line was removed from the diff' },
+    });
+
+    await loadPage(page);
+    const section = goSection(page);
+    await expect(section).toBeVisible();
+
+    // The comment should appear with an Outdated badge
+    const outdatedBadge = section.locator('.outdated-badge');
+    await expect(outdatedBadge).toBeVisible({ timeout: 5_000 });
+    await expect(outdatedBadge).toHaveText('Outdated');
+
+    // The comment body should be readable
+    await expect(section.locator('.comment-body')).toContainText('This line was removed from the diff');
+  });
+
+  test('outdated diff comment is resolvable', async ({ page, request }) => {
+    const filePath = await getServerGoPath(request);
+    const nonHunkLine = await findNonHunkLine(request, filePath);
+
+    const commentResp = await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Resolve me after outdated' },
+    });
+    const comment = await commentResp.json();
+
+    await loadPage(page);
+    const section = goSection(page);
+
+    // Verify outdated badge appears
+    await expect(section.locator('.outdated-badge')).toBeVisible({ timeout: 5_000 });
+
+    // Resolve the comment via API
+    await request.put(`/api/comment/${comment.id}/resolve?path=${encodeURIComponent(filePath)}`, {
+      data: { resolved: true },
+    });
+
+    // Reload and verify resolved state with outdated badge
+    await loadPage(page);
+    const sectionAfter = goSection(page);
+    await expect(sectionAfter.locator('.outdated-badge')).toBeVisible();
+    await expect(sectionAfter.locator('.comment-card.resolved-card')).toBeVisible();
+  });
+
+  test('outdated comment shows in All Comments panel', async ({ page, request }) => {
+    const filePath = await getServerGoPath(request);
+    const nonHunkLine = await findNonHunkLine(request, filePath);
+
+    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Panel outdated check' },
+    });
+
+    await loadPage(page);
+
+    // Open comments panel
+    await page.locator('#commentCount').click();
+    await expect(page.locator('#commentsPanel')).toBeVisible();
+
+    // Comment should appear in the panel
+    await expect(page.locator('#commentsPanel')).toContainText('Panel outdated check');
+  });
+
+  test('normal diff comment does NOT get Outdated badge', async ({ page, request }) => {
+    const filePath = await getServerGoPath(request);
+
+    // Find a line that IS in a diff hunk (addition line)
+    const diffResp = await request.get(`/api/file/diff?path=${encodeURIComponent(filePath)}`);
+    const diffData = await diffResp.json();
+    const hunks = diffData.hunks || [];
+    let inHunkLine = 0;
+    for (const hunk of hunks) {
+      for (const line of hunk.Lines) {
+        if (line.Type === 'add' && line.NewNum) {
+          inHunkLine = line.NewNum;
+          break;
+        }
+      }
+      if (inHunkLine) break;
+    }
+    expect(inHunkLine).toBeGreaterThan(0);
+
+    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: inHunkLine, end_line: inHunkLine, body: 'Normal diff comment' },
+    });
+
+    await loadPage(page);
+    const section = goSection(page);
+    await expect(section).toBeVisible();
+
+    // Comment should appear WITHOUT Outdated badge
+    await expect(section.locator('.comment-card')).toBeVisible();
+    await expect(section.locator('.comment-body')).toContainText('Normal diff comment');
+    await expect(section.locator('.outdated-badge')).toHaveCount(0);
+  });
+
+  test('outdated comment has full CRUD (edit and delete)', async ({ page, request }) => {
+    const filePath = await getServerGoPath(request);
+    const nonHunkLine = await findNonHunkLine(request, filePath);
+
+    const commentResp = await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Editable outdated comment' },
+    });
+    const comment = await commentResp.json();
+
+    await loadPage(page);
+    const section = goSection(page);
+
+    // Verify outdated badge appears
+    await expect(section.locator('.outdated-badge')).toBeVisible({ timeout: 5_000 });
+    await expect(section.locator('.comment-body')).toContainText('Editable outdated comment');
+
+    // Edit the comment via API
+    await request.put(`/api/comment/${comment.id}?path=${encodeURIComponent(filePath)}`, {
+      data: { body: 'Edited outdated comment' },
+    });
+
+    await loadPage(page);
+    await expect(goSection(page).locator('.comment-body')).toContainText('Edited outdated comment');
+    await expect(goSection(page).locator('.outdated-badge')).toBeVisible();
+
+    // Delete the comment via API
+    await request.delete(`/api/comment/${comment.id}?path=${encodeURIComponent(filePath)}`);
+
+    await loadPage(page);
+    await expect(goSection(page).locator('.outdated-badge')).toHaveCount(0);
+    await expect(goSection(page).locator('.comment-card')).toHaveCount(0);
+  });
+});

--- a/e2e/tests/outdated-diff-comments.spec.ts
+++ b/e2e/tests/outdated-diff-comments.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { clearAllComments, loadPage, goSection } from './helpers';
+import { clearAllComments, loadPage, goSection, addComment } from './helpers';
 
 // Get the server.go file path from the session
 async function getServerGoPath(request: APIRequestContext): Promise<string> {
@@ -31,6 +31,7 @@ async function getRenderedDiffKeys(request: APIRequestContext, filePath: string)
 // Find a new-side line number that is NOT in any diff hunk for the file
 async function findNonHunkLine(request: APIRequestContext, filePath: string): Promise<number> {
   const keys = await getRenderedDiffKeys(request, filePath);
+  expect(keys.size).toBeGreaterThan(0); // Guard: diff must have real hunks
   // Pick a line number that's not in any hunk. Start from 1000.
   for (let n = 1000; n < 2000; n++) {
     if (!keys.has(n + ':')) return n;
@@ -58,9 +59,7 @@ test.describe('Outdated Diff Comments', () => {
     // This simulates what happens when a comment was on a line that existed in
     // a previous round's diff but the agent removed that change.
     const nonHunkLine = await findNonHunkLine(request, filePath);
-    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
-      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'This line was removed from the diff' },
-    });
+    await addComment(request, filePath, nonHunkLine, 'This line was removed from the diff');
 
     await loadPage(page);
     const section = goSection(page);
@@ -79,10 +78,7 @@ test.describe('Outdated Diff Comments', () => {
     const filePath = await getServerGoPath(request);
     const nonHunkLine = await findNonHunkLine(request, filePath);
 
-    const commentResp = await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
-      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Resolve me after outdated' },
-    });
-    const comment = await commentResp.json();
+    const comment = await addComment(request, filePath, nonHunkLine, 'Resolve me after outdated');
 
     await loadPage(page);
     const section = goSection(page);
@@ -106,9 +102,7 @@ test.describe('Outdated Diff Comments', () => {
     const filePath = await getServerGoPath(request);
     const nonHunkLine = await findNonHunkLine(request, filePath);
 
-    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
-      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Panel outdated check' },
-    });
+    await addComment(request, filePath, nonHunkLine, 'Panel outdated check');
 
     await loadPage(page);
 
@@ -139,9 +133,7 @@ test.describe('Outdated Diff Comments', () => {
     }
     expect(inHunkLine).toBeGreaterThan(0);
 
-    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
-      data: { start_line: inHunkLine, end_line: inHunkLine, body: 'Normal diff comment' },
-    });
+    await addComment(request, filePath, inHunkLine, 'Normal diff comment');
 
     await loadPage(page);
     const section = goSection(page);
@@ -157,10 +149,7 @@ test.describe('Outdated Diff Comments', () => {
     const filePath = await getServerGoPath(request);
     const nonHunkLine = await findNonHunkLine(request, filePath);
 
-    const commentResp = await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
-      data: { start_line: nonHunkLine, end_line: nonHunkLine, body: 'Editable outdated comment' },
-    });
-    const comment = await commentResp.json();
+    const comment = await addComment(request, filePath, nonHunkLine, 'Editable outdated comment');
 
     await loadPage(page);
     const section = goSection(page);

--- a/e2e/tests/threading.spec.ts
+++ b/e2e/tests/threading.spec.ts
@@ -282,4 +282,34 @@ test.describe('Comment Threading', () => {
     // After resolving, card should collapse even though it was a live thread
     await expect(section.locator('.comment-card.collapsed')).toHaveCount(1);
   });
+
+  test('reply form persists expanded state and text when opening a new comment form on same file', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Review this');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Expand reply input and type text
+    await card.locator('.reply-input').click();
+    await expect(card.locator('.reply-textarea')).toBeFocused();
+    await card.locator('.reply-textarea').fill('draft reply text');
+    await expect(card.locator('.reply-form-buttons')).toBeVisible();
+
+    // Open a new comment form on a different line of the SAME file to trigger re-render
+    const thirdLineBlock = section.locator('.line-block').nth(2);
+    await thirdLineBlock.hover();
+    await section.locator('.line-comment-gutter').nth(2).click();
+
+    // Verify the new comment form opened
+    await expect(section.locator('.comment-form')).toBeVisible();
+
+    // Verify reply form survived the re-render
+    await expect(card.locator('.reply-form.expanded')).toBeVisible();
+    await expect(card.locator('.reply-textarea')).toHaveValue('draft reply text');
+    await expect(card.locator('.reply-form-buttons')).toBeVisible();
+  });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2944,6 +2944,62 @@
     }
   }
 
+  // Helper: render comments whose line keys don't appear in any diff hunk.
+  // These are "outdated" — the comment exists but the line is gone from the current diff.
+  function appendOutdatedDiffComments(container, file, commentsMap, hunks) {
+    // Build set of all end_line:side keys present in the diff hunks
+    const renderedKeys = new Set();
+    for (const hunk of hunks) {
+      for (const line of hunk.Lines) {
+        if (line.Type === 'del' && line.OldNum) {
+          renderedKeys.add(line.OldNum + ':old');
+        }
+        if (line.Type === 'add' && line.NewNum) {
+          renderedKeys.add(line.NewNum + ':');
+        }
+        if (line.Type === 'context') {
+          if (line.OldNum) renderedKeys.add(line.OldNum + ':old');
+          if (line.NewNum) renderedKeys.add(line.NewNum + ':');
+        }
+      }
+    }
+
+    // Collect comments whose keys were not rendered
+    const outdatedComments = [];
+    for (const key of Object.keys(commentsMap)) {
+      if (!renderedKeys.has(key)) {
+        for (const comment of commentsMap[key]) {
+          if (comment.scope !== 'file') {
+            outdatedComments.push(comment);
+          }
+        }
+      }
+    }
+
+    if (outdatedComments.length === 0) return;
+
+    // Render outdated comments section at the bottom of the diff
+    const section = document.createElement('div');
+    section.className = 'outdated-diff-comments';
+
+    for (const comment of outdatedComments) {
+      const el = comment.resolved
+        ? createResolvedElement(comment, file.path)
+        : createCommentElement(comment, file.path);
+      el.classList.add('outdated-comment');
+      const headerLeft = el.querySelector('.comment-header-left');
+      if (headerLeft) {
+        const badge = document.createElement('span');
+        badge.className = 'outdated-badge';
+        badge.textContent = 'Outdated';
+        headerLeft.appendChild(badge);
+      }
+      section.appendChild(el);
+    }
+
+    container.appendChild(section);
+  }
+
   // ===== Unified diff (interleaved lines, single pane) =====
   function renderDiffUnified(file) {
     const container = document.createElement('div');
@@ -3043,6 +3099,8 @@
         visualIdx++;
       }
     }
+
+    appendOutdatedDiffComments(container, file, commentsMap, hunks);
 
     return container;
   }
@@ -3163,6 +3221,8 @@
         }
       }
     }
+
+    appendOutdatedDiffComments(container, file, commentsMap, hunks);
 
     return container;
   }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -195,6 +195,9 @@
   let agentName = 'agent';
   const pendingAgentRequests = new Set();
 
+  // Track active reply form state so it survives DOM re-renders (commentId → { text })
+  const activeReplyForms = new Map();
+
   // Track manually toggled collapse state (comment ID → boolean, true = collapsed)
   const commentCollapseOverrides = {};
 
@@ -1653,6 +1656,18 @@
     for (let i = 0; i < fileForms.length; i++) {
       const ta = document.querySelector('.comment-form[data-form-key="' + fileForms[i].formKey + '"] textarea');
       if (ta) fileForms[i].draftBody = ta.value;
+    }
+    // Save expanded reply form state before DOM re-render
+    const section = document.getElementById('file-section-' + filePath);
+    if (section) {
+      const expandedForms = section.querySelectorAll('.reply-form.expanded');
+      for (let i = 0; i < expandedForms.length; i++) {
+        const card = expandedForms[i].closest('.comment-card');
+        if (card && card.dataset.commentId) {
+          const ta = expandedForms[i].querySelector('.reply-textarea');
+          activeReplyForms.set(card.dataset.commentId, { text: ta ? ta.value : '' });
+        }
+      }
     }
   }
 
@@ -5265,6 +5280,7 @@
       input.replaceWith(textarea);
       form.appendChild(buttons);
       textarea.focus();
+      activeReplyForms.set(commentId, { text: textarea.value });
     }
 
     function collapse() {
@@ -5273,9 +5289,15 @@
       textarea.replaceWith(input);
       input.value = '';
       if (buttons.parentNode) buttons.remove();
+      activeReplyForms.delete(commentId);
     }
 
     input.addEventListener('focus', expand);
+
+    // Keep reply form state in sync for surviving re-renders
+    textarea.addEventListener('input', function() {
+      activeReplyForms.set(commentId, { text: textarea.value });
+    });
 
     cancelBtn.addEventListener('click', collapse);
 
@@ -5319,6 +5341,7 @@
           });
         }
 
+        activeReplyForms.delete(commentId);
         refreshFileComments(filePath);
       } catch (err) {
         console.error('Failed to add reply:', err);
@@ -5341,6 +5364,15 @@
         }
       }
     });
+
+    // Restore saved reply form state after DOM re-render
+    const saved = activeReplyForms.get(commentId);
+    if (saved && saved.text) {
+      form.classList.add('expanded');
+      textarea.value = saved.text;
+      input.replaceWith(textarea);
+      form.appendChild(buttons);
+    }
 
     return form;
   }
@@ -5989,6 +6021,7 @@
         files.sort(fileSortComparator);
 
         activeForms = [];
+        activeReplyForms.clear();
         activeFilePath = null;
         selectionStart = null;
         selectionEnd = null;
@@ -6633,6 +6666,7 @@
     if (reloadInFlight) return reloadInFlight;
     reloadInFlight = (async function() {
       try {
+        activeReplyForms.clear();
         document.getElementById('filesContainer').innerHTML =
           '<div class="loading" style="padding: 40px; text-align: center; color: var(--fg-muted);">Loading...</div>';
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3447,6 +3447,10 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   color: var(--fg-dimmed);
   padding: 12px 16px;
 }
+.outdated-diff-comments {
+  border-top: 1px solid var(--border);
+  padding: 8px 0;
+}
 .outdated-badge {
   font-size: 10px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- When a comment's line disappears from diff hunks (e.g., agent undoes a change), the comment was invisible inline — only visible in All Comments panel
- Added `appendOutdatedDiffComments()` that detects unrendered comments after hunk rendering and shows them at the bottom of the diff section with "Outdated" badge
- Uses existing `outdated-badge` CSS (same as orphaned files from #279)
- Full CRUD: edit, delete, resolve all work on outdated comments

## Review
- [x] Code review: passed (CSS gap and test convention deviation fixed)
- [x] TDD verified: 3/5 tests fail without fix, 5/5 pass with fix

## Test plan
- 5 new E2E tests: outdated badge rendering, resolve, All Comments panel, regression guard (normal comments don't get badge), full CRUD
- See also: #324 for the backend complement (carry-forward for code files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)