### PR TITLE
fix: collapse reply form after submit; auto-close empty comment forms

### DIFF
--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -375,6 +375,8 @@ test.describe('Cross-File Comments', () => {
     // Form should be open
     await expect(serverSection.locator('.comment-form')).toBeVisible();
     await expect(page.locator('.comment-form')).toHaveCount(1);
+    // Fill so it isn't auto-closed when the second form opens
+    await serverSection.locator('.comment-form textarea').fill('first');
 
     // Now open comment form on handler.js
     const handlerSection = jsSection(page);

--- a/e2e/tests/multi-form.spec.ts
+++ b/e2e/tests/multi-form.spec.ts
@@ -41,6 +41,27 @@ test.describe('Multi-Form Comments', () => {
     await expect(secondForm.locator('textarea')).toBeFocused();
   });
 
+  test('opening a new comment form closes existing empty form', async ({ page }) => {
+    // Open form on server.go (leave empty)
+    const goSec = goSection(page);
+    const goAddition = goSec.locator('.diff-split-side.addition').first();
+    await goAddition.hover();
+    await goAddition.locator('.diff-comment-btn').click();
+    await expect(goSec.locator('.comment-form')).toBeVisible();
+
+    // Open form on handler.js without filling first
+    const jsSec = jsSection(page);
+    const jsAddition = jsSec.locator('.diff-split-side.addition').first();
+    await jsAddition.scrollIntoViewIfNeeded();
+    await jsAddition.hover();
+    await jsAddition.locator('.diff-comment-btn').click();
+
+    // First (empty) form should be closed; only second visible
+    await expect(jsSec.locator('.comment-form')).toBeVisible();
+    await expect(goSec.locator('.comment-form')).toHaveCount(0);
+    await expect(page.locator('.comment-form')).toHaveCount(1);
+  });
+
   test('submitting one form does not affect other open forms', async ({ page }) => {
     // Open form on server.go
     const goSec = goSection(page);
@@ -213,6 +234,8 @@ test.describe('Multi-Form Comments', () => {
     await firstLineBlock.hover();
     await section.locator('.line-comment-gutter').first().click();
     await expect(section.locator('.comment-form')).toHaveCount(1);
+    // Fill so it isn't auto-closed when the second form opens
+    await section.locator('.comment-form textarea').fill('first');
 
     // Open second form on a different line
     const thirdLineBlock = section.locator('.line-block').nth(2);
@@ -242,6 +265,8 @@ test.describe('Multi-Form Comments', () => {
     await firstAdd.hover();
     await firstAdd.locator('.diff-comment-btn').click();
     await expect(goSec.locator('.comment-form')).toHaveCount(1);
+    // Fill so it isn't auto-closed when the second form opens
+    await goSec.locator('.comment-form textarea').fill('first');
 
     // Open form on second addition
     await secondAdd.scrollIntoViewIfNeeded();

--- a/e2e/tests/threading.spec.ts
+++ b/e2e/tests/threading.spec.ts
@@ -75,6 +75,78 @@ test.describe('Comment Threading', () => {
     await expect(section.locator('.reply-body')).toContainText('Addressed this');
   });
 
+  test('reply form collapses and clears after successful submit', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Review this');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    await card.locator('.reply-input').click();
+    await card.locator('.reply-textarea').fill('Addressed this');
+    await card.locator('.reply-form .btn-primary').click();
+
+    // Reply rendered
+    await expect(section.locator('.comment-reply')).toHaveCount(1);
+
+    // Form should collapse back to compact input, NOT remain expanded with re-populated text
+    await expect(card.locator('.reply-input')).toBeVisible();
+    await expect(card.locator('.reply-form.expanded')).toHaveCount(0);
+    await expect(card.locator('.reply-textarea')).toHaveCount(0);
+    await expect(card.locator('.reply-input')).toHaveValue('');
+  });
+
+  test('opening a new reply form closes other empty expanded reply forms', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'First comment');
+    await addComment(request, mdPath, 2, 'Second comment');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const firstCard = section.locator('.comment-card').filter({ hasText: 'First comment' });
+    const secondCard = section.locator('.comment-card').filter({ hasText: 'Second comment' });
+    await expect(firstCard).toBeVisible();
+    await expect(secondCard).toBeVisible();
+
+    // Expand first reply form (leave empty)
+    await firstCard.locator('.reply-input').click();
+    await expect(firstCard.locator('.reply-form.expanded')).toHaveCount(1);
+
+    // Expand second reply form
+    await secondCard.locator('.reply-input').click();
+    await expect(secondCard.locator('.reply-form.expanded')).toHaveCount(1);
+
+    // First (empty) reply form should collapse
+    await expect(firstCard.locator('.reply-form.expanded')).toHaveCount(0);
+    await expect(firstCard.locator('.reply-input')).toBeVisible();
+  });
+
+  test('opening a new reply form keeps other reply forms with text', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'First comment');
+    await addComment(request, mdPath, 2, 'Second comment');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const firstCard = section.locator('.comment-card').filter({ hasText: 'First comment' });
+    const secondCard = section.locator('.comment-card').filter({ hasText: 'Second comment' });
+
+    await firstCard.locator('.reply-input').click();
+    await firstCard.locator('.reply-textarea').fill('draft reply');
+
+    await secondCard.locator('.reply-input').click();
+
+    // Both reply forms expanded; first retains its text
+    await expect(firstCard.locator('.reply-form.expanded')).toHaveCount(1);
+    await expect(secondCard.locator('.reply-form.expanded')).toHaveCount(1);
+    await expect(firstCard.locator('.reply-textarea')).toHaveValue('draft reply');
+  });
+
   test('reply form supports Ctrl+Enter submit', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Check this');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3963,6 +3963,18 @@
     return { filePath, startLine, endLine, afterBlockIndex, side };
   }
 
+  function closeEmptyForms(exceptKey) {
+    const toClose = [];
+    activeForms.forEach(function(f) {
+      if (f.formKey === exceptKey) return;
+      if (f.editingId) return; // never auto-close edit-in-progress forms
+      const ta = document.querySelector('.comment-form[data-form-key="' + f.formKey + '"] textarea');
+      const text = ta ? ta.value : (f.draftBody || '');
+      if (!text.trim()) toClose.push(f);
+    });
+    toClose.forEach(function(f) { cancelComment(f); });
+  }
+
   function openForm(newForm) {
     const fk = formKey(newForm);
     const existing = activeForms.find(function(f) { return f.formKey === fk; });
@@ -3974,6 +3986,7 @@
       focusCommentTextarea(existing.formKey);
       return;
     }
+    closeEmptyForms(fk);
     addForm(newForm);
     activeFilePath = newForm.filePath;
     selectionStart = newForm.startLine;
@@ -3997,6 +4010,7 @@
       focusCommentTextarea(existing.formKey);
       return;
     }
+    closeEmptyForms(fk);
     addForm(newForm);
     renderFileByPath(filePath);
     focusCommentTextarea(newForm.formKey);
@@ -5633,6 +5647,7 @@
         }
 
         activeReplyForms.delete(commentId);
+        collapse();
         refreshFileComments(filePath);
       } catch (err) {
         console.error('Failed to add reply:', err);


### PR DESCRIPTION
## Summary
- Reply form now collapses and clears on successful submit instead of restoring with the just-sent text on re-render. Cause: `saveOpenFormContent` re-saved the still-expanded form's text into `activeReplyForms` after the submit handler deleted it; the new render then restored from that saved state.
- Opening a new comment form now closes other open forms that are empty (forms with text or in-edit are kept).

## Review
- [x] Code review: passed (no blockers)
- [x] Parity audit: in sync with crit-web/

## Test plan
- [x] `e2e/tests/threading.spec.ts` — new "collapses and clears after successful submit" test, plus reply auto-close-empty / keep-with-text
- [x] `e2e/tests/multi-form.spec.ts` — new "closes existing empty form" test
- [x] All existing multi-form / threading / comments e2e specs pass

See also: tomasz-tomczyk/crit-web#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)