### PR TITLE
fix: exclude vendored Go packages from coverage profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+        run: |
+          PKGS=$(go list ./... | grep -v /node_modules/)
+          go test -coverprofile=coverage.out -covermode=atomic $PKGS
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,5 @@ ignore:
   - "e2e/"
   - "node_modules/"
   - "integrations/"
+  - "gen_integration_hashes.go"
+  - "integration_hashes_gen.go"


### PR DESCRIPTION
## Summary
- Filters `node_modules/flatted/golang/` out of `go test` coverage profile — it's a vendored Go package with 0% coverage that was dragging down the Codecov number vs what `go test` reports per-package
- Adds generated files (`gen_integration_hashes.go`, `integration_hashes_gen.go`) to codecov ignore

## Test plan
- [ ] CI passes
- [ ] Codecov number should match the ~58.5% that `go test` reports for the main package

🤖 Generated with [Claude Code](https://claude.com/claude-code)