### PR TITLE
fix: fetch comment replies from crit-web during share sync

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,10 +158,10 @@ func printQR(url string, showQR bool) {
 func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, sharePaths []string, authToken string, showQR bool) {
 	localIDs := buildLocalIDSet(existingCfg)
 	localFingerprints := buildLocalFingerprints(existingCfg)
-	if webComments, err := fetchNewWebComments(existingCfg.ShareURL, localIDs, localFingerprints, authToken); err != nil {
+	if fetched, err := fetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, authToken); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not pull remote comments: %v\n", err)
-	} else if len(webComments) > 0 {
-		if err := mergeWebComments(critPath, webComments); err != nil {
+	} else if len(fetched.NewComments) > 0 || len(fetched.ReplyUpdates) > 0 {
+		if err := mergeWebComments(critPath, fetched.NewComments, fetched.ReplyUpdates); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not merge remote comments: %v\n", err)
 		}
 	}
@@ -310,24 +310,32 @@ func runFetch(args []string) {
 	localIDs := buildLocalIDSet(cj)
 	localFingerprints := buildLocalFingerprints(cj)
 
-	webComments, err := fetchNewWebComments(cj.ShareURL, localIDs, localFingerprints, authToken)
+	fetched, err := fetchWebComments(cj.ShareURL, localIDs, localFingerprints, authToken)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching remote comments: %v\n", err)
 		os.Exit(1)
 	}
 
-	if len(webComments) == 0 {
+	if len(fetched.NewComments) == 0 && len(fetched.ReplyUpdates) == 0 {
 		fmt.Println("No new comments.")
 		fmt.Printf("Review file: %s\n", critPath)
 		return
 	}
 
-	if err := mergeWebComments(critPath, webComments); err != nil {
+	if err := mergeWebComments(critPath, fetched.NewComments, fetched.ReplyUpdates); err != nil {
 		fmt.Fprintf(os.Stderr, "Error saving review file: %v\n", err)
 		os.Exit(1)
 	}
 
-	printFetchedComments(webComments)
+	printFetchedComments(fetched.NewComments)
+	if len(fetched.ReplyUpdates) > 0 {
+		replyCount := 0
+		for _, replies := range fetched.ReplyUpdates {
+			replyCount += len(replies)
+		}
+		fmt.Printf("Updated %d comment(s) with new replies.\n", len(fetched.ReplyUpdates))
+		_ = replyCount
+	}
 	fmt.Printf("Review file: %s\n", critPath)
 }
 

--- a/share.go
+++ b/share.go
@@ -289,18 +289,25 @@ func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolv
 	return comments, round
 }
 
+// webReply is the shape of a reply nested inside a webComment.
+type webReply struct {
+	Body              string `json:"body"`
+	AuthorDisplayName string `json:"author_display_name"`
+}
+
 // webComment is the shape of a comment returned by GET /api/reviews/:token/comments.
 type webComment struct {
-	Body              string `json:"body"`
-	FilePath          string `json:"file_path"`
-	StartLine         int    `json:"start_line"`
-	EndLine           int    `json:"end_line"`
-	ReviewRound       int    `json:"review_round"`
-	Resolved          bool   `json:"resolved"`
-	ExternalID        string `json:"external_id"`
-	AuthorDisplayName string `json:"author_display_name"`
-	Quote             string `json:"quote"`
-	Scope             string `json:"scope"`
+	Body              string     `json:"body"`
+	FilePath          string     `json:"file_path"`
+	StartLine         int        `json:"start_line"`
+	EndLine           int        `json:"end_line"`
+	ReviewRound       int        `json:"review_round"`
+	Resolved          bool       `json:"resolved"`
+	ExternalID        string     `json:"external_id"`
+	AuthorDisplayName string     `json:"author_display_name"`
+	Quote             string     `json:"quote"`
+	Scope             string     `json:"scope"`
+	Replies           []webReply `json:"replies"`
 }
 
 // buildLocalFingerprints returns a set of body+file+line fingerprints for all
@@ -321,53 +328,57 @@ func buildLocalFingerprints(cj CritJSON) map[string]bool {
 	return fps
 }
 
-// fetchNewWebComments fetches comments from crit-web and returns only those
-// not already present locally (identified by external_id or body+line fingerprint).
-//
-// Called automatically inside runShare when an existing ShareURL is detected —
-// i.e., when the agent calls `crit share <files>` after applying changes from
-// the crit-web prompt. This captures any web-reviewer comments added after the
-// prompt was generated (e.g., a late-arriving review) so they appear in local
-// the review file before the next round is pushed.
-//
-// shareURL is the full review URL, e.g. "https://crit.md/r/abc123".
-func fetchNewWebComments(shareURL string, localIDs map[string]bool, localFingerprints map[string]bool, authToken string) ([]webComment, error) {
+// fetchWebCommentsResult holds both new comments and reply updates for existing ones.
+type fetchWebCommentsResult struct {
+	NewComments  []webComment
+	ReplyUpdates map[string][]webReply // external_id -> replies from web
+}
+
+// fetchWebComments fetches all comments from crit-web, returning new comments
+// and reply updates for existing comments that have replies added on the web.
+func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprints map[string]bool, authToken string) (fetchWebCommentsResult, error) {
+	var result fetchWebCommentsResult
+	result.ReplyUpdates = make(map[string][]webReply)
+
 	token := path.Base(shareURL)
 	u, err := url.Parse(shareURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid share URL: %w", err)
+		return result, fmt.Errorf("invalid share URL: %w", err)
 	}
 	apiURL := u.Scheme + "://" + u.Host + "/api/reviews/" + token + "/comments"
 
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return result, fmt.Errorf("creating request: %w", err)
 	}
 	setBearer(req, authToken)
 
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetching remote comments: %w", err)
+		return result, fmt.Errorf("fetching remote comments: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil // review gone
+		return result, nil // review gone
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("remote comments returned status %d", resp.StatusCode)
+		return result, fmt.Errorf("remote comments returned status %d", resp.StatusCode)
 	}
 
 	var all []webComment
 	if err := json.NewDecoder(resp.Body).Decode(&all); err != nil {
-		return nil, fmt.Errorf("decoding remote comments: %w", err)
+		return result, fmt.Errorf("decoding remote comments: %w", err)
 	}
 
-	var newOnes []webComment
 	for _, wc := range all {
 		if wc.ExternalID != "" && localIDs[wc.ExternalID] {
-			continue // already have this locally by ID
+			// Comment exists locally — check for new replies from web
+			if len(wc.Replies) > 0 {
+				result.ReplyUpdates[wc.ExternalID] = wc.Replies
+			}
+			continue
 		}
 		if wc.ExternalID == "" {
 			fp := fmt.Sprintf("%s|%s|%d|%d", wc.Body, wc.FilePath, wc.StartLine, wc.EndLine)
@@ -375,9 +386,9 @@ func fetchNewWebComments(shareURL string, localIDs map[string]bool, localFingerp
 				continue // web-authored comment already imported
 			}
 		}
-		newOnes = append(newOnes, wc)
+		result.NewComments = append(result.NewComments, wc)
 	}
-	return newOnes, nil
+	return result, nil
 }
 
 // upsertResult holds the response from an upsert (PUT) to crit-web.
@@ -528,7 +539,8 @@ func highestWebIndex(cj CritJSON) int {
 
 // mergeWebComments adds web-reviewer comments into the review file under their respective
 // files or into review_comments for review-level (scope:"review") comments.
-func mergeWebComments(critPath string, newComments []webComment) error {
+// It also merges reply updates for existing comments identified by external_id.
+func mergeWebComments(critPath string, newComments []webComment, replyUpdates ...map[string][]webReply) error {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
 		return err
@@ -548,6 +560,13 @@ func mergeWebComments(critPath string, newComments []webComment) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, wc := range newComments {
 		webCount++
+		var replies []Reply
+		for _, wr := range wc.Replies {
+			replies = append(replies, Reply{
+				Body:   wr.Body,
+				Author: wr.AuthorDisplayName,
+			})
+		}
 		c := Comment{
 			ID:          fmt.Sprintf("web-%d", webCount),
 			StartLine:   wc.StartLine,
@@ -557,6 +576,7 @@ func mergeWebComments(critPath string, newComments []webComment) error {
 			Author:      wc.AuthorDisplayName,
 			Scope:       wc.Scope,
 			ReviewRound: wc.ReviewRound,
+			Replies:     replies,
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}
@@ -569,8 +589,51 @@ func mergeWebComments(critPath string, newComments []webComment) error {
 		}
 	}
 
+	// Merge reply updates for existing comments (matched by external_id).
+	if len(replyUpdates) > 0 && len(replyUpdates[0]) > 0 {
+		updates := replyUpdates[0]
+		for filePath, cf := range cj.Files {
+			for i, c := range cf.Comments {
+				if webReplies, ok := updates[c.ID]; ok {
+					cj.Files[filePath] = mergeRepliesIntoFile(cf, i, webReplies)
+					cf = cj.Files[filePath]
+				}
+			}
+		}
+		for i, c := range cj.ReviewComments {
+			if webReplies, ok := updates[c.ID]; ok {
+				cj.ReviewComments[i] = mergeRepliesIntoComment(c, webReplies)
+			}
+		}
+	}
+
 	cj.UpdatedAt = now
 	return saveCritJSON(critPath, cj)
+}
+
+// mergeRepliesIntoFile updates a comment at index i in a CritJSONFile with web replies,
+// deduplicating by body to avoid adding replies that already exist locally.
+func mergeRepliesIntoFile(cf CritJSONFile, i int, webReplies []webReply) CritJSONFile {
+	cf.Comments[i] = mergeRepliesIntoComment(cf.Comments[i], webReplies)
+	return cf
+}
+
+// mergeRepliesIntoComment merges web replies into a comment, deduplicating by body.
+func mergeRepliesIntoComment(c Comment, webReplies []webReply) Comment {
+	existing := make(map[string]bool)
+	for _, r := range c.Replies {
+		existing[r.Body] = true
+	}
+	for _, wr := range webReplies {
+		if existing[wr.Body] {
+			continue
+		}
+		c.Replies = append(c.Replies, Reply{
+			Body:   wr.Body,
+			Author: wr.AuthorDisplayName,
+		})
+	}
+	return c
 }
 
 // updateShareState writes LastShareHash and ReviewRound back to the review file.

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -230,6 +230,46 @@ func seedCommentAt(t *testing.T, baseURL, token, file, body string, startLine, e
 	}
 }
 
+// seedCommentGetID seeds a comment and returns its crit-web ID (for use with seedReply).
+func seedCommentGetID(t *testing.T, baseURL, token, file, body string, startLine, endLine int) string {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]any{
+		"file": file, "start_line": startLine, "end_line": endLine, "body": body,
+	})
+	resp, err := http.Post(baseURL+"/api/reviews/"+token+"/seed-comment", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("seed-comment failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed-comment returned %d", resp.StatusCode)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding seed-comment response: %v", err)
+	}
+	return result.ID
+}
+
+// seedReply seeds a reply to an existing comment on crit-web.
+func seedReply(t *testing.T, baseURL, token, commentID, body string) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]any{"body": body})
+	resp, err := http.Post(
+		baseURL+"/api/reviews/"+token+"/seed-reply/"+commentID,
+		"application/json", bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatalf("seed-reply failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed-reply returned %d", resp.StatusCode)
+	}
+}
+
 // seedReviewComment seeds a review-level (file-agnostic) comment on crit-web.
 func seedReviewComment(t *testing.T, baseURL, token, body string) {
 	t.Helper()
@@ -1392,5 +1432,166 @@ func TestShareSyncOrphanedFile(t *testing.T) {
 	}
 	if fileComment.Scope != "file" {
 		t.Errorf("file comment scope = %q, want 'file'", fileComment.Scope)
+	}
+}
+
+// TestShareSyncFetchReplies verifies that replies to web-authored comments
+// are fetched back into the local .crit.json when running crit fetch (via re-share).
+func TestShareSyncFetchReplies(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	// Share a simple review
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Seed a comment on crit-web and add two replies to it
+	commentID := seedCommentGetID(t, baseURL, token, "plan.md", "needs more detail", 3, 3)
+	seedReply(t, baseURL, token, commentID, "first reply from web")
+	seedReply(t, baseURL, token, commentID, "second reply from web")
+
+	// Update content to force a re-share (triggers fetch)
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (revised)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	critShareCmd(t, binary, baseURL, dir, "plan.md")
+
+	// Verify the web comment was fetched with its replies
+	cj := readCritJSON(t, dir)
+	var webComment *Comment
+	for i, c := range cj.Files["plan.md"].Comments {
+		if strings.HasPrefix(c.ID, "web-") && c.Body == "needs more detail" {
+			webComment = &cj.Files["plan.md"].Comments[i]
+			break
+		}
+	}
+	if webComment == nil {
+		t.Fatal("web comment 'needs more detail' not found in local .crit.json")
+	}
+
+	// This is the core assertion: replies must be present
+	if len(webComment.Replies) != 2 {
+		t.Fatalf("expected 2 replies on web comment, got %d", len(webComment.Replies))
+	}
+
+	replyBodies := map[string]bool{}
+	for _, r := range webComment.Replies {
+		replyBodies[r.Body] = true
+	}
+	if !replyBodies["first reply from web"] {
+		t.Error("missing reply 'first reply from web'")
+	}
+	if !replyBodies["second reply from web"] {
+		t.Error("missing reply 'second reply from web'")
+	}
+
+	// Verify reply authors are set
+	for _, r := range webComment.Replies {
+		if r.Author == "" {
+			t.Errorf("reply %q has empty author", r.Body)
+		}
+	}
+
+	t.Logf("Fetch replies test passed. Review: %s", extractURL(t, output))
+}
+
+// TestShareSyncFetchRepliesOnExistingComments verifies that when a shared comment
+// (with external_id) gets replies on crit-web, those replies are fetched back.
+// This tests the case where the comment already exists locally (not a new web comment).
+// Note: the first share (POST) doesn't set external_id — only upsert (PUT) does.
+// So we need to re-share once to set external_ids before seeding the reply.
+func TestShareSyncFetchRepliesOnExistingComments(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	// Share a review with a local comment
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "local comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	// Re-share with a content change so the upsert (PUT) sets external_id on the comment.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (v2)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	critShareCmd(t, binary, baseURL, dir, "plan.md")
+
+	// Now the comment on crit-web has external_id "c1". Find its crit-web internal ID.
+	resp, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/comments", baseURL, token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var full []struct {
+		ID         string `json:"id"`
+		ExternalID string `json:"external_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&full); err != nil {
+		t.Fatalf("decoding comments: %v", err)
+	}
+	var webID string
+	for _, f := range full {
+		if f.ExternalID == "c1" {
+			webID = f.ID
+			break
+		}
+	}
+	if webID == "" {
+		t.Fatalf("could not find crit-web ID for comment with external_id c1, got: %+v", full)
+	}
+
+	// Add a reply on crit-web to the shared comment
+	seedReply(t, baseURL, token, webID, "web reply to local comment")
+
+	// Update content and re-share again to trigger fetch with reply updates
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 (v3)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	critShareCmd(t, binary, baseURL, dir, "plan.md")
+
+	// Verify the local comment now has the reply
+	cj := readCritJSON(t, dir)
+	var localComment *Comment
+	for i, c := range cj.Files["plan.md"].Comments {
+		if c.ID == "c1" {
+			localComment = &cj.Files["plan.md"].Comments[i]
+			break
+		}
+	}
+	if localComment == nil {
+		t.Fatal("local comment c1 not found after re-share")
+	}
+
+	replyFound := false
+	for _, r := range localComment.Replies {
+		if r.Body == "web reply to local comment" {
+			replyFound = true
+			break
+		}
+	}
+	if !replyFound {
+		t.Errorf("expected reply 'web reply to local comment' on comment c1, got replies: %+v", localComment.Replies)
 	}
 }

--- a/share_test.go
+++ b/share_test.go
@@ -161,15 +161,15 @@ func TestFetchNewWebComments_FiltersLocalComments(t *testing.T) {
 	defer srv.Close()
 
 	localIDs := map[string]bool{"c1": true}
-	got, err := fetchNewWebComments(srv.URL+"/r/testtoken", localIDs, nil, "")
+	result, err := fetchWebComments(srv.URL+"/r/testtoken", localIDs, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 new comment, got %d", len(got))
+	if len(result.NewComments) != 1 {
+		t.Fatalf("expected 1 new comment, got %d", len(result.NewComments))
 	}
-	if got[0].Body != "web reviewer note" {
-		t.Errorf("expected body 'web reviewer note', got %q", got[0].Body)
+	if result.NewComments[0].Body != "web reviewer note" {
+		t.Errorf("expected body 'web reviewer note', got %q", result.NewComments[0].Body)
 	}
 }
 
@@ -179,12 +179,12 @@ func TestFetchNewWebComments_404ReturnsNil(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, err := fetchNewWebComments(srv.URL+"/r/gone", nil, nil, "")
+	result, err := fetchWebComments(srv.URL+"/r/gone", nil, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error for 404: %v", err)
 	}
-	if got != nil {
-		t.Errorf("expected nil for 404, got %v", got)
+	if result.NewComments != nil {
+		t.Errorf("expected nil for 404, got %v", result.NewComments)
 	}
 }
 
@@ -194,7 +194,7 @@ func TestFetchNewWebComments_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchNewWebComments(srv.URL+"/r/broken", nil, nil, "")
+	_, err := fetchWebComments(srv.URL+"/r/broken", nil, nil, "")
 	if err == nil {
 		t.Fatal("expected error for 500 response")
 	}
@@ -1231,7 +1231,7 @@ func TestFetchNewWebComments_SendsBearerToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	fetchNewWebComments(srv.URL+"/r/tok", nil, nil, "crit_testtoken")
+	fetchWebComments(srv.URL+"/r/tok", nil, nil, "crit_testtoken")
 	if gotAuth != "Bearer crit_testtoken" {
 		t.Errorf("expected Authorization: Bearer crit_testtoken, got %q", gotAuth)
 	}


### PR DESCRIPTION
## Summary
- `crit fetch` (and re-share sync) silently dropped replies from web-authored comments because `webComment` struct had no `Replies` field
- Add `webReply` struct and `Replies` field to `webComment`
- Update `mergeWebComments` to map replies onto `Comment.Replies` for new comments
- Add `fetchWebComments()` that also returns reply updates for existing comments (matched by `external_id`)
- Update `runFetch` and `runShareExisting` callers

## Review
- [x] All 21 share integration tests pass (19 existing + 2 new)
- [x] Full unit test suite passes

## Test plan
- `TestShareSyncFetchReplies` — share, seed comment + 2 replies on web, re-share, verify replies in local `.crit.json`
- `TestShareSyncFetchRepliesOnExistingComments` — share with local comment, upsert to set external_id, seed reply on web, re-share, verify reply merged into existing local comment
- See also: tomasz-tomczyk/crit-web#103 (seed-reply endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)