### PR TITLE
feat: redesign disconnected state as a sticky banner

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6463,13 +6463,12 @@
   }
 
   function showDisconnected() {
-    const overlay = document.createElement('div');
-    overlay.className = 'disconnected-overlay';
-    const box = document.createElement('div');
-    box.className = 'disconnected-dialog';
-    box.innerHTML = '<div class="disconnected-title">Server stopped</div><div class="disconnected-message">You can close this tab.</div>';
-    overlay.appendChild(box);
-    document.body.appendChild(overlay);
+    const header = document.querySelector('.header');
+    const banner = document.createElement('div');
+    banner.className = 'disconnected-banner';
+    banner.textContent = 'Server stopped \u2014 you can safely close this tab';
+    banner.style.top = header.offsetHeight + 'px';
+    header.insertAdjacentElement('afterend', banner);
   }
 
   // ===== Share =====

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6466,9 +6466,24 @@
     const header = document.querySelector('.header');
     const banner = document.createElement('div');
     banner.className = 'disconnected-banner';
-    banner.textContent = 'Server stopped \u2014 you can safely close this tab';
+    banner.setAttribute('role', 'status');
+    banner.setAttribute('aria-live', 'polite');
+
+    const pill = document.createElement('div');
+    pill.className = 'disconnected-pill';
+    pill.innerHTML = '<svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="6" fill="currentColor" opacity="0.18"/><circle cx="7" cy="7" r="6" stroke="currentColor" stroke-width="1.25"/><path d="M4.5 7.1 L6.3 8.9 L9.5 5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Session complete';
+
+    const text = document.createElement('span');
+    text.className = 'disconnected-text';
+    text.textContent = 'Server stopped \u2014 your review is now read only. Safe to close this tab.';
+
+    banner.appendChild(pill);
+    banner.appendChild(text);
     banner.style.top = header.offsetHeight + 'px';
     header.insertAdjacentElement('afterend', banner);
+
+    const mainLayout = document.querySelector('.main-layout');
+    if (mainLayout) mainLayout.classList.add('is-finished');
   }
 
   // ===== Share =====

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1636,32 +1636,22 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 
 
-/* ===== Disconnected Overlay ===== */
-.disconnected-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--crit-overlay-bg-heavy);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10000;
-}
-.disconnected-dialog {
-  background: var(--crit-editor-bg);
-  border: 1px solid var(--crit-border);
-  border-radius: 12px;
-  padding: 32px 40px;
+/* ===== Disconnected Banner ===== */
+.disconnected-banner {
+  position: sticky;
+  z-index: 99;
+  padding: 6px 24px;
+  background: var(--crit-yellow-bg);
+  border-bottom: 1px solid var(--crit-yellow-border);
   text-align: center;
-  color: var(--crit-editor-fg);
-  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--crit-yellow);
+  animation: disconnected-banner-in 0.3s ease-out;
 }
-.disconnected-title {
-  font-size: 20px;
-  font-weight: 600;
-  margin-bottom: 8px;
-}
-.disconnected-message {
-  color: var(--crit-editor-fg-secondary);
+@keyframes disconnected-banner-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ===== Waiting Overlay ===== */

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1640,18 +1640,58 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .disconnected-banner {
   position: sticky;
   z-index: 99;
-  padding: 6px 24px;
-  background: var(--crit-yellow-bg);
-  border-bottom: 1px solid var(--crit-yellow-border);
-  text-align: center;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--crit-yellow);
-  animation: disconnected-banner-in 0.3s ease-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 10px 24px;
+  background: var(--crit-bg-card);
+  border-bottom: 1px solid var(--crit-border);
+  animation: disconnected-banner-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 @keyframes disconnected-banner-in {
-  from { opacity: 0; transform: translateY(-4px); }
+  from { opacity: 0; transform: translateY(-6px); }
   to { opacity: 1; transform: translateY(0); }
+}
+.disconnected-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px 3px 7px;
+  background: var(--crit-finish-pill-bg);
+  border: 1px solid var(--crit-finish-pill-border);
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--crit-finish-pill-fg);
+  flex-shrink: 0;
+}
+.disconnected-pill svg {
+  flex-shrink: 0;
+  animation: disconnected-check-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 0.25s both;
+}
+@keyframes disconnected-check-pop {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+.disconnected-text {
+  font-size: 13px;
+  color: var(--crit-finish-body-fg);
+}
+.main-layout.is-finished::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  background: var(--crit-finish-scrim);
+  pointer-events: none;
+  animation: disconnected-scrim-in 0.6s ease 0.15s both;
+  backdrop-filter: blur(0.5px);
+}
+@keyframes disconnected-scrim-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* ===== Waiting Overlay ===== */

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -119,7 +119,6 @@
 
   /* ---- UI states ---- */
   --crit-overlay-bg:       rgba(0,0,0,0.5);
-  --crit-overlay-bg-heavy: rgba(0,0,0,0.6);
   --crit-btn-danger-hover-bg:  rgba(247, 118, 142, 0.1);
   --crit-toast-error-bg:       rgba(247, 118, 142, 0.14);
   --crit-toast-ghost-hover-bg: rgba(255,255,255,0.06);
@@ -235,7 +234,6 @@
     --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
     --crit-overlay-bg:       rgba(0,0,0,0.5);
-    --crit-overlay-bg-heavy: rgba(0,0,0,0.6);
     --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);
     --crit-toast-error-bg:       rgba(196, 31, 42, 0.1);
     --crit-toast-ghost-hover-bg: rgba(0,0,0,0.04);
@@ -351,7 +349,6 @@
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
   --crit-overlay-bg:       rgba(0,0,0,0.5);
-  --crit-overlay-bg-heavy: rgba(0,0,0,0.6);
   --crit-btn-danger-hover-bg:  rgba(247, 118, 142, 0.1);
   --crit-toast-error-bg:       rgba(247, 118, 142, 0.14);
   --crit-toast-ghost-hover-bg: rgba(255,255,255,0.06);
@@ -466,7 +463,6 @@
   --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
   --crit-overlay-bg:       rgba(0,0,0,0.5);
-  --crit-overlay-bg-heavy: rgba(0,0,0,0.6);
   --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);
   --crit-toast-error-bg:       rgba(196, 31, 42, 0.1);
   --crit-toast-ghost-hover-bg: rgba(0,0,0,0.04);

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -117,6 +117,13 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Finish/disconnected state ---- */
+  --crit-finish-pill-bg:     rgba(86, 211, 100, 0.10);
+  --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
+  --crit-finish-pill-fg:     #56d364;
+  --crit-finish-body-fg:     #9ba3bf;
+  --crit-finish-scrim:       rgba(14, 15, 19, 0.55);
+
   /* ---- UI states ---- */
   --crit-overlay-bg:       rgba(0,0,0,0.5);
   --crit-btn-danger-hover-bg:  rgba(247, 118, 142, 0.1);
@@ -233,6 +240,13 @@
     --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
     --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
+    /* ---- Finish/disconnected state ---- */
+    --crit-finish-pill-bg:     rgba(22, 127, 48, 0.08);
+    --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
+    --crit-finish-pill-fg:     #167f30;
+    --crit-finish-body-fg:     #5a6275;
+    --crit-finish-scrim:       rgba(245, 246, 250, 0.60);
+
     --crit-overlay-bg:       rgba(0,0,0,0.5);
     --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);
     --crit-toast-error-bg:       rgba(196, 31, 42, 0.1);
@@ -348,6 +362,13 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Finish/disconnected state ---- */
+  --crit-finish-pill-bg:     rgba(86, 211, 100, 0.10);
+  --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
+  --crit-finish-pill-fg:     #56d364;
+  --crit-finish-body-fg:     #9ba3bf;
+  --crit-finish-scrim:       rgba(14, 15, 19, 0.55);
+
   --crit-overlay-bg:       rgba(0,0,0,0.5);
   --crit-btn-danger-hover-bg:  rgba(247, 118, 142, 0.1);
   --crit-toast-error-bg:       rgba(247, 118, 142, 0.14);
@@ -461,6 +482,14 @@
   --crit-yellow-subtle: rgba(122, 88, 0, 0.06);
   --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
   --crit-yellow-border: rgba(122, 88, 0, 0.16);
+
+  /* ---- Finish/disconnected state ---- */
+  --crit-finish-bg:          #f8f9fc;
+  --crit-finish-pill-bg:     rgba(22, 127, 48, 0.08);
+  --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
+  --crit-finish-pill-fg:     #167f30;
+  --crit-finish-body-fg:     #5a6275;
+  --crit-finish-scrim:       rgba(245, 246, 250, 0.60);
 
   --crit-overlay-bg:       rgba(0,0,0,0.5);
   --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -484,7 +484,6 @@
   --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
   /* ---- Finish/disconnected state ---- */
-  --crit-finish-bg:          #f8f9fc;
   --crit-finish-pill-bg:     rgba(22, 127, 48, 0.08);
   --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
   --crit-finish-pill-fg:     #167f30;


### PR DESCRIPTION
## Summary
- Replaces the full-screen blocking overlay ("Server stopped" modal) with a slim sticky banner inserted after the header — full width, non-intrusive
- Banner shows a green "Session complete" pill + single-line message: "Server stopped — your review is now read only. Safe to close this tab."
- Adds a soft fixed scrim over the diff content to reinforce the read-only terminal state without obscuring the review
- Introduces `--crit-finish-*` theme variables across all 4 theme blocks

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (disconnected state is crit-only; no local server in crit-web)

## Test plan
- Trigger server stop while browser is open — banner appears below header, full width
- Verify in dark, light, and system themes
- Verify diff content is still readable through the scrim

🤖 Generated with [Claude Code](https://claude.com/claude-code)