### PR TITLE
fix: remove blur/scrim overlay from disconnected state

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6503,8 +6503,6 @@
     banner.style.top = header.offsetHeight + 'px';
     header.insertAdjacentElement('afterend', banner);
 
-    const mainLayout = document.querySelector('.main-layout');
-    if (mainLayout) mainLayout.classList.add('is-finished');
   }
 
   // ===== Share =====

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1679,20 +1679,6 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   font-size: 13px;
   color: var(--crit-finish-body-fg);
 }
-.main-layout.is-finished::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 10;
-  background: var(--crit-finish-scrim);
-  pointer-events: none;
-  animation: disconnected-scrim-in 0.6s ease 0.15s both;
-  backdrop-filter: blur(0.5px);
-}
-@keyframes disconnected-scrim-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
 
 /* ===== Waiting Overlay ===== */
 .waiting-overlay {

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -122,7 +122,6 @@
   --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
   --crit-finish-pill-fg:     #56d364;
   --crit-finish-body-fg:     #9ba3bf;
-  --crit-finish-scrim:       rgba(14, 15, 19, 0.55);
 
   /* ---- UI states ---- */
   --crit-overlay-bg:       rgba(0,0,0,0.5);
@@ -245,7 +244,6 @@
     --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
     --crit-finish-pill-fg:     #167f30;
     --crit-finish-body-fg:     #5a6275;
-    --crit-finish-scrim:       rgba(245, 246, 250, 0.60);
 
     --crit-overlay-bg:       rgba(0,0,0,0.5);
     --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);
@@ -367,7 +365,6 @@
   --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
   --crit-finish-pill-fg:     #56d364;
   --crit-finish-body-fg:     #9ba3bf;
-  --crit-finish-scrim:       rgba(14, 15, 19, 0.55);
 
   --crit-overlay-bg:       rgba(0,0,0,0.5);
   --crit-btn-danger-hover-bg:  rgba(247, 118, 142, 0.1);
@@ -488,7 +485,6 @@
   --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
   --crit-finish-pill-fg:     #167f30;
   --crit-finish-body-fg:     #5a6275;
-  --crit-finish-scrim:       rgba(245, 246, 250, 0.60);
 
   --crit-overlay-bg:       rgba(0,0,0,0.5);
   --crit-btn-danger-hover-bg:  rgba(196, 31, 42, 0.08);


### PR DESCRIPTION
## Summary
- Remove the darkened/blurred main body overlay from the disconnected state added in #347
- Keep the sticky "Session complete" banner untouched
- Removes `.main-layout.is-finished::after` CSS, `is-finished` JS class toggle, and `--crit-finish-scrim` theme variables

## Test plan
- Verified no remaining references to `is-finished` or `finish-scrim` in frontend/

🤖 Generated with [Claude Code](https://claude.com/claude-code)