### PR TITLE
feat: auto-expand small unchanged gaps between diff hunks

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -81,6 +81,51 @@ func Capitalize(s string) string {
 }
 GOFILE
 
+# routes.go — will produce a multi-hunk diff with a large gap (>8 unchanged lines)
+# between changed areas, so spacers remain after auto-expansion of small gaps.
+cat > routes.go << 'GOFILE'
+package main
+
+import "net/http"
+
+func setupRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/users", handleUsers)
+	mux.HandleFunc("/api/posts", handlePosts)
+}
+
+func handleUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handlePosts(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleComments(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleTags(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSearch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleDashboard(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleAnalytics(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+GOFILE
+
 git add -A
 git commit -q -m "initial commit"
 
@@ -193,6 +238,58 @@ GOFILE
 
 # Delete deleted.txt
 rm deleted.txt
+
+# Modify routes.go to produce a multi-hunk diff with a large gap (>8 unchanged lines)
+# between hunks. This ensures spacers remain visible for testing after auto-expansion.
+# Hunk 1: change imports (top). Hunk 2: add new route + function (bottom).
+# The 10+ unchanged handler functions in between create a gap >8 lines.
+cat > routes.go << 'GOFILE'
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func setupRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/users", handleUsers)
+	mux.HandleFunc("/api/posts", handlePosts)
+	mux.HandleFunc("/api/health", handleHealth)
+}
+
+func handleUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handlePosts(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleComments(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleTags(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSearch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleDashboard(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleAnalytics(w http.ResponseWriter, r *http.Request) {
+	log.Println("analytics endpoint hit")
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+GOFILE
 
 # Add plan.md with comprehensive markdown
 cat > plan.md << 'MDFILE'

--- a/e2e/tests/auto-expand-gaps.spec.ts
+++ b/e2e/tests/auto-expand-gaps.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+function serverSection(page: Page) {
+  return page.locator('#file-section-server\\.go');
+}
+
+// ============================================================
+// Auto-expand small gaps (≤ 8 lines) between diff hunks
+// ============================================================
+test.describe('Auto-expand small gaps — Split Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('small gaps between hunks are auto-expanded (no spacer visible)', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // server.go has gaps of 8 and 5 lines between its 3 hunks — both ≤ 8,
+    // so no spacers should be rendered at all
+    await expect(section.locator('.diff-spacer')).toHaveCount(0);
+  });
+
+  test('auto-expanded context lines render with correct line numbers', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // After auto-expansion, the context lines between hunks should be visible
+    // as regular diff rows with line numbers.
+    // Look for context rows (not addition, not deletion, not empty) with line numbers.
+    const contextRows = section.locator('.diff-split-row');
+    const count = await contextRows.count();
+
+    // Find a context row: both sides present, neither addition nor deletion
+    let foundContext = false;
+    for (let i = 0; i < count; i++) {
+      const row = contextRows.nth(i);
+      const right = row.locator('.diff-split-side.right');
+      const isAddition = await right.evaluate(el => el.classList.contains('addition'));
+      const isDeletion = await right.evaluate(el => el.classList.contains('deletion'));
+      const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
+      if (!isAddition && !isDeletion && !isEmpty) {
+        const numText = await right.locator('.diff-gutter-num').textContent();
+        if (numText && numText.trim()) {
+          foundContext = true;
+          // Verify line number is a positive integer
+          expect(parseInt(numText.trim(), 10)).toBeGreaterThan(0);
+          break;
+        }
+      }
+    }
+    expect(foundContext).toBe(true);
+  });
+
+  test('auto-expanded context lines are commentable (gutter + button works)', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // Find a context line in the expanded gap area and verify commenting works
+    const rows = section.locator('.diff-split-row');
+    const count = await rows.count();
+
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(i);
+      const right = row.locator('.diff-split-side.right');
+      const isAddition = await right.evaluate(el => el.classList.contains('addition'));
+      const isDeletion = await right.evaluate(el => el.classList.contains('deletion'));
+      const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
+      if (!isAddition && !isDeletion && !isEmpty) {
+        const numText = await right.locator('.diff-gutter-num').textContent();
+        if (numText && numText.trim()) {
+          await right.hover();
+          const commentBtn = right.locator('.diff-comment-btn');
+          await expect(commentBtn).toBeVisible();
+          await commentBtn.click();
+
+          const textarea = page.locator('.comment-form textarea');
+          await expect(textarea).toBeVisible();
+          await textarea.fill('Comment on auto-expanded context line');
+          await page.locator('.comment-form .btn-primary').click();
+
+          const card = section.locator('.comment-card');
+          await expect(card).toBeVisible();
+          await expect(card.locator('.comment-body')).toContainText('Comment on auto-expanded context line');
+          break;
+        }
+      }
+    }
+  });
+
+  test('only one hunk header remains after merging all small gaps', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // With all gaps ≤ 8, all hunks merge into one, so only one hunk header
+    const hunkHeaders = section.locator('.diff-hunk-header');
+    await expect(hunkHeaders).toHaveCount(1);
+  });
+});
+
+test.describe('Auto-expand small gaps — Unified Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+    await unifiedBtn.click();
+    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+  });
+
+  test('small gaps are auto-expanded in unified mode (no spacer)', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    await expect(section.locator('.diff-spacer')).toHaveCount(0);
+  });
+
+  test('auto-expanded context lines in unified mode have correct line numbers', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // Find a context line (not addition, not deletion)
+    const contextLine = section.locator('.diff-container.unified .diff-line:not(.addition):not(.deletion)').first();
+    await expect(contextLine).toBeVisible();
+
+    // Both old and new line numbers should be present
+    const gutterNums = contextLine.locator('.diff-gutter-num');
+    const oldNum = await gutterNums.nth(0).textContent();
+    const newNum = await gutterNums.nth(1).textContent();
+    expect(oldNum && oldNum.trim()).toBeTruthy();
+    expect(newNum && newNum.trim()).toBeTruthy();
+  });
+
+  test('auto-expanded context lines are commentable in unified mode', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    const contextLine = section.locator('.diff-container.unified .diff-line:not(.addition):not(.deletion)').first();
+    await expect(contextLine).toBeVisible();
+    await contextLine.hover();
+
+    const commentBtn = contextLine.locator('.diff-comment-btn');
+    await expect(commentBtn).toBeVisible();
+    await commentBtn.click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('Unified auto-expanded comment');
+    await page.locator('.comment-form .btn-primary').click();
+
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+    await expect(card.locator('.comment-body')).toContainText('Unified auto-expanded comment');
+  });
+});
+
+test.describe('Large gaps still show spacer', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('large gaps (> 8 lines) still show spacer with expand text', async ({ page }) => {
+    // routes.go has a gap of >8 unchanged lines between its two hunks,
+    // so the spacer should still be visible after auto-expansion.
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+
+    const routesSection = page.locator('#file-section-routes\\.go');
+    const spacer = routesSection.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
+    await expect(spacer).toContainText('Expand');
+  });
+});
+
+test.describe('Auto-expand does not break other files', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('handler.js (new file, single hunk) renders correctly', async ({ page }) => {
+    const handlerSection = page.locator('#file-section-handler\\.js');
+    await expect(handlerSection).toBeVisible();
+
+    // New file should have all addition lines, no spacers
+    await expect(handlerSection.locator('.diff-spacer')).toHaveCount(0);
+    const additionSide = handlerSection.locator('.diff-split-side.addition');
+    await expect(additionSide.first()).toBeVisible();
+  });
+
+  test('auto-expanded file still renders hunk header', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // Should have at least one hunk header even after merging
+    const hunkHeader = section.locator('.diff-hunk-header');
+    await expect(hunkHeader.first()).toBeVisible();
+    await expect(hunkHeader.first().locator('.hunk-text')).toContainText('@@');
+  });
+});

--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -65,8 +65,13 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
   test('spacer shows "Expand" between hunks', async ({ page }) => {
     await loadPage(page);
 
-    // server.go has a multi-hunk diff, so spacers should exist
-    const spacer = page.locator('.diff-spacer').first();
+    // routes.go has a large gap (>8 lines) between hunks, so a spacer should exist.
+    // Click on it in the file tree to expand and lazy-load its content.
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+
+    const routesSection = page.locator('#file-section-routes\\.go');
+    const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
     await expect(spacer).toContainText('Expand');
     await expect(spacer).toContainText('unchanged line');
@@ -75,46 +80,55 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
   test('clicking spacer expands context lines', async ({ page }) => {
     await loadPage(page);
 
-    // Find the server.go section which has multi-hunk diffs with spacers
-    const serverSection = page.locator('#file-section-server\\.go');
-    await expect(serverSection).toBeVisible();
+    // routes.go has a large gap between hunks — use it for spacer expansion testing
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+
+    const routesSection = page.locator('#file-section-routes\\.go');
 
     // Count spacers before click
-    const spacersBefore = serverSection.locator('.diff-spacer');
+    const spacersBefore = routesSection.locator('.diff-spacer');
+    await expect(spacersBefore.first()).toBeVisible();
     const spacerCountBefore = await spacersBefore.count();
     expect(spacerCountBefore).toBeGreaterThan(0);
 
     // Count diff rows before expansion
-    const rowsBefore = await serverSection.locator('.diff-split-row').count();
+    const rowsBefore = await routesSection.locator('.diff-split-row').count();
 
     // Click the first spacer
     const firstSpacer = spacersBefore.first();
     await firstSpacer.click();
 
     // After clicking, the spacer count should decrease by 1 (it gets merged)
-    const spacerCountAfter = await serverSection.locator('.diff-spacer').count();
-    expect(spacerCountAfter).toBeLessThan(spacerCountBefore);
+    await expect(async () => {
+      const spacerCountAfter = await routesSection.locator('.diff-spacer').count();
+      expect(spacerCountAfter).toBeLessThan(spacerCountBefore);
+    }).toPass();
 
     // More rows should be visible after expansion
-    const rowsAfter = await serverSection.locator('.diff-split-row').count();
+    const rowsAfter = await routesSection.locator('.diff-split-row').count();
     expect(rowsAfter).toBeGreaterThan(rowsBefore);
   });
 
   test('expanded lines have comment gutter (+ button) on hover', async ({ page }) => {
     await loadPage(page);
 
-    const serverSection = page.locator('#file-section-server\\.go');
-    const spacer = serverSection.locator('.diff-spacer').first();
+    // routes.go has a large gap spacer for expansion testing
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+
+    const routesSection = page.locator('#file-section-routes\\.go');
+    const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
 
     // Click the spacer to expand context lines
     await spacer.click();
 
     // Wait for re-render — new rows should appear
-    await expect(serverSection.locator('.diff-split-row').first()).toBeVisible();
+    await expect(routesSection.locator('.diff-split-row').first()).toBeVisible();
 
     // Hover over one of the split sides in the section — the comment button should become visible
-    const splitSide = serverSection.locator('.diff-split-side').first();
+    const splitSide = routesSection.locator('.diff-split-side').first();
     await splitSide.hover();
 
     const commentBtn = splitSide.locator('.diff-comment-btn');

--- a/e2e/tests/expanded-comments.spec.ts
+++ b/e2e/tests/expanded-comments.spec.ts
@@ -5,16 +5,21 @@ function serverSection(page: Page) {
   return page.locator('#file-section-server\\.go');
 }
 
-// Expand the first spacer in server.go and return the section locator
-async function expandFirstSpacer(page: Page) {
+// Get the server.go section with context lines already visible.
+// Small gaps (≤ 8 lines) are auto-expanded, so context lines between
+// hunks are rendered immediately without clicking a spacer.
+async function getServerSectionWithContext(page: Page) {
   const section = serverSection(page);
   await expect(section).toBeVisible();
-  const spacer = section.locator('.diff-spacer').first();
-  await expect(spacer).toBeVisible();
-  await spacer.click();
-  // Wait for expanded rows to appear
+  // Wait for split rows to appear
   await expect(section.locator('.diff-split-row').first()).toBeVisible();
   return section;
+}
+
+// Legacy alias: server.go's small gaps are auto-expanded, so context lines
+// are visible immediately. This just returns the server.go section.
+async function expandFirstSpacer(page: Page) {
+  return getServerSectionWithContext(page);
 }
 
 // Find a context line on the right (new) side — a row where right side
@@ -225,12 +230,7 @@ test.describe('Expanded Context Comments — Unified Mode', () => {
     const section = serverSection(page);
     await expect(section).toBeVisible();
 
-    // Expand spacer in unified mode
-    const spacer = section.locator('.diff-spacer').first();
-    await expect(spacer).toBeVisible();
-    await spacer.click();
-
-    // Find a context line (not addition, not deletion) in unified mode
+    // Context lines between auto-expanded small gaps are already visible
     const contextLine = section.locator('.diff-container.unified .diff-line:not(.addition):not(.deletion)').first();
     await expect(contextLine).toBeVisible();
     await contextLine.hover();
@@ -252,10 +252,7 @@ test.describe('Expanded Context Comments — Unified Mode', () => {
   test('edit comment on expanded context line in unified mode', async ({ page }) => {
     const section = serverSection(page);
 
-    const spacer = section.locator('.diff-spacer').first();
-    await expect(spacer).toBeVisible();
-    await spacer.click();
-
+    // Context lines are already visible from auto-expansion
     const contextLine = section.locator('.diff-container.unified .diff-line:not(.addition):not(.deletion)').first();
     await contextLine.hover();
     await contextLine.locator('.diff-comment-btn').click();
@@ -278,10 +275,7 @@ test.describe('Expanded Context Comments — Unified Mode', () => {
   test('delete comment on expanded context line in unified mode', async ({ page }) => {
     const section = serverSection(page);
 
-    const spacer = section.locator('.diff-spacer').first();
-    await expect(spacer).toBeVisible();
-    await spacer.click();
-
+    // Context lines are already visible from auto-expansion
     const contextLine = section.locator('.diff-container.unified .diff-line:not(.addition):not(.deletion)').first();
     await contextLine.hover();
     await contextLine.locator('.diff-comment-btn').click();

--- a/e2e/tests/file-tree.spec.ts
+++ b/e2e/tests/file-tree.spec.ts
@@ -15,10 +15,10 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file tree lists all files from the session', async ({ page }) => {
-    // Git fixture has: plan.md, server.go, handler.js, deleted.txt (committed)
-    // + utils.go (staged), config.yaml (untracked) = 6 total
+    // Git fixture has: plan.md, server.go, handler.js, deleted.txt, routes.go (committed)
+    // + utils.go (staged), config.yaml (untracked) = 7 total
     const treeFiles = page.locator('.tree-file');
-    await expect(treeFiles).toHaveCount(6);
+    await expect(treeFiles).toHaveCount(7);
   });
 
   test('file tree shows correct file names', async ({ page }) => {
@@ -117,9 +117,9 @@ test.describe('File Tree — Git Mode', () => {
     const addedIcons = page.locator('.tree-file-status-icon.added');
     await expect(addedIcons).toHaveCount(3);
 
-    // server.go and utils.go (staged modification) are modified
+    // server.go, routes.go, and utils.go (staged modification) are modified
     const modifiedIcons = page.locator('.tree-file-status-icon.modified');
-    await expect(modifiedIcons).toHaveCount(2);
+    await expect(modifiedIcons).toHaveCount(3);
 
     // deleted.txt is deleted
     const deletedIcons = page.locator('.tree-file-status-icon.deleted');

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -39,8 +39,8 @@ test.describe('Scope Toggle', () => {
   test('switching to branch scope shows only committed files', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'branch');
-    // Branch: server.go, deleted.txt, plan.md, handler.js (4 committed)
-    await expect(page.locator('.file-section')).toHaveCount(4);
+    // Branch: server.go, deleted.txt, plan.md, handler.js, routes.go (5 committed)
+    await expect(page.locator('.file-section')).toHaveCount(5);
     await expect(page.locator('.file-section', { hasText: 'server.go' })).toBeVisible();
     await expect(page.locator('.file-section', { hasText: 'plan.md' })).toBeVisible();
   });

--- a/e2e/tests/syntax-highlighting.spec.ts
+++ b/e2e/tests/syntax-highlighting.spec.ts
@@ -99,12 +99,8 @@ test.describe('Syntax Highlighting — Expanded Context', () => {
     await loadPage(page);
     const section = goSection(page);
 
-    // Expand a spacer
-    const spacer = section.locator('.diff-spacer').first();
-    await expect(spacer).toBeVisible();
-    await spacer.click();
-
-    // Find a context line in the expanded area and check for spans
+    // server.go's small gaps are auto-expanded, so context lines are already
+    // visible without clicking a spacer. Find a context line and check for spans.
     const rows = section.locator('.diff-split-row');
     const count = await rows.count();
     let foundHighlighted = false;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1734,6 +1734,7 @@
           file.previousContent = loaded.previousContent;
           file.comments = loaded.comments;
           file.diffHunks = loaded.diffHunks;
+          file._autoExpandDone = false;
           file.lineBlocks = loaded.lineBlocks;
           file.previousLineBlocks = loaded.previousLineBlocks;
           file.tocItems = loaded.tocItems;
@@ -3016,6 +3017,47 @@
   }
 
   // ===== Unified diff (interleaved lines, single pane) =====
+  // Pre-process diffHunks: merge adjacent hunks where the gap between them
+  // is ≤ 8 unchanged lines. This removes visual noise from tiny spacers.
+  // Mutates file.diffHunks in place so it only runs once per file.
+  function autoExpandSmallGaps(file) {
+    if (!file.content || !file.diffHunks || file.diffHunks.length < 2) return;
+    if (file._autoExpandDone) return;
+    file._autoExpandDone = true;
+
+    const contentLines = file.content.split('\n');
+    const hunks = file.diffHunks;
+    let i = 0;
+    while (i < hunks.length - 1) {
+      const prevNewEnd = hunks[i].NewStart + hunks[i].NewCount;
+      const prevOldEnd = hunks[i].OldStart + hunks[i].OldCount;
+      const gap = hunks[i + 1].NewStart - prevNewEnd;
+      if (gap > 0 && gap <= 8) {
+        // Build context lines to bridge the gap
+        const contextLines = [];
+        for (let j = 0; j < gap; j++) {
+          const newLineNum = prevNewEnd + j;
+          const oldLineNum = prevOldEnd + j;
+          const text = newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
+          contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
+        }
+        // Merge: prev hunk + context lines + next hunk → single hunk
+        const merged = {
+          OldStart: hunks[i].OldStart,
+          NewStart: hunks[i].NewStart,
+          Header: hunks[i].Header,
+          Lines: hunks[i].Lines.concat(contextLines, hunks[i + 1].Lines)
+        };
+        merged.OldCount = (hunks[i + 1].OldStart + hunks[i + 1].OldCount) - merged.OldStart;
+        merged.NewCount = (hunks[i + 1].NewStart + hunks[i + 1].NewCount) - merged.NewStart;
+        // Replace both with merged — don't increment i to check merged against next
+        hunks.splice(i, 2, merged);
+      } else {
+        i++;
+      }
+    }
+  }
+
   function renderDiffUnified(file) {
     const container = document.createElement('div');
     container.className = 'diff-container unified';
@@ -3025,6 +3067,8 @@
       container.innerHTML = '<div class="diff-no-changes">No changes</div>';
       return container;
     }
+
+    autoExpandSmallGaps(file);
 
     const { diffCommentsMap: commentsMap } = buildCommentIndices(file.comments);
     const commentVisualSet = buildUnifiedCommentVisualSet(hunks, file.comments);
@@ -3130,6 +3174,8 @@
       container.innerHTML = '<div class="diff-no-changes">No changes</div>';
       return container;
     }
+
+    autoExpandSmallGaps(file);
 
     const { diffCommentsMap: commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 


### PR DESCRIPTION
## Summary
- When the gap between two adjacent diff hunks is ≤8 lines, automatically expand the context and merge the hunks at render time
- Eliminates visual noise from trivially small "Expand N unchanged lines" spacers
- Adds `routes.go` test fixture with a large gap (>8 lines) to keep spacer tests viable

## Test plan
- [ ] 10 new E2E tests in `auto-expand-gaps.spec.ts` covering split/unified modes, small gap auto-expansion, large gap spacer preservation, and commentability
- [ ] Existing `expanded-comments`, `diff-rendering`, `file-tree`, `scope-toggle`, `syntax-highlighting` tests updated and passing
- [ ] All 35 affected tests pass locally

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)