### PR TITLE
fix: wrap errors in atomicWriteFile with operation context

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -117,29 +117,33 @@ func atomicWriteFile(target string, data []byte, perm os.FileMode) error {
 
 	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"*.tmp")
 	if err != nil {
-		return err
+		return fmt.Errorf("create temp file: %w", err)
 	}
 	tmpName := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
-		return err
+		return fmt.Errorf("write temp file: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
-		return err
+		return fmt.Errorf("sync temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
-		return err
+		return fmt.Errorf("close temp file: %w", err)
 	}
 	if err := os.Chmod(tmpName, perm); err != nil {
 		os.Remove(tmpName)
-		return err
+		return fmt.Errorf("chmod temp file: %w", err)
 	}
-	return os.Rename(tmpName, target)
+	if err := os.Rename(tmpName, target); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename temp file to target: %w", err)
+	}
+	return nil
 }
 
 // writeSessionFile writes a session entry to ~/.crit/sessions/<key>.json.


### PR DESCRIPTION
## Summary
- Wrap all 6 error returns in `atomicWriteFile` with `fmt.Errorf` and `%w` for clear operation context
- Clean up temp file on rename failure (previously leaked)
- This is the primary data persistence path — callers can now distinguish which step failed

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` passes
- [x] Reviewed by Go expert agent — approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)