### PR TITLE
fix: preserve replies on fingerprint-matched comments + audit cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,8 +157,8 @@ func printQR(url string, showQR bool) {
 
 func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, sharePaths []string, authToken string, showQR bool) {
 	localIDs := buildLocalIDSet(existingCfg)
-	localFingerprints := buildLocalFingerprints(existingCfg)
-	if fetched, err := fetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, authToken); err != nil {
+	localFingerprints, localFingerprintIDs := buildLocalFingerprintIndex(existingCfg)
+	if fetched, err := fetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not pull remote comments: %v\n", err)
 	} else if len(fetched.NewComments) > 0 || len(fetched.ReplyUpdates) > 0 {
 		if err := mergeWebComments(critPath, fetched.NewComments, fetched.ReplyUpdates); err != nil {
@@ -187,24 +187,21 @@ func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, 
 }
 
 func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL, authToken string, showQR bool) {
-	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
-	cliArgs := loadCliArgsFromReviewFile(critPath)
-
-	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken, cliArgs)
+	res, err := shareReviewFiles(critPath, files, filePaths, svcURL, authToken)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := persistShareState(critPath, url, deleteToken, shareScope(filePaths)); err != nil {
+	if err := persistShareState(critPath, res.URL, res.DeleteToken, shareScope(filePaths)); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not save share state to review file: %v\n", err)
 	}
 
 	initialComments, _ := loadCommentsForUpsert(critPath, filePaths)
-	_ = updateShareState(critPath, computeShareHash(files, initialComments), reviewRound)
+	_ = updateShareState(critPath, computeShareHash(files, initialComments), res.ReviewRound)
 
-	fmt.Println(url)
-	printQR(url, showQR)
+	fmt.Println(res.URL)
+	printQR(res.URL, showQR)
 
 	if authToken == "" {
 		showLoginHint()
@@ -308,9 +305,9 @@ func runFetch(args []string) {
 
 	authToken := resolveAuthToken(loadShareConfig())
 	localIDs := buildLocalIDSet(cj)
-	localFingerprints := buildLocalFingerprints(cj)
+	localFingerprints, localFingerprintIDs := buildLocalFingerprintIndex(cj)
 
-	fetched, err := fetchWebComments(cj.ShareURL, localIDs, localFingerprints, authToken)
+	fetched, err := fetchWebComments(cj.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching remote comments: %v\n", err)
 		os.Exit(1)
@@ -333,8 +330,7 @@ func runFetch(args []string) {
 		for _, replies := range fetched.ReplyUpdates {
 			replyCount += len(replies)
 		}
-		fmt.Printf("Updated %d comment(s) with new replies.\n", len(fetched.ReplyUpdates))
-		_ = replyCount
+		fmt.Printf("Updated %d comment(s) with %d new reply(ies).\n", len(fetched.ReplyUpdates), replyCount)
 	}
 	fmt.Printf("Review file: %s\n", critPath)
 }

--- a/server.go
+++ b/server.go
@@ -356,10 +356,7 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	critPath := s.session.Load().critJSONPath()
-	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
-	cliArgs := loadCliArgsFromReviewFile(critPath)
-
-	url, deleteToken, err := shareFilesToWeb(files, comments, s.shareURL, reviewRound, s.authToken, cliArgs)
+	res, err := shareReviewFiles(critPath, files, filePaths, s.shareURL, s.authToken)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
@@ -367,9 +364,9 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.session.Load().SetSharedURLAndToken(url, deleteToken)
+	s.session.Load().SetSharedURLAndToken(res.URL, res.DeleteToken)
 	s.session.Load().SetShareScope(shareScope(filePaths))
-	writeJSON(w, map[string]any{"url": url, "delete_token": deleteToken})
+	writeJSON(w, map[string]any{"url": res.URL, "delete_token": res.DeleteToken})
 }
 
 // handleFile returns file content + metadata for a single file.

--- a/share.go
+++ b/share.go
@@ -107,6 +107,33 @@ func buildSharePayload(files []shareFile, comments []shareComment, reviewRound i
 	return payload
 }
 
+// shareReviewFilesResult is the outcome of a fresh share upload.
+type shareReviewFilesResult struct {
+	URL         string
+	DeleteToken string
+	ReviewRound int
+	Comments    []shareComment
+}
+
+// shareReviewFiles loads comments + cli_args from the review file at critPath
+// and POSTs the files to crit-web. Used by both the CLI (`crit share`) and the
+// server's POST /api/share endpoint so payload wiring stays in one place.
+func shareReviewFiles(critPath string, files []shareFile, filePaths []string, svcURL, authToken string) (shareReviewFilesResult, error) {
+	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
+	cliArgs := loadCliArgsFromReviewFile(critPath)
+
+	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken, cliArgs)
+	if err != nil {
+		return shareReviewFilesResult{}, err
+	}
+	return shareReviewFilesResult{
+		URL:         url,
+		DeleteToken: deleteToken,
+		ReviewRound: reviewRound,
+		Comments:    comments,
+	}, nil
+}
+
 // shareFilesToWeb uploads files to a crit-web instance and returns the share URL and delete token.
 func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string, reviewRound int, authToken string, cliArgs []string) (string, string, error) {
 	payload := buildSharePayload(files, comments, reviewRound, cliArgs)
@@ -151,13 +178,19 @@ func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string
 }
 
 // loadCliArgsFromReviewFile reads the review file and returns the stored cli_args.
+// A missing file is treated as "no args"; other read or unmarshal errors are
+// logged to stderr so they don't silently disappear.
 func loadCliArgsFromReviewFile(critPath string) []string {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "warning: failed to load cli_args from review file: %v\n", err)
+		}
 		return nil
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to load cli_args from review file: %v\n", err)
 		return nil
 	}
 	return cj.CliArgs
@@ -314,18 +347,34 @@ type webComment struct {
 // local comments. Used to deduplicate web-authored comments (which have no
 // ExternalID) on repeated shares.
 func buildLocalFingerprints(cj CritJSON) map[string]bool {
+	fps, _ := buildLocalFingerprintIndex(cj)
+	return fps
+}
+
+// buildLocalFingerprintIndex returns both the fingerprint set and a map from
+// fingerprint to local comment ID. The ID map lets callers look up the local
+// comment when a web comment matches by fingerprint (so replies can be merged
+// instead of dropped).
+func buildLocalFingerprintIndex(cj CritJSON) (map[string]bool, map[string]string) {
 	fps := make(map[string]bool)
+	ids := make(map[string]string)
 	for path, f := range cj.Files {
 		for _, c := range f.Comments {
 			key := fmt.Sprintf("%s|%s|%d|%d", c.Body, path, c.StartLine, c.EndLine)
 			fps[key] = true
+			if c.ID != "" {
+				ids[key] = c.ID
+			}
 		}
 	}
 	for _, c := range cj.ReviewComments {
 		key := fmt.Sprintf("%s||0|0", c.Body)
 		fps[key] = true
+		if c.ID != "" {
+			ids[key] = c.ID
+		}
 	}
-	return fps
+	return fps, ids
 }
 
 // fetchWebCommentsResult holds both new comments and reply updates for existing ones.
@@ -336,7 +385,10 @@ type fetchWebCommentsResult struct {
 
 // fetchWebComments fetches all comments from crit-web, returning new comments
 // and reply updates for existing comments that have replies added on the web.
-func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprints map[string]bool, authToken string) (fetchWebCommentsResult, error) {
+// localFingerprintIDs maps body+file+line fingerprints to the local comment ID,
+// so that web comments matching a previously-imported web-N comment by
+// fingerprint can have their replies merged instead of dropped.
+func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprints map[string]bool, localFingerprintIDs map[string]string, authToken string) (fetchWebCommentsResult, error) {
 	var result fetchWebCommentsResult
 	result.ReplyUpdates = make(map[string][]webReply)
 
@@ -383,7 +435,12 @@ func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprin
 		if wc.ExternalID == "" {
 			fp := fmt.Sprintf("%s|%s|%d|%d", wc.Body, wc.FilePath, wc.StartLine, wc.EndLine)
 			if localFingerprints[fp] {
-				continue // web-authored comment already imported
+				// Web-authored comment already imported as web-N. Capture
+				// any new replies before discarding the duplicate body.
+				if localID, ok := localFingerprintIDs[fp]; ok && len(wc.Replies) > 0 {
+					result.ReplyUpdates[localID] = wc.Replies
+				}
+				continue
 			}
 		}
 		result.NewComments = append(result.NewComments, wc)
@@ -540,7 +597,8 @@ func highestWebIndex(cj CritJSON) int {
 // mergeWebComments adds web-reviewer comments into the review file under their respective
 // files or into review_comments for review-level (scope:"review") comments.
 // It also merges reply updates for existing comments identified by external_id.
-func mergeWebComments(critPath string, newComments []webComment, replyUpdates ...map[string][]webReply) error {
+// Pass nil for replyUpdates to skip reply merging.
+func mergeWebComments(critPath string, newComments []webComment, replyUpdates map[string][]webReply) error {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
 		return err
@@ -590,32 +648,24 @@ func mergeWebComments(critPath string, newComments []webComment, replyUpdates ..
 	}
 
 	// Merge reply updates for existing comments (matched by external_id).
-	if len(replyUpdates) > 0 && len(replyUpdates[0]) > 0 {
-		updates := replyUpdates[0]
+	if len(replyUpdates) > 0 {
 		for filePath, cf := range cj.Files {
-			for i, c := range cf.Comments {
-				if webReplies, ok := updates[c.ID]; ok {
-					cj.Files[filePath] = mergeRepliesIntoFile(cf, i, webReplies)
-					cf = cj.Files[filePath]
+			for i := range cf.Comments {
+				if webReplies, ok := replyUpdates[cf.Comments[i].ID]; ok {
+					cf.Comments[i] = mergeRepliesIntoComment(cf.Comments[i], webReplies)
 				}
 			}
+			cj.Files[filePath] = cf
 		}
-		for i, c := range cj.ReviewComments {
-			if webReplies, ok := updates[c.ID]; ok {
-				cj.ReviewComments[i] = mergeRepliesIntoComment(c, webReplies)
+		for i := range cj.ReviewComments {
+			if webReplies, ok := replyUpdates[cj.ReviewComments[i].ID]; ok {
+				cj.ReviewComments[i] = mergeRepliesIntoComment(cj.ReviewComments[i], webReplies)
 			}
 		}
 	}
 
 	cj.UpdatedAt = now
 	return saveCritJSON(critPath, cj)
-}
-
-// mergeRepliesIntoFile updates a comment at index i in a CritJSONFile with web replies,
-// deduplicating by body to avoid adding replies that already exist locally.
-func mergeRepliesIntoFile(cf CritJSONFile, i int, webReplies []webReply) CritJSONFile {
-	cf.Comments[i] = mergeRepliesIntoComment(cf.Comments[i], webReplies)
-	return cf
 }
 
 // mergeRepliesIntoComment merges web replies into a comment, deduplicating by body.

--- a/share_test.go
+++ b/share_test.go
@@ -143,241 +143,253 @@ func TestLoadCommentsForUpsert_ReviewLevelComments(t *testing.T) {
 	}
 }
 
-func TestFetchNewWebComments_FiltersLocalComments(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]map[string]any{
-			{
-				"body": "web reviewer note", "file_path": "plan.md",
-				"start_line": 5, "end_line": 5, "review_round": 1,
-				"resolved": false, "external_id": nil,
-			},
-			{
-				"body": "existing local", "file_path": "plan.md",
-				"start_line": 1, "end_line": 1, "review_round": 1,
-				"resolved": false, "external_id": "c1",
-			},
+func TestFetchWebComments(t *testing.T) {
+	t.Run("filters local comments by external_id", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"body": "web reviewer note", "file_path": "plan.md",
+					"start_line": 5, "end_line": 5, "review_round": 1,
+					"resolved": false, "external_id": nil,
+				},
+				{
+					"body": "existing local", "file_path": "plan.md",
+					"start_line": 1, "end_line": 1, "review_round": 1,
+					"resolved": false, "external_id": "c1",
+				},
+			})
+		}))
+		defer srv.Close()
+
+		localIDs := map[string]bool{"c1": true}
+		result, err := fetchWebComments(srv.URL+"/r/testtoken", localIDs, nil, nil, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.NewComments) != 1 {
+			t.Fatalf("expected 1 new comment, got %d", len(result.NewComments))
+		}
+		if result.NewComments[0].Body != "web reviewer note" {
+			t.Errorf("expected body 'web reviewer note', got %q", result.NewComments[0].Body)
+		}
+	})
+
+	t.Run("404 returns no comments without error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := fetchWebComments(srv.URL+"/r/gone", nil, nil, nil, "")
+		if err != nil {
+			t.Fatalf("unexpected error for 404: %v", err)
+		}
+		if result.NewComments != nil {
+			t.Errorf("expected nil for 404, got %v", result.NewComments)
+		}
+	})
+
+	t.Run("server error propagates", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		if _, err := fetchWebComments(srv.URL+"/r/broken", nil, nil, nil, ""); err == nil {
+			t.Fatal("expected error for 500 response")
+		}
+	})
+}
+
+func TestBuildSharePayload(t *testing.T) {
+	t.Run("single file", func(t *testing.T) {
+		files := []shareFile{
+			{Path: "plan.md", Content: "# My Plan\n\nStep 1: do the thing"},
+		}
+		payload := buildSharePayload(files, nil, 1, nil)
+
+		pFiles, ok := payload["files"].([]map[string]any)
+		if !ok {
+			t.Fatal("expected files array in payload")
+		}
+		if len(pFiles) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(pFiles))
+		}
+		if pFiles[0]["path"] != "plan.md" {
+			t.Errorf("expected path plan.md, got %s", pFiles[0]["path"])
+		}
+		if pFiles[0]["content"] != "# My Plan\n\nStep 1: do the thing" {
+			t.Errorf("unexpected content: %s", pFiles[0]["content"])
+		}
+		if payload["review_round"] != 1 {
+			t.Errorf("expected review_round 1, got %v", payload["review_round"])
+		}
+		comments, ok := payload["comments"].([]shareComment)
+		if !ok {
+			t.Fatal("expected comments array")
+		}
+		if len(comments) != 0 {
+			t.Errorf("expected 0 comments, got %d", len(comments))
+		}
+	})
+
+	t.Run("multi file", func(t *testing.T) {
+		files := []shareFile{
+			{Path: "plan.md", Content: "# Plan"},
+			{Path: "src/main.go", Content: "package main"},
+		}
+		payload := buildSharePayload(files, nil, 2, nil)
+
+		pFiles := payload["files"].([]map[string]any)
+		if len(pFiles) != 2 {
+			t.Fatalf("expected 2 files, got %d", len(pFiles))
+		}
+		if payload["review_round"] != 2 {
+			t.Errorf("expected review_round 2, got %v", payload["review_round"])
+		}
+	})
+
+	t.Run("with comments", func(t *testing.T) {
+		files := []shareFile{
+			{Path: "plan.md", Content: "# Plan"},
+		}
+		comments := []shareComment{
+			{File: "plan.md", StartLine: 1, EndLine: 3, Body: "Needs more detail", Author: "Claude"},
+		}
+		payload := buildSharePayload(files, comments, 1, nil)
+
+		pComments := payload["comments"].([]shareComment)
+		if len(pComments) != 1 {
+			t.Fatalf("expected 1 comment, got %d", len(pComments))
+		}
+		if pComments[0].Author != "Claude" {
+			t.Errorf("expected author Claude, got %s", pComments[0].Author)
+		}
+	})
+}
+
+func TestShareFilesToWeb(t *testing.T) {
+	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
+
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if r.URL.Path != "/api/reviews" {
+				t.Errorf("expected /api/reviews, got %s", r.URL.Path)
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("expected application/json content type")
+			}
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			pf, ok := payload["files"].([]any)
+			if !ok || len(pf) != 1 {
+				t.Fatalf("expected 1 file in payload")
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          "https://crit.md/r/abc123",
+				"delete_token": "tok_secret",
+			})
+		}))
+		defer srv.Close()
+
+		url, token, err := shareFilesToWeb(files, nil, srv.URL, 1, "", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if url != "https://crit.md/r/abc123" {
+			t.Errorf("expected url https://crit.md/r/abc123, got %s", url)
+		}
+		if token != "tok_secret" {
+			t.Errorf("expected token tok_secret, got %s", token)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "content too large"})
+		}))
+		defer srv.Close()
+
+		if _, _, err := shareFilesToWeb(files, nil, srv.URL, 1, "", nil); err == nil {
+			t.Fatal("expected error for server error response")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		if _, _, err := shareFilesToWeb(files, nil, "http://localhost:1", 1, "", nil); err == nil {
+			t.Fatal("expected error for unreachable server")
+		}
+	})
+}
+
+func TestUnpublishFromWeb(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		respBody  map[string]string
+		token     string
+		wantErr   bool
+		assertReq bool // when true, verify method/path/delete_token
+	}{
+		{
+			name:      "success",
+			status:    http.StatusNoContent,
+			token:     "tok_secret",
+			assertReq: true,
+		},
+		{
+			name:     "server error",
+			status:   http.StatusInternalServerError,
+			respBody: map[string]string{"error": "internal error"},
+			token:    "bad_token",
+			wantErr:  true,
+		},
+		{
+			// 404 treated as "already deleted" — idempotent.
+			name:   "already deleted",
+			status: http.StatusNotFound,
+			token:  "old_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.assertReq {
+					if r.Method != http.MethodDelete {
+						t.Errorf("expected DELETE, got %s", r.Method)
+					}
+					if r.URL.Path != "/api/reviews" {
+						t.Errorf("expected /api/reviews, got %s", r.URL.Path)
+					}
+					var body map[string]string
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					if body["delete_token"] != tt.token {
+						t.Errorf("expected delete_token %q, got %q", tt.token, body["delete_token"])
+					}
+				}
+				w.WriteHeader(tt.status)
+				if tt.respBody != nil {
+					_ = json.NewEncoder(w).Encode(tt.respBody)
+				}
+			}))
+			defer srv.Close()
+
+			err := unpublishFromWeb(srv.URL, tt.token, "")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 		})
-	}))
-	defer srv.Close()
-
-	localIDs := map[string]bool{"c1": true}
-	result, err := fetchWebComments(srv.URL+"/r/testtoken", localIDs, nil, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(result.NewComments) != 1 {
-		t.Fatalf("expected 1 new comment, got %d", len(result.NewComments))
-	}
-	if result.NewComments[0].Body != "web reviewer note" {
-		t.Errorf("expected body 'web reviewer note', got %q", result.NewComments[0].Body)
-	}
-}
-
-func TestFetchNewWebComments_404ReturnsNil(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	result, err := fetchWebComments(srv.URL+"/r/gone", nil, nil, "")
-	if err != nil {
-		t.Fatalf("unexpected error for 404: %v", err)
-	}
-	if result.NewComments != nil {
-		t.Errorf("expected nil for 404, got %v", result.NewComments)
-	}
-}
-
-func TestFetchNewWebComments_ServerError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	_, err := fetchWebComments(srv.URL+"/r/broken", nil, nil, "")
-	if err == nil {
-		t.Fatal("expected error for 500 response")
-	}
-}
-
-func TestBuildSharePayload_SingleFile(t *testing.T) {
-	files := []shareFile{
-		{Path: "plan.md", Content: "# My Plan\n\nStep 1: do the thing"},
-	}
-	payload := buildSharePayload(files, nil, 1, nil)
-
-	// Multi-file format is always used
-	pFiles, ok := payload["files"].([]map[string]any)
-	if !ok {
-		t.Fatal("expected files array in payload")
-	}
-	if len(pFiles) != 1 {
-		t.Fatalf("expected 1 file, got %d", len(pFiles))
-	}
-	if pFiles[0]["path"] != "plan.md" {
-		t.Errorf("expected path plan.md, got %s", pFiles[0]["path"])
-	}
-	if pFiles[0]["content"] != "# My Plan\n\nStep 1: do the thing" {
-		t.Errorf("unexpected content: %s", pFiles[0]["content"])
-	}
-	if payload["review_round"] != 1 {
-		t.Errorf("expected review_round 1, got %v", payload["review_round"])
-	}
-	comments, ok := payload["comments"].([]shareComment)
-	if !ok {
-		t.Fatal("expected comments array")
-	}
-	if len(comments) != 0 {
-		t.Errorf("expected 0 comments, got %d", len(comments))
-	}
-}
-
-func TestBuildSharePayload_MultiFile(t *testing.T) {
-	files := []shareFile{
-		{Path: "plan.md", Content: "# Plan"},
-		{Path: "src/main.go", Content: "package main"},
-	}
-	payload := buildSharePayload(files, nil, 2, nil)
-
-	pFiles := payload["files"].([]map[string]any)
-	if len(pFiles) != 2 {
-		t.Fatalf("expected 2 files, got %d", len(pFiles))
-	}
-	if payload["review_round"] != 2 {
-		t.Errorf("expected review_round 2, got %v", payload["review_round"])
-	}
-}
-
-func TestBuildSharePayload_WithComments(t *testing.T) {
-	files := []shareFile{
-		{Path: "plan.md", Content: "# Plan"},
-	}
-	comments := []shareComment{
-		{File: "plan.md", StartLine: 1, EndLine: 3, Body: "Needs more detail", Author: "Claude"},
-	}
-	payload := buildSharePayload(files, comments, 1, nil)
-
-	pComments := payload["comments"].([]shareComment)
-	if len(pComments) != 1 {
-		t.Fatalf("expected 1 comment, got %d", len(pComments))
-	}
-	if pComments[0].Author != "Claude" {
-		t.Errorf("expected author Claude, got %s", pComments[0].Author)
-	}
-}
-
-func TestShareFilesToWeb_Success(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		if r.URL.Path != "/api/reviews" {
-			t.Errorf("expected /api/reviews, got %s", r.URL.Path)
-		}
-		if r.Header.Get("Content-Type") != "application/json" {
-			t.Errorf("expected application/json content type")
-		}
-
-		var payload map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		files, ok := payload["files"].([]any)
-		if !ok || len(files) != 1 {
-			t.Fatalf("expected 1 file in payload")
-		}
-
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{
-			"url":          "https://crit.md/r/abc123",
-			"delete_token": "tok_secret",
-		})
-	}))
-	defer server.Close()
-
-	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	url, token, err := shareFilesToWeb(files, nil, server.URL, 1, "", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if url != "https://crit.md/r/abc123" {
-		t.Errorf("expected url https://crit.md/r/abc123, got %s", url)
-	}
-	if token != "tok_secret" {
-		t.Errorf("expected token tok_secret, got %s", token)
-	}
-}
-
-func TestShareFilesToWeb_ServerError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		json.NewEncoder(w).Encode(map[string]string{"error": "content too large"})
-	}))
-	defer server.Close()
-
-	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	_, _, err := shareFilesToWeb(files, nil, server.URL, 1, "", nil)
-	if err == nil {
-		t.Fatal("expected error for server error response")
-	}
-}
-
-func TestShareFilesToWeb_NetworkError(t *testing.T) {
-	files := []shareFile{{Path: "plan.md", Content: "# Plan"}}
-	_, _, err := shareFilesToWeb(files, nil, "http://localhost:1", 1, "", nil)
-	if err == nil {
-		t.Fatal("expected error for unreachable server")
-	}
-}
-
-func TestUnpublishFromWeb_Success(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("expected DELETE, got %s", r.Method)
-		}
-		if r.URL.Path != "/api/reviews" {
-			t.Errorf("expected /api/reviews, got %s", r.URL.Path)
-		}
-
-		var body map[string]string
-		json.NewDecoder(r.Body).Decode(&body)
-		if body["delete_token"] != "tok_secret" {
-			t.Errorf("expected delete_token tok_secret, got %s", body["delete_token"])
-		}
-
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
-
-	err := unpublishFromWeb(server.URL, "tok_secret", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestUnpublishFromWeb_ServerError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
-	}))
-	defer server.Close()
-
-	err := unpublishFromWeb(server.URL, "bad_token", "")
-	if err == nil {
-		t.Fatal("expected error for server error")
-	}
-}
-
-func TestUnpublishFromWeb_AlreadyDeleted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	// 404 is treated as "already deleted" — not an error (idempotent)
-	err := unpublishFromWeb(server.URL, "old_token", "")
-	if err != nil {
-		t.Fatalf("not-found should not be an error (already deleted): %v", err)
 	}
 }
 
@@ -1223,7 +1235,7 @@ func TestUnpublishFromWeb_SendsBearerToken(t *testing.T) {
 	}
 }
 
-func TestFetchNewWebComments_SendsBearerToken(t *testing.T) {
+func TestFetchWebComments_SendsBearerToken(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -1231,7 +1243,7 @@ func TestFetchNewWebComments_SendsBearerToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	fetchWebComments(srv.URL+"/r/tok", nil, nil, "crit_testtoken")
+	fetchWebComments(srv.URL+"/r/tok", nil, nil, nil, "crit_testtoken")
 	if gotAuth != "Bearer crit_testtoken" {
 		t.Errorf("expected Authorization: Bearer crit_testtoken, got %q", gotAuth)
 	}
@@ -1640,7 +1652,7 @@ func TestMergeWebComments(t *testing.T) {
 		{Body: "web comment", FilePath: "main.go", StartLine: 5, EndLine: 5, AuthorDisplayName: "Web User"},
 		{Body: "review note", Scope: "review", AuthorDisplayName: "Reviewer"},
 	}
-	if err := mergeWebComments(critPath, newComments); err != nil {
+	if err := mergeWebComments(critPath, newComments, nil); err != nil {
 		t.Fatalf("mergeWebComments: %v", err)
 	}
 
@@ -1721,4 +1733,98 @@ func TestBuildLocalFingerprints(t *testing.T) {
 			t.Errorf("expected 0 fingerprints, got %d", len(fps))
 		}
 	})
+}
+
+// TestFetchWebComments_FingerprintMatchPreservesReplies guards the bug where a
+// web comment that matched a previously-imported web-N comment by fingerprint
+// silently dropped any new replies attached to it.
+func TestFetchWebComments_FingerprintMatchPreservesReplies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"body":         "web-authored note",
+				"file_path":    "plan.md",
+				"start_line":   3,
+				"end_line":     3,
+				"review_round": 1,
+				"resolved":     false,
+				"external_id":  nil,
+				"replies": []map[string]any{
+					{"body": "follow-up reply", "author_display_name": "Alice"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Local already has the matching comment imported as web-1 (no replies yet).
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{{
+				ID:        "web-1",
+				Body:      "web-authored note",
+				StartLine: 3,
+				EndLine:   3,
+			}}},
+		},
+	}
+	fps, fpIDs := buildLocalFingerprintIndex(cj)
+
+	result, err := fetchWebComments(srv.URL+"/r/tok", buildLocalIDSet(cj), fps, fpIDs, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.NewComments) != 0 {
+		t.Errorf("expected 0 new comments (fingerprint dedupe), got %d", len(result.NewComments))
+	}
+	replies, ok := result.ReplyUpdates["web-1"]
+	if !ok {
+		t.Fatalf("expected ReplyUpdates entry for web-1, got %v", result.ReplyUpdates)
+	}
+	if len(replies) != 1 || replies[0].Body != "follow-up reply" {
+		t.Errorf("unexpected replies for web-1: %+v", replies)
+	}
+}
+
+// TestMergeWebComments_AppliesReplyUpdates ensures that mergeWebComments
+// persists reply updates onto an existing comment matched by ID.
+func TestMergeWebComments_AppliesReplyUpdates(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit.json")
+
+	cj := CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {Comments: []Comment{{
+				ID:        "c1",
+				Body:      "look here",
+				StartLine: 10,
+				EndLine:   10,
+			}}},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(critPath, data, 0o644); err != nil {
+		t.Fatalf("write crit json: %v", err)
+	}
+
+	updates := map[string][]webReply{
+		"c1": {{Body: "thanks", AuthorDisplayName: "Bob"}},
+	}
+	if err := mergeWebComments(critPath, nil, updates); err != nil {
+		t.Fatalf("mergeWebComments: %v", err)
+	}
+
+	out, _ := os.ReadFile(critPath)
+	var got CritJSON
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	comments := got.Files["main.go"].Comments
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if len(comments[0].Replies) != 1 || comments[0].Replies[0].Body != "thanks" {
+		t.Errorf("expected merged reply, got %+v", comments[0].Replies)
+	}
 }


### PR DESCRIPTION
## Summary
Release audit follow-up addressing findings from v0.10.0..HEAD review.

**Bug fix (P0):**
- Web-authored replies were silently dropped when their parent comment was matched by fingerprint instead of external_id

**Refactors:**
- Replace variadic `replyUpdates` anti-pattern with fixed map argument
- Refactor `mergeWebComments` to iterate by index (no mid-range mutation)
- Log non-NotExist errors in `loadCliArgsFromReviewFile` (no silent swallow)
- Use `replyCount` in `runFetch` print message
- Extract `shareReviewFiles` helper (dedup `runShareNew` + `handleShare`)

**Tests:**
- Rename `TestFetchNewWebComments_*` → `TestFetchWebComments_*` after function rename
- Consolidate duplicated test groups into table-driven subtests
- New regression: `TestFetchWebComments_FingerprintMatchPreservesReplies`
- New coverage: `TestMergeWebComments_AppliesReplyUpdates`

## Review
- [x] Code review: passed (go-expert agent — verdict: ship)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean

## Test plan
- [ ] Local `make e2e-share` (skipped during audit — requires running crit-web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)