### PR TITLE
test: improve unit test coverage

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -459,6 +461,227 @@ func TestShowLoginHint_PreservesExistingConfig(t *testing.T) {
 	json.Unmarshal(data, &raw)
 	if _, ok := raw["share_url"]; !ok {
 		t.Error("share_url should be preserved after showLoginHint")
+	}
+}
+
+// TestRunAuth_Dispatch verifies the runAuth dispatch logic via subprocess
+// (printAuthUsage calls os.Exit).
+func TestRunAuth_Dispatch_NoArgs(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_AuthNoArgs", "--")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit for auth with no args")
+	}
+}
+
+func TestHelperProcess_AuthNoArgs(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	runAuth(nil)
+}
+
+func TestRunAuth_Dispatch_UnknownCommand(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_AuthUnknown", "--")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit for auth with unknown command")
+	}
+}
+
+func TestHelperProcess_AuthUnknown(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	runAuth([]string{"invalid-command"})
+}
+
+// TestRunAuthWhoami_NotLoggedIn verifies whoami output when no token is set.
+func TestRunAuthWhoami_NotLoggedIn(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_AuthWhoamiNotLoggedIn", "--")
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1", "HOME="+home)
+	// Ensure CRIT_AUTH_TOKEN is not set
+	var env []string
+	for _, e := range cmd.Env {
+		if !strings.HasPrefix(e, "CRIT_AUTH_TOKEN=") {
+			env = append(env, e)
+		}
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("whoami exited with error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "Not logged in") {
+		t.Errorf("expected 'Not logged in' message, got: %s", out)
+	}
+}
+
+func TestHelperProcess_AuthWhoamiNotLoggedIn(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	runAuthWhoami(nil)
+}
+
+// TestRunAuthLogout_NotLoggedIn verifies logout output when no token is set.
+func TestRunAuthLogout_NotLoggedIn(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_AuthLogoutNotLoggedIn", "--")
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1", "HOME="+home)
+	var env []string
+	for _, e := range cmd.Env {
+		if !strings.HasPrefix(e, "CRIT_AUTH_TOKEN=") {
+			env = append(env, e)
+		}
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("logout exited with error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "Not logged in") {
+		t.Errorf("expected 'Not logged in' message, got: %s", out)
+	}
+}
+
+func TestHelperProcess_AuthLogoutNotLoggedIn(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	runAuthLogout(nil)
+}
+
+// TestRunAuthLogout_EnvToken verifies logout message when token is from env var.
+func TestRunAuthLogout_EnvToken(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_AuthLogoutEnvToken", "--")
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1", "HOME="+home, "CRIT_AUTH_TOKEN=crit_env_token")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("logout exited with error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "CRIT_AUTH_TOKEN") {
+		t.Errorf("expected env var message, got: %s", out)
+	}
+}
+
+func TestHelperProcess_AuthLogoutEnvToken(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	runAuthLogout(nil)
+}
+
+func TestParseAuthLoginFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		force bool
+	}{
+		{"no flags", nil, false},
+		{"empty args", []string{}, false},
+		{"force flag", []string{"--force"}, true},
+		{"force with other args", []string{"--verbose", "--force"}, true},
+		{"unknown flags ignored", []string{"--unknown"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := parseAuthLoginFlags(tt.args)
+			if f.force != tt.force {
+				t.Errorf("force = %v, want %v", f.force, tt.force)
+			}
+		})
+	}
+}
+
+func TestRevokeToken_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if revokeToken(srv.URL, "crit_tok") {
+		t.Error("expected revokeToken to return false for 500")
+	}
+}
+
+func TestFetchWhoami_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, _, err := fetchWhoami(srv.URL, "crit_tok")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}
+
+func TestFetchWhoami_NetworkError(t *testing.T) {
+	_, _, err := fetchWhoami("http://127.0.0.1:1", "crit_tok")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestFetchWhoami_NameOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"name": "Tomasz",
+		})
+	}))
+	defer srv.Close()
+
+	name, email, err := fetchWhoami(srv.URL, "crit_tok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "Tomasz" {
+		t.Errorf("name = %q, want Tomasz", name)
+	}
+	if email != "" {
+		t.Errorf("email = %q, want empty", email)
+	}
+}
+
+func TestRequestDeviceCode_NotFoundNoBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		// No JSON body — just 404
+	}))
+	defer srv.Close()
+
+	_, err := requestDeviceCode(srv.URL)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if got := err.Error(); got != "login is not available on this server" {
+		t.Errorf("error = %q, want default message", got)
+	}
+}
+
+func TestRequestDeviceCode_AcceptsHTTP200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"device_code":               "dc_200",
+			"verification_uri_complete": "https://crit.md/auth/cli?code=sc_200",
+			"interval":                  10,
+			"expires_in":                600,
+		})
+	}))
+	defer srv.Close()
+
+	code, err := requestDeviceCode(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code.DeviceCode != "dc_200" {
+		t.Errorf("device_code = %q, want dc_200", code.DeviceCode)
 	}
 }
 

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -571,6 +571,329 @@ func TestListSessionsForRepoRoot_NoPartialMatch(t *testing.T) {
 	}
 }
 
+func TestAtomicWriteFile_Success(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "test.txt")
+	data := []byte("hello world")
+
+	if err := atomicWriteFile(target, data, 0644); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading target: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("content = %q, want %q", string(got), "hello world")
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("permissions = %o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestAtomicWriteFile_CreatesDirectories(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sub", "dir", "test.txt")
+
+	if err := atomicWriteFile(target, []byte("nested"), 0600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if string(got) != "nested" {
+		t.Errorf("content = %q, want %q", string(got), "nested")
+	}
+}
+
+func TestAtomicWriteFile_OverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "overwrite.txt")
+
+	// Write initial content
+	if err := atomicWriteFile(target, []byte("first"), 0644); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	// Overwrite
+	if err := atomicWriteFile(target, []byte("second"), 0644); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("content = %q, want %q", string(got), "second")
+	}
+}
+
+func TestAtomicWriteFile_NoTempFilesLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "clean.txt")
+
+	if err := atomicWriteFile(target, []byte("clean"), 0644); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, de := range entries {
+		if strings.HasSuffix(de.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", de.Name())
+		}
+	}
+}
+
+func TestAtomicWriteFile_RestrictivePermissions(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "secret.txt")
+
+	if err := atomicWriteFile(target, []byte("secret"), 0600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("permissions = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestReadPortFromPipe_ValidPort(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	portCh, errCh := readPortFromPipe(r)
+
+	// Write a valid port
+	fmt.Fprintln(w, "8080")
+	w.Close()
+
+	select {
+	case port := <-portCh:
+		if port != 8080 {
+			t.Errorf("port = %d, want 8080", port)
+		}
+	case err := <-errCh:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadPortFromPipe_ErrorPrefix(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	portCh, errCh := readPortFromPipe(r)
+
+	fmt.Fprintln(w, "error:port already in use")
+	w.Close()
+
+	select {
+	case <-portCh:
+		t.Fatal("expected error, not port")
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "port already in use") {
+			t.Errorf("error = %q, want to contain 'port already in use'", err.Error())
+		}
+	}
+}
+
+func TestReadPortFromPipe_InvalidPort(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	portCh, errCh := readPortFromPipe(r)
+
+	fmt.Fprintln(w, "notanumber")
+	w.Close()
+
+	select {
+	case <-portCh:
+		t.Fatal("expected error for invalid port")
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestReadPortFromPipe_ClosedWithoutWriting(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	portCh, errCh := readPortFromPipe(r)
+	w.Close() // Close without writing anything
+
+	select {
+	case <-portCh:
+		t.Fatal("expected error when pipe closed without writing")
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestSignalReadiness(t *testing.T) {
+	t.Run("writes port to pipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe: %v", err)
+		}
+
+		signalReadiness(w, 3456)
+
+		var got int
+		fmt.Fscanf(r, "%d", &got)
+		r.Close()
+
+		if got != 3456 {
+			t.Errorf("read port = %d, want 3456", got)
+		}
+	})
+
+	t.Run("noop when pipe is nil", func(t *testing.T) {
+		// Should not panic
+		signalReadiness(nil, 3456)
+	})
+}
+
+func TestReadDaemonLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	t.Run("reads trimmed log content", func(t *testing.T) {
+		key := "logtest123456"
+		logPath, err := sessionLogPath(key)
+		if err != nil {
+			t.Fatalf("sessionLogPath: %v", err)
+		}
+		os.MkdirAll(filepath.Dir(logPath), 0700)
+		os.WriteFile(logPath, []byte("  error: something bad happened  \n"), 0644)
+
+		msg := readDaemonLog(key)
+		if msg != "error: something bad happened" {
+			t.Errorf("readDaemonLog = %q, want trimmed content", msg)
+		}
+	})
+
+	t.Run("returns empty for missing log", func(t *testing.T) {
+		msg := readDaemonLog("nonexistent123")
+		if msg != "" {
+			t.Errorf("readDaemonLog = %q, want empty", msg)
+		}
+	})
+}
+
+func TestOpenReadyPipe_NoEnvVar(t *testing.T) {
+	t.Setenv("_CRIT_READY_FD", "")
+	os.Unsetenv("_CRIT_READY_FD")
+
+	pipe := openReadyPipe()
+	if pipe != nil {
+		pipe.Close()
+		t.Error("expected nil when _CRIT_READY_FD is not set")
+	}
+}
+
+func TestOpenReadyPipe_WrongValue(t *testing.T) {
+	t.Setenv("_CRIT_READY_FD", "99")
+
+	pipe := openReadyPipe()
+	if pipe != nil {
+		pipe.Close()
+		t.Error("expected nil when _CRIT_READY_FD is not 3")
+	}
+}
+
+func TestSessionLogPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := sessionLogPath("abc123def456")
+	if err != nil {
+		t.Fatalf("sessionLogPath: %v", err)
+	}
+	want := filepath.Join(home, ".crit", "sessions", "abc123def456.log")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestReviewFilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := reviewFilePath("mykey123456")
+	if err != nil {
+		t.Fatalf("reviewFilePath: %v", err)
+	}
+	want := filepath.Join(home, ".crit", "reviews", "mykey123456.json")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestIsDaemonAlive_NegativePID(t *testing.T) {
+	if isDaemonAlive(sessionEntry{PID: -1, Port: 9999}) {
+		t.Error("negative PID should not be alive")
+	}
+}
+
+func TestIsDaemonAlive_NoPort(t *testing.T) {
+	if isDaemonAlive(sessionEntry{PID: os.Getpid(), Port: 0}) {
+		t.Error("port 0 should not be alive")
+	}
+}
+
+func TestRemoveSessionFile_CleansUpAssociatedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	key := "cleanup12345a"
+	sessDir := filepath.Join(home, ".crit", "sessions")
+	os.MkdirAll(sessDir, 0700)
+
+	// Create session file and associated files
+	os.WriteFile(filepath.Join(sessDir, key+".json"), []byte("{}"), 0644)
+	os.WriteFile(filepath.Join(sessDir, key+".log"), []byte("log"), 0644)
+	os.WriteFile(filepath.Join(sessDir, key+".lock"), []byte(""), 0644)
+
+	removeSessionFile(key)
+
+	for _, ext := range []string{".json", ".log", ".lock"} {
+		path := filepath.Join(sessDir, key+ext)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", path)
+		}
+	}
+}
+
 func TestCleanOrphanedSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/diff_test.go
+++ b/diff_test.go
@@ -294,3 +294,43 @@ func TestDiffEntriesToHunks_SeparateHunks(t *testing.T) {
 		t.Errorf("expected 2 separate hunks for distant changes, got %d", len(hunks))
 	}
 }
+
+func TestMapOldLineToNew_AllRemoved(t *testing.T) {
+	// Old: a, b, c  →  New: (empty)
+	entries := ComputeLineDiff("a\nb\nc", "")
+	m := MapOldLineToNew(entries)
+	// All old lines were removed, so each should map to 0 (no corresponding new line).
+	for i := 1; i <= 3; i++ {
+		if got, exists := m[i]; !exists {
+			t.Errorf("m[%d] missing, expected an entry for removed line", i)
+		} else if got != 0 {
+			t.Errorf("m[%d] = %d, want 0 for removed line", i, got)
+		}
+	}
+}
+
+func TestMapOldLineToNew_AllAdded(t *testing.T) {
+	// Old: (empty)  →  New: a, b, c
+	entries := ComputeLineDiff("", "a\nb\nc")
+	m := MapOldLineToNew(entries)
+	// No old lines to map, map should be empty or contain no old-line entries.
+	if len(m) != 0 {
+		t.Errorf("expected empty map for all-added, got %d entries", len(m))
+	}
+}
+
+func TestMapOldLineToNew_MixedOperations(t *testing.T) {
+	// Old: a, b, c, d, e  →  New: a, x, c, y, e
+	entries := ComputeLineDiff("a\nb\nc\nd\ne", "a\nx\nc\ny\ne")
+	m := MapOldLineToNew(entries)
+	// a:1→1, b:2→removed (maps to next: 3 or x:2), c:3→3, d:4→removed (maps to next: 5 or y:4), e:5→5
+	if m[1] != 1 {
+		t.Errorf("m[1] = %d, want 1", m[1])
+	}
+	if m[3] != 3 {
+		t.Errorf("m[3] = %d, want 3", m[3])
+	}
+	if m[5] != 5 {
+		t.Errorf("m[5] = %d, want 5", m[5])
+	}
+}

--- a/git_test.go
+++ b/git_test.go
@@ -1473,3 +1473,50 @@ func TestDiffNumstatBinary(t *testing.T) {
 		t.Errorf("image.png: got +%d/-%d, want +0/-0", s.Additions, s.Deletions)
 	}
 }
+
+func TestFileDiffForCommit_RootCommit(t *testing.T) {
+	dir := initTestRepo(t)
+	// Get the initial (root) commit SHA.
+	sha := runGit(t, dir, "rev-parse", "HEAD")
+
+	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	if err != nil {
+		t.Fatalf("FileDiffForCommit on root commit: %v", err)
+	}
+	if len(hunks) == 0 {
+		t.Error("expected hunks for root commit diff")
+	}
+}
+
+func TestFileDiffForCommit_NormalCommit(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "README.md"), "# Test\n\nUpdated content\n")
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "update readme")
+	sha := runGit(t, dir, "rev-parse", "HEAD")
+
+	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	if err != nil {
+		t.Fatalf("FileDiffForCommit: %v", err)
+	}
+	if len(hunks) == 0 {
+		t.Error("expected hunks for modified file commit")
+	}
+}
+
+func TestFileDiffForCommit_FileNotInCommit(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "other.go"), "package main")
+	runGit(t, dir, "add", "other.go")
+	runGit(t, dir, "commit", "-m", "add other")
+	sha := runGit(t, dir, "rev-parse", "HEAD")
+
+	// README.md was not changed in this commit.
+	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	if err != nil {
+		t.Fatalf("FileDiffForCommit: %v", err)
+	}
+	if len(hunks) != 0 {
+		t.Errorf("expected 0 hunks for file not in commit, got %d", len(hunks))
+	}
+}

--- a/github_test.go
+++ b/github_test.go
@@ -2302,3 +2302,100 @@ func TestBulkAddCommentsToCritJSON_PopulatesAnchor(t *testing.T) {
 		t.Errorf("Anchor = %q, want %q", comments[0].Anchor, "import \"net/http\"")
 	}
 }
+
+// --- processBulkReviewEntry tests ---
+
+func TestProcessBulkReviewEntry_ReviewScope(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}}
+	e := BulkCommentEntry{Body: "overall looks good", Scope: "review"}
+	err := processBulkReviewEntry(&cj, 0, e, "reviewer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cj.ReviewComments) != 1 {
+		t.Fatalf("expected 1 review comment, got %d", len(cj.ReviewComments))
+	}
+	if cj.ReviewComments[0].Body != "overall looks good" {
+		t.Errorf("body = %q, want 'overall looks good'", cj.ReviewComments[0].Body)
+	}
+	if cj.ReviewComments[0].Author != "reviewer" {
+		t.Errorf("author = %q, want 'reviewer'", cj.ReviewComments[0].Author)
+	}
+}
+
+func TestProcessBulkReviewEntry_WithLineRejectsNoFile(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}}
+	e := BulkCommentEntry{Body: "bad", Scope: "review", Line: 5}
+	err := processBulkReviewEntry(&cj, 0, e, "author")
+	if err == nil {
+		t.Error("expected error when review entry has line number")
+	}
+}
+
+func TestProcessBulkReviewEntry_NonReviewScopeWithFile(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}}
+	// When scope != "review" but File/Path are set, it errors because
+	// file-scoped comments should go through processBulkFileOrLineEntry.
+	e := BulkCommentEntry{Body: "bad", Scope: "line", File: "test.go"}
+	err := processBulkReviewEntry(&cj, 1, e, "author")
+	if err == nil {
+		t.Error("expected error when non-review scope has file set")
+	}
+}
+
+func TestProcessBulkReviewEntry_NoFileFallsThrough(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}}
+	// When no file/path is set and scope is not "review", it still adds a review comment.
+	e := BulkCommentEntry{Body: "general feedback", Scope: "line"}
+	err := processBulkReviewEntry(&cj, 0, e, "author")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cj.ReviewComments) != 1 {
+		t.Errorf("expected 1 review comment, got %d", len(cj.ReviewComments))
+	}
+}
+
+// --- addFileCommentToCritJSON additional tests ---
+
+func TestAddFileCommentToCritJSON_Success(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "test.go"), "package main\n")
+
+	// Create initial crit.json.
+	cj := CritJSON{
+		Branch:  "main",
+		BaseRef: "abc",
+		Files:   map[string]CritJSONFile{},
+	}
+	critPath := filepath.Join(dir, ".crit.json")
+	data, _ := json.Marshal(cj)
+	os.WriteFile(critPath, data, 0644)
+
+	err := addFileCommentToCritJSON("test.go", "file-level feedback", "reviewer", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Re-read and verify.
+	data, err = os.ReadFile(critPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result CritJSON
+	json.Unmarshal(data, &result)
+
+	cf, ok := result.Files["test.go"]
+	if !ok {
+		t.Fatal("expected test.go in files")
+	}
+	if len(cf.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(cf.Comments))
+	}
+	if cf.Comments[0].Body != "file-level feedback" {
+		t.Errorf("body = %q", cf.Comments[0].Body)
+	}
+	if cf.Comments[0].Scope != "file" {
+		t.Errorf("scope = %q, want file", cf.Comments[0].Scope)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1087,3 +1087,307 @@ func TestHelperProcess_Fetch(t *testing.T) {
 	outputDir := os.Getenv("GO_TEST_FETCH_OUTPUT_DIR")
 	runFetch([]string{"--output", outputDir})
 }
+
+func TestPlural(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "s"},
+		{1, ""},
+		{2, "s"},
+		{100, "s"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			if got := plural(tt.n); got != tt.want {
+				t.Errorf("plural(%d) = %q, want %q", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPluralReply(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "ies"},
+		{1, "y"},
+		{2, "ies"},
+		{5, "ies"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			if got := pluralReply(tt.n); got != tt.want {
+				t.Errorf("pluralReply(%d) = %q, want %q", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseShareFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		outputDir string
+		svcURL    string
+		showQR    bool
+		files     []string
+	}{
+		{
+			name:  "no flags",
+			args:  []string{"plan.md"},
+			files: []string{"plan.md"},
+		},
+		{
+			name:      "output flag long form",
+			args:      []string{"--output", "/tmp/out", "plan.md"},
+			outputDir: "/tmp/out",
+			files:     []string{"plan.md"},
+		},
+		{
+			name:      "output flag short form",
+			args:      []string{"-o", "/tmp/out", "plan.md"},
+			outputDir: "/tmp/out",
+			files:     []string{"plan.md"},
+		},
+		{
+			name:   "share-url flag",
+			args:   []string{"--share-url", "https://custom.example.com", "plan.md"},
+			svcURL: "https://custom.example.com",
+			files:  []string{"plan.md"},
+		},
+		{
+			name:   "qr flag",
+			args:   []string{"--qr", "plan.md"},
+			showQR: true,
+			files:  []string{"plan.md"},
+		},
+		{
+			name:      "all flags combined",
+			args:      []string{"--output", "/tmp/out", "--share-url", "https://x.com", "--qr", "a.md", "b.md"},
+			outputDir: "/tmp/out",
+			svcURL:    "https://x.com",
+			showQR:    true,
+			files:     []string{"a.md", "b.md"},
+		},
+		{
+			name:  "no args",
+			args:  nil,
+			files: nil,
+		},
+		{
+			name:  "multiple files only",
+			args:  []string{"a.md", "b.go", "c.txt"},
+			files: []string{"a.md", "b.go", "c.txt"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sf := parseShareFlags(tt.args)
+			if sf.outputDir != tt.outputDir {
+				t.Errorf("outputDir = %q, want %q", sf.outputDir, tt.outputDir)
+			}
+			if sf.svcURL != tt.svcURL {
+				t.Errorf("svcURL = %q, want %q", sf.svcURL, tt.svcURL)
+			}
+			if sf.showQR != tt.showQR {
+				t.Errorf("showQR = %v, want %v", sf.showQR, tt.showQR)
+			}
+			if len(sf.files) != len(tt.files) {
+				t.Fatalf("files = %v, want %v", sf.files, tt.files)
+			}
+			for i := range tt.files {
+				if sf.files[i] != tt.files[i] {
+					t.Errorf("files[%d] = %q, want %q", i, sf.files[i], tt.files[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadShareFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create test files
+	p1 := filepath.Join(dir, "plan.md")
+	p2 := filepath.Join(dir, "notes.txt")
+	os.WriteFile(p1, []byte("# My Plan"), 0644)
+	os.WriteFile(p2, []byte("Some notes"), 0644)
+
+	t.Run("loads single file", func(t *testing.T) {
+		files := loadShareFiles([]string{p1})
+		if len(files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(files))
+		}
+		if files[0].Content != "# My Plan" {
+			t.Errorf("content = %q", files[0].Content)
+		}
+	})
+
+	t.Run("loads multiple files", func(t *testing.T) {
+		files := loadShareFiles([]string{p1, p2})
+		if len(files) != 2 {
+			t.Fatalf("expected 2 files, got %d", len(files))
+		}
+		if files[0].Content != "# My Plan" {
+			t.Errorf("file 0 content = %q", files[0].Content)
+		}
+		if files[1].Content != "Some notes" {
+			t.Errorf("file 1 content = %q", files[1].Content)
+		}
+	})
+
+	t.Run("absolute path made relative", func(t *testing.T) {
+		files := loadShareFiles([]string{p1})
+		// The absolute path should be converted to a relative path
+		if files[0].Path == "" {
+			t.Error("expected non-empty path")
+		}
+		// The path should not be the full absolute path (unless cwd is /)
+		if filepath.IsAbs(files[0].Path) {
+			// It's OK if the relative conversion fails (e.g., different volume on Windows),
+			// but on Unix it should succeed
+			wd, _ := os.Getwd()
+			if wd != "/" {
+				t.Logf("path stayed absolute: %q (cwd: %q)", files[0].Path, wd)
+			}
+		}
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		files := loadShareFiles(nil)
+		if files != nil {
+			t.Errorf("expected nil, got %v", files)
+		}
+	})
+}
+
+func TestPrintQR_NoopWhenFalse(t *testing.T) {
+	// printQR with showQR=false should not panic and should be a no-op
+	printQR("https://example.com", false)
+}
+
+func TestCleanupOnApproval_EmptyPath(t *testing.T) {
+	// Should be a no-op when reviewPath is empty
+	cleanupOnApproval(true, "", true)
+}
+
+func TestResolvePlanSlug_UsesNameWhenProvided(t *testing.T) {
+	slug := resolvePlanSlug("my-custom-name", []byte("# Some Heading"))
+	if slug != "my-custom-name" {
+		t.Errorf("resolvePlanSlug with name = %q, want my-custom-name", slug)
+	}
+}
+
+func TestResolvePlanSlug_DerivesFromContent(t *testing.T) {
+	slug := resolvePlanSlug("", []byte("# Auth Flow\n\nDetails here"))
+	if slug == "" {
+		t.Error("expected non-empty slug derived from content")
+	}
+	if !strings.Contains(slug, "auth-flow") {
+		t.Errorf("slug = %q, expected to contain 'auth-flow'", slug)
+	}
+}
+
+// --- parseCommentFlags tests ---
+
+func TestParseCommentFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want commentFlags
+	}{
+		{
+			name: "no flags",
+			args: []string{"hello", "world"},
+			want: commentFlags{args: []string{"hello", "world"}},
+		},
+		{
+			name: "author flag",
+			args: []string{"--author", "alice", "comment body"},
+			want: commentFlags{author: "alice", args: []string{"comment body"}},
+		},
+		{
+			name: "reply-to flag",
+			args: []string{"--reply-to", "c_abc123", "reply body"},
+			want: commentFlags{replyTo: "c_abc123", args: []string{"reply body"}},
+		},
+		{
+			name: "resolve flag",
+			args: []string{"--resolve", "done"},
+			want: commentFlags{resolve: true, args: []string{"done"}},
+		},
+		{
+			name: "path flag",
+			args: []string{"--path", "main.go", "fix here"},
+			want: commentFlags{path: "main.go", args: []string{"fix here"}},
+		},
+		{
+			name: "json flag",
+			args: []string{"--json"},
+			want: commentFlags{json: true},
+		},
+		{
+			name: "plan flag",
+			args: []string{"--plan", "my-plan", "comment"},
+			want: commentFlags{plan: "my-plan", args: []string{"comment"}},
+		},
+		{
+			name: "multiple flags combined",
+			args: []string{"--author", "bob", "--reply-to", "c1", "--resolve", "fixed it"},
+			want: commentFlags{
+				author:  "bob",
+				replyTo: "c1",
+				resolve: true,
+				args:    []string{"fixed it"},
+			},
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: commentFlags{},
+		},
+		{
+			name: "output flag",
+			args: []string{"--output", "/tmp/review", "body"},
+			want: commentFlags{outputDir: "/tmp/review", args: []string{"body"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommentFlags(tt.args)
+			if got.author != tt.want.author {
+				t.Errorf("author = %q, want %q", got.author, tt.want.author)
+			}
+			if got.replyTo != tt.want.replyTo {
+				t.Errorf("replyTo = %q, want %q", got.replyTo, tt.want.replyTo)
+			}
+			if got.resolve != tt.want.resolve {
+				t.Errorf("resolve = %v, want %v", got.resolve, tt.want.resolve)
+			}
+			if got.path != tt.want.path {
+				t.Errorf("path = %q, want %q", got.path, tt.want.path)
+			}
+			if got.json != tt.want.json {
+				t.Errorf("json = %v, want %v", got.json, tt.want.json)
+			}
+			if got.plan != tt.want.plan {
+				t.Errorf("plan = %q, want %q", got.plan, tt.want.plan)
+			}
+			if got.outputDir != tt.want.outputDir {
+				t.Errorf("outputDir = %q, want %q", got.outputDir, tt.want.outputDir)
+			}
+			if len(got.args) != len(tt.want.args) {
+				t.Errorf("args len = %d, want %d", len(got.args), len(tt.want.args))
+			} else {
+				for i := range got.args {
+					if got.args[i] != tt.want.args[i] {
+						t.Errorf("args[%d] = %q, want %q", i, got.args[i], tt.want.args[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -2332,3 +2332,1190 @@ func TestHandleAgentRequest_MethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405, got %d", w.Code)
 	}
 }
+
+// --- handleCommits tests ---
+
+func TestHandleCommits_GET(t *testing.T) {
+	srv, session := newTestServer(t)
+
+	// Session with Mode "files" and no VCS — returns null/nil.
+	session.mu.Lock()
+	session.Mode = "files"
+	session.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/commits", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("GET /api/commits: status = %d, want 200", w.Code)
+	}
+	// Non-git session returns null (no commits).
+	body := strings.TrimSpace(w.Body.String())
+	if body != "null" {
+		t.Errorf("expected null for non-git session, got %s", body)
+	}
+}
+
+func TestHandleCommits_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/commits", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleCommits_GitMode(t *testing.T) {
+	dir := initTestRepo(t)
+	// Create a feature branch with a commit.
+	runGit(t, dir, "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(dir, "new.go"), "package main")
+	runGit(t, dir, "add", "new.go")
+	runGit(t, dir, "commit", "-m", "add new file")
+
+	session := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feature",
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	srv, err := NewServer(session, frontendFS, "", "", "", "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/commits", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var commits []CommitInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &commits); err != nil {
+		t.Fatalf("JSON decode: %v", err)
+	}
+	if len(commits) == 0 {
+		t.Error("expected at least one commit")
+	}
+}
+
+// --- handleBranches tests ---
+
+func TestHandleBranches_NoVCS(t *testing.T) {
+	srv, session := newTestServer(t)
+	// Ensure VCS is nil (files mode).
+	session.mu.Lock()
+	session.VCS = nil
+	session.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/branches", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var branches []string
+	if err := json.Unmarshal(w.Body.Bytes(), &branches); err != nil {
+		t.Fatalf("JSON decode: %v", err)
+	}
+	if len(branches) != 0 {
+		t.Errorf("expected empty branches for no VCS, got %v", branches)
+	}
+}
+
+func TestHandleBranches_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/branches", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleBranches_WithGitVCS(t *testing.T) {
+	dir := initTestRepo(t)
+
+	session := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	srv, err := NewServer(session, frontendFS, "", "", "", "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/branches", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	// No remotes in test repo, so empty list is expected.
+	var branches []string
+	if err := json.Unmarshal(w.Body.Bytes(), &branches); err != nil {
+		t.Fatalf("JSON decode: %v", err)
+	}
+}
+
+// --- handleBaseBranch tests ---
+
+func TestHandleBaseBranch_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/base-branch", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleBaseBranch_EmptyBranch(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"branch": ""}`)
+	req := httptest.NewRequest("POST", "/api/base-branch", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty branch", w.Code)
+	}
+}
+
+func TestHandleBaseBranch_InvalidJSON(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`not json`)
+	req := httptest.NewRequest("POST", "/api/base-branch", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for invalid JSON", w.Code)
+	}
+}
+
+// --- handleQR tests ---
+
+func TestHandleQR_Success(t *testing.T) {
+	srv, _ := newTestServer(t)
+	// Note: /api/qr is NOT guarded by withReady, so it works even without a session.
+	noSessionSrv, err := NewServer(nil, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = srv // keep reference for potential use
+
+	req := httptest.NewRequest("GET", "/api/qr?url=https://crit.md/r/test123", nil)
+	w := httptest.NewRecorder()
+	noSessionSrv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "image/svg+xml" {
+		t.Errorf("Content-Type = %q, want image/svg+xml", contentType)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "<svg") {
+		t.Error("response should contain SVG markup")
+	}
+	if !strings.Contains(body, "<rect") {
+		t.Error("response should contain rect elements for QR modules")
+	}
+}
+
+func TestHandleQR_MissingURL(t *testing.T) {
+	srv, err := NewServer(nil, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("GET", "/api/qr", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for missing url param", w.Code)
+	}
+}
+
+func TestHandleQR_MethodNotAllowed(t *testing.T) {
+	srv, err := NewServer(nil, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("POST", "/api/qr", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleEvents (SSE) tests ---
+
+func TestHandleEvents_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/events", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleEvents_SSEHeaders(t *testing.T) {
+	srv, session := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/events", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		srv.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	// Send an event then cancel.
+	time.Sleep(50 * time.Millisecond)
+	session.notify(SSEEvent{Type: "comments-changed"})
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Verify SSE headers.
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	cc := w.Header().Get("Cache-Control")
+	if cc != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", cc)
+	}
+	conn := w.Header().Get("Connection")
+	if conn != "keep-alive" {
+		t.Errorf("Connection = %q, want keep-alive", conn)
+	}
+
+	// Verify event data was written.
+	body := w.Body.String()
+	if !strings.Contains(body, "event: comments-changed") {
+		t.Errorf("expected SSE event in body, got: %s", body)
+	}
+}
+
+// --- buildPlanFeedback tests ---
+
+func TestBuildPlanFeedback(t *testing.T) {
+	session := &Session{
+		Mode:        "plan",
+		PlanDir:     "/tmp/plans/my-feature",
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+	srv, err := NewServer(session, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := srv.buildPlanFeedback("/home/user/.crit/reviews/abc123.json")
+
+	if !strings.Contains(result, "my-feature") {
+		t.Errorf("expected slug 'my-feature' in feedback, got: %s", result)
+	}
+	if !strings.Contains(result, "/home/user/.crit/reviews/abc123.json") {
+		t.Errorf("expected critJSON path in feedback, got: %s", result)
+	}
+	if !strings.Contains(result, "crit comment --plan") {
+		t.Errorf("expected crit comment hint in feedback, got: %s", result)
+	}
+}
+
+// --- handleFileCommentResolve tests ---
+
+func TestHandleFileCommentResolve(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this bug", "", "")
+
+	tests := []struct {
+		name       string
+		resolved   bool
+		wantStatus int
+	}{
+		{"resolve", true, 200},
+		{"unresolve", false, 200},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"resolved": %v}`, tt.resolved)
+			req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/resolve?path=test.md", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d, body = %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			var result Comment
+			json.Unmarshal(w.Body.Bytes(), &result)
+			if result.Resolved != tt.resolved {
+				t.Errorf("resolved = %v, want %v", result.Resolved, tt.resolved)
+			}
+		})
+	}
+}
+
+func TestHandleFileCommentResolve_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"resolved": true}`)
+	req := httptest.NewRequest("PUT", "/api/comment/nonexistent/resolve?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleFileCommentResolve_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/comment/c1/resolve?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleFileCommentResolve_InvalidBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/resolve?path=test.md", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for invalid JSON", w.Code)
+	}
+}
+
+// --- handleReviewCommentResolve tests ---
+
+func TestHandleReviewCommentResolve(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("general note", "")
+
+	tests := []struct {
+		name     string
+		resolved bool
+	}{
+		{"resolve", true},
+		{"unresolve", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"resolved": %v}`, tt.resolved)
+			req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/resolve", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+			if w.Code != 200 {
+				t.Errorf("[%s] status = %d, want 200, body = %s", tt.name, w.Code, w.Body.String())
+			}
+			var result Comment
+			json.Unmarshal(w.Body.Bytes(), &result)
+			if result.Resolved != tt.resolved {
+				t.Errorf("resolved = %v, want %v", result.Resolved, tt.resolved)
+			}
+		})
+	}
+}
+
+func TestHandleReviewCommentResolve_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"resolved": true}`)
+	req := httptest.NewRequest("PUT", "/api/review-comment/nonexistent/resolve", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleReviewCommentResolve_InvalidBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/resolve", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleReviewCommentResolve_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/review-comment/c1/resolve", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleReviewCommentUpdate tests ---
+
+func TestHandleReviewCommentUpdate_DELETE(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("delete me", "")
+
+	req := httptest.NewRequest("DELETE", "/api/review-comment/"+c.ID, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 204 {
+		t.Errorf("DELETE: status = %d, want 204", w.Code)
+	}
+
+	// Verify deleted.
+	comments := session.GetReviewComments()
+	if len(comments) != 0 {
+		t.Errorf("expected 0 comments after delete, got %d", len(comments))
+	}
+}
+
+func TestHandleReviewCommentUpdate_DELETE_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("DELETE", "/api/review-comment/nonexistent", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleReviewCommentUpdate_PUT_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "updated"}`)
+	req := httptest.NewRequest("PUT", "/api/review-comment/nonexistent", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleReviewCommentUpdate_PUT_EmptyBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("original", "")
+
+	body := strings.NewReader(`{"body": ""}`)
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID, body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty body", w.Code)
+	}
+}
+
+func TestHandleReviewCommentUpdate_PUT_InvalidJSON(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("original", "")
+
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID, strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleReviewCommentUpdate_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/review-comment/c1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleReplyCRUD additional tests ---
+
+func TestHandleReplyCRUD_PUT_EmptyBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent")
+
+	body := strings.NewReader(`{"body": ""}`)
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/"+reply.ID+"?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty reply body", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_PUT_InvalidJSON(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent")
+
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/"+reply.ID+"?path=test.md", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for invalid JSON", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_PUT_NotFound(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	body := strings.NewReader(`{"body": "updated"}`)
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/nonexistent?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404 for nonexistent reply", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_DELETE_NotFound(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	req := httptest.NewRequest("DELETE", "/api/comment/"+c.ID+"/replies/nonexistent?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_POST_EmptyBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	body := strings.NewReader(`{"body": "", "author": "agent"}`)
+	req := httptest.NewRequest("POST", "/api/comment/"+c.ID+"/replies?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty reply body", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_POST_InvalidJSON(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	req := httptest.NewRequest("POST", "/api/comment/"+c.ID+"/replies?path=test.md", strings.NewReader("bad json"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for invalid JSON", w.Code)
+	}
+}
+
+func TestHandleReplyCRUD_MethodNotAllowed(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	req := httptest.NewRequest("PATCH", "/api/comment/"+c.ID+"/replies?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- Review comment reply CRUD additional tests ---
+
+func TestReviewCommentReplyCRUD_PUT_EmptyBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+	reply, _ := session.AddReviewCommentReply(c.ID, "reply text", "agent")
+
+	body := strings.NewReader(`{"body": ""}`)
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/replies/"+reply.ID, body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty reply body", w.Code)
+	}
+}
+
+func TestReviewCommentReplyCRUD_PUT_NotFound(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+
+	body := strings.NewReader(`{"body": "updated"}`)
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/replies/nonexistent", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestReviewCommentReplyCRUD_DELETE_NotFound(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+
+	req := httptest.NewRequest("DELETE", "/api/review-comment/"+c.ID+"/replies/nonexistent", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestReviewCommentReplyCRUD_POST_EmptyBody(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+
+	body := strings.NewReader(`{"body": "", "author": "agent"}`)
+	req := httptest.NewRequest("POST", "/api/review-comment/"+c.ID+"/replies", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestReviewCommentReplyCRUD_POST_InvalidJSON(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("note", "")
+
+	req := httptest.NewRequest("POST", "/api/review-comment/"+c.ID+"/replies", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// --- handleFileCommentUpdate additional tests ---
+
+func TestHandleFileCommentUpdate_DELETE(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "delete me", "", "")
+
+	req := httptest.NewRequest("DELETE", "/api/comment/"+c.ID+"?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Errorf("DELETE: status = %d, want 200", w.Code)
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "deleted" {
+		t.Errorf("expected status 'deleted', got %v", resp)
+	}
+}
+
+func TestHandleFileCommentUpdate_DELETE_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("DELETE", "/api/comment/nonexistent?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleFileCommentUpdate_PUT_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "updated"}`)
+	req := httptest.NewRequest("PUT", "/api/comment/nonexistent?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleFileCommentUpdate_PUT_InvalidJSON(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"?path=test.md", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleFileCommentUpdate_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("PATCH", "/api/comment/c1?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleHealth additional tests ---
+
+func TestHandleHealth_WithBrowserClients(t *testing.T) {
+	srv, session := newTestServer(t)
+	session.BrowserConnect()
+	defer session.BrowserDisconnect()
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["browser_clients"] != true {
+		t.Errorf("browser_clients = %v, want true", resp["browser_clients"])
+	}
+}
+
+func TestHandleHealth_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/health", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleFinish additional tests ---
+
+func TestHandleFinish_AllResolved(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.SetCommentResolved("test.md", c.ID, true)
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	prompt, _ := resp["prompt"].(string)
+	if !strings.Contains(prompt, "resolved") {
+		t.Errorf("expected 'resolved' in prompt, got: %s", prompt)
+	}
+	if resp["approved"] != true {
+		t.Errorf("approved = %v, want true", resp["approved"])
+	}
+}
+
+func TestHandleFinish_PlanMode(t *testing.T) {
+	session := &Session{
+		Mode:        "plan",
+		PlanDir:     "/tmp/plans/test-plan",
+		RepoRoot:    t.TempDir(),
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{
+			{
+				Path:     "plan.md",
+				AbsPath:  "/tmp/plan.md",
+				Status:   "added",
+				FileType: "markdown",
+				Content:  "# Plan",
+				Comments: []Comment{{ID: "c1", Body: "needs work", StartLine: 1, EndLine: 1}},
+			},
+		},
+	}
+	srv, err := NewServer(session, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	prompt, _ := resp["prompt"].(string)
+	if !strings.Contains(prompt, "crit comment --plan") {
+		t.Errorf("plan mode finish should mention crit comment --plan, got: %s", prompt)
+	}
+}
+
+func TestHandleFinish_WithStatus(t *testing.T) {
+	var buf strings.Builder
+	session := &Session{
+		Mode:        "files",
+		RepoRoot:    t.TempDir(),
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{
+			{
+				Path:     "test.md",
+				AbsPath:  "/tmp/test.md",
+				Status:   "added",
+				FileType: "markdown",
+				Content:  "hello",
+				Comments: []Comment{{ID: "c1", Body: "fix", StartLine: 1, EndLine: 1}},
+			},
+		},
+	}
+	srv, err := NewServer(session, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set status on the Server, not the Session.
+	srv.status = &Status{w: &buf, color: false}
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	output := buf.String()
+	if output == "" {
+		t.Error("expected status output")
+	}
+}
+
+func TestHandleFinish_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleFileComments additional tests ---
+
+func TestHandleFileComments_POST_FileScope(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "file-level note", "scope": "file"}`)
+	req := httptest.NewRequest("POST", "/api/file/comments?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 201 {
+		t.Fatalf("status = %d, want 201, body = %s", w.Code, w.Body.String())
+	}
+	var c Comment
+	json.Unmarshal(w.Body.Bytes(), &c)
+	if c.Scope != "file" {
+		t.Errorf("scope = %q, want file", c.Scope)
+	}
+}
+
+func TestHandleFileComments_POST_EmptyBody(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "", "start_line": 1, "end_line": 1}`)
+	req := httptest.NewRequest("POST", "/api/file/comments?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleFileComments_POST_InvalidLineRange(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "test", "start_line": 0, "end_line": 1}`)
+	req := httptest.NewRequest("POST", "/api/file/comments?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for invalid line range", w.Code)
+	}
+}
+
+func TestHandleFileComments_POST_EndBeforeStart(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": "test", "start_line": 5, "end_line": 2}`)
+	req := httptest.NewRequest("POST", "/api/file/comments?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for end < start", w.Code)
+	}
+}
+
+func TestHandleFileComments_POST_InvalidJSON(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/file/comments?path=test.md", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleFileComments_MissingPath(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file/comments", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for missing path", w.Code)
+	}
+}
+
+func TestHandleFileComments_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("DELETE", "/api/file/comments?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleConfig additional tests ---
+
+func TestHandleConfig_WithAuthToken(t *testing.T) {
+	session := &Session{
+		Mode:        "files",
+		RepoRoot:    t.TempDir(),
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+	srv, err := NewServer(session, frontendFS, "https://crit.md", "test-token", "tester", "v2.0.0", 3000, "claude -p")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["agent_cmd_enabled"] != true {
+		t.Error("expected agent_cmd_enabled=true")
+	}
+	if resp["auth_logged_in"] != true {
+		t.Error("expected auth_logged_in=true")
+	}
+}
+
+// --- handleSession scope tests ---
+
+func TestHandleSession_WithScope(t *testing.T) {
+	dir := initTestRepo(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(dir, "new.go"), "package main\n")
+	runGit(t, dir, "add", "new.go")
+	runGit(t, dir, "commit", "-m", "add new file")
+
+	session := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feature",
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	srv, err := NewServer(session, frontendFS, "", "", "", "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/session?scope=branch", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["mode"] != "git" {
+		t.Errorf("mode = %v, want git", resp["mode"])
+	}
+}
+
+// --- handleReviewComments additional tests ---
+
+func TestHandleReviewComments_POST_EmptyBody(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := strings.NewReader(`{"body": ""}`)
+	req := httptest.NewRequest("POST", "/api/comments", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty body", w.Code)
+	}
+}
+
+func TestHandleReviewComments_POST_InvalidJSON(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/comments", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleReviewComments_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("PUT", "/api/comments", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleCommentByID additional tests ---
+
+func TestHandleCommentByID_EmptyID(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("PUT", "/api/comment/", strings.NewReader(`{"body": "test"}`))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty ID", w.Code)
+	}
+}
+
+// --- handleReviewCommentByID additional tests ---
+
+func TestHandleReviewCommentByID_EmptyID(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("PUT", "/api/review-comment/", strings.NewReader(`{"body": "test"}`))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty ID", w.Code)
+	}
+}
+
+// --- handleFileDiff additional tests ---
+
+func TestHandleFileDiff_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/file/diff?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleFile additional tests ---
+
+func TestHandleFile_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/file?path=test.md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleSession with commit parameter ---
+
+func TestHandleSession_WithCommit(t *testing.T) {
+	dir := initTestRepo(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(dir, "new.go"), "package main\n")
+	runGit(t, dir, "add", "new.go")
+	runGit(t, dir, "commit", "-m", "add new file")
+	sha := runGit(t, dir, "rev-parse", "HEAD")
+
+	session := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feature",
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	srv, err := NewServer(session, frontendFS, "", "", "", "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/session?commit="+sha, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	files, ok := resp["files"].([]any)
+	if !ok {
+		t.Fatal("expected files array in response")
+	}
+	if len(files) == 0 {
+		t.Error("expected files when scoped to specific commit")
+	}
+}
+
+func TestHandleSession_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/session", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 405 {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// --- handleFiles additional tests ---
+
+func TestHandleFiles_EmptyPath(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/files/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 for empty path", w.Code)
+	}
+}
+
+func TestHandleFiles_PathTraversal_DotDot(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/files/../../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	// Should return 400 or 403.
+	if w.Code == 200 {
+		t.Error("path traversal should not return 200")
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -4219,3 +4219,513 @@ func TestHandleCritJSONDeleted(t *testing.T) {
 		t.Error("deletedCommentIDs should be nil")
 	}
 }
+
+// --- GetShareScope / SetShareScope tests ---
+
+func TestGetShareScope(t *testing.T) {
+	s := &Session{
+		subscribers:   make(map[chan SSEEvent]struct{}),
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	// Initially empty.
+	if got := s.GetShareScope(); got != "" {
+		t.Errorf("initial share scope = %q, want empty", got)
+	}
+
+	// Set and retrieve.
+	s.SetShareScope("abc123")
+	if got := s.GetShareScope(); got != "abc123" {
+		t.Errorf("share scope = %q, want abc123", got)
+	}
+
+	// Overwrite.
+	s.SetShareScope("def456")
+	if got := s.GetShareScope(); got != "def456" {
+		t.Errorf("share scope = %q, want def456", got)
+	}
+}
+
+// --- availableScopes tests ---
+
+func TestAvailableScopes_NilVCS(t *testing.T) {
+	scopes := availableScopes("main", nil)
+	if len(scopes) != 1 || scopes[0] != "all" {
+		t.Errorf("expected [all] for nil VCS, got %v", scopes)
+	}
+}
+
+func TestAvailableScopes_EmptyBaseRef(t *testing.T) {
+	dir := initTestRepo(t)
+	// Create a file and stage it.
+	writeFile(t, filepath.Join(dir, "staged.go"), "package main")
+	runGit(t, dir, "add", "staged.go")
+
+	// Use a real GitVCS pointed at the test repo.
+	// Need to chdir for GitVCS to work.
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	vcs := &GitVCS{}
+	scopes := availableScopes("", vcs)
+	// With empty baseRef, "branch" scope should not be added.
+	for _, s := range scopes {
+		if s == "branch" {
+			t.Error("branch scope should not appear with empty baseRef")
+		}
+	}
+	// "all" should always be present.
+	if scopes[0] != "all" {
+		t.Errorf("first scope should be 'all', got %q", scopes[0])
+	}
+}
+
+// --- GetSessionInfoScoped tests ---
+
+func TestGetSessionInfoScoped_EmptyScope(t *testing.T) {
+	s := newTestSession(t)
+	s.Mode = "files"
+
+	info := s.GetSessionInfoScoped("", "")
+	if info.Mode != "files" {
+		t.Errorf("mode = %q, want files", info.Mode)
+	}
+	// Should delegate to GetSessionInfo, which returns file list.
+	if len(info.Files) == 0 {
+		t.Error("expected at least one file in session info")
+	}
+}
+
+func TestGetSessionInfoScoped_AllScope(t *testing.T) {
+	s := newTestSession(t)
+	s.Mode = "files"
+
+	info := s.GetSessionInfoScoped("all", "")
+	if info.Mode != "files" {
+		t.Errorf("mode = %q, want files", info.Mode)
+	}
+}
+
+func TestGetSessionInfoScoped_PlanMode(t *testing.T) {
+	s := &Session{
+		Mode:        "plan",
+		PlanDir:     "/tmp/test-plan",
+		RepoRoot:    t.TempDir(),
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{
+			{Path: "plan.md", FileType: "markdown", Content: "# Plan", Comments: []Comment{}},
+		},
+	}
+
+	info := s.GetSessionInfoScoped("branch", "")
+	if info.Mode != "plan" {
+		t.Errorf("mode = %q, want plan", info.Mode)
+	}
+}
+
+func TestGetSessionInfoScoped_GitScopeNoVCS(t *testing.T) {
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    t.TempDir(),
+		Branch:      "feature",
+		BaseRef:     "main",
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	info := s.GetSessionInfoScoped("branch", "")
+	// No VCS means no files can be resolved.
+	if len(info.Files) != 0 {
+		t.Errorf("expected 0 files without VCS, got %d", len(info.Files))
+	}
+	if info.Mode != "git" {
+		t.Errorf("mode = %q, want git", info.Mode)
+	}
+}
+
+// --- emitRoundStatus tests ---
+
+func TestEmitRoundStatus_NilStatus(t *testing.T) {
+	s := &Session{
+		status:      nil,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+	// Should be a no-op, not panic.
+	s.emitRoundStatus(5)
+}
+
+func TestEmitRoundStatus_WithStatus(t *testing.T) {
+	var buf strings.Builder
+	s := &Session{
+		status:      &Status{w: &buf, color: false},
+		ReviewRound: 2,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{
+			{
+				Path: "plan.md",
+				PreviousComments: []Comment{
+					{ID: "c1", Resolved: true},
+					{ID: "c2", Resolved: false},
+					{ID: "c3", Resolved: false},
+				},
+			},
+		},
+	}
+
+	s.emitRoundStatus(3)
+
+	output := buf.String()
+	if output == "" {
+		t.Error("expected status output, got empty")
+	}
+}
+
+// --- Shutdown tests ---
+
+func TestShutdown(t *testing.T) {
+	s := &Session{
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+	ch := s.Subscribe()
+	defer s.Unsubscribe(ch)
+
+	s.Shutdown()
+
+	select {
+	case event := <-ch:
+		if event.Type != "server-shutdown" {
+			t.Errorf("event type = %q, want server-shutdown", event.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no shutdown event received")
+	}
+}
+
+// --- BrowserDisconnect tests ---
+
+func TestBrowserConnectDisconnect(t *testing.T) {
+	s := &Session{
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	if s.HasBrowserClients() {
+		t.Error("initially should have no browser clients")
+	}
+
+	s.BrowserConnect()
+	if !s.HasBrowserClients() {
+		t.Error("after connect, should have browser clients")
+	}
+
+	s.BrowserDisconnect()
+	if s.HasBrowserClients() {
+		t.Error("after disconnect, should have no browser clients")
+	}
+
+	// BrowserDisconnect should not go below 0.
+	s.BrowserDisconnect()
+	if s.HasBrowserClients() {
+		t.Error("double disconnect should still show no clients")
+	}
+}
+
+// --- mergeReviewCommentsFromDisk tests ---
+
+func TestMergeReviewCommentsFromDisk_AddNew(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "existing"},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	diskComments := []Comment{
+		{ID: "r1", Body: "existing"},
+		{ID: "r2", Body: "new from disk"},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if !changed {
+		t.Error("expected changed=true when adding new comment")
+	}
+	if len(s.reviewComments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(s.reviewComments))
+	}
+}
+
+func TestMergeReviewCommentsFromDisk_RemoveDeleted(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "keep"},
+			{ID: "r2", Body: "will be deleted"},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	// Disk only has r1 — r2 was deleted externally.
+	diskComments := []Comment{
+		{ID: "r1", Body: "keep"},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if !changed {
+		t.Error("expected changed=true when removing deleted comment")
+	}
+	if len(s.reviewComments) != 1 {
+		t.Errorf("expected 1 comment, got %d", len(s.reviewComments))
+	}
+	if s.reviewComments[0].ID != "r1" {
+		t.Errorf("expected r1, got %s", s.reviewComments[0].ID)
+	}
+}
+
+func TestMergeReviewCommentsFromDisk_NoChange(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "same"},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	diskComments := []Comment{
+		{ID: "r1", Body: "same"},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if changed {
+		t.Error("expected changed=false when nothing changed")
+	}
+}
+
+func TestMergeReviewCommentsFromDisk_ResolvedStateSync(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "note", Resolved: false},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	diskComments := []Comment{
+		{ID: "r1", Body: "note", Resolved: true},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if !changed {
+		t.Error("expected changed=true when resolved state changes")
+	}
+	if !s.reviewComments[0].Resolved {
+		t.Error("expected resolved=true after merge")
+	}
+}
+
+func TestMergeReviewCommentsFromDisk_NewReplies(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "note", Replies: []Reply{{ID: "rp1", Body: "existing reply"}}},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	diskComments := []Comment{
+		{ID: "r1", Body: "note", Replies: []Reply{
+			{ID: "rp1", Body: "existing reply"},
+			{ID: "rp2", Body: "new reply from disk"},
+		}},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if !changed {
+		t.Error("expected changed=true when new replies added")
+	}
+	if len(s.reviewComments[0].Replies) != 2 {
+		t.Errorf("expected 2 replies, got %d", len(s.reviewComments[0].Replies))
+	}
+}
+
+// --- filterDeletedReviewComments tests ---
+
+func TestFilterDeletedReviewComments_NoneDeleted(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1"}, {ID: "r2"},
+		},
+	}
+	diskComments := []Comment{
+		{ID: "r1"}, {ID: "r2"},
+	}
+	changed := s.filterDeletedReviewComments(diskComments)
+	if changed {
+		t.Error("expected no change when all comments exist on disk")
+	}
+}
+
+func TestFilterDeletedReviewComments_SomeDeleted(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1"}, {ID: "r2"}, {ID: "r3"},
+		},
+	}
+	diskComments := []Comment{
+		{ID: "r1"}, {ID: "r3"},
+	}
+	changed := s.filterDeletedReviewComments(diskComments)
+	if !changed {
+		t.Error("expected change when comment deleted from disk")
+	}
+	if len(s.reviewComments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(s.reviewComments))
+	}
+}
+
+// --- computeScopedDiffHunks tests ---
+
+func TestComputeScopedDiffHunks_UntrackedFile(t *testing.T) {
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "untracked", "package main\n", "", "", nil)
+	if len(hunks) == 0 {
+		t.Error("expected hunks for untracked file")
+	}
+}
+
+func TestComputeScopedDiffHunks_AddedFileAllScope(t *testing.T) {
+	hunks := computeScopedDiffHunks("test.go", "all", "", "added", "package main\n", "", "", nil)
+	if len(hunks) == 0 {
+		t.Error("expected hunks for added file with all scope")
+	}
+}
+
+func TestComputeScopedDiffHunks_AddedFileUnstagedScope(t *testing.T) {
+	// scope=unstaged + status=added => does not use FileDiffUnifiedNewFile
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "added", "package main\n", "", "", nil)
+	// No VCS to fall back on, should return nil.
+	if hunks != nil {
+		t.Error("expected nil hunks for added file with unstaged scope and no VCS")
+	}
+}
+
+func TestComputeScopedDiffHunks_NilVCS(t *testing.T) {
+	hunks := computeScopedDiffHunks("test.go", "branch", "", "modified", "package main\n", "main", "/tmp", nil)
+	if hunks != nil {
+		t.Error("expected nil hunks with no VCS")
+	}
+}
+
+// --- scopedHunks tests ---
+
+func TestScopedHunks_NilVCS(t *testing.T) {
+	fc := FileChange{Path: "test.go", Status: "modified"}
+	hunks := scopedHunks(fc, "branch", "", "main", "/tmp", nil)
+	if hunks != nil {
+		t.Error("expected nil hunks with nil VCS")
+	}
+}
+
+func TestScopedHunks_AddedFile(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
+	runGit(t, dir, "add", "new.go")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	fc := FileChange{Path: "new.go", Status: "added"}
+	hunks := scopedHunks(fc, "branch", "", "main", dir, &GitVCS{})
+	if len(hunks) == 0 {
+		t.Error("expected hunks for added file showing full content")
+	}
+}
+
+func TestScopedHunks_UntrackedFile(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "untracked.go"), "package main\n")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	fc := FileChange{Path: "untracked.go", Status: "untracked"}
+	hunks := scopedHunks(fc, "all", "", "", dir, &GitVCS{})
+	if len(hunks) == 0 {
+		t.Error("expected hunks for untracked file")
+	}
+}
+
+// --- GetSessionInfoScoped with git VCS ---
+
+func TestGetSessionInfoScoped_GitBranchScope(t *testing.T) {
+	dir := initTestRepo(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
+	runGit(t, dir, "add", "new.go")
+	runGit(t, dir, "commit", "-m", "add new file")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feature",
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	info := s.GetSessionInfoScoped("branch", "")
+	if info.Mode != "git" {
+		t.Errorf("mode = %q, want git", info.Mode)
+	}
+	if len(info.Files) == 0 {
+		t.Error("expected files in branch scope")
+	}
+	found := false
+	for _, f := range info.Files {
+		if f.Path == "new.go" {
+			found = true
+			if f.Status != "added" {
+				t.Errorf("new.go status = %q, want added", f.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected new.go in branch scope files")
+	}
+}
+
+func TestGetSessionInfoScoped_CommitScope(t *testing.T) {
+	dir := initTestRepo(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
+	runGit(t, dir, "add", "new.go")
+	runGit(t, dir, "commit", "-m", "add new file")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// Get the commit SHA.
+	sha := runGit(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		Branch:      "feature",
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	info := s.GetSessionInfoScoped("", sha)
+	if len(info.Files) == 0 {
+		t.Error("expected files when scoped to specific commit")
+	}
+}

--- a/share_test.go
+++ b/share_test.go
@@ -1474,6 +1474,200 @@ func TestMergeRepliesIntoComment(t *testing.T) {
 	})
 }
 
+func TestResolveAuthToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		envToken  string
+		envSet    bool
+		cfgToken  string
+		wantToken string
+	}{
+		{
+			name:      "env takes priority over config",
+			envToken:  "env_token",
+			envSet:    true,
+			cfgToken:  "cfg_token",
+			wantToken: "env_token",
+		},
+		{
+			name:      "config used when no env",
+			envSet:    false,
+			cfgToken:  "cfg_token",
+			wantToken: "cfg_token",
+		},
+		{
+			name:      "empty when nothing set",
+			envSet:    false,
+			cfgToken:  "",
+			wantToken: "",
+		},
+		{
+			name:      "empty env string still counts as set",
+			envToken:  "",
+			envSet:    true,
+			cfgToken:  "cfg_token",
+			wantToken: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envSet {
+				t.Setenv("CRIT_AUTH_TOKEN", tt.envToken)
+			} else {
+				t.Setenv("CRIT_AUTH_TOKEN", "")
+				os.Unsetenv("CRIT_AUTH_TOKEN")
+			}
+			cfg := Config{AuthToken: tt.cfgToken}
+			got := resolveAuthToken(cfg)
+			if got != tt.wantToken {
+				t.Errorf("resolveAuthToken() = %q, want %q", got, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestCommentToShareComment(t *testing.T) {
+	t.Run("basic conversion", func(t *testing.T) {
+		c := Comment{
+			ID:          "c1",
+			StartLine:   10,
+			EndLine:     15,
+			Body:        "fix this",
+			Quote:       "old code",
+			Author:      "Alice",
+			ReviewRound: 2,
+		}
+		sc := commentToShareComment(c, "main.go", "line", false, false)
+		if sc.File != "main.go" {
+			t.Errorf("File = %q, want main.go", sc.File)
+		}
+		if sc.StartLine != 10 || sc.EndLine != 15 {
+			t.Errorf("lines = %d-%d, want 10-15", sc.StartLine, sc.EndLine)
+		}
+		if sc.Body != "fix this" {
+			t.Errorf("Body = %q", sc.Body)
+		}
+		if sc.Quote != "old code" {
+			t.Errorf("Quote = %q", sc.Quote)
+		}
+		if sc.Author != "Alice" {
+			t.Errorf("Author = %q", sc.Author)
+		}
+		if sc.ReviewRound != 2 {
+			t.Errorf("ReviewRound = %d, want 2", sc.ReviewRound)
+		}
+		if sc.Scope != "line" {
+			t.Errorf("Scope = %q, want line", sc.Scope)
+		}
+	})
+
+	t.Run("includes resolved when flag set", func(t *testing.T) {
+		c := Comment{Resolved: true}
+		sc := commentToShareComment(c, "", "", true, false)
+		if !sc.Resolved {
+			t.Error("expected Resolved=true when includeResolved=true")
+		}
+	})
+
+	t.Run("excludes resolved when flag not set", func(t *testing.T) {
+		c := Comment{Resolved: true}
+		sc := commentToShareComment(c, "", "", false, false)
+		if sc.Resolved {
+			t.Error("expected Resolved=false when includeResolved=false")
+		}
+	})
+
+	t.Run("sets external ID when flag set", func(t *testing.T) {
+		c := Comment{ID: "c123"}
+		sc := commentToShareComment(c, "", "", false, true)
+		if sc.ExternalID != "c123" {
+			t.Errorf("ExternalID = %q, want c123", sc.ExternalID)
+		}
+	})
+
+	t.Run("omits external ID when flag not set", func(t *testing.T) {
+		c := Comment{ID: "c123"}
+		sc := commentToShareComment(c, "", "", false, false)
+		if sc.ExternalID != "" {
+			t.Errorf("ExternalID = %q, want empty", sc.ExternalID)
+		}
+	})
+
+	t.Run("converts replies", func(t *testing.T) {
+		c := Comment{
+			Body: "note",
+			Replies: []Reply{
+				{Body: "done", Author: "Bob"},
+				{Body: "verified", Author: "Alice"},
+			},
+		}
+		sc := commentToShareComment(c, "f.md", "", false, false)
+		if len(sc.Replies) != 2 {
+			t.Fatalf("expected 2 replies, got %d", len(sc.Replies))
+		}
+		if sc.Replies[0].Body != "done" || sc.Replies[0].Author != "Bob" {
+			t.Errorf("reply[0] = %+v", sc.Replies[0])
+		}
+	})
+
+	t.Run("review round zero omitted", func(t *testing.T) {
+		c := Comment{ReviewRound: 0}
+		sc := commentToShareComment(c, "", "", false, false)
+		if sc.ReviewRound != 0 {
+			t.Errorf("ReviewRound = %d, want 0 (omitted for round 0)", sc.ReviewRound)
+		}
+	})
+}
+
+func TestMergeWebComments(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	// Setup initial review file
+	cj := CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {Comments: []Comment{
+				{ID: "c1", Body: "existing", StartLine: 1, EndLine: 1},
+			}},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(critPath, data, 0644)
+
+	// Merge new comments
+	newComments := []webComment{
+		{Body: "web comment", FilePath: "main.go", StartLine: 5, EndLine: 5, AuthorDisplayName: "Web User"},
+		{Body: "review note", Scope: "review", AuthorDisplayName: "Reviewer"},
+	}
+	if err := mergeWebComments(critPath, newComments); err != nil {
+		t.Fatalf("mergeWebComments: %v", err)
+	}
+
+	// Read back and verify
+	data, _ = os.ReadFile(critPath)
+	var result CritJSON
+	json.Unmarshal(data, &result)
+
+	mainComments := result.Files["main.go"].Comments
+	if len(mainComments) != 2 {
+		t.Fatalf("expected 2 comments in main.go, got %d", len(mainComments))
+	}
+	if mainComments[1].Body != "web comment" {
+		t.Errorf("new comment body = %q", mainComments[1].Body)
+	}
+	if mainComments[1].ID != "web-1" {
+		t.Errorf("new comment ID = %q, want web-1", mainComments[1].ID)
+	}
+
+	if len(result.ReviewComments) != 1 {
+		t.Fatalf("expected 1 review comment, got %d", len(result.ReviewComments))
+	}
+	if result.ReviewComments[0].Body != "review note" {
+		t.Errorf("review comment body = %q", result.ReviewComments[0].Body)
+	}
+}
+
 func TestBuildLocalFingerprints(t *testing.T) {
 	t.Run("file comments with path body lines", func(t *testing.T) {
 		cj := CritJSON{


### PR DESCRIPTION
## Summary
- Add ~2,900 lines of new tests across 9 files, improving coverage from 60.1% to 66.0% (+5.9pp)
- Server handlers: handleCommits, handleBranches, handleBaseBranch, handleQR, handleEvents, handleFinish, handleConfig, handleSession, handleShareURL, handleReplyCRUD, and more
- Session methods: GetSessionInfoScoped, availableScopes, computeScopedDiffHunks, mergeReviewCommentsFromDisk, BrowserConnect/Disconnect, Shutdown
- Auth: requestDeviceCode, pollDeviceToken, pollForToken, saveAuthToken, revokeToken, fetchWhoami, showLoginHint, parseAuthLoginFlags
- Daemon: sessionKey, session file round-trips, acquireSessionLock, isDaemonAlive, findSessionForCWDBranch, listSessionsForRepoRoot, cleanOrphanedSessions
- Reviewed and deduplicated by independent Go expert agent (10 duplicates removed, 1 empty assertion fixed)

## Review
- [x] Code review: passed (independent Go expert review)
- [x] Parity audit: N/A (test-only)

## Test plan
- [x] `go test -race ./...` passes
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)