### PR TITLE
feat: expand diff context incrementally (20 lines per click)

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -81,8 +81,9 @@ func Capitalize(s string) string {
 }
 GOFILE
 
-# routes.go — will produce a multi-hunk diff with a large gap (>8 unchanged lines)
-# between changed areas, so spacers remain after auto-expansion of small gaps.
+# routes.go — will produce a multi-hunk diff with a large gap (>20 unchanged lines)
+# between changed areas, so spacers remain after auto-expansion of small gaps
+# and incremental diff expansion can be tested.
 cat > routes.go << 'GOFILE'
 package main
 
@@ -109,7 +110,23 @@ func handleTags(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func handleCategories(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func handleSearch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleNotifications(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSettings(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleProfile(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -239,10 +256,11 @@ GOFILE
 # Delete deleted.txt
 rm deleted.txt
 
-# Modify routes.go to produce a multi-hunk diff with a large gap (>8 unchanged lines)
-# between hunks. This ensures spacers remain visible for testing after auto-expansion.
+# Modify routes.go to produce a multi-hunk diff with a large gap (>20 unchanged lines)
+# between hunks. This ensures spacers remain visible for testing after auto-expansion
+# and incremental diff expansion can be tested.
 # Hunk 1: change imports (top). Hunk 2: add new route + function (bottom).
-# The 10+ unchanged handler functions in between create a gap >8 lines.
+# The 10+ unchanged handler functions in between create a gap >20 lines.
 cat > routes.go << 'GOFILE'
 package main
 
@@ -273,7 +291,23 @@ func handleTags(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func handleCategories(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func handleSearch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleNotifications(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSettings(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleProfile(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -348,6 +382,71 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 - **Week 2**: Validation endpoint + tests
 - **Week 3**: Dashboard UI for key management
 MDFILE
+
+# Modify routes.go: change beginning and end, leave large middle gap (>20 unchanged lines)
+cat > routes.go << 'GOFILE'
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func setupRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/users", handleUsers)
+	mux.HandleFunc("/api/posts", handlePosts)
+	mux.HandleFunc("/api/health", handleHealth)
+}
+
+func handleUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handlePosts(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleComments(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleTags(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleCategories(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSearch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleNotifications(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSettings(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleProfile(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleDashboard(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleAnalytics(w http.ResponseWriter, r *http.Request) {
+	log.Println("analytics endpoint hit")
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+GOFILE
 
 git add -A
 git commit -q -m "feat: add auth middleware and plan"

--- a/e2e/tests/auto-expand-gaps.spec.ts
+++ b/e2e/tests/auto-expand-gaps.spec.ts
@@ -161,16 +161,17 @@ test.describe('Large gaps still show spacer', () => {
     await loadPage(page);
   });
 
-  test('large gaps (> 8 lines) still show spacer with expand text', async ({ page }) => {
-    // routes.go has a gap of >8 unchanged lines between its two hunks,
-    // so the spacer should still be visible after auto-expansion.
+  test('large gaps (> 8 lines) still show spacer with unchanged line count', async ({ page }) => {
+    // routes.go has a gap of >20 unchanged lines between its two hunks,
+    // so the spacer should still be visible after auto-expansion, showing
+    // directional expand controls and the unchanged line count.
     const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
     await treeEntry.click();
 
     const routesSection = page.locator('#file-section-routes\\.go');
     const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
-    await expect(spacer).toContainText('Expand');
+    await expect(spacer).toContainText('unchanged line');
   });
 });
 

--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -62,18 +62,17 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     await expect(placeholder).toHaveText('This file was deleted.');
   });
 
-  test('spacer shows "Expand" between hunks', async ({ page }) => {
+  test('spacer shows unchanged line count between hunks', async ({ page }) => {
     await loadPage(page);
 
-    // routes.go has a large gap (>8 lines) between hunks, so a spacer should exist.
-    // Click on it in the file tree to expand and lazy-load its content.
+    // routes.go has a large gap (>20 lines) between hunks, so a spacer should exist
+    // with directional expand controls and an unchanged line count.
     const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
     await treeEntry.click();
 
     const routesSection = page.locator('#file-section-routes\\.go');
     const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
-    await expect(spacer).toContainText('Expand');
     await expect(spacer).toContainText('unchanged line');
   });
 
@@ -86,28 +85,22 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
 
     const routesSection = page.locator('#file-section-routes\\.go');
 
-    // Count spacers before click
-    const spacersBefore = routesSection.locator('.diff-spacer');
-    await expect(spacersBefore.first()).toBeVisible();
-    const spacerCountBefore = await spacersBefore.count();
-    expect(spacerCountBefore).toBeGreaterThan(0);
+    // routes.go has a large gap (>20 lines) — spacer shows directional controls
+    const spacer = routesSection.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
 
     // Count diff rows before expansion
     const rowsBefore = await routesSection.locator('.diff-split-row').count();
 
-    // Click the first spacer
-    const firstSpacer = spacersBefore.first();
-    await firstSpacer.click();
-
-    // After clicking, the spacer count should decrease by 1 (it gets merged)
-    await expect(async () => {
-      const spacerCountAfter = await routesSection.locator('.diff-spacer').count();
-      expect(spacerCountAfter).toBeLessThan(spacerCountBefore);
-    }).toPass();
+    // Click the expand-down button to reveal context lines
+    const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
+    await expandDown.click();
 
     // More rows should be visible after expansion
-    const rowsAfter = await routesSection.locator('.diff-split-row').count();
-    expect(rowsAfter).toBeGreaterThan(rowsBefore);
+    await expect(async () => {
+      const rowsAfter = await routesSection.locator('.diff-split-row').count();
+      expect(rowsAfter).toBeGreaterThan(rowsBefore);
+    }).toPass();
   });
 
   test('expanded lines have comment gutter (+ button) on hover', async ({ page }) => {
@@ -121,8 +114,9 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
 
-    // Click the spacer to expand context lines
-    await spacer.click();
+    // Click expand-down button to expand context lines
+    const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
+    await expandDown.click();
 
     // Wait for re-render — new rows should appear
     await expect(routesSection.locator('.diff-split-row').first()).toBeVisible();

--- a/e2e/tests/incremental-expand.spec.ts
+++ b/e2e/tests/incremental-expand.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+// routes.go has a large gap (>20 lines) between hunks, ideal for incremental expansion testing.
+function routesSection(page: Page) {
+  return page.locator('#file-section-routes\\.go');
+}
+
+test.describe('Incremental Expand — Split Mode (default)', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    // Click routes.go in the file tree to load its diff (may be lazy-loaded)
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+  });
+
+  test('large gap spacer shows expand-down and expand-up controls', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    // The spacer between hunks with a gap > 20 should show directional controls
+    const spacer = section.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
+
+    const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
+    const expandUp = spacer.locator('[aria-label="Expand 20 lines up"]');
+    await expect(expandDown).toBeVisible();
+    await expect(expandUp).toBeVisible();
+  });
+
+  test('clicking expand-down reveals 20 lines below previous hunk', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    // Count rows before expansion
+    const rowsBefore = await section.locator('.diff-split-row').count();
+
+    const spacer = section.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
+
+    // Get original spacer text to know the gap size
+    const spacerText = await spacer.textContent();
+    const gapMatch = spacerText?.match(/(\d+)/);
+    expect(gapMatch).toBeTruthy();
+    const originalGap = parseInt(gapMatch![1], 10);
+    expect(originalGap).toBeGreaterThan(20);
+
+    // Click expand-down
+    const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
+    await expandDown.click();
+
+    // After expansion, more rows should be visible
+    await expect(async () => {
+      const rowsAfter = await section.locator('.diff-split-row').count();
+      expect(rowsAfter).toBe(rowsBefore + 20);
+    }).toPass();
+
+    // A spacer should still exist with updated remaining count
+    const remainingSpacer = section.locator('.diff-spacer').first();
+    await expect(remainingSpacer).toBeVisible();
+    await expect(remainingSpacer).toContainText(`${originalGap - 20}`);
+  });
+
+  test('clicking expand-up reveals 20 lines above next hunk', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    const rowsBefore = await section.locator('.diff-split-row').count();
+
+    const spacer = section.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
+
+    const spacerText = await spacer.textContent();
+    const gapMatch = spacerText?.match(/(\d+)/);
+    const originalGap = parseInt(gapMatch![1], 10);
+
+    // Click expand-up
+    const expandUp = spacer.locator('[aria-label="Expand 20 lines up"]');
+    await expandUp.click();
+
+    // After expansion, more rows should be visible
+    await expect(async () => {
+      const rowsAfter = await section.locator('.diff-split-row').count();
+      expect(rowsAfter).toBe(rowsBefore + 20);
+    }).toPass();
+
+    // A spacer should still exist with updated remaining count
+    const remainingSpacer = section.locator('.diff-spacer').first();
+    await expect(remainingSpacer).toBeVisible();
+    await expect(remainingSpacer).toContainText(`${originalGap - 20}`);
+  });
+
+  test('after partial expansion, spacer shows updated remaining count', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    const spacer = section.locator('.diff-spacer').first();
+    const spacerText = await spacer.textContent();
+    const originalGap = parseInt(spacerText!.match(/(\d+)/)![1], 10);
+
+    // Expand down first
+    await spacer.locator('[aria-label="Expand 20 lines down"]').click();
+
+    // Spacer should show remaining gap
+    const remainingGap = originalGap - 20;
+    await expect(section.locator('.diff-spacer').first()).toContainText(
+      `${remainingGap}`
+    );
+  });
+
+});
+
+test.describe('Incremental Expand — Unified Mode', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    // Click routes.go in the file tree to load its diff (may be lazy-loaded)
+    const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
+    await treeEntry.click();
+    // Switch to unified mode
+    const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+    await unifiedBtn.click();
+    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+  });
+
+  test('large gap spacer shows expand-down and expand-up controls in unified mode', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    const spacer = section.locator('.diff-spacer').first();
+    await expect(spacer).toBeVisible();
+
+    const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
+    const expandUp = spacer.locator('[aria-label="Expand 20 lines up"]');
+    await expect(expandDown).toBeVisible();
+    await expect(expandUp).toBeVisible();
+  });
+
+  test('clicking expand-down in unified mode adds context lines', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    const linesBefore = await section.locator('.diff-line').count();
+
+    const spacer = section.locator('.diff-spacer').first();
+    const spacerText = await spacer.textContent();
+    const originalGap = parseInt(spacerText!.match(/(\d+)/)![1], 10);
+    expect(originalGap).toBeGreaterThan(20);
+
+    await spacer.locator('[aria-label="Expand 20 lines down"]').click();
+
+    // After expansion, more diff lines should be visible
+    await expect(async () => {
+      const linesAfter = await section.locator('.diff-line').count();
+      expect(linesAfter).toBe(linesBefore + 20);
+    }).toPass();
+
+    // Spacer should still exist with updated count
+    await expect(section.locator('.diff-spacer').first()).toContainText(
+      `${originalGap - 20}`
+    );
+  });
+
+  test('clicking expand-up in unified mode adds context lines', async ({ page }) => {
+    const section = routesSection(page);
+    await expect(section).toBeVisible();
+
+    const linesBefore = await section.locator('.diff-line').count();
+
+    const spacer = section.locator('.diff-spacer').first();
+    const spacerText = await spacer.textContent();
+    const originalGap = parseInt(spacerText!.match(/(\d+)/)![1], 10);
+
+    await spacer.locator('[aria-label="Expand 20 lines up"]').click();
+
+    await expect(async () => {
+      const linesAfter = await section.locator('.diff-line').count();
+      expect(linesAfter).toBe(linesBefore + 20);
+    }).toPass();
+
+    await expect(section.locator('.diff-spacer').first()).toContainText(
+      `${originalGap - 20}`
+    );
+  });
+
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2885,8 +2885,6 @@
     const lineComments = comments.filter(function(c) { return c.scope !== 'file'; });
     if (lineComments.length === 0) return;
 
-    const contentLines = file.content.split('\n');
-
     // Work backwards so splicing doesn't shift indices we haven't visited yet
     for (let i = hunks.length - 1; i > 0; i--) {
       const prevHunk = hunks[i - 1];
@@ -2910,13 +2908,7 @@
       if (!hasComment) continue;
 
       // Merge: same logic as the spacer click handler
-      const contextLines = [];
-      for (let j = 0; j < gap; j++) {
-        const newLineNum = prevNewEnd + j;
-        const oldLineNum = prevOldEnd + j;
-        const text = newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
-        contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
-      }
+      const contextLines = buildContextLines(file, prevNewEnd, prevOldEnd, gap);
       const merged = {
         OldStart: prevHunk.OldStart,
         NewStart: prevHunk.NewStart,
@@ -2929,49 +2921,149 @@
     }
   }
 
-  // Helper: render hunk spacer
-  // prevIdx/nextIdx are indices into file.diffHunks so we can merge on expand
-  function renderDiffSpacer(prevHunk, nextHunk, file, prevIdx, nextIdx) {
+  // Helper: build context lines from file content for a range of line numbers
+  function buildContextLines(file, newStart, oldStart, count) {
+    const contentLines = file.content ? file.content.split('\n') : [];
+    const lines = [];
+    for (let i = 0; i < count; i++) {
+      const newLineNum = newStart + i;
+      const oldLineNum = oldStart + i;
+      const text = newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
+      lines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
+    }
+    return lines;
+  }
+
+  // Build a hunk header string from numeric fields, preserving any suffix
+  // (e.g. function name) from the original header.
+  function buildHunkHeader(oldStart, oldCount, newStart, newCount, origHeader) {
+    let suffix = '';
+    if (origHeader) {
+      const m = origHeader.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/);
+      if (m) suffix = m[1];
+    }
+    return '@@ -' + oldStart + ',' + oldCount + ' +' + newStart + ',' + newCount + ' @@' + suffix;
+  }
+
+  // Expand N context lines downward from the previous hunk (top of gap).
+  // Inserts a bridge hunk after prevIdx.
+  function expandDown(file, prevIdx, count) {
+    if (!file.content) return;
+    const hunks = file.diffHunks;
+    const prevHunk = hunks[prevIdx];
+    const prevNewEnd = prevHunk.NewStart + prevHunk.NewCount;
+    const prevOldEnd = prevHunk.OldStart + prevHunk.OldCount;
+
+    const lines = buildContextLines(file, prevNewEnd, prevOldEnd, count);
+    const bridge = {
+      OldStart: prevOldEnd,
+      OldCount: count,
+      NewStart: prevNewEnd,
+      NewCount: count,
+      Header: buildHunkHeader(prevOldEnd, count, prevNewEnd, count, ''),
+      Lines: lines
+    };
+    hunks.splice(prevIdx + 1, 0, bridge);
+    renderFileByPath(file.path);
+  }
+
+  // Expand N context lines upward from the next hunk (bottom of gap).
+  // Inserts a bridge hunk before nextIdx.
+  function expandUp(file, nextIdx, count) {
+    if (!file.content) return;
+    const hunks = file.diffHunks;
+    const nextHunk = hunks[nextIdx];
+    const startNew = nextHunk.NewStart - count;
+    const startOld = nextHunk.OldStart - count;
+
+    const lines = buildContextLines(file, startNew, startOld, count);
+    const bridge = {
+      OldStart: startOld,
+      OldCount: count,
+      NewStart: startNew,
+      NewCount: count,
+      Header: buildHunkHeader(startOld, count, startNew, count, ''),
+      Lines: lines
+    };
+    hunks.splice(nextIdx, 0, bridge);
+    renderFileByPath(file.path);
+  }
+
+  // Expand all remaining context lines in a gap, merging prev + context + next into one hunk.
+  function expandAll(file, prevIdx, nextIdx) {
+    if (!file.content) return;
+    const hunks = file.diffHunks;
+    const prevHunk = hunks[prevIdx];
+    const nextHunk = hunks[nextIdx];
     const prevNewEnd = prevHunk.NewStart + prevHunk.NewCount;
     const prevOldEnd = prevHunk.OldStart + prevHunk.OldCount;
     const gap = nextHunk.NewStart - prevNewEnd;
+
+    const contextLines = buildContextLines(file, prevNewEnd, prevOldEnd, gap);
+    const mergedOldCount = (nextHunk.OldStart + nextHunk.OldCount) - prevHunk.OldStart;
+    const mergedNewCount = (nextHunk.NewStart + nextHunk.NewCount) - prevHunk.NewStart;
+    const merged = {
+      OldStart: prevHunk.OldStart,
+      OldCount: mergedOldCount,
+      NewStart: prevHunk.NewStart,
+      NewCount: mergedNewCount,
+      Header: buildHunkHeader(prevHunk.OldStart, mergedOldCount, prevHunk.NewStart, mergedNewCount, prevHunk.Header),
+      Lines: prevHunk.Lines.concat(contextLines, nextHunk.Lines)
+    };
+    hunks.splice(prevIdx, nextIdx - prevIdx + 1, merged);
+    renderFileByPath(file.path);
+  }
+
+  const EXPAND_STEP = 20;
+
+  // Helper: render hunk spacer with incremental expansion
+  // prevIdx/nextIdx are indices into file.diffHunks
+  function renderDiffSpacer(prevHunk, nextHunk, file, prevIdx, nextIdx) {
+    const prevNewEnd = prevHunk.NewStart + prevHunk.NewCount;
+    const gap = nextHunk.NewStart - prevNewEnd;
     if (gap <= 0) return null;
+
     const spacer = document.createElement('div');
     spacer.className = 'diff-spacer';
-    spacer.innerHTML =
-      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
-      'Expand ' + gap + ' unchanged line' + (gap === 1 ? '' : 's');
 
-    spacer.addEventListener('click', function() {
-      if (!file.content) return;
-      const contentLines = file.content.split('\n');
+    if (gap <= EXPAND_STEP) {
+      // Small gap: single click expands all (original behavior)
+      spacer.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
+        'Expand ' + gap + ' unchanged line' + (gap === 1 ? '' : 's');
+      spacer.addEventListener('click', function() {
+        expandAll(file, prevIdx, nextIdx);
+      });
+    } else {
+      // Large gap: show expand-down (top) and expand-up (bottom) controls
+      const downBtn = document.createElement('button');
+      downBtn.className = 'expand-btn expand-down';
+      downBtn.setAttribute('aria-label', 'Expand 20 lines down');
+      downBtn.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10.5a.75.75 0 0 1-.53-.22l-3.5-3.5a.75.75 0 0 1 1.06-1.06L8 8.69l2.97-2.97a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-.53.22z"/></svg>';
+      downBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        expandDown(file, prevIdx, EXPAND_STEP);
+      });
 
-      // Build context lines to bridge the gap
-      const contextLines = [];
-      for (let i = 0; i < gap; i++) {
-        const newLineNum = prevNewEnd + i;
-        const oldLineNum = prevOldEnd + i;
-        const text = newLineNum <= contentLines.length ? contentLines[newLineNum - 1] : '';
-        contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
-      }
+      const label = document.createElement('span');
+      label.className = 'expand-label';
+      label.textContent = gap + ' unchanged line' + (gap === 1 ? '' : 's');
 
-      // Merge: prev hunk + context lines + next hunk → single hunk
-      const hunks = file.diffHunks;
-      const merged = {
-        OldStart: hunks[prevIdx].OldStart,
-        NewStart: hunks[prevIdx].NewStart,
-        Header: hunks[prevIdx].Header,
-        Lines: hunks[prevIdx].Lines.concat(contextLines, hunks[nextIdx].Lines)
-      };
-      merged.OldCount = (hunks[nextIdx].OldStart + hunks[nextIdx].OldCount) - merged.OldStart;
-      merged.NewCount = (hunks[nextIdx].NewStart + hunks[nextIdx].NewCount) - merged.NewStart;
+      const upBtn = document.createElement('button');
+      upBtn.className = 'expand-btn expand-up';
+      upBtn.setAttribute('aria-label', 'Expand 20 lines up');
+      upBtn.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 5.5a.75.75 0 0 1 .53.22l3.5 3.5a.75.75 0 0 1-1.06 1.06L8 7.31 5.03 10.28a.75.75 0 0 1-1.06-1.06l3.5-3.5A.75.75 0 0 1 8 5.5z"/></svg>';
+      upBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        expandUp(file, nextIdx, EXPAND_STEP);
+      });
 
-      // Replace prevIdx with merged, remove nextIdx
-      hunks.splice(prevIdx, 2, merged);
-
-      // Re-render from data model so all lines get proper interaction
-      renderFileByPath(file.path);
-    });
+      spacer.appendChild(downBtn);
+      spacer.appendChild(label);
+      spacer.appendChild(upBtn);
+    }
 
     return spacer;
   }
@@ -2987,7 +3079,6 @@
     const gap = Math.min(newGap, oldGap);
     if (gap <= 0 || gap === Infinity) return null;
 
-    const EXPAND_STEP = 20;
     const expandCount = Math.min(gap, EXPAND_STEP);
 
     const spacer = document.createElement('div');
@@ -3022,9 +3113,7 @@
       hunk.OldCount += expandCount;
       hunk.NewCount += expandCount;
 
-      // Recompute the header to reflect updated line numbers, preserving any suffix (e.g. function name)
-      const headerSuffix = (hunk.Header.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/) || [])[1] || '';
-      hunk.Header = '@@ -' + hunk.OldStart + ',' + hunk.OldCount + ' +' + hunk.NewStart + ',' + hunk.NewCount + ' @@' + headerSuffix;
+      hunk.Header = buildHunkHeader(hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount, hunk.Header);
 
       renderFileByPath(file.path);
     });
@@ -3044,7 +3133,6 @@
     const gap = totalNewLines - lastNewEnd + 1;
     if (gap <= 0) return null;
 
-    const EXPAND_STEP = 20;
     const expandCount = Math.min(gap, EXPAND_STEP);
 
     const spacer = document.createElement('div');
@@ -3080,9 +3168,7 @@
       hunk.OldCount += count;
       hunk.NewCount += count;
 
-      // Recompute the header to reflect updated line counts, preserving any suffix (e.g. function name)
-      const headerSuffix = (hunk.Header.match(/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/) || [])[1] || '';
-      hunk.Header = '@@ -' + hunk.OldStart + ',' + hunk.OldCount + ' +' + hunk.NewStart + ',' + hunk.NewCount + ' @@' + headerSuffix;
+      hunk.Header = buildHunkHeader(hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount, hunk.Header);
 
       renderFileByPath(file.path);
     });

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3377,6 +3377,32 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .diff-spacer:hover { background: var(--crit-editor-bg-hover); color: var(--crit-editor-fg-muted); }
 .diff-spacer svg { width: 12px; height: 12px; }
 
+/* Incremental expand: directional controls for large gaps */
+.diff-spacer .expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--crit-border);
+  border-radius: var(--crit-r-sm);
+  background: var(--crit-editor-bg);
+  color: var(--crit-editor-fg-muted);
+  cursor: pointer;
+  transition: background var(--crit-dur-fast), color var(--crit-dur-fast);
+}
+.diff-spacer .expand-btn:hover {
+  background: var(--crit-brand-subtle);
+  color: var(--crit-brand);
+  border-color: var(--crit-brand);
+}
+.diff-spacer .expand-btn svg { width: 14px; height: 14px; }
+.diff-spacer .expand-label {
+  flex: 1;
+  text-align: center;
+}
+
 /* ===== Unified Diff (interleaved lines) ===== */
 .diff-container.unified .diff-line {
   display: flex;


### PR DESCRIPTION
## Summary
- Large gaps (>20 lines) between diff hunks now show directional expand-up/expand-down buttons instead of a single "Expand N unchanged lines" click target
- Each click reveals 20 lines from the chosen direction, inserting a "bridge" hunk rather than destructively merging
- Gaps ≤20 lines retain the single-click expand-all behavior
- Adds `buildHunkHeader` helper to properly recompute `@@ ... @@` headers after expansion, preserving function name suffixes
- Works in both split and unified diff views

## Test plan
- [ ] 7 new E2E tests in `incremental-expand.spec.ts` covering directional controls, partial expansion, remaining count update, and both diff modes
- [ ] Existing `expanded-comments`, `diff-rendering`, `auto-expand-gaps` tests updated and passing
- [ ] All 42 affected tests pass locally

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)