### PR TITLE
fix: hide TOC panel when buildToc has no headings

### DIFF
--- a/e2e/tests/toc-refresh.singlefile.spec.ts
+++ b/e2e/tests/toc-refresh.singlefile.spec.ts
@@ -63,6 +63,27 @@ test.describe('TOC Refresh on File Change — Single File Mode', () => {
     await expect(tocList.locator('a', { hasText: 'Authentication Plan' })).toHaveCount(0);
   });
 
+  test('TOC button and panel hide when all headings are removed', async ({ page, request }) => {
+    await loadPage(page);
+
+    // Open TOC so the panel is visible — sets up the regression scenario
+    const toggle = page.locator('#tocToggle');
+    await toggle.click();
+    const toc = page.locator('#toc');
+    await expect(toc).not.toHaveClass(/toc-hidden/);
+
+    // Replace plan.md with content that has no headings at all
+    const planPath = path.join(fixtureDir, 'plan.md');
+    fs.writeFileSync(planPath, 'Just a paragraph.\n\nNo headings here at all.\n');
+
+    // Trigger round-complete so the frontend rebuilds the TOC
+    await request.post('/api/round-complete');
+
+    // Toggle button should hide and panel should re-hide itself
+    await expect(toggle).toBeHidden({ timeout: 5000 });
+    await expect(toc).toHaveClass(/toc-hidden/);
+  });
+
   test('TOC updates when a heading is added after round-complete', async ({ page, request }) => {
     await loadPage(page);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6818,6 +6818,7 @@
 
     function hideToc() {
       toggleBtn.style.display = 'none';
+      tocEl.classList.add('toc-hidden');
     }
 
     // TOC only for single-file markdown reviews


### PR DESCRIPTION
## Summary
- Defensive parity fix matching tomasz-tomczyk/crit-web#113.
- `hideToc()` only hid the toggle button. If the panel had been opened from a previous render where headings existed (or via cookie restore), a subsequent `buildToc()` call with no headings would leave the panel visible but empty.
- Now `hideToc()` also adds `toc-hidden` to the panel.

## Test plan
- New test in `e2e/tests/toc-refresh.singlefile.spec.ts`:
  - Open TOC with headings → modify file to remove all headings → `POST /api/round-complete` → both toggle button and panel are hidden.
- See also: tomasz-tomczyk/crit-web#113

🤖 Generated with [Claude Code](https://claude.com/claude-code)