### PR TITLE
fix: preserve GitHubID in carryForwardComment to prevent duplicate PR comments

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1897,6 +1897,7 @@ func TestCarryForwardComment(t *testing.T) {
 		Resolved:       true,
 		CarriedForward: false,
 		ReviewRound:    1,
+		GitHubID:       98765,
 	}
 
 	carried := carryForwardComment(old, "c42", "2026-02-01T00:00:00Z")
@@ -1936,6 +1937,9 @@ func TestCarryForwardComment(t *testing.T) {
 	}
 	if carried.Quote != "func foo() {}" {
 		t.Errorf("Quote = %q, want %q", carried.Quote, "func foo() {}")
+	}
+	if carried.GitHubID != 98765 {
+		t.Errorf("GitHubID = %d, want 98765", carried.GitHubID)
 	}
 }
 

--- a/watch.go
+++ b/watch.go
@@ -324,6 +324,7 @@ func carryForwardComment(old Comment, newID string, now string) Comment {
 		Live:           old.Live,
 		ReviewRound:    old.ReviewRound,
 		Replies:        old.Replies,
+		GitHubID:       old.GitHubID,
 	}
 }
 

--- a/watch_test.go
+++ b/watch_test.go
@@ -374,6 +374,26 @@ func TestCarryForwardComment_PreservesQuote(t *testing.T) {
 	}
 }
 
+func TestCarryForwardComment_PreservesGitHubID(t *testing.T) {
+	old := Comment{
+		ID:        "c_old",
+		StartLine: 10,
+		EndLine:   10,
+		Body:      "Fix this",
+		Author:    "reviewer",
+		Scope:     "line",
+		CreatedAt: "2026-04-13T10:00:00Z",
+		UpdatedAt: "2026-04-13T10:00:00Z",
+		GitHubID:  12345,
+	}
+
+	carried := carryForwardComment(old, "c_new", "2026-04-13T11:00:00Z")
+
+	if carried.GitHubID != 12345 {
+		t.Errorf("GitHubID = %d, want 12345", carried.GitHubID)
+	}
+}
+
 // TestWatchGit_SkipsGitStatusWhenNotWaiting verifies that watchGit does not
 // detect edits when waitingForAgent is false, and does detect them once
 // waitingForAgent is set to true.


### PR DESCRIPTION
## Summary
- `carryForwardComment()` in `watch.go` was missing `GitHubID` field when constructing the carried-forward comment
- This caused GitHub PR comments (fetched via `crit pull`) to lose their `GitHubID` after a round-complete, making `crit push` treat them as new comments and post duplicates

Closes #314

## Review
- [x] Code review: passed (go-expert fresh review, all 19 Comment fields verified mapped)
- [x] Parity audit: N/A (backend-only change)

## Test plan
- [x] New test: `TestCarryForwardComment_PreservesGitHubID` in `watch_test.go`
- [x] Updated existing `TestCarryForwardComment` in `session_test.go` to cover GitHubID
- [x] Full test suite passes with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)