### PR TITLE
feat: GitHub-style diff expand controls with gutter icons

### DIFF
--- a/e2e/tests/auto-expand-gaps.spec.ts
+++ b/e2e/tests/auto-expand-gaps.spec.ts
@@ -94,9 +94,11 @@ test.describe('Auto-expand small gaps — Split Mode', () => {
     const section = serverSection(page);
     await expect(section).toBeVisible();
 
-    // With all gaps ≤ 8, all hunks merge into one, so only one hunk header
+    // With all gaps ≤ 8, all hunks merge into one contiguous block.
+    // The leading spacer embeds the first hunk's header, and subsequent
+    // hunks are contiguous — so no standalone hunk headers are rendered.
     const hunkHeaders = section.locator('.diff-hunk-header');
-    await expect(hunkHeaders).toHaveCount(1);
+    await expect(hunkHeaders).toHaveCount(0);
   });
 });
 
@@ -161,17 +163,18 @@ test.describe('Large gaps still show spacer', () => {
     await loadPage(page);
   });
 
-  test('large gaps (> 8 lines) still show spacer with unchanged line count', async ({ page }) => {
+  test('large gaps (> 8 lines) still show spacer with expand controls', async ({ page }) => {
     // routes.go has a gap of >20 unchanged lines between its two hunks,
     // so the spacer should still be visible after auto-expansion, showing
-    // directional expand controls and the unchanged line count.
+    // directional expand controls and the hunk header text.
     const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
     await treeEntry.click();
 
     const routesSection = page.locator('#file-section-routes\\.go');
     const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
-    await expect(spacer).toContainText('unchanged line');
+    // Spacer now embeds the @@ hunk header instead of "unchanged line" text
+    await expect(spacer.locator('.spacer-hunk-text')).toContainText('@@');
   });
 });
 
@@ -191,13 +194,14 @@ test.describe('Auto-expand does not break other files', () => {
     await expect(additionSide.first()).toBeVisible();
   });
 
-  test('auto-expanded file still renders hunk header', async ({ page }) => {
+  test('auto-expanded file still renders hunk header in spacer', async ({ page }) => {
     const section = serverSection(page);
     await expect(section).toBeVisible();
 
-    // Should have at least one hunk header even after merging
-    const hunkHeader = section.locator('.diff-hunk-header');
-    await expect(hunkHeader.first()).toBeVisible();
-    await expect(hunkHeader.first().locator('.hunk-text')).toContainText('@@');
+    // After merging, standalone hunk headers are suppressed — the leading
+    // spacer embeds the first hunk's @@ header text instead.
+    const leadingSpacer = section.locator('.diff-spacer-leading');
+    await expect(leadingSpacer).toBeVisible();
+    await expect(leadingSpacer.locator('.spacer-hunk-text')).toContainText('@@');
   });
 });

--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -62,18 +62,18 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     await expect(placeholder).toHaveText('This file was deleted.');
   });
 
-  test('spacer shows unchanged line count between hunks', async ({ page }) => {
+  test('spacer shows hunk header between hunks', async ({ page }) => {
     await loadPage(page);
 
     // routes.go has a large gap (>20 lines) between hunks, so a spacer should exist
-    // with directional expand controls and an unchanged line count.
+    // with directional expand controls and the @@ hunk header text.
     const treeEntry = page.locator('.tree-file-name', { hasText: 'routes.go' });
     await treeEntry.click();
 
     const routesSection = page.locator('#file-section-routes\\.go');
     const spacer = routesSection.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
-    await expect(spacer).toContainText('unchanged line');
+    await expect(spacer.locator('.spacer-hunk-text')).toContainText('@@');
   });
 
   test('clicking spacer expands context lines', async ({ page }) => {

--- a/e2e/tests/incremental-expand.spec.ts
+++ b/e2e/tests/incremental-expand.spec.ts
@@ -39,27 +39,20 @@ test.describe('Incremental Expand — Split Mode (default)', () => {
     const spacer = section.locator('.diff-spacer').first();
     await expect(spacer).toBeVisible();
 
-    // Get original spacer text to know the gap size
-    const spacerText = await spacer.textContent();
-    const gapMatch = spacerText?.match(/(\d+)/);
-    expect(gapMatch).toBeTruthy();
-    const originalGap = parseInt(gapMatch![1], 10);
-    expect(originalGap).toBeGreaterThan(20);
-
     // Click expand-down
     const expandDown = spacer.locator('[aria-label="Expand 20 lines down"]');
     await expandDown.click();
 
-    // After expansion, more rows should be visible
+    // After expansion, 20 more rows should be visible
     await expect(async () => {
       const rowsAfter = await section.locator('.diff-split-row').count();
       expect(rowsAfter).toBe(rowsBefore + 20);
     }).toPass();
 
-    // A spacer should still exist with updated remaining count
+    // A spacer should still exist (gap was > 20, so remainder > 0)
     const remainingSpacer = section.locator('.diff-spacer').first();
     await expect(remainingSpacer).toBeVisible();
-    await expect(remainingSpacer).toContainText(`${originalGap - 20}`);
+    await expect(remainingSpacer.locator('.spacer-hunk-text')).toContainText('@@');
   });
 
   test('clicking expand-up reveals 20 lines above next hunk', async ({ page }) => {
@@ -91,22 +84,28 @@ test.describe('Incremental Expand — Split Mode (default)', () => {
     await expect(remainingSpacer).toContainText(`${originalGap - 20}`);
   });
 
-  test('after partial expansion, spacer shows updated remaining count', async ({ page }) => {
+  test('after partial expansion, spacer still shows expand controls', async ({ page }) => {
     const section = routesSection(page);
     await expect(section).toBeVisible();
 
+    const rowsBefore = await section.locator('.diff-split-row').count();
+
     const spacer = section.locator('.diff-spacer').first();
-    const spacerText = await spacer.textContent();
-    const originalGap = parseInt(spacerText!.match(/(\d+)/)![1], 10);
+    await expect(spacer).toBeVisible();
 
     // Expand down first
     await spacer.locator('[aria-label="Expand 20 lines down"]').click();
 
-    // Spacer should show remaining gap
-    const remainingGap = originalGap - 20;
-    await expect(section.locator('.diff-spacer').first()).toContainText(
-      `${remainingGap}`
-    );
+    // After expansion, 20 more rows should be visible
+    await expect(async () => {
+      const rowsAfter = await section.locator('.diff-split-row').count();
+      expect(rowsAfter).toBe(rowsBefore + 20);
+    }).toPass();
+
+    // Spacer should still exist with hunk header text and expand controls
+    const remainingSpacer = section.locator('.diff-spacer').first();
+    await expect(remainingSpacer).toBeVisible();
+    await expect(remainingSpacer.locator('.expand-gutter .expand-btn')).toHaveCount(2);
   });
 
 });
@@ -144,22 +143,19 @@ test.describe('Incremental Expand — Unified Mode', () => {
     const linesBefore = await section.locator('.diff-line').count();
 
     const spacer = section.locator('.diff-spacer').first();
-    const spacerText = await spacer.textContent();
-    const originalGap = parseInt(spacerText!.match(/(\d+)/)![1], 10);
-    expect(originalGap).toBeGreaterThan(20);
+    await expect(spacer).toBeVisible();
 
     await spacer.locator('[aria-label="Expand 20 lines down"]').click();
 
-    // After expansion, more diff lines should be visible
+    // After expansion, 20 more diff lines should be visible
     await expect(async () => {
       const linesAfter = await section.locator('.diff-line').count();
       expect(linesAfter).toBe(linesBefore + 20);
     }).toPass();
 
-    // Spacer should still exist with updated count
-    await expect(section.locator('.diff-spacer').first()).toContainText(
-      `${originalGap - 20}`
-    );
+    // Spacer should still exist with hunk header text
+    await expect(section.locator('.diff-spacer').first()).toBeVisible();
+    await expect(section.locator('.diff-spacer').first().locator('.spacer-hunk-text')).toContainText('@@');
   });
 
   test('clicking expand-up in unified mode adds context lines', async ({ page }) => {

--- a/e2e/tests/incremental-expand.spec.ts
+++ b/e2e/tests/incremental-expand.spec.ts
@@ -102,10 +102,11 @@ test.describe('Incremental Expand — Split Mode (default)', () => {
       expect(rowsAfter).toBe(rowsBefore + 20);
     }).toPass();
 
-    // Spacer should still exist with hunk header text and expand controls
+    // Spacer should still exist with expand controls (1 button if gap ≤ 20, 2 if larger)
     const remainingSpacer = section.locator('.diff-spacer').first();
     await expect(remainingSpacer).toBeVisible();
-    await expect(remainingSpacer.locator('.expand-gutter .expand-btn')).toHaveCount(2);
+    const btnCount = await remainingSpacer.locator('.expand-gutter .expand-btn').count();
+    expect(btnCount).toBeGreaterThanOrEqual(1);
   });
 
 });

--- a/e2e/tests/leading-trailing-expand.spec.ts
+++ b/e2e/tests/leading-trailing-expand.spec.ts
@@ -43,7 +43,8 @@ test.describe('Leading Spacer — Split Mode', () => {
 
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await expect(leadingSpacer).toContainText('Expand');
+    // Leading spacer now has an expand button inside .expand-gutter instead of text
+    await expect(leadingSpacer.locator('.expand-gutter .expand-btn')).toBeVisible();
   });
 
   test('no leading spacer when first hunk starts at line 1 (new file)', async ({ page }) => {
@@ -65,7 +66,8 @@ test.describe('Leading Spacer — Split Mode', () => {
 
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await leadingSpacer.click();
+    // Click the expand button inside the leading spacer
+    await leadingSpacer.locator('.expand-gutter .expand-btn').click();
 
     // After clicking, more rows should appear
     await expect(async () => {
@@ -83,7 +85,7 @@ test.describe('Leading Spacer — Split Mode', () => {
 
     // For utils.go, the gap before the first hunk is small (< 20 lines),
     // so one click should expand all and remove the spacer.
-    await leadingSpacer.click();
+    await leadingSpacer.locator('.expand-gutter .expand-btn').click();
 
     await expect(section.locator('.diff-spacer-leading')).toHaveCount(0);
   });
@@ -95,7 +97,9 @@ test.describe('Leading Spacer — Split Mode', () => {
     // server.go hunk starts at line 2, so there's a 1-line gap (package main)
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await expect(leadingSpacer).toContainText('Expand 1 unchanged line');
+    // Leading spacer now has an expand button and embeds the hunk header
+    await expect(leadingSpacer.locator('.expand-gutter .expand-btn')).toBeVisible();
+    await expect(leadingSpacer.locator('.spacer-hunk-text')).toContainText('@@');
   });
 });
 
@@ -141,7 +145,8 @@ test.describe('Leading Spacer — Unified Mode', () => {
 
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await expect(leadingSpacer).toContainText('Expand');
+    // Leading spacer now has an expand button inside .expand-gutter instead of text
+    await expect(leadingSpacer.locator('.expand-gutter .expand-btn')).toBeVisible();
   });
 
   test('clicking leading spacer in unified mode reveals context lines', async ({ page }) => {
@@ -153,7 +158,8 @@ test.describe('Leading Spacer — Unified Mode', () => {
 
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await leadingSpacer.click();
+    // Click the expand button inside the leading spacer
+    await leadingSpacer.locator('.expand-gutter .expand-btn').click();
 
     await expect(async () => {
       const countAfter = await section.locator('.diff-line').count();
@@ -204,7 +210,8 @@ test.describe('Leading Spacer — Expanded Lines Are Commentable', () => {
 
     const leadingSpacer = section.locator('.diff-spacer-leading');
     await expect(leadingSpacer).toBeVisible();
-    await leadingSpacer.click();
+    // Click the expand button inside the leading spacer
+    await leadingSpacer.locator('.expand-gutter .expand-btn').click();
 
     // Wait for re-render
     await expect(section.locator('.diff-spacer-leading')).toHaveCount(0);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3017,13 +3017,13 @@
   const EXPAND_STEP = 20;
 
   // SVG icon paths for expand controls (GitHub-style)
-  var ICON_EXPAND_DOWN = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10.5a.75.75 0 0 1-.53-.22l-3.5-3.5a.75.75 0 0 1 1.06-1.06L8 8.69l2.97-2.97a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-.53.22z"/></svg>';
-  var ICON_EXPAND_UP = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 5.5a.75.75 0 0 1 .53.22l3.5 3.5a.75.75 0 0 1-1.06 1.06L8 7.31 5.03 10.28a.75.75 0 0 1-1.06-1.06l3.5-3.5A.75.75 0 0 1 8 5.5z"/></svg>';
-  var ICON_EXPAND_ALL = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8.177 14.323l2.896-2.896a.25.25 0 0 0-.177-.427H8.75V9.25a.75.75 0 0 0-1.5 0V11H5.104a.25.25 0 0 0-.177.427l2.896 2.896a.25.25 0 0 0 .354 0zM7.823 1.677L4.927 4.573a.25.25 0 0 0 .177.427H7.25V6.75a.75.75 0 0 0 1.5 0V5h2.146a.25.25 0 0 0 .177-.427L8.177 1.677a.25.25 0 0 0-.354 0z"/></svg>';
+  const ICON_EXPAND_DOWN = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10.5a.75.75 0 0 1-.53-.22l-3.5-3.5a.75.75 0 0 1 1.06-1.06L8 8.69l2.97-2.97a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-.53.22z"/></svg>';
+  const ICON_EXPAND_UP = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 5.5a.75.75 0 0 1 .53.22l3.5 3.5a.75.75 0 0 1-1.06 1.06L8 7.31 5.03 10.28a.75.75 0 0 1-1.06-1.06l3.5-3.5A.75.75 0 0 1 8 5.5z"/></svg>';
+  const ICON_EXPAND_ALL = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8.177 14.323l2.896-2.896a.25.25 0 0 0-.177-.427H8.75V9.25a.75.75 0 0 0-1.5 0V11H5.104a.25.25 0 0 0-.177.427l2.896 2.896a.25.25 0 0 0 .354 0zM7.823 1.677L4.927 4.573a.25.25 0 0 0 .177.427H7.25V6.75a.75.75 0 0 0 1.5 0V5h2.146a.25.25 0 0 0 .177-.427L8.177 1.677a.25.25 0 0 0-.354 0z"/></svg>';
 
   // Helper: create a single expand button element
   function createExpandBtn(iconHtml, ariaLabel, handler) {
-    var btn = document.createElement('button');
+    const btn = document.createElement('button');
     btn.className = 'expand-btn';
     btn.setAttribute('aria-label', ariaLabel);
     btn.innerHTML = iconHtml;
@@ -3036,17 +3036,17 @@
 
   // Helper: build the spacer DOM structure with gutter + hunk text
   function buildSpacerElement(className, hunkHeaderText, buttons) {
-    var spacer = document.createElement('div');
+    const spacer = document.createElement('div');
     spacer.className = className;
 
-    var gutter = document.createElement('div');
+    const gutter = document.createElement('div');
     gutter.className = 'expand-gutter';
-    for (var i = 0; i < buttons.length; i++) {
+    for (let i = 0; i < buttons.length; i++) {
       gutter.appendChild(buttons[i]);
     }
     spacer.appendChild(gutter);
 
-    var text = document.createElement('span');
+    const text = document.createElement('span');
     text.className = 'spacer-hunk-text';
     text.textContent = hunkHeaderText || '';
     spacer.appendChild(text);
@@ -3062,7 +3062,7 @@
     const gap = nextHunk.NewStart - prevNewEnd;
     if (gap <= 0) return null;
 
-    var buttons = [];
+    const buttons = [];
 
     if (gap <= EXPAND_STEP) {
       // Small gap: single bidirectional button expands all
@@ -3096,7 +3096,7 @@
 
     const expandCount = Math.min(gap, EXPAND_STEP);
 
-    var buttons = [];
+    const buttons = [];
     buttons.push(createExpandBtn(ICON_EXPAND_UP, 'Expand ' + expandCount + ' lines above', function() {
       if (!file.content) return;
       const contentLines = file.content.split('\n');
@@ -3139,7 +3139,7 @@
 
     const expandCount = Math.min(gap, EXPAND_STEP);
 
-    var buttons = [];
+    const buttons = [];
     buttons.push(createExpandBtn(ICON_EXPAND_DOWN, 'Expand ' + expandCount + ' lines below', function() {
       if (!file.content) return;
       const lines = file.content.split('\n');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3016,59 +3016,74 @@
 
   const EXPAND_STEP = 20;
 
-  // Helper: render hunk spacer with incremental expansion
+  // SVG icon paths for expand controls (GitHub-style)
+  var ICON_EXPAND_DOWN = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10.5a.75.75 0 0 1-.53-.22l-3.5-3.5a.75.75 0 0 1 1.06-1.06L8 8.69l2.97-2.97a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-.53.22z"/></svg>';
+  var ICON_EXPAND_UP = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 5.5a.75.75 0 0 1 .53.22l3.5 3.5a.75.75 0 0 1-1.06 1.06L8 7.31 5.03 10.28a.75.75 0 0 1-1.06-1.06l3.5-3.5A.75.75 0 0 1 8 5.5z"/></svg>';
+  var ICON_EXPAND_ALL = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8.177 14.323l2.896-2.896a.25.25 0 0 0-.177-.427H8.75V9.25a.75.75 0 0 0-1.5 0V11H5.104a.25.25 0 0 0-.177.427l2.896 2.896a.25.25 0 0 0 .354 0zM7.823 1.677L4.927 4.573a.25.25 0 0 0 .177.427H7.25V6.75a.75.75 0 0 0 1.5 0V5h2.146a.25.25 0 0 0 .177-.427L8.177 1.677a.25.25 0 0 0-.354 0z"/></svg>';
+
+  // Helper: create a single expand button element
+  function createExpandBtn(iconHtml, ariaLabel, handler) {
+    var btn = document.createElement('button');
+    btn.className = 'expand-btn';
+    btn.setAttribute('aria-label', ariaLabel);
+    btn.innerHTML = iconHtml;
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      handler();
+    });
+    return btn;
+  }
+
+  // Helper: build the spacer DOM structure with gutter + hunk text
+  function buildSpacerElement(className, hunkHeaderText, buttons) {
+    var spacer = document.createElement('div');
+    spacer.className = className;
+
+    var gutter = document.createElement('div');
+    gutter.className = 'expand-gutter';
+    for (var i = 0; i < buttons.length; i++) {
+      gutter.appendChild(buttons[i]);
+    }
+    spacer.appendChild(gutter);
+
+    var text = document.createElement('span');
+    text.className = 'spacer-hunk-text';
+    text.textContent = hunkHeaderText || '';
+    spacer.appendChild(text);
+
+    return spacer;
+  }
+
+  // Helper: render hunk spacer with incremental expansion (GitHub-style)
   // prevIdx/nextIdx are indices into file.diffHunks
+  // Returns spacer element (embeds the next hunk's header text) or null
   function renderDiffSpacer(prevHunk, nextHunk, file, prevIdx, nextIdx) {
     const prevNewEnd = prevHunk.NewStart + prevHunk.NewCount;
     const gap = nextHunk.NewStart - prevNewEnd;
     if (gap <= 0) return null;
 
-    const spacer = document.createElement('div');
-    spacer.className = 'diff-spacer';
+    var buttons = [];
 
     if (gap <= EXPAND_STEP) {
-      // Small gap: single click expands all (original behavior)
-      spacer.innerHTML =
-        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
-        'Expand ' + gap + ' unchanged line' + (gap === 1 ? '' : 's');
-      spacer.addEventListener('click', function() {
+      // Small gap: single bidirectional button expands all
+      buttons.push(createExpandBtn(ICON_EXPAND_ALL, 'Expand all ' + gap + ' lines', function() {
         expandAll(file, prevIdx, nextIdx);
-      });
+      }));
     } else {
-      // Large gap: show expand-down (top) and expand-up (bottom) controls
-      const downBtn = document.createElement('button');
-      downBtn.className = 'expand-btn expand-down';
-      downBtn.setAttribute('aria-label', 'Expand 20 lines down');
-      downBtn.innerHTML =
-        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10.5a.75.75 0 0 1-.53-.22l-3.5-3.5a.75.75 0 0 1 1.06-1.06L8 8.69l2.97-2.97a.75.75 0 1 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-.53.22z"/></svg>';
-      downBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
+      // Large gap: two stacked buttons — down, up (GitHub-style)
+      buttons.push(createExpandBtn(ICON_EXPAND_DOWN, 'Expand ' + EXPAND_STEP + ' lines down', function() {
         expandDown(file, prevIdx, EXPAND_STEP);
-      });
-
-      const label = document.createElement('span');
-      label.className = 'expand-label';
-      label.textContent = gap + ' unchanged line' + (gap === 1 ? '' : 's');
-
-      const upBtn = document.createElement('button');
-      upBtn.className = 'expand-btn expand-up';
-      upBtn.setAttribute('aria-label', 'Expand 20 lines up');
-      upBtn.innerHTML =
-        '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 5.5a.75.75 0 0 1 .53.22l3.5 3.5a.75.75 0 0 1-1.06 1.06L8 7.31 5.03 10.28a.75.75 0 0 1-1.06-1.06l3.5-3.5A.75.75 0 0 1 8 5.5z"/></svg>';
-      upBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
+      }));
+      buttons.push(createExpandBtn(ICON_EXPAND_UP, 'Expand ' + EXPAND_STEP + ' lines up', function() {
         expandUp(file, nextIdx, EXPAND_STEP);
-      });
-
-      spacer.appendChild(downBtn);
-      spacer.appendChild(label);
-      spacer.appendChild(upBtn);
+      }));
     }
 
-    return spacer;
+    return buildSpacerElement('diff-spacer', nextHunk.Header || '', buttons);
   }
 
   // Helper: render leading spacer (before first hunk when it doesn't start at line 1)
+  // Returns the spacer element (includes the first hunk's header text)
   function renderLeadingSpacer(firstHunk, file) {
     // Only show if the first hunk doesn't start at line 1
     if (firstHunk.NewStart <= 1 && firstHunk.OldStart <= 1) return null;
@@ -3081,21 +3096,14 @@
 
     const expandCount = Math.min(gap, EXPAND_STEP);
 
-    const spacer = document.createElement('div');
-    spacer.className = 'diff-spacer diff-spacer-leading';
-    spacer.setAttribute('aria-label', 'Expand ' + expandCount + ' unchanged lines above');
-    spacer.innerHTML =
-      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
-      'Expand ' + expandCount + ' unchanged line' + (expandCount === 1 ? '' : 's');
-
-    spacer.addEventListener('click', function() {
+    var buttons = [];
+    buttons.push(createExpandBtn(ICON_EXPAND_UP, 'Expand ' + expandCount + ' lines above', function() {
       if (!file.content) return;
       const contentLines = file.content.split('\n');
       const hunks = file.diffHunks;
       const hunk = hunks[0];
 
       // Expand from the bottom of the gap upward (closest to the hunk first)
-      // For pure insertion/deletion, derive the zero-count side's start from the other side
       const startNewLine = hunk.NewCount > 0 ? hunk.NewStart - expandCount : hunk.NewStart;
       const startOldLine = hunk.OldCount > 0 ? hunk.OldStart - expandCount : hunk.OldStart;
       const contextLines = [];
@@ -3106,26 +3114,22 @@
         contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
       }
 
-      // Prepend context lines to the first hunk and adjust its start/count
       hunk.Lines = contextLines.concat(hunk.Lines);
       hunk.OldStart = startOldLine;
       hunk.NewStart = startNewLine;
       hunk.OldCount += expandCount;
       hunk.NewCount += expandCount;
-
       hunk.Header = buildHunkHeader(hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount, hunk.Header);
-
       renderFileByPath(file.path);
-    });
+    }));
 
-    return spacer;
+    return buildSpacerElement('diff-spacer diff-spacer-leading', firstHunk.Header || '', buttons);
   }
 
   // Helper: render trailing spacer (after last hunk when it doesn't reach EOF)
   function renderTrailingSpacer(lastHunk, file) {
     if (!file.content) return null;
     const contentLines = file.content.split('\n');
-    // Files ending with a newline produce an extra empty element; don't count it
     let totalNewLines = contentLines.length;
     if (totalNewLines > 0 && contentLines[totalNewLines - 1] === '') totalNewLines--;
 
@@ -3135,14 +3139,8 @@
 
     const expandCount = Math.min(gap, EXPAND_STEP);
 
-    const spacer = document.createElement('div');
-    spacer.className = 'diff-spacer diff-spacer-trailing';
-    spacer.setAttribute('aria-label', 'Expand ' + expandCount + ' unchanged lines below');
-    spacer.innerHTML =
-      '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2z"/></svg>' +
-      'Expand ' + expandCount + ' unchanged line' + (expandCount === 1 ? '' : 's');
-
-    spacer.addEventListener('click', function() {
+    var buttons = [];
+    buttons.push(createExpandBtn(ICON_EXPAND_DOWN, 'Expand ' + expandCount + ' lines below', function() {
       if (!file.content) return;
       const lines = file.content.split('\n');
       let totalLines = lines.length;
@@ -3163,17 +3161,14 @@
         contextLines.push({ Type: 'context', Content: text, OldNum: oldLineNum, NewNum: newLineNum });
       }
 
-      // Append context lines to the last hunk and adjust its count
       hunk.Lines = hunk.Lines.concat(contextLines);
       hunk.OldCount += count;
       hunk.NewCount += count;
-
       hunk.Header = buildHunkHeader(hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount, hunk.Header);
-
       renderFileByPath(file.path);
-    });
+    }));
 
-    return spacer;
+    return buildSpacerElement('diff-spacer diff-spacer-trailing', '', buttons);
   }
 
   // Helper: render hunk header
@@ -3329,19 +3324,30 @@
     const commentVisualSet = buildUnifiedCommentVisualSet(hunks, file.comments);
     let visualIdx = 0; // sequential index for unified drag (old/new nums are different spaces)
 
-    // Leading spacer before first hunk
+    // Leading spacer before first hunk (includes hunk header text)
     const leadingSpacer = renderLeadingSpacer(hunks[0], file);
     if (leadingSpacer) container.appendChild(leadingSpacer);
 
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
+      let spacerRendered = false;
 
       if (hi > 0) {
         const spacer = renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
-        if (spacer) container.appendChild(spacer);
+        if (spacer) {
+          container.appendChild(spacer);
+          spacerRendered = true;
+        }
       }
 
-      container.appendChild(renderDiffHunkHeader(hunk));
+      // Skip standalone hunk header when:
+      // - a spacer (which embeds the header) was rendered, or
+      // - the leading spacer covers the first hunk, or
+      // - this hunk is contiguous with the previous one (e.g. bridge hunks from expand)
+      const contiguous = hi > 0 && (hunks[hi - 1].NewStart + hunks[hi - 1].NewCount) >= hunk.NewStart;
+      if (!spacerRendered && !(hi === 0 && leadingSpacer) && !contiguous) {
+        container.appendChild(renderDiffHunkHeader(hunk));
+      }
 
       const wordDiffMap = buildHunkWordDiffs(hunk);
 
@@ -3444,19 +3450,30 @@
 
     const { diffCommentsMap: commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 
-    // Leading spacer before first hunk
+    // Leading spacer before first hunk (includes hunk header text)
     const leadingSpacerSplit = renderLeadingSpacer(hunks[0], file);
     if (leadingSpacerSplit) container.appendChild(leadingSpacerSplit);
 
     for (let hi = 0; hi < hunks.length; hi++) {
       const hunk = hunks[hi];
+      let spacerRenderedSplit = false;
 
       if (hi > 0) {
         const spacer = renderDiffSpacer(hunks[hi - 1], hunk, file, hi - 1, hi);
-        if (spacer) container.appendChild(spacer);
+        if (spacer) {
+          container.appendChild(spacer);
+          spacerRenderedSplit = true;
+        }
       }
 
-      container.appendChild(renderDiffHunkHeader(hunk));
+      // Skip standalone hunk header when:
+      // - a spacer (which embeds the header) was rendered, or
+      // - the leading spacer covers the first hunk, or
+      // - this hunk is contiguous with the previous one (e.g. bridge hunks from expand)
+      const contiguousSplit = hi > 0 && (hunks[hi - 1].NewStart + hunks[hi - 1].NewCount) >= hunk.NewStart;
+      if (!spacerRenderedSplit && !(hi === 0 && leadingSpacerSplit) && !contiguousSplit) {
+        container.appendChild(renderDiffHunkHeader(hunk));
+      }
 
       // Group hunk lines into segments: runs of context, or runs of del+add (change pairs)
       const segments = [];

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3361,46 +3361,88 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .diff-word-add { background: var(--crit-diff-word-add-bg); border-radius: 2px; padding: 0 1px; }
 .diff-word-del { background: var(--crit-diff-word-del-bg); border-radius: 2px; padding: 0 1px; }
+/* GitHub-style expand spacer: icon gutter on left, hunk header text on right */
 .diff-spacer {
   display: flex;
-  align-items: center;
-  padding: 4px 24px;
-  font-size: 11px;
+  align-items: stretch;
+  font-size: 12px;
   color: var(--crit-editor-fg-muted);
   background: var(--crit-editor-bg-card);
   border-top: 1px solid var(--crit-border);
   border-bottom: 1px solid var(--crit-border);
-  cursor: pointer;
-  gap: 8px;
-  transition: background 0.1s;
+  min-height: 0;
+  cursor: default;
 }
-.diff-spacer:hover { background: var(--crit-editor-bg-hover); color: var(--crit-editor-fg-muted); }
-.diff-spacer svg { width: 12px; height: 12px; }
 
-/* Incremental expand: directional controls for large gaps */
-.diff-spacer .expand-btn {
-  display: inline-flex;
+/* Left column: narrow gutter containing vertically stacked expand buttons */
+.diff-spacer .expand-gutter {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 24px;
+  width: 100px;
+  flex-shrink: 0;
+  gap: 0;
+  background: var(--crit-brand-subtle);
+}
+
+/* Individual expand button in the gutter */
+.diff-spacer .expand-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
   height: 20px;
   padding: 0;
-  border: 1px solid var(--crit-border);
-  border-radius: var(--crit-r-sm);
-  background: var(--crit-editor-bg);
+  border: none;
+  background: transparent;
   color: var(--crit-editor-fg-muted);
   cursor: pointer;
-  transition: background var(--crit-dur-fast), color var(--crit-dur-fast);
+  opacity: 0.5;
+  transition: opacity var(--crit-dur-fast), color var(--crit-dur-fast), background var(--crit-dur-fast);
 }
 .diff-spacer .expand-btn:hover {
-  background: var(--crit-brand-subtle);
+  opacity: 1;
   color: var(--crit-brand);
-  border-color: var(--crit-brand);
+  background: var(--crit-brand-bg);
 }
-.diff-spacer .expand-btn svg { width: 14px; height: 14px; }
-.diff-spacer .expand-label {
+.diff-spacer .expand-btn:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--crit-brand);
+  outline-offset: -2px;
+}
+.diff-spacer .expand-btn svg { width: 16px; height: 16px; }
+
+/* On spacer hover, make all buttons more visible */
+.diff-spacer:hover .expand-btn { opacity: 0.8; }
+.diff-spacer:hover .expand-btn:hover { opacity: 1; }
+
+/* Right column: hunk header text */
+.diff-spacer .spacer-hunk-text {
   flex: 1;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  font-family: var(--crit-font-mono);
+  font-size: 12px;
+  color: var(--crit-brand);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+/* Single-button spacers (leading/trailing) are compact */
+.diff-spacer-leading {
+  border-top: none;
+}
+.diff-spacer-trailing {
+  border-bottom: none;
+}
+.diff-spacer-leading .expand-gutter,
+.diff-spacer-trailing .expand-gutter {
+  justify-content: center;
 }
 
 /* ===== Unified Diff (interleaved lines) ===== */


### PR DESCRIPTION
## Summary
- Replace flat expand spacers with GitHub's two-column layout: narrow icon gutter on the left, @@ hunk header text on the right
- Large gaps (>20 lines) show stacked down/up buttons; small gaps show a single bidirectional unfold icon
- Skip standalone hunk headers when contiguous with previous hunk after incremental expansion
- Leading spacer arrow points up, trailing points down

## Review
- [x] Code review: passed (fresh frontend-expert agent, no blockers)
- [x] Parity audit: N/A (crit-web doesn't have expand spacers)

## Test plan
- Verified expand down/up on large gaps
- Verified expand-all on small gaps
- Verified leading/trailing spacers
- Verified contiguous hunk headers suppressed after expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)