### PR TITLE
feat: add expand controls before first and after last diff hunk

### DIFF
--- a/e2e/tests/auto-expand-gaps.spec.ts
+++ b/e2e/tests/auto-expand-gaps.spec.ts
@@ -19,8 +19,8 @@ test.describe('Auto-expand small gaps — Split Mode', () => {
     await expect(section).toBeVisible();
 
     // server.go has gaps of 8 and 5 lines between its 3 hunks — both ≤ 8,
-    // so no spacers should be rendered at all
-    await expect(section.locator('.diff-spacer')).toHaveCount(0);
+    // so no inter-hunk spacers should be rendered (leading/trailing spacers may still appear)
+    await expect(section.locator('.diff-spacer:not(.diff-spacer-leading):not(.diff-spacer-trailing)')).toHaveCount(0);
   });
 
   test('auto-expanded context lines render with correct line numbers', async ({ page }) => {
@@ -113,7 +113,7 @@ test.describe('Auto-expand small gaps — Unified Mode', () => {
     const section = serverSection(page);
     await expect(section).toBeVisible();
 
-    await expect(section.locator('.diff-spacer')).toHaveCount(0);
+    await expect(section.locator('.diff-spacer:not(.diff-spacer-leading):not(.diff-spacer-trailing)')).toHaveCount(0);
   });
 
   test('auto-expanded context lines in unified mode have correct line numbers', async ({ page }) => {

--- a/e2e/tests/leading-trailing-expand.spec.ts
+++ b/e2e/tests/leading-trailing-expand.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+// utils.go has a staged change that appends a Reverse function at the end.
+// The diff hunk starts mid-file (OldStart=8, NewStart=8), NOT at line 1,
+// so a leading spacer should appear before the first hunk.
+function utilsSection(page: Page) {
+  return page.locator('#file-section-utils\\.go');
+}
+
+// server.go has multi-hunk diffs. The first hunk starts at line 2 (imports),
+// so a leading spacer should appear (gap=1 for the package declaration).
+// The last hunk ends at EOF, so NO trailing spacer should appear.
+function serverSection(page: Page) {
+  return page.locator('#file-section-server\\.go');
+}
+
+// handler.js is a newly added file — its single hunk starts at NewStart=1.
+// No leading spacer should appear for new files.
+function handlerSection(page: Page) {
+  return page.locator('#file-section-handler\\.js');
+}
+
+async function switchToUnified(page: Page) {
+  const btn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+  await expect(btn).toBeVisible();
+  await btn.click();
+  await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+}
+
+// ============================================================
+// Leading Spacer — Split Mode
+// ============================================================
+test.describe('Leading Spacer — Split Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('leading spacer appears before first hunk when it does not start at line 1', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await expect(leadingSpacer).toContainText('Expand');
+  });
+
+  test('no leading spacer when first hunk starts at line 1 (new file)', async ({ page }) => {
+    const section = handlerSection(page);
+    await expect(section).toBeVisible();
+
+    // handler.js is a new file; its hunk starts at line 1, so no leading spacer
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toHaveCount(0);
+  });
+
+  test('clicking leading spacer reveals context lines above the first hunk', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    // Count rows before clicking
+    const rowsBefore = section.locator('.diff-split-row');
+    const countBefore = await rowsBefore.count();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await leadingSpacer.click();
+
+    // After clicking, more rows should appear
+    await expect(async () => {
+      const countAfter = await section.locator('.diff-split-row').count();
+      expect(countAfter).toBeGreaterThan(countBefore);
+    }).toPass();
+  });
+
+  test('leading spacer disappears after expanding all lines to line 1', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+
+    // For utils.go, the gap before the first hunk is small (< 20 lines),
+    // so one click should expand all and remove the spacer.
+    await leadingSpacer.click();
+
+    await expect(section.locator('.diff-spacer-leading')).toHaveCount(0);
+  });
+
+  test('server.go leading spacer shows for 1-line gap', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    // server.go hunk starts at line 2, so there's a 1-line gap (package main)
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await expect(leadingSpacer).toContainText('Expand 1 unchanged line');
+  });
+});
+
+// ============================================================
+// Trailing Spacer — Split Mode
+// ============================================================
+test.describe('Trailing Spacer — Split Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('no trailing spacer when last hunk reaches EOF (server.go)', async ({ page }) => {
+    const section = serverSection(page);
+    await expect(section).toBeVisible();
+
+    const trailingSpacer = section.locator('.diff-spacer-trailing');
+    await expect(trailingSpacer).toHaveCount(0);
+  });
+
+  test('no trailing spacer when last hunk reaches EOF (utils.go)', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const trailingSpacer = section.locator('.diff-spacer-trailing');
+    await expect(trailingSpacer).toHaveCount(0);
+  });
+});
+
+// ============================================================
+// Leading Spacer — Unified Mode
+// ============================================================
+test.describe('Leading Spacer — Unified Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToUnified(page);
+  });
+
+  test('leading spacer appears in unified mode', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await expect(leadingSpacer).toContainText('Expand');
+  });
+
+  test('clicking leading spacer in unified mode reveals context lines', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const linesBefore = section.locator('.diff-line');
+    const countBefore = await linesBefore.count();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await leadingSpacer.click();
+
+    await expect(async () => {
+      const countAfter = await section.locator('.diff-line').count();
+      expect(countAfter).toBeGreaterThan(countBefore);
+    }).toPass();
+  });
+
+  test('no leading spacer in unified mode for new file', async ({ page }) => {
+    const section = handlerSection(page);
+    await expect(section).toBeVisible();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toHaveCount(0);
+  });
+});
+
+// ============================================================
+// Trailing Spacer — Unified Mode
+// ============================================================
+test.describe('Trailing Spacer — Unified Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToUnified(page);
+  });
+
+  test('no trailing spacer in unified mode when last hunk reaches EOF', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const trailingSpacer = section.locator('.diff-spacer-trailing');
+    await expect(trailingSpacer).toHaveCount(0);
+  });
+});
+
+// ============================================================
+// Expanded context lines are commentable
+// ============================================================
+test.describe('Leading Spacer — Expanded Lines Are Commentable', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+  });
+
+  test('expanded leading context lines have comment gutter buttons', async ({ page }) => {
+    const section = utilsSection(page);
+    await expect(section).toBeVisible();
+
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await leadingSpacer.click();
+
+    // Wait for re-render
+    await expect(section.locator('.diff-spacer-leading')).toHaveCount(0);
+
+    // Hover over one of the new split sides — comment button should appear
+    const splitSide = section.locator('.diff-split-side').first();
+    await splitSide.scrollIntoViewIfNeeded();
+    await splitSide.hover();
+
+    const commentBtn = splitSide.locator('.diff-comment-btn');
+    await expect(commentBtn).toBeVisible();
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2976,6 +2976,120 @@
     return spacer;
   }
 
+  // Helper: render leading spacer (before first hunk when it doesn't start at line 1)
+  function renderLeadingSpacer(firstHunk, file) {
+    // Only show if the first hunk doesn't start at line 1
+    if (firstHunk.NewStart <= 1 && firstHunk.OldStart <= 1) return null;
+    // For pure insertion (OldCount===0) or pure deletion (NewCount===0), git uses
+    // position-after semantics for the zero-count side — ignore it for gap calculation.
+    const newGap = firstHunk.NewCount > 0 ? firstHunk.NewStart - 1 : Infinity;
+    const oldGap = firstHunk.OldCount > 0 ? firstHunk.OldStart - 1 : Infinity;
+    const gap = Math.min(newGap, oldGap);
+    if (gap <= 0 || gap === Infinity) return null;
+
+    const EXPAND_STEP = 20;
+    const expandCount = Math.min(gap, EXPAND_STEP);
+
+    const spacer = document.createElement('div');
+    spacer.className = 'diff-spacer diff-spacer-leading';
+    spacer.setAttribute('aria-label', 'Expand ' + expandCount + ' unchanged lines above');
+    spacer.innerHTML =
+      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
+      'Expand ' + expandCount + ' unchanged line' + (expandCount === 1 ? '' : 's');
+
+    spacer.addEventListener('click', function() {
+      if (!file.content) return;
+      const contentLines = file.content.split('\n');
+      const hunks = file.diffHunks;
+      const hunk = hunks[0];
+
+      // Expand from the bottom of the gap upward (closest to the hunk first)
+      // For pure insertion/deletion, derive the zero-count side's start from the other side
+      const startNewLine = hunk.NewCount > 0 ? hunk.NewStart - expandCount : hunk.NewStart;
+      const startOldLine = hunk.OldCount > 0 ? hunk.OldStart - expandCount : hunk.OldStart;
+      const contextLines = [];
+      for (let i = 0; i < expandCount; i++) {
+        const newLineNum = startNewLine + i;
+        const oldLineNum = startOldLine + i;
+        const text = newLineNum > 0 && newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
+        contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
+      }
+
+      // Prepend context lines to the first hunk and adjust its start/count
+      hunk.Lines = contextLines.concat(hunk.Lines);
+      hunk.OldStart = startOldLine;
+      hunk.NewStart = startNewLine;
+      hunk.OldCount += expandCount;
+      hunk.NewCount += expandCount;
+
+      // Recompute the header to reflect updated line numbers, preserving any suffix (e.g. function name)
+      const headerSuffix = (hunk.Header.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/) || [])[1] || '';
+      hunk.Header = '@@ -' + hunk.OldStart + ',' + hunk.OldCount + ' +' + hunk.NewStart + ',' + hunk.NewCount + ' @@' + headerSuffix;
+
+      renderFileByPath(file.path);
+    });
+
+    return spacer;
+  }
+
+  // Helper: render trailing spacer (after last hunk when it doesn't reach EOF)
+  function renderTrailingSpacer(lastHunk, file) {
+    if (!file.content) return null;
+    const contentLines = file.content.split('\n');
+    // Files ending with a newline produce an extra empty element; don't count it
+    let totalNewLines = contentLines.length;
+    if (totalNewLines > 0 && contentLines[totalNewLines - 1] === '') totalNewLines--;
+
+    const lastNewEnd = lastHunk.NewStart + lastHunk.NewCount;
+    const gap = totalNewLines - lastNewEnd + 1;
+    if (gap <= 0) return null;
+
+    const EXPAND_STEP = 20;
+    const expandCount = Math.min(gap, EXPAND_STEP);
+
+    const spacer = document.createElement('div');
+    spacer.className = 'diff-spacer diff-spacer-trailing';
+    spacer.setAttribute('aria-label', 'Expand ' + expandCount + ' unchanged lines below');
+    spacer.innerHTML =
+      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
+      'Expand ' + expandCount + ' unchanged line' + (expandCount === 1 ? '' : 's');
+
+    spacer.addEventListener('click', function() {
+      if (!file.content) return;
+      const lines = file.content.split('\n');
+      let totalLines = lines.length;
+      if (totalLines > 0 && lines[totalLines - 1] === '') totalLines--;
+      const hunks = file.diffHunks;
+      const hunk = hunks[hunks.length - 1];
+
+      const hunkNewEnd = hunk.NewStart + hunk.NewCount;
+      const hunkOldEnd = hunk.OldStart + hunk.OldCount;
+      const remaining = totalLines - hunkNewEnd + 1;
+      const count = Math.min(remaining, EXPAND_STEP);
+
+      const contextLines = [];
+      for (let i = 0; i < count; i++) {
+        const newLineNum = hunkNewEnd + i;
+        const oldLineNum = hunkOldEnd + i;
+        const text = newLineNum <= lines.length ? lines[newLineNum - 1] : '';
+        contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
+      }
+
+      // Append context lines to the last hunk and adjust its count
+      hunk.Lines = hunk.Lines.concat(contextLines);
+      hunk.OldCount += count;
+      hunk.NewCount += count;
+
+      // Recompute the header to reflect updated line counts, preserving any suffix (e.g. function name)
+      const headerSuffix = (hunk.Header.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/) || [])[1] || '';
+      hunk.Header = '@@ -' + hunk.OldStart + ',' + hunk.OldCount + ' +' + hunk.NewStart + ',' + hunk.NewCount + ' @@' + headerSuffix;
+
+      renderFileByPath(file.path);
+    });
+
+    return spacer;
+  }
+
   // Helper: render hunk header
   function renderDiffHunkHeader(hunk) {
     const hunkHeader = document.createElement('div');
@@ -3129,6 +3243,10 @@
     const commentVisualSet = buildUnifiedCommentVisualSet(hunks, file.comments);
     let visualIdx = 0; // sequential index for unified drag (old/new nums are different spaces)
 
+    // Leading spacer before first hunk
+    const leadingSpacer = renderLeadingSpacer(hunks[0], file);
+    if (leadingSpacer) container.appendChild(leadingSpacer);
+
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
 
@@ -3214,6 +3332,10 @@
       }
     }
 
+    // Trailing spacer after last hunk
+    const trailingSpacerUnified = renderTrailingSpacer(hunks[hunks.length - 1], file);
+    if (trailingSpacerUnified) container.appendChild(trailingSpacerUnified);
+
     appendOutdatedDiffComments(container, file, commentsMap, hunks);
 
     return container;
@@ -3235,6 +3357,10 @@
     autoExpandSmallGaps(file);
 
     const { diffCommentsMap: commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
+
+    // Leading spacer before first hunk
+    const leadingSpacerSplit = renderLeadingSpacer(hunks[0], file);
+    if (leadingSpacerSplit) container.appendChild(leadingSpacerSplit);
 
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
@@ -3339,6 +3465,10 @@
         }
       }
     }
+
+    // Trailing spacer after last hunk
+    const trailingSpacerSplit = renderTrailingSpacer(hunks[hunks.length - 1], file);
+    if (trailingSpacerSplit) container.appendChild(trailingSpacerSplit);
 
     appendOutdatedDiffComments(container, file, commentsMap, hunks);
 


### PR DESCRIPTION
## Summary
- Adds an expand-down spacer before the first diff hunk when it doesn't start at line 1
- Adds an expand-up spacer after the last diff hunk when it doesn't reach EOF
- Expands 20 lines per click, matching GitHub/GitLab conventions
- Handles pure insertion/deletion edge cases (zero-count hunk gap computation)
- Recomputes hunk headers after expansion to keep line numbers accurate
- Works in both split and unified diff views

## Test plan
- [ ] 12 new E2E tests in `leading-trailing-expand.spec.ts` covering visibility, click behavior, commentability in both modes
- [ ] Auto-expand-gaps test selectors updated for compatibility with leading/trailing spacers
- [ ] All 47 affected tests pass locally

Closes #335
Supersedes #321 (which covered leading spacer only — this adds both leading and trailing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)