### PR TITLE
refactor: port hook lifecycle and a11y fixes from crit-web for parity

### DIFF
--- a/e2e/tests/hide-resolved.spec.ts
+++ b/e2e/tests/hide-resolved.spec.ts
@@ -106,8 +106,11 @@ test.describe('Hide Resolved', () => {
     });
     await expect(resolvedBlockAfter.first()).toBeHidden();
 
-    // Verify localStorage value
-    const stored = await page.evaluate(() => localStorage.getItem('crit-hide-resolved'));
+    // Verify cookie value
+    const stored = await page.evaluate(() => {
+      const match = document.cookie.match(/(?:^|;\s*)crit-hide-resolved=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : null;
+    });
     expect(stored).toBe('true');
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5891,7 +5891,8 @@
       const f = btn.dataset.filter;
       const isActive = f === commentsActiveFilter;
       btn.classList.toggle('active', isActive);
-      btn.setAttribute('aria-pressed', String(isActive));
+      btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      btn.setAttribute('tabindex', isActive ? '0' : '-1');
       const countEl = btn.querySelector('.filter-count');
       if (!countEl) return;
       if (f === 'all') countEl.textContent = totalCount;
@@ -7402,15 +7403,43 @@
     togglePRPanel();
   });
 
-  // Segmented pill filter
-  document.getElementById('commentsFilterPill').addEventListener('click', function(e) {
-    const btn = e.target.closest('.toggle-btn');
+  // Segmented pill filter (radiogroup with roving tabindex)
+  const filterPillEl = document.getElementById('commentsFilterPill');
+  function activateFilterBtn(btn, focus) {
     if (!btn) return;
     commentsActiveFilter = btn.dataset.filter;
-    document.querySelectorAll('#commentsFilterPill .toggle-btn').forEach(function(b) { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
-    btn.classList.add('active');
-    btn.setAttribute('aria-pressed', 'true');
+    filterPillEl.querySelectorAll('.toggle-btn').forEach(function(b) {
+      const active = b === btn;
+      b.classList.toggle('active', active);
+      b.setAttribute('aria-checked', active ? 'true' : 'false');
+      b.setAttribute('tabindex', active ? '0' : '-1');
+    });
+    if (focus) btn.focus();
     renderCommentsPanel();
+  }
+  filterPillEl.addEventListener('click', function(e) {
+    const btn = e.target.closest('.toggle-btn');
+    if (!btn) return;
+    activateFilterBtn(btn, false);
+  });
+  filterPillEl.addEventListener('keydown', function(e) {
+    const btns = Array.from(filterPillEl.querySelectorAll('.toggle-btn'));
+    const currentIdx = btns.findIndex(function(b) { return b === document.activeElement; });
+    if (currentIdx === -1) return;
+    let nextIdx = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      nextIdx = (currentIdx + 1) % btns.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      nextIdx = (currentIdx - 1 + btns.length) % btns.length;
+    } else if (e.key === 'Home') {
+      nextIdx = 0;
+    } else if (e.key === 'End') {
+      nextIdx = btns.length - 1;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    activateFilterBtn(btns[nextIdx], true);
   });
 
   // Expand all / Collapse all

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7426,7 +7426,7 @@
     const btns = Array.from(filterPillEl.querySelectorAll('.toggle-btn'));
     const currentIdx = btns.findIndex(function(b) { return b === document.activeElement; });
     if (currentIdx === -1) return;
-    let nextIdx = null;
+    let nextIdx;
     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
       nextIdx = (currentIdx + 1) % btns.length;
     } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,10 +139,10 @@
         </div>
       </div>
       <div class="comments-panel-header-row2">
-        <div class="comments-filter-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
-          <button type="button" class="toggle-btn active" data-filter="all" aria-pressed="true">All <span class="filter-count">0</span></button>
-          <button type="button" class="toggle-btn" data-filter="open" aria-pressed="false">Open <span class="filter-count">0</span></button>
-          <button type="button" class="toggle-btn" data-filter="resolved" aria-pressed="false">Resolved <span class="filter-count">0</span></button>
+        <div class="comments-filter-toggle" id="commentsFilterPill" role="radiogroup" aria-label="Filter comments">
+          <button type="button" class="toggle-btn active" data-filter="all" role="radio" aria-checked="true" tabindex="0">All <span class="filter-count">0</span></button>
+          <button type="button" class="toggle-btn" data-filter="open" role="radio" aria-checked="false" tabindex="-1">Open <span class="filter-count">0</span></button>
+          <button type="button" class="toggle-btn" data-filter="resolved" role="radio" aria-checked="false" tabindex="-1">Resolved <span class="filter-count">0</span></button>
         </div>
         <button type="button" class="comments-panel-expand-all" id="commentsPanelExpandAll" aria-pressed="false">Expand all</button>
       </div>


### PR DESCRIPTION
## Summary
Parity port from crit-web's release audit (crit-web#129). Three fixes were identified there; only one ports cleanly to crit:

**Applied — comments-panel filter pill a11y**
- `frontend/index.html`: `role="radiogroup"` parent; each button is `role="radio"` + `aria-checked` + roving `tabindex` (replaces `aria-pressed`).
- `frontend/app.js`: ArrowLeft/Right/Up/Down (wrap), Home/End keyboard navigation. Click + keyboard route through shared `activateFilterBtn` helper. Re-render path keeps `aria-checked` / `tabindex` in sync.

**Skipped — lifecycle fixes (don't apply here)**
- *Panel idempotency guard:* in crit-web the comments panel is created in JS inside a LiveView hook's `mounted()`, so duplicate-mount and stale-orphan races are real. Here, the panel is **static markup** in `frontend/index.html` (lines 129-151). No creation-on-mount path → no fix needed.
- *`trackedSetTimeout` cleanup:* crit's frontend is a top-level IIFE loaded once. There is no destroy/teardown phase; pending timers naturally die with the document on full navigation. Adding the helper without a destroyed callsite would be dead code.

The fourth audit fix (`crit-hide-resolved` cache) already shipped via #368.

## Test plan
- [x] `node --check frontend/app.js` — clean
- [ ] Tab into the segmented filter pill: ArrowLeft/Right/Home/End move focus + activate
- [ ] Screen reader announces "All, radio button, 1 of 3, checked" instead of "All, button, pressed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)