### PR TITLE
fix: add response.ok checks and fix doFinishReview error recovery

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4578,6 +4578,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ body: body.trim() })
         });
+        if (!res.ok) throw new Error('Server returned ' + res.status);
         const updated = await res.json();
         const idx = file.comments.findIndex(c => c.id === formObj.editingId);
         if (idx >= 0) file.comments[idx] = updated;
@@ -4601,6 +4602,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
+        if (!res.ok) throw new Error('Server returned ' + res.status);
         const newComment = await res.json();
         file.comments.push(newComment);
         created = newComment;
@@ -6182,9 +6184,11 @@
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch {}
-    } catch {}
-
-    setUIState('waiting');
+      setUIState('waiting');
+    } catch (err) {
+      console.error('Error finishing review:', err);
+      showMiniToast('Failed to finish review');
+    }
   }
 
   async function resolveAllAndFinish() {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -835,7 +835,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   text-align: center;
   min-height: 60px;
 }
-.mermaid-rendered svg {
+.mermaid svg {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
## Summary
- Add `response.ok` validation in `submitComment()` for both PUT and POST paths — previously, server errors were silently swallowed and could corrupt the comment array or lose the user's draft
- Move `setUIState('waiting')` inside try block in `doFinishReview()` — previously, a fetch failure would strand the user on the waiting overlay with no way to return to editing
- Fix dead `.mermaid-rendered` CSS selector to target actual `.mermaid` class used by mermaid diagram rendering

## Test plan
- [ ] Add a comment, verify it saves successfully (golden path)
- [ ] Verify mermaid diagrams still render with correct max-width constraint
- [ ] (Manual) Simulate server error during comment save — user should see error toast, form stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)