### PR TITLE
fix: clarify Hide resolved comments label in settings

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7514,9 +7514,9 @@
     // Hide resolved row
     const hideResolved = localStorage.getItem('crit-hide-resolved') === 'true';
     html += '<div class="settings-display-row">';
-    html += '<span class="settings-display-label">Hide resolved</span>';
+    html += '<span class="settings-display-label">Hide resolved comments</span>';
     html += '<label class="comments-panel-switch">';
-    html += '<input type="checkbox" id="hideResolvedToggle" aria-label="Hide resolved"' + (hideResolved ? ' checked' : '') + '>';
+    html += '<input type="checkbox" id="hideResolvedToggle" aria-label="Hide resolved comments"' + (hideResolved ? ' checked' : '') + '>';
     html += '<span class="comments-panel-switch-track"><span class="comments-panel-switch-thumb"></span></span>';
     html += '</label>';
     html += '</div>';


### PR DESCRIPTION
## Summary
- Settings label "Hide resolved" → "Hide resolved comments" (clearer; aria-label too)

Companion: tomasz-tomczyk/crit-web#121

## Test plan
- [x] Existing E2E test "Hide resolved" matcher still passes (substring match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)