### PR TITLE
feat: include cli_args in share payload for local session refresh

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,8 +188,9 @@ func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, 
 
 func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL, authToken string, showQR bool) {
 	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
+	cliArgs := loadCliArgsFromReviewFile(critPath)
 
-	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken)
+	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken, cliArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/server.go
+++ b/server.go
@@ -357,8 +357,9 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 
 	critPath := s.session.Load().critJSONPath()
 	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
+	cliArgs := loadCliArgsFromReviewFile(critPath)
 
-	url, deleteToken, err := shareFilesToWeb(files, comments, s.shareURL, reviewRound, s.authToken)
+	url, deleteToken, err := shareFilesToWeb(files, comments, s.shareURL, reviewRound, s.authToken, cliArgs)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)

--- a/session.go
+++ b/session.go
@@ -227,6 +227,7 @@ type CritJSON struct {
 	ShareScope     string                  `json:"share_scope,omitempty"`
 	LastShareHash  string                  `json:"last_share_hash,omitempty"`
 	ReviewComments []Comment               `json:"review_comments,omitempty"`
+	CliArgs        []string                `json:"cli_args,omitempty"`
 	Files          map[string]CritJSONFile `json:"files"`
 }
 
@@ -1546,6 +1547,7 @@ type writeFilesSnapshot struct {
 	deleteToken    string
 	shareScope     string
 	reviewComments []Comment
+	cliArgs        []string
 	// Per-file data needed for the merge. We copy comments so the snapshot
 	// is independent of later in-memory mutations.
 	files []writeFileSnapshot
@@ -1621,6 +1623,7 @@ func buildCritJSON(snap writeFilesSnapshot) CritJSON {
 	cj.DeleteToken = snap.deleteToken
 	cj.ShareScope = snap.shareScope
 	cj.ReviewComments = snap.reviewComments
+	cj.CliArgs = snap.cliArgs
 
 	for _, fs := range snap.files {
 		mergeFileSnapshotIntoCritJSON(&cj, fs)
@@ -1736,6 +1739,7 @@ func (s *Session) snapshotForWrite(critPath string) writeFilesSnapshot {
 		deleteToken:    s.deleteToken,
 		shareScope:     s.shareScope,
 		reviewComments: rc,
+		cliArgs:        s.CLIArgs,
 		files:          make([]writeFileSnapshot, len(s.Files)),
 	}
 	for i, f := range s.Files {

--- a/share.go
+++ b/share.go
@@ -84,7 +84,7 @@ type shareComment struct {
 }
 
 // buildSharePayload constructs the JSON payload for POST /api/reviews.
-func buildSharePayload(files []shareFile, comments []shareComment, reviewRound int) map[string]any {
+func buildSharePayload(files []shareFile, comments []shareComment, reviewRound int, cliArgs []string) map[string]any {
 	fileList := make([]map[string]any, len(files))
 	for i, f := range files {
 		entry := map[string]any{"path": f.Path, "content": f.Content}
@@ -96,16 +96,20 @@ func buildSharePayload(files []shareFile, comments []shareComment, reviewRound i
 	if comments == nil {
 		comments = []shareComment{}
 	}
-	return map[string]any{
+	payload := map[string]any{
 		"files":        fileList,
 		"review_round": reviewRound,
 		"comments":     comments,
 	}
+	if len(cliArgs) > 0 {
+		payload["cli_args"] = cliArgs
+	}
+	return payload
 }
 
 // shareFilesToWeb uploads files to a crit-web instance and returns the share URL and delete token.
-func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string, reviewRound int, authToken string) (string, string, error) {
-	payload := buildSharePayload(files, comments, reviewRound)
+func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string, reviewRound int, authToken string, cliArgs []string) (string, string, error) {
+	payload := buildSharePayload(files, comments, reviewRound, cliArgs)
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return "", "", fmt.Errorf("marshaling payload: %w", err)
@@ -144,6 +148,19 @@ func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string
 		return "", "", fmt.Errorf("decoding share response: %w", err)
 	}
 	return result.URL, result.DeleteToken, nil
+}
+
+// loadCliArgsFromReviewFile reads the review file and returns the stored cli_args.
+func loadCliArgsFromReviewFile(critPath string) []string {
+	data, err := os.ReadFile(critPath)
+	if err != nil {
+		return nil
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return nil
+	}
+	return cj.CliArgs
 }
 
 // unpublishFromWeb deletes a shared review from a crit-web instance.
@@ -401,6 +418,9 @@ func upsertShareToWeb(cfg CritJSON, files []shareFile, comments []shareComment, 
 		"files":        fileList,
 		"comments":     comments,
 		"review_round": cfg.ReviewRound,
+	}
+	if len(cfg.CliArgs) > 0 {
+		payload["cli_args"] = cfg.CliArgs
 	}
 
 	body, err := json.Marshal(payload)

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -1317,7 +1317,7 @@ func TestShareSyncOrphanedFile(t *testing.T) {
 		{File: "old-code.go", Body: "file-level note about removal", Scope: "file"},
 	}
 
-	url, _, err := shareFilesToWeb(files, comments, baseURL, 2, "")
+	url, _, err := shareFilesToWeb(files, comments, baseURL, 2, "", nil)
 	if err != nil {
 		t.Fatalf("sharing with orphaned file failed: %v", err)
 	}

--- a/share_test.go
+++ b/share_test.go
@@ -204,7 +204,7 @@ func TestBuildSharePayload_SingleFile(t *testing.T) {
 	files := []shareFile{
 		{Path: "plan.md", Content: "# My Plan\n\nStep 1: do the thing"},
 	}
-	payload := buildSharePayload(files, nil, 1)
+	payload := buildSharePayload(files, nil, 1, nil)
 
 	// Multi-file format is always used
 	pFiles, ok := payload["files"].([]map[string]any)
@@ -237,7 +237,7 @@ func TestBuildSharePayload_MultiFile(t *testing.T) {
 		{Path: "plan.md", Content: "# Plan"},
 		{Path: "src/main.go", Content: "package main"},
 	}
-	payload := buildSharePayload(files, nil, 2)
+	payload := buildSharePayload(files, nil, 2, nil)
 
 	pFiles := payload["files"].([]map[string]any)
 	if len(pFiles) != 2 {
@@ -255,7 +255,7 @@ func TestBuildSharePayload_WithComments(t *testing.T) {
 	comments := []shareComment{
 		{File: "plan.md", StartLine: 1, EndLine: 3, Body: "Needs more detail", Author: "Claude"},
 	}
-	payload := buildSharePayload(files, comments, 1)
+	payload := buildSharePayload(files, comments, 1, nil)
 
 	pComments := payload["comments"].([]shareComment)
 	if len(pComments) != 1 {
@@ -296,7 +296,7 @@ func TestShareFilesToWeb_Success(t *testing.T) {
 	defer server.Close()
 
 	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	url, token, err := shareFilesToWeb(files, nil, server.URL, 1, "")
+	url, token, err := shareFilesToWeb(files, nil, server.URL, 1, "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestShareFilesToWeb_ServerError(t *testing.T) {
 	defer server.Close()
 
 	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	_, _, err := shareFilesToWeb(files, nil, server.URL, 1, "")
+	_, _, err := shareFilesToWeb(files, nil, server.URL, 1, "", nil)
 	if err == nil {
 		t.Fatal("expected error for server error response")
 	}
@@ -324,7 +324,7 @@ func TestShareFilesToWeb_ServerError(t *testing.T) {
 
 func TestShareFilesToWeb_NetworkError(t *testing.T) {
 	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	_, _, err := shareFilesToWeb(files, nil, "http://localhost:1", 1, "")
+	_, _, err := shareFilesToWeb(files, nil, "http://localhost:1", 1, "", nil)
 	if err == nil {
 		t.Fatal("expected error for unreachable server")
 	}
@@ -1011,7 +1011,7 @@ func TestBuildSharePayload_WithStatusAndOrphaned(t *testing.T) {
 		{Path: "removed.go", Content: "", Status: "removed"},
 		{Path: "nostat.md", Content: "# Hello"},
 	}
-	payload := buildSharePayload(files, nil, 1)
+	payload := buildSharePayload(files, nil, 1, nil)
 
 	pFiles, ok := payload["files"].([]map[string]any)
 	if !ok {
@@ -1105,7 +1105,7 @@ func TestBuildSharePayload_WithReplies(t *testing.T) {
 			{Body: "verified", Author: "Alice"},
 		},
 	}}
-	payload := buildSharePayload(files, comments, 1)
+	payload := buildSharePayload(files, comments, 1, nil)
 	cs := payload["comments"].([]shareComment)
 	if len(cs) != 1 {
 		t.Fatalf("expected 1 comment, got %d", len(cs))
@@ -1121,6 +1121,75 @@ func TestBuildSharePayload_WithReplies(t *testing.T) {
 	}
 }
 
+func TestBuildSharePayload_WithCliArgs(t *testing.T) {
+	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
+
+	t.Run("included when provided", func(t *testing.T) {
+		args := []string{"plan.md", "notes.md"}
+		payload := buildSharePayload(files, nil, 1, args)
+		got, ok := payload["cli_args"].([]string)
+		if !ok {
+			t.Fatal("expected cli_args in payload")
+		}
+		if len(got) != 2 || got[0] != "plan.md" || got[1] != "notes.md" {
+			t.Errorf("unexpected cli_args: %v", got)
+		}
+	})
+
+	t.Run("omitted when nil", func(t *testing.T) {
+		payload := buildSharePayload(files, nil, 1, nil)
+		if _, ok := payload["cli_args"]; ok {
+			t.Error("cli_args should be absent when nil")
+		}
+	})
+
+	t.Run("omitted when empty", func(t *testing.T) {
+		payload := buildSharePayload(files, nil, 1, []string{})
+		if _, ok := payload["cli_args"]; ok {
+			t.Error("cli_args should be absent when empty")
+		}
+	})
+}
+
+func TestLoadCliArgsFromReviewFile(t *testing.T) {
+	t.Run("reads args from valid file", func(t *testing.T) {
+		dir := t.TempDir()
+		critPath := filepath.Join(dir, "review.json")
+		cj := CritJSON{
+			Branch:  "main",
+			CliArgs: []string{"plan.md", "design.md"},
+			Files:   map[string]CritJSONFile{},
+		}
+		data, _ := json.Marshal(cj)
+		os.WriteFile(critPath, data, 0644)
+
+		got := loadCliArgsFromReviewFile(critPath)
+		if len(got) != 2 || got[0] != "plan.md" || got[1] != "design.md" {
+			t.Errorf("expected [plan.md design.md], got %v", got)
+		}
+	})
+
+	t.Run("returns nil for missing file", func(t *testing.T) {
+		got := loadCliArgsFromReviewFile("/nonexistent/path.json")
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("returns nil for file without cli_args", func(t *testing.T) {
+		dir := t.TempDir()
+		critPath := filepath.Join(dir, "review.json")
+		cj := CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}
+		data, _ := json.Marshal(cj)
+		os.WriteFile(critPath, data, 0644)
+
+		got := loadCliArgsFromReviewFile(critPath)
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
 func TestShareFilesToWeb_SendsBearerToken(t *testing.T) {
 	var gotAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1134,7 +1203,7 @@ func TestShareFilesToWeb_SendsBearerToken(t *testing.T) {
 	defer server.Close()
 
 	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	shareFilesToWeb(files, nil, server.URL, 1, "crit_testtoken")
+	shareFilesToWeb(files, nil, server.URL, 1, "crit_testtoken", nil)
 	if gotAuth != "Bearer crit_testtoken" {
 		t.Errorf("expected Authorization: Bearer crit_testtoken, got %q", gotAuth)
 	}


### PR DESCRIPTION
## Summary
- Adds `cli_args` field to `CritJSON` struct so original CLI arguments persist in the review file
- Includes `cli_args` in both POST (new share) and PUT (upsert) payloads to crit-web
- Adds `loadCliArgsFromReviewFile` helper for the share path to read stored args

Companion PR: tomasz-tomczyk/crit-web#102

Closes #342

## Test plan
- [x] Unit tests for `buildSharePayload` with/without cli_args
- [x] Unit tests for `loadCliArgsFromReviewFile` (missing file, empty args, populated args)
- [x] All existing share tests updated and passing
- [x] Share integration tests pass (`make e2e-share`)
- [x] `go test ./... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)