### PR TITLE
fix: log JSON encode errors in writeJSON

### DIFF
--- a/server.go
+++ b/server.go
@@ -1390,5 +1390,7 @@ func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
 
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("writeJSON: encode error: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- `writeJSON` now logs encode failures via `log.Printf` instead of silently dropping them
- Consistent with existing `log.Printf` usage elsewhere in `server.go`
- No panic/fatal — a failed encode on one response doesn't crash the server

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` passes
- [x] Reviewed by Go expert agent — approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)