### PR TITLE
feat: redesign comments panel with segmented filter and collapsible groups

### DIFF
--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -66,7 +66,7 @@ test.describe('Comments Panel — Git Mode', () => {
     await page.keyboard.press('Shift+C');
 
     await expect(page.locator('.comments-panel-empty')).toBeVisible();
-    await expect(page.locator('.comments-panel-empty')).toContainText('No unresolved comments');
+    await expect(page.locator('.comments-panel-empty')).toContainText('No comments yet');
   });
 
   test('panel shows comment cards', async ({ page, request }) => {
@@ -232,8 +232,8 @@ test.describe('Comments Panel — Git Mode', () => {
     await loadPage(page);
     await page.keyboard.press('Shift+C');
 
-    // Toggle show resolved
-    await page.locator('.comments-panel-switch-track').click();
+    // Switch to Resolved filter
+    await page.locator('#commentsFilterPill .toggle-btn[data-filter="resolved"]').click();
 
     const card = panelCards(page).first();
     await expect(card).toBeVisible();
@@ -272,8 +272,8 @@ test.describe('Comments Panel — Git Mode', () => {
 
     await page.keyboard.press('Shift+C');
 
-    // Show resolved comments
-    await page.locator('.comments-panel-switch-track').click();
+    // Switch to Resolved filter
+    await page.locator('#commentsFilterPill .toggle-btn[data-filter="resolved"]').click();
     await expect(panelCards(page)).toHaveCount(1);
 
     // Click the resolved card

--- a/e2e/tests/panel-redesign.spec.ts
+++ b/e2e/tests/panel-redesign.spec.ts
@@ -1,0 +1,334 @@
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test';
+import * as fs from 'fs';
+import { clearAllComments, loadPage, mdSection, switchToDocumentView, addComment, getMdPath } from './helpers';
+
+function commentsPanel(page: Page) {
+  return page.locator('#commentsPanel');
+}
+
+function panelCards(page: Page) {
+  return page.locator('.panel-comment-block .comment-card');
+}
+
+function filterPill(page: Page) {
+  return page.locator('#commentsFilterPill');
+}
+
+function filterBtn(page: Page, filter: 'all' | 'open' | 'resolved') {
+  return filterPill(page).locator(`.toggle-btn[data-filter="${filter}"]`);
+}
+
+function filterCount(page: Page, filter: 'all' | 'open' | 'resolved') {
+  return filterBtn(page, filter).locator('.filter-count');
+}
+
+function expandAllBtn(page: Page) {
+  return page.locator('#commentsPanelExpandAll');
+}
+
+function countBadge(page: Page) {
+  return page.locator('#commentsPanelCountBadge');
+}
+
+async function openPanel(page: Page) {
+  await page.keyboard.press('Shift+C');
+  await expect(commentsPanel(page)).not.toHaveClass(/comments-panel-hidden/);
+}
+
+async function waitForRound(request: APIRequestContext, previousRound: number) {
+  await expect(async () => {
+    const session = await request.get('/api/session').then(r => r.json());
+    expect(session.review_round).toBeGreaterThan(previousRound);
+  }).toPass({ timeout: 5000 });
+}
+
+async function finishAndResolve(request: APIRequestContext) {
+  const session = await request.get('/api/session').then(r => r.json());
+  const currentRound = session.review_round;
+
+  const finishRes = await request.post('/api/finish');
+  const finishData = await finishRes.json();
+  const critJsonPath = finishData.review_file;
+
+  const critJson = JSON.parse(fs.readFileSync(critJsonPath, 'utf-8'));
+  for (const fileKey of Object.keys(critJson.files)) {
+    for (const comment of critJson.files[fileKey].comments) {
+      comment.resolved = true;
+      comment.resolution_note = 'Fixed';
+    }
+  }
+  fs.writeFileSync(critJsonPath, JSON.stringify(critJson, null, 2));
+
+  await request.post('/api/round-complete');
+  await waitForRound(request, currentRound);
+}
+
+// ============================================================
+// Panel Redesign — Header, Segmented Filter, File Groups, Expand All
+// ============================================================
+test.describe('Panel Redesign', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  // ----------------------------------------------------------
+  // 1. Panel header shows count badge
+  // ----------------------------------------------------------
+  test('count badge shows correct total', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'First comment');
+    await addComment(request, mdPath, 3, 'Second comment');
+    await addComment(request, mdPath, 5, 'Third comment');
+    await loadPage(page);
+
+    await openPanel(page);
+    await expect(countBadge(page)).toHaveText('3');
+  });
+
+  test('count badge shows 0 when no comments', async ({ page }) => {
+    await loadPage(page);
+    await openPanel(page);
+    await expect(countBadge(page)).toHaveText('0');
+  });
+
+  // ----------------------------------------------------------
+  // 2. Segmented filter — All / Open / Resolved
+  // ----------------------------------------------------------
+  test('All filter is active by default', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'A comment');
+    await loadPage(page);
+    await openPanel(page);
+
+    await expect(filterBtn(page, 'all')).toHaveClass(/active/);
+    await expect(filterBtn(page, 'open')).not.toHaveClass(/active/);
+    await expect(filterBtn(page, 'resolved')).not.toHaveClass(/active/);
+  });
+
+  test('Open filter shows only unresolved comments', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+
+    // Create a comment, resolve it, then add a new unresolved one
+    await addComment(request, mdPath, 1, 'Will be resolved');
+    await finishAndResolve(request);
+    await addComment(request, mdPath, 2, 'Still open');
+
+    await loadPage(page);
+    await openPanel(page);
+
+    // All shows both
+    await expect(panelCards(page)).toHaveCount(2);
+
+    // Open shows only unresolved
+    await filterBtn(page, 'open').click();
+    await expect(filterBtn(page, 'open')).toHaveClass(/active/);
+    await expect(panelCards(page)).toHaveCount(1);
+    await expect(panelCards(page).first().locator('.comment-body')).toContainText('Still open');
+  });
+
+  test('Resolved filter shows only resolved comments', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+
+    await addComment(request, mdPath, 1, 'Will be resolved');
+    await finishAndResolve(request);
+    await addComment(request, mdPath, 2, 'Still open');
+
+    await loadPage(page);
+    await openPanel(page);
+
+    await filterBtn(page, 'resolved').click();
+    await expect(filterBtn(page, 'resolved')).toHaveClass(/active/);
+    await expect(panelCards(page)).toHaveCount(1);
+    await expect(panelCards(page).first()).toHaveClass(/resolved-card/);
+  });
+
+  // ----------------------------------------------------------
+  // 3. Filter counts are correct
+  // ----------------------------------------------------------
+  test('filter pill counts match actual comment counts', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+
+    // 1 resolved + 2 open = 3 total
+    await addComment(request, mdPath, 1, 'Will be resolved');
+    await finishAndResolve(request);
+    await addComment(request, mdPath, 2, 'Open one');
+    await addComment(request, mdPath, 3, 'Open two');
+
+    await loadPage(page);
+    await openPanel(page);
+
+    await expect(filterCount(page, 'all')).toHaveText('3');
+    await expect(filterCount(page, 'open')).toHaveText('2');
+    await expect(filterCount(page, 'resolved')).toHaveText('1');
+  });
+
+  test('filter counts update when a comment is added', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'First');
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await openPanel(page);
+
+    await expect(filterCount(page, 'all')).toHaveText('1');
+    await expect(filterCount(page, 'open')).toHaveText('1');
+
+    // Add a comment via UI
+    const section = mdSection(page);
+    const lineBlock = section.locator('.line-block').nth(2);
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').nth(2).click();
+    await page.locator('.comment-form textarea').fill('Second via UI');
+    await page.locator('.comment-form .btn-primary').click();
+
+    await expect(filterCount(page, 'all')).toHaveText('2');
+    await expect(filterCount(page, 'open')).toHaveText('2');
+  });
+
+  // ----------------------------------------------------------
+  // 4. Collapsible file groups
+  // ----------------------------------------------------------
+  test('clicking file group header collapses and expands comments', async ({ page, request }) => {
+    const session = await (await request.get('/api/session')).json();
+    const mdPath = session.files.find((f: { path: string }) => f.path.endsWith('.md'))?.path;
+    const goPath = session.files.find((f: { path: string }) => f.path.endsWith('.go'))?.path;
+    expect(mdPath).toBeTruthy();
+    expect(goPath).toBeTruthy();
+
+    await addComment(request, mdPath!, 1, 'MD comment');
+    await addComment(request, goPath!, 1, 'Go comment');
+    await loadPage(page);
+    await openPanel(page);
+
+    // Both groups visible, 2 cards total
+    const fileGroups = page.locator('.comments-panel-file-group');
+    await expect(fileGroups).toHaveCount(2);
+    await expect(panelCards(page)).toHaveCount(2);
+
+    // Click first file group header to collapse
+    const firstGroupHeader = fileGroups.first().locator('.comments-panel-file-name');
+    await firstGroupHeader.click();
+    await expect(fileGroups.first()).toHaveClass(/collapsed/);
+
+    // Cards in collapsed group are hidden; other group still shows its card
+    const firstGroupCards = fileGroups.first().locator('.comment-card');
+    await expect(firstGroupCards.first()).toBeHidden();
+
+    // Click again to expand
+    await firstGroupHeader.click();
+    await expect(fileGroups.first()).not.toHaveClass(/collapsed/);
+    await expect(firstGroupCards.first()).toBeVisible();
+  });
+
+  test('file group header shows chevron and comment count', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Comment A');
+    await addComment(request, mdPath, 3, 'Comment B');
+
+    const session = await (await request.get('/api/session')).json();
+    const goPath = session.files.find((f: { path: string }) => f.path.endsWith('.go'))?.path;
+    expect(goPath).toBeTruthy();
+    await addComment(request, goPath!, 1, 'Go comment');
+
+    await loadPage(page);
+    await openPanel(page);
+
+    const fileGroups = page.locator('.comments-panel-file-group');
+    await expect(fileGroups).toHaveCount(2);
+
+    // Each group header has a chevron and count
+    const firstHeader = fileGroups.first().locator('.comments-panel-file-name');
+    await expect(firstHeader.locator('.comments-panel-file-chevron')).toBeVisible();
+    await expect(firstHeader.locator('.comments-panel-file-count')).toBeVisible();
+  });
+
+  // ----------------------------------------------------------
+  // 5. Expand all / Collapse all toggle
+  // ----------------------------------------------------------
+  test('Expand all button label starts as "Expand all"', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Test comment');
+    await loadPage(page);
+    await openPanel(page);
+
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
+  });
+
+  test('clicking Expand all expands cards and label changes to Collapse all', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Comment to expand');
+    await loadPage(page);
+    await openPanel(page);
+
+    // Click Expand all
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
+
+    // Cards should not have collapsed class
+    const cards = panelCards(page);
+    await expect(cards).toHaveCount(1);
+    await expect(cards.first()).not.toHaveClass(/collapsed/);
+  });
+
+  test('clicking Collapse all collapses cards and label reverts', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Comment to collapse');
+    await loadPage(page);
+    await openPanel(page);
+
+    // Expand then collapse
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
+
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
+
+    // Cards should have collapsed class
+    await expect(panelCards(page).first()).toHaveClass(/collapsed/);
+  });
+
+  // ----------------------------------------------------------
+  // 6. Expand all affects inline comments in the document body
+  // ----------------------------------------------------------
+  test('Collapse all also collapses inline comment blocks in document', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Inline test comment');
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await openPanel(page);
+
+    // Ensure inline comment card exists and is visible
+    const inlineCard = mdSection(page).locator('.comment-card[data-comment-id]').first();
+    await expect(inlineCard).toBeVisible();
+
+    // Expand all first (ensure everything is expanded)
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
+    await expect(inlineCard).not.toHaveClass(/collapsed/);
+
+    // Collapse all — should affect both panel and inline cards
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
+    await expect(inlineCard).toHaveClass(/collapsed/);
+  });
+
+  test('Expand all expands previously collapsed inline comments', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Inline expand test');
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await openPanel(page);
+
+    const inlineCard = mdSection(page).locator('.comment-card[data-comment-id]').first();
+    await expect(inlineCard).toBeVisible();
+
+    // Collapse all first
+    await expandAllBtn(page).click();
+    await expandAllBtn(page).click();
+    await expect(inlineCard).toHaveClass(/collapsed/);
+
+    // Expand all — inline card should be expanded again
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
+    await expect(inlineCard).not.toHaveClass(/collapsed/);
+  });
+});

--- a/e2e/tests/panel-redesign.spec.ts
+++ b/e2e/tests/panel-redesign.spec.ts
@@ -244,46 +244,53 @@ test.describe('Panel Redesign', () => {
   // ----------------------------------------------------------
   // 5. Expand all / Collapse all toggle
   // ----------------------------------------------------------
-  test('Expand all button label starts as "Expand all"', async ({ page, request }) => {
+  test('Expand all button label starts as "Collapse all" when cards are expanded', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Test comment');
     await loadPage(page);
     await openPanel(page);
 
-    await expect(expandAllBtn(page)).toHaveText('Expand all');
+    // Cards start expanded, so the button offers to collapse
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
   });
 
-  test('clicking Expand all expands cards and label changes to Collapse all', async ({ page, request }) => {
+  test('clicking Collapse all collapses cards and label changes to Expand all', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Comment to expand');
     await loadPage(page);
     await openPanel(page);
 
-    // Click Expand all
-    await expandAllBtn(page).click();
+    // Cards start expanded; button says "Collapse all"
     await expect(expandAllBtn(page)).toHaveText('Collapse all');
 
-    // Cards should not have collapsed class
+    // Click Collapse all
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
+
+    // Cards should have collapsed class
     const cards = panelCards(page);
     await expect(cards).toHaveCount(1);
-    await expect(cards.first()).not.toHaveClass(/collapsed/);
+    await expect(cards.first()).toHaveClass(/collapsed/);
   });
 
-  test('clicking Collapse all collapses cards and label reverts', async ({ page, request }) => {
+  test('clicking Expand all after collapse expands cards and label reverts', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Comment to collapse');
     await loadPage(page);
     await openPanel(page);
 
-    // Expand then collapse
+    // Cards start expanded; collapse them first
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
+    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
+    await expect(panelCards(page).first()).toHaveClass(/collapsed/);
+
+    // Expand all again
     await expandAllBtn(page).click();
     await expect(expandAllBtn(page)).toHaveText('Collapse all');
 
-    await expandAllBtn(page).click();
-    await expect(expandAllBtn(page)).toHaveText('Expand all');
-
-    // Cards should have collapsed class
-    await expect(panelCards(page).first()).toHaveClass(/collapsed/);
+    // Cards should not have collapsed class
+    await expect(panelCards(page).first()).not.toHaveClass(/collapsed/);
   });
 
   // ----------------------------------------------------------
@@ -300,8 +307,7 @@ test.describe('Panel Redesign', () => {
     const inlineCard = mdSection(page).locator('.comment-card[data-comment-id]').first();
     await expect(inlineCard).toBeVisible();
 
-    // Expand all first (ensure everything is expanded)
-    await expandAllBtn(page).click();
+    // Cards start expanded; button says "Collapse all"
     await expect(expandAllBtn(page)).toHaveText('Collapse all');
     await expect(inlineCard).not.toHaveClass(/collapsed/);
 
@@ -321,9 +327,10 @@ test.describe('Panel Redesign', () => {
     const inlineCard = mdSection(page).locator('.comment-card[data-comment-id]').first();
     await expect(inlineCard).toBeVisible();
 
-    // Collapse all first
+    // Cards start expanded; collapse them first
+    await expect(expandAllBtn(page)).toHaveText('Collapse all');
     await expandAllBtn(page).click();
-    await expandAllBtn(page).click();
+    await expect(expandAllBtn(page)).toHaveText('Expand all');
     await expect(inlineCard).toHaveClass(/collapsed/);
 
     // Expand all — inline card should be expanded again

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5886,19 +5886,46 @@
     return parts.wrapper;
   }
 
+  // Track active filter: 'all', 'open', 'resolved'
+  let commentsActiveFilter = 'all';
+
   function renderCommentsPanel() {
     const panel = document.getElementById('commentsPanel');
     if (panel.classList.contains('comments-panel-hidden')) return;
 
-    const showResolved = document.getElementById('showResolvedToggle').checked;
     const body = document.getElementById('commentsPanelBody');
     const savedScroll = body.scrollTop;
     body.innerHTML = '';
 
-    // Show/hide the filter bar only when resolved comments exist
-    const hasResolved = files.some(function(f) { return f.comments.some(function(c) { return c.resolved; }); })
-      || reviewComments.some(function(c) { return c.resolved; });
-    document.getElementById('commentsPanelFilter').style.display = hasResolved ? '' : 'none';
+    // Compute counts
+    const allFileComments = files.reduce(function(acc, f) { return acc.concat(f.comments); }, []);
+    const allComments = reviewComments.concat(allFileComments);
+    const totalCount = allComments.length;
+    const openCount = allComments.filter(function(c) { return !c.resolved; }).length;
+    const resolvedCount = allComments.filter(function(c) { return c.resolved; }).length;
+
+    // Update count badge
+    var badge = document.getElementById('commentsPanelCountBadge');
+    if (badge) badge.textContent = totalCount;
+
+    // Update pill counts
+    var pillBtns = document.querySelectorAll('#commentsFilterPill .comments-filter-pill-btn');
+    pillBtns.forEach(function(btn) {
+      var countEl = btn.querySelector('.filter-count');
+      if (!countEl) return;
+      var f = btn.dataset.filter;
+      if (f === 'all') countEl.textContent = totalCount;
+      else if (f === 'open') countEl.textContent = openCount;
+      else if (f === 'resolved') countEl.textContent = resolvedCount;
+    });
+    updateCommentsFilterIndicator();
+
+    // Filter function based on active pill
+    var visibleFilter = function(c) {
+      if (commentsActiveFilter === 'open') return !c.resolved;
+      if (commentsActiveFilter === 'resolved') return c.resolved;
+      return true;
+    };
 
     let hasComments = false;
 
@@ -5908,40 +5935,34 @@
     }
 
     // Render review-level (general) comments first
-    const visibleReviewComments = reviewComments.filter(function(c) {
-      return showResolved ? true : !c.resolved;
-    });
+    const visibleReviewComments = reviewComments.filter(visibleFilter);
     if (visibleReviewComments.length > 0) {
       hasComments = true;
       const group = document.createElement('div');
       group.className = 'comments-panel-file-group';
 
-      const groupName = document.createElement('div');
-      groupName.className = 'comments-panel-file-name';
-      groupName.textContent = 'Review';
-      group.appendChild(groupName);
+      group.appendChild(createFileGroupHeader('Review', visibleReviewComments.length, group));
 
+      const cards = document.createElement('div');
+      cards.className = 'comments-panel-file-cards';
       for (let j = 0; j < visibleReviewComments.length; j++) {
         const comment = visibleReviewComments[j];
-        // If editing this comment, show editor instead
         if (reviewCommentEditingId === comment.id) {
-          group.appendChild(createReviewCommentEditor(comment));
+          cards.appendChild(createReviewCommentEditor(comment));
           continue;
         }
-        group.appendChild(createPanelCommentCard(comment, null));
+        cards.appendChild(createPanelCommentCard(comment, null));
       }
+      group.appendChild(cards);
       body.appendChild(group);
     }
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      const visibleComments = file.comments.filter(function(c) {
-        return showResolved ? true : !c.resolved;
-      });
+      const visibleComments = file.comments.filter(visibleFilter);
       if (visibleComments.length === 0) continue;
       hasComments = true;
 
-      // Sort by start_line
       visibleComments.sort(function(a, b) { return a.start_line - b.start_line; });
 
       const group = document.createElement('div');
@@ -5949,28 +5970,96 @@
 
       // File name header (only in multi-file mode)
       if (files.length > 1) {
-        const fileName = document.createElement('div');
-        fileName.className = 'comments-panel-file-name';
-        fileName.textContent = file.path;
-        fileName.title = file.path;
-        group.appendChild(fileName);
+        group.appendChild(createFileGroupHeader(file.path, visibleComments.length, group));
       }
 
+      const cards = document.createElement('div');
+      cards.className = 'comments-panel-file-cards';
       for (let j = 0; j < visibleComments.length; j++) {
         const comment = visibleComments[j];
-        group.appendChild(createPanelCommentCard(comment, file.path));
+        cards.appendChild(createPanelCommentCard(comment, file.path));
       }
-
+      group.appendChild(cards);
       body.appendChild(group);
     }
 
     if (!hasComments && !reviewCommentFormActive) {
       const empty = document.createElement('div');
       empty.className = 'comments-panel-empty';
-      empty.textContent = showResolved ? 'No comments yet' : 'No unresolved comments';
+      var emptyMsg = commentsActiveFilter === 'open' ? 'No open comments' : commentsActiveFilter === 'resolved' ? 'No resolved comments' : 'No comments yet';
+      empty.textContent = emptyMsg;
       body.appendChild(empty);
     }
     body.scrollTop = savedScroll;
+    updateExpandAllLabel();
+  }
+
+  function createFileGroupHeader(label, count, groupEl) {
+    var groupName = document.createElement('div');
+    groupName.className = 'comments-panel-file-name';
+
+    var chevron = document.createElement('span');
+    chevron.className = 'comments-panel-file-chevron';
+    chevron.textContent = '\u25BC';
+    groupName.appendChild(chevron);
+
+    var nameText = document.createElement('span');
+    nameText.className = 'comments-panel-file-name-text';
+    nameText.textContent = label;
+    nameText.title = label;
+    groupName.appendChild(nameText);
+
+    var countEl = document.createElement('span');
+    countEl.className = 'comments-panel-file-count';
+    countEl.textContent = count;
+    groupName.appendChild(countEl);
+
+    groupName.addEventListener('click', function() {
+      groupEl.classList.toggle('collapsed');
+    });
+
+    return groupName;
+  }
+
+  function updateCommentsFilterIndicator() {
+    var indicator = document.getElementById('commentsFilterIndicator');
+    var pill = document.getElementById('commentsFilterPill');
+    if (!indicator || !pill) return;
+    var activeBtn = pill.querySelector('.comments-filter-pill-btn.active');
+    if (!activeBtn) return;
+    var pillRect = pill.getBoundingClientRect();
+    var btnRect = activeBtn.getBoundingClientRect();
+    indicator.style.left = (btnRect.left - pillRect.left) + 'px';
+    indicator.style.width = btnRect.width + 'px';
+  }
+
+  function updateExpandAllLabel() {
+    var btn = document.getElementById('commentsPanelExpandAll');
+    if (!btn) return;
+    var panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
+    var inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
+    var allCards = Array.from(panelCards).concat(Array.from(inlineCards));
+    var anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
+    btn.textContent = anyExpanded ? 'Collapse all' : 'Expand all';
+  }
+
+  function toggleExpandAllComments() {
+    var panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
+    var inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
+    var allCards = Array.from(panelCards).concat(Array.from(inlineCards));
+    var anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
+
+    allCards.forEach(function(card) {
+      if (anyExpanded) {
+        card.classList.add('collapsed');
+      } else {
+        card.classList.remove('collapsed');
+      }
+      var id = card.dataset.commentId;
+      if (id) commentCollapseOverrides[id] = anyExpanded;
+    });
+
+    updateExpandAllLabel();
   }
 
   function scrollToComment(commentId, filePath) {
@@ -7314,8 +7403,20 @@
     togglePRPanel();
   });
 
-  document.getElementById('showResolvedToggle').addEventListener('change', function() {
+  // Segmented pill filter
+  document.getElementById('commentsFilterPill').addEventListener('click', function(e) {
+    var btn = e.target.closest('.comments-filter-pill-btn');
+    if (!btn) return;
+    commentsActiveFilter = btn.dataset.filter;
+    document.querySelectorAll('#commentsFilterPill .comments-filter-pill-btn').forEach(function(b) { b.classList.remove('active'); });
+    btn.classList.add('active');
+    updateCommentsFilterIndicator();
     renderCommentsPanel();
+  });
+
+  // Expand all / Collapse all
+  document.getElementById('commentsPanelExpandAll').addEventListener('click', function() {
+    toggleExpandAllComments();
   });
 
   // ===== Settings Panel =====

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5909,7 +5909,7 @@
     if (badge) badge.textContent = totalCount;
 
     // Update pill counts
-    var pillBtns = document.querySelectorAll('#commentsFilterPill .comments-filter-pill-btn');
+    var pillBtns = document.querySelectorAll('#commentsFilterPill .toggle-btn');
     pillBtns.forEach(function(btn) {
       var countEl = btn.querySelector('.filter-count');
       if (!countEl) return;
@@ -5918,7 +5918,6 @@
       else if (f === 'open') countEl.textContent = openCount;
       else if (f === 'resolved') countEl.textContent = resolvedCount;
     });
-    updateCommentsFilterIndicator();
 
     // Filter function based on active pill
     var visibleFilter = function(c) {
@@ -6019,18 +6018,6 @@
     });
 
     return groupName;
-  }
-
-  function updateCommentsFilterIndicator() {
-    var indicator = document.getElementById('commentsFilterIndicator');
-    var pill = document.getElementById('commentsFilterPill');
-    if (!indicator || !pill) return;
-    var activeBtn = pill.querySelector('.comments-filter-pill-btn.active');
-    if (!activeBtn) return;
-    var pillRect = pill.getBoundingClientRect();
-    var btnRect = activeBtn.getBoundingClientRect();
-    indicator.style.left = (btnRect.left - pillRect.left) + 'px';
-    indicator.style.width = btnRect.width + 'px';
   }
 
   function updateExpandAllLabel() {
@@ -7405,12 +7392,11 @@
 
   // Segmented pill filter
   document.getElementById('commentsFilterPill').addEventListener('click', function(e) {
-    var btn = e.target.closest('.comments-filter-pill-btn');
+    var btn = e.target.closest('.toggle-btn');
     if (!btn) return;
     commentsActiveFilter = btn.dataset.filter;
-    document.querySelectorAll('#commentsFilterPill .comments-filter-pill-btn').forEach(function(b) { b.classList.remove('active'); });
+    document.querySelectorAll('#commentsFilterPill .toggle-btn').forEach(function(b) { b.classList.remove('active'); });
     btn.classList.add('active');
-    updateCommentsFilterIndicator();
     renderCommentsPanel();
   });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5905,22 +5905,22 @@
     const resolvedCount = allComments.filter(function(c) { return c.resolved; }).length;
 
     // Update count badge
-    var badge = document.getElementById('commentsPanelCountBadge');
+    const badge = document.getElementById('commentsPanelCountBadge');
     if (badge) badge.textContent = totalCount;
 
     // Update pill counts
-    var pillBtns = document.querySelectorAll('#commentsFilterPill .toggle-btn');
+    const pillBtns = document.querySelectorAll('#commentsFilterPill .toggle-btn');
     pillBtns.forEach(function(btn) {
-      var countEl = btn.querySelector('.filter-count');
+      const countEl = btn.querySelector('.filter-count');
       if (!countEl) return;
-      var f = btn.dataset.filter;
+      const f = btn.dataset.filter;
       if (f === 'all') countEl.textContent = totalCount;
       else if (f === 'open') countEl.textContent = openCount;
       else if (f === 'resolved') countEl.textContent = resolvedCount;
     });
 
     // Filter function based on active pill
-    var visibleFilter = function(c) {
+    const visibleFilter = function(c) {
       if (commentsActiveFilter === 'open') return !c.resolved;
       if (commentsActiveFilter === 'resolved') return c.resolved;
       return true;
@@ -5985,7 +5985,7 @@
     if (!hasComments && !reviewCommentFormActive) {
       const empty = document.createElement('div');
       empty.className = 'comments-panel-empty';
-      var emptyMsg = commentsActiveFilter === 'open' ? 'No open comments' : commentsActiveFilter === 'resolved' ? 'No resolved comments' : 'No comments yet';
+      const emptyMsg = commentsActiveFilter === 'open' ? 'No open comments' : commentsActiveFilter === 'resolved' ? 'No resolved comments' : 'No comments yet';
       empty.textContent = emptyMsg;
       body.appendChild(empty);
     }
@@ -5994,21 +5994,21 @@
   }
 
   function createFileGroupHeader(label, count, groupEl) {
-    var groupName = document.createElement('div');
+    const groupName = document.createElement('div');
     groupName.className = 'comments-panel-file-name';
 
-    var chevron = document.createElement('span');
+    const chevron = document.createElement('span');
     chevron.className = 'comments-panel-file-chevron';
     chevron.textContent = '\u25BC';
     groupName.appendChild(chevron);
 
-    var nameText = document.createElement('span');
+    const nameText = document.createElement('span');
     nameText.className = 'comments-panel-file-name-text';
     nameText.textContent = label;
     nameText.title = label;
     groupName.appendChild(nameText);
 
-    var countEl = document.createElement('span');
+    const countEl = document.createElement('span');
     countEl.className = 'comments-panel-file-count';
     countEl.textContent = count;
     groupName.appendChild(countEl);
@@ -6021,20 +6021,20 @@
   }
 
   function updateExpandAllLabel() {
-    var btn = document.getElementById('commentsPanelExpandAll');
+    const btn = document.getElementById('commentsPanelExpandAll');
     if (!btn) return;
-    var panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
-    var inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
-    var allCards = Array.from(panelCards).concat(Array.from(inlineCards));
-    var anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
+    const panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
+    const inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
+    const allCards = Array.from(panelCards).concat(Array.from(inlineCards));
+    const anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
     btn.textContent = anyExpanded ? 'Collapse all' : 'Expand all';
   }
 
   function toggleExpandAllComments() {
-    var panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
-    var inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
-    var allCards = Array.from(panelCards).concat(Array.from(inlineCards));
-    var anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
+    const panelCards = document.querySelectorAll('#commentsPanelBody .comment-card');
+    const inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card');
+    const allCards = Array.from(panelCards).concat(Array.from(inlineCards));
+    const anyExpanded = allCards.some(function(c) { return !c.classList.contains('collapsed'); });
 
     allCards.forEach(function(card) {
       if (anyExpanded) {
@@ -6042,7 +6042,7 @@
       } else {
         card.classList.remove('collapsed');
       }
-      var id = card.dataset.commentId;
+      const id = card.dataset.commentId;
       if (id) commentCollapseOverrides[id] = anyExpanded;
     });
 
@@ -7392,7 +7392,7 @@
 
   // Segmented pill filter
   document.getElementById('commentsFilterPill').addEventListener('click', function(e) {
-    var btn = e.target.closest('.toggle-btn');
+    const btn = e.target.closest('.toggle-btn');
     if (!btn) return;
     commentsActiveFilter = btn.dataset.filter;
     document.querySelectorAll('#commentsFilterPill .toggle-btn').forEach(function(b) { b.classList.remove('active'); });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5996,6 +5996,9 @@
   function createFileGroupHeader(label, count, groupEl) {
     const groupName = document.createElement('div');
     groupName.className = 'comments-panel-file-name';
+    groupName.setAttribute('role', 'button');
+    groupName.setAttribute('tabindex', '0');
+    groupName.setAttribute('aria-expanded', 'true');
 
     const chevron = document.createElement('span');
     chevron.className = 'comments-panel-file-chevron';
@@ -6015,6 +6018,15 @@
 
     groupName.addEventListener('click', function() {
       groupEl.classList.toggle('collapsed');
+      const expanded = !groupEl.classList.contains('collapsed');
+      groupName.setAttribute('aria-expanded', String(expanded));
+    });
+
+    groupName.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        groupName.click();
+      }
     });
 
     return groupName;
@@ -7395,8 +7407,9 @@
     const btn = e.target.closest('.toggle-btn');
     if (!btn) return;
     commentsActiveFilter = btn.dataset.filter;
-    document.querySelectorAll('#commentsFilterPill .toggle-btn').forEach(function(b) { b.classList.remove('active'); });
+    document.querySelectorAll('#commentsFilterPill .toggle-btn').forEach(function(b) { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
     btn.classList.add('active');
+    btn.setAttribute('aria-pressed', 'true');
     renderCommentsPanel();
   });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -128,20 +128,25 @@
   </div>
   <div class="comments-panel comments-panel-hidden" id="commentsPanel">
     <div class="comments-panel-header">
-      <span class="comments-panel-title">Comments</span>
-      <div class="comments-panel-header-actions">
-        <button class="comments-panel-add-btn" id="panelAddCommentBtn" title="Add a general comment (G)">+ Add</button>
-        <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
+      <div class="comments-panel-header-row1">
+        <div class="comments-panel-header-left">
+          <span class="comments-panel-title">Comments</span>
+          <span class="comments-panel-count-badge" id="commentsPanelCountBadge">0</span>
+        </div>
+        <div class="comments-panel-header-actions">
+          <button class="comments-panel-add-btn" id="panelAddCommentBtn" title="Add a general comment (G)">+ Add</button>
+          <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
+        </div>
       </div>
-    </div>
-    <div class="comments-panel-filter" id="commentsPanelFilter" style="display:none">
-      <label class="comments-panel-switch">
-        <input type="checkbox" id="showResolvedToggle">
-        <span class="comments-panel-switch-track">
-          <span class="comments-panel-switch-thumb"></span>
-        </span>
-        <span class="comments-panel-switch-text">Show resolved</span>
-      </label>
+      <div class="comments-panel-header-row2">
+        <div class="comments-filter-pill" id="commentsFilterPill" role="group" aria-label="Filter comments">
+          <div class="comments-filter-pill-indicator" id="commentsFilterIndicator"></div>
+          <button class="comments-filter-pill-btn active" data-filter="all">All <span class="filter-count">0</span></button>
+          <button class="comments-filter-pill-btn" data-filter="open">Open <span class="filter-count">0</span></button>
+          <button class="comments-filter-pill-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+        </div>
+        <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
+      </div>
     </div>
     <div class="comments-panel-body" id="commentsPanelBody" aria-live="polite" aria-label="Comments list"></div>
   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -140,9 +140,9 @@
       </div>
       <div class="comments-panel-header-row2">
         <div class="comments-filter-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
-          <button class="toggle-btn active" data-filter="all">All <span class="filter-count">0</span></button>
-          <button class="toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
-          <button class="toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+          <button class="toggle-btn active" data-filter="all" aria-pressed="true">All <span class="filter-count">0</span></button>
+          <button class="toggle-btn" data-filter="open" aria-pressed="false">Open <span class="filter-count">0</span></button>
+          <button class="toggle-btn" data-filter="resolved" aria-pressed="false">Resolved <span class="filter-count">0</span></button>
         </div>
         <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,11 +139,10 @@
         </div>
       </div>
       <div class="comments-panel-header-row2">
-        <div class="comments-filter-pill" id="commentsFilterPill" role="group" aria-label="Filter comments">
-          <div class="comments-filter-pill-indicator" id="commentsFilterIndicator"></div>
-          <button class="comments-filter-pill-btn active" data-filter="all">All <span class="filter-count">0</span></button>
-          <button class="comments-filter-pill-btn" data-filter="open">Open <span class="filter-count">0</span></button>
-          <button class="comments-filter-pill-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+        <div class="comments-filter-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
+          <button class="toggle-btn active" data-filter="all">All <span class="filter-count">0</span></button>
+          <button class="toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
+          <button class="toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
         </div>
         <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
       </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2647,44 +2647,23 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   padding: 10px 16px 12px;
 }
 
-/* Segmented pill filter */
-.comments-filter-pill {
-  position: relative;
+/* Comments filter — reuses .scope-toggle + .toggle-btn */
+.comments-filter-toggle {
   display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--crit-border);
-  background: var(--crit-bg-card);
-  border-radius: 9999px;
-}
-.comments-filter-pill-indicator {
-  position: absolute;
-  height: 100%;
-  border-radius: 9999px;
   background: var(--crit-editor-bg-elevated);
   border: 1px solid var(--crit-border);
-  transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: none;
+  border-radius: 6px;
+  padding: 2px;
+  gap: 1px;
 }
-.comments-filter-pill-btn {
+.comments-filter-toggle .toggle-btn {
+  font-size: 11px;
+  padding: 3px 10px;
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 4px;
-  padding: 4px 10px;
-  cursor: pointer;
-  background: none;
-  border: none;
-  color: var(--crit-editor-fg-muted);
-  position: relative;
-  z-index: 1;
-  transition: color 0.15s;
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
 }
-.comments-filter-pill-btn:hover { color: var(--crit-editor-fg); }
-.comments-filter-pill-btn.active { color: var(--crit-brand); }
-.comments-filter-pill-btn .filter-count {
+.comments-filter-toggle .filter-count {
   font-weight: 400;
   opacity: 0.7;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2576,25 +2576,45 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .comments-panel::-webkit-scrollbar-thumb { background: var(--crit-editor-scrollbar-thumb); border-radius: 3px; }
 .comments-panel-hidden { display: none; }
 
+/* Two-row panel header */
 .comments-panel-header {
-  padding: 12px 16px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   border-bottom: 1px solid var(--crit-border);
   flex-shrink: 0;
 }
+.comments-panel-header-row1 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 0;
+}
+.comments-panel-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .comments-panel-title {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: var(--crit-editor-fg);
+}
+.comments-panel-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 500;
   color: var(--crit-editor-fg-muted);
+  background: var(--crit-editor-bg-elevated);
+  border-radius: 9999px;
+  line-height: 1;
 }
 .comments-panel-header-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 .comments-panel-add-btn {
   background: none;
@@ -2603,9 +2623,9 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   cursor: pointer;
   font-size: 11px;
   font-weight: 500;
-  padding: 2px 8px;
+  padding: 3px 8px;
   border-radius: 4px;
-  line-height: 1.4;
+  line-height: 1;
 }
 .comments-panel-add-btn:hover { background: var(--crit-editor-bg-hover); color: var(--crit-editor-fg); border-color: var(--crit-editor-fg-muted); }
 .comments-panel-close {
@@ -2613,12 +2633,77 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   border: none;
   color: var(--crit-editor-fg-muted);
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 6px;
+  font-size: 11px;
+  padding: 2px 4px;
   border-radius: 4px;
   line-height: 1;
 }
 .comments-panel-close:hover { background: var(--crit-editor-bg-hover); color: var(--crit-editor-fg); }
+
+.comments-panel-header-row2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px 12px;
+}
+
+/* Segmented pill filter */
+.comments-filter-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--crit-border);
+  background: var(--crit-bg-card);
+  border-radius: 9999px;
+}
+.comments-filter-pill-indicator {
+  position: absolute;
+  height: 100%;
+  border-radius: 9999px;
+  background: var(--crit-editor-bg-elevated);
+  border: 1px solid var(--crit-border);
+  transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+.comments-filter-pill-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 10px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  position: relative;
+  z-index: 1;
+  transition: color 0.15s;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.comments-filter-pill-btn:hover { color: var(--crit-editor-fg); }
+.comments-filter-pill-btn.active { color: var(--crit-brand); }
+.comments-filter-pill-btn .filter-count {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+/* Expand all / Collapse all link */
+.comments-panel-expand-all {
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+  white-space: nowrap;
+}
+.comments-panel-expand-all:hover { color: var(--crit-editor-fg); }
 
 /* Panel comment cards — real .comment-card inside the panel */
 .panel-comment-block {
@@ -2638,57 +2723,6 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 }
 .comments-panel-body > .comment-form-wrapper .comment-form {
   margin: 0;
-}
-
-/* Filter bar with custom switch */
-.comments-panel-filter {
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--crit-border);
-  flex-shrink: 0;
-}
-.comments-panel-switch {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  user-select: none;
-}
-.comments-panel-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
-.comments-panel-switch-track {
-  position: relative;
-  width: 28px;
-  height: 16px;
-  background: var(--crit-editor-bg-elevated);
-  border-radius: 8px;
-  border: 1px solid var(--crit-border);
-  transition: background 0.2s, border-color 0.2s;
-  flex-shrink: 0;
-}
-.comments-panel-switch-thumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 10px;
-  height: 10px;
-  background: var(--crit-editor-fg-muted);
-  border-radius: 50%;
-  transition: transform 0.2s, background 0.2s;
-}
-.comments-panel-switch input:checked + .comments-panel-switch-track {
-  background: var(--crit-brand-subtle);
-  border-color: var(--crit-brand);
-}
-.comments-panel-switch input:checked + .comments-panel-switch-track .comments-panel-switch-thumb {
-  transform: translateX(12px);
-  background: var(--crit-brand);
-}
-.comments-panel-switch input:focus-visible + .comments-panel-switch-track {
-  outline: 2px solid var(--crit-brand);
-  outline-offset: 1px;
-}
-.comments-panel-switch-text {
-  font-size: 12px;
-  color: var(--crit-editor-fg-muted);
 }
 
 /* Panel body */
@@ -2719,14 +2753,44 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   border-top: 1px solid var(--crit-border);
 }
 .comments-panel-file-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 10px 12px 2px;
   font-family: var(--crit-font-mono);
   font-size: 11px;
   font-weight: 500;
   color: var(--crit-editor-fg-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.comments-panel-file-name:hover {
+  color: var(--crit-editor-fg);
+}
+.comments-panel-file-chevron {
+  flex-shrink: 0;
+  font-size: 9px;
+  transition: transform 0.15s;
+  display: inline-block;
+}
+.comments-panel-file-group.collapsed .comments-panel-file-chevron {
+  transform: rotate(-90deg);
+}
+.comments-panel-file-name-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+}
+.comments-panel-file-count {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--crit-editor-fg-muted);
+  opacity: 0.6;
+  margin-left: auto;
+}
+.comments-panel-file-group.collapsed .comments-panel-file-cards {
+  display: none;
 }
 
 .comment-card-highlight {


### PR DESCRIPTION
## Summary
- **Two-row header layout**: Row 1 has Comments title + count badge, + Add button, and close. Row 2 has segmented filter pill and expand/collapse all toggle.
- **Segmented filter pill** (All/Open/Resolved) replaces the old "Show resolved" checkbox toggle, reusing the existing `.scope-toggle` + `.toggle-btn` pattern.
- **Collapsible file groups** with chevron indicator and per-group comment count badge.
- **Expand all / Collapse all** toggle that affects both panel and inline comment cards.

Comment card styling is unchanged.

## Test plan
- [ ] Open a review with multiple files containing comments (both open and resolved)
- [ ] Verify two-row header renders: title + badge on row 1, filter pill + expand all on row 2
- [ ] Click each filter pill button (All, Open, Resolved) and confirm correct filtering
- [ ] Verify count badge updates correctly as comments are added/resolved
- [ ] Click file group headers to collapse/expand individual groups
- [ ] Click "Expand all" / "Collapse all" and verify it toggles all comment cards (panel + inline)
- [ ] Test in light, dark, and system themes
- [ ] Confirm no regressions in comment editing, resolving, or adding new comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)