### PR TITLE
feat: send + cache verified author identity on share

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -321,19 +321,12 @@ func runAuthLogout(args []string) {
 	}
 
 	serverURL := resolveShareURL("", cfg, defaultShareURL)
+	// Revoke server-side first while the token is still valid, then clear
+	// local credentials. clearAuthIdentity() removes the token and all
+	// cached identity fields in a single write — keep this in sync with
+	// the 401-handling paths that also call it.
 	revoked := revokeToken(serverURL, token)
-
-	if err := removeAuthToken(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error removing token from config: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Clear cached identity
-	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
-		delete(m, "auth_user_name")
-		delete(m, "auth_user_email")
-		return nil
-	})
+	clearAuthIdentity()
 
 	if revoked {
 		fmt.Fprintln(os.Stderr, "  Logged out.")
@@ -372,52 +365,118 @@ func runAuthWhoami(args []string) {
 	}
 
 	serverURL := resolveShareURL("", cfg, defaultShareURL)
-	name, email, err := fetchWhoami(serverURL, token)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	who, err := fetchWhoami(ctx, serverURL, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  Token is invalid or revoked. Run 'crit auth login' to re-authenticate.\n")
 		return
 	}
 
-	if email != "" {
-		fmt.Fprintf(os.Stderr, "  Logged in as %s (%s)\n", name, email)
+	if who.Email != "" {
+		fmt.Fprintf(os.Stderr, "  Logged in as %s (%s)\n", who.Name, who.Email)
 	} else {
-		fmt.Fprintf(os.Stderr, "  Logged in as %s\n", name)
+		fmt.Fprintf(os.Stderr, "  Logged in as %s\n", who.Name)
 	}
 }
 
 // whoamiResponse holds the response from GET /api/auth/whoami.
 type whoamiResponse struct {
+	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Email string `json:"email"`
 }
 
-// fetchWhoami calls the whoami endpoint and returns the user's name and email.
-func fetchWhoami(serverURL string, token string) (string, string, error) {
-	req, err := http.NewRequest(http.MethodGet, serverURL+"/api/auth/whoami", nil)
+// fetchWhoami calls the whoami endpoint and returns the user's whoamiResponse.
+func fetchWhoami(ctx context.Context, serverURL string, token string) (whoamiResponse, error) {
+	var result whoamiResponse
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/api/auth/whoami", nil)
 	if err != nil {
-		return "", "", err
+		return result, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	// Timeout is owned by the caller's context — don't double-bound via client.Timeout.
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("contacting server: %w", err)
+		return result, fmt.Errorf("contacting server: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", "", fmt.Errorf("invalid or revoked token")
+		return result, errWhoamiUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("server returned status %d", resp.StatusCode)
+		return result, fmt.Errorf("server returned status %d", resp.StatusCode)
 	}
 
-	var result whoamiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", "", fmt.Errorf("decoding response: %w", err)
+		return result, fmt.Errorf("decoding response: %w", err)
 	}
-	return result.Name, result.Email, nil
+	return result, nil
+}
+
+// errWhoamiUnauthorized indicates the token was rejected by the server.
+var errWhoamiUnauthorized = errors.New("invalid or revoked token")
+
+// lazyBackfillAuthUserID populates cfg.AuthUserID from the server when the
+// token is set but the user id has not been cached yet (e.g. after upgrading
+// from a version that did not store it). On success the value is persisted to
+// the global config and cfg is updated in place. On 401 the cached identity
+// is cleared. Other errors are best-effort: cfg is left unchanged.
+func lazyBackfillAuthUserID(cfg *Config) {
+	if cfg == nil || cfg.AuthToken == "" || cfg.AuthUserID != "" {
+		return
+	}
+	serverURL := resolveShareURL("", *cfg, defaultShareURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	who, err := fetchWhoami(ctx, serverURL, cfg.AuthToken)
+	if err != nil {
+		if errors.Is(err, errWhoamiUnauthorized) {
+			clearAuthIdentity()
+			cfg.AuthToken = ""
+			cfg.AuthUserID = ""
+			cfg.AuthUserName = ""
+			cfg.AuthUserEmail = ""
+		}
+		return
+	}
+	if who.ID == "" {
+		return
+	}
+	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		idRaw, _ := json.Marshal(who.ID)
+		m["auth_user_id"] = idRaw
+		if who.Name != "" {
+			nameRaw, _ := json.Marshal(who.Name)
+			m["auth_user_name"] = nameRaw
+		}
+		if who.Email != "" {
+			emailRaw, _ := json.Marshal(who.Email)
+			m["auth_user_email"] = emailRaw
+		}
+		return nil
+	})
+	cfg.AuthUserID = who.ID
+	if who.Name != "" {
+		cfg.AuthUserName = who.Name
+	}
+	if who.Email != "" {
+		cfg.AuthUserEmail = who.Email
+	}
+}
+
+// clearAuthIdentity removes the cached token and user identity fields from the
+// global config. Called when the server returns 401 on a share/upsert.
+func clearAuthIdentity() {
+	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		delete(m, "auth_token")
+		delete(m, "auth_user_id")
+		delete(m, "auth_user_name")
+		delete(m, "auth_user_email")
+		return nil
+	})
 }
 
 // errHintAlreadyShown is a sentinel error used by showLoginHint to skip

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -385,15 +386,15 @@ func TestFetchWhoami_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	name, email, err := fetchWhoami(srv.URL, "crit_tok")
+	who, err := fetchWhoami(context.Background(), srv.URL, "crit_tok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != "Tomasz" {
-		t.Errorf("name = %q, want Tomasz", name)
+	if who.Name != "Tomasz" {
+		t.Errorf("name = %q, want Tomasz", who.Name)
 	}
-	if email != "tomasz@example.com" {
-		t.Errorf("email = %q", email)
+	if who.Email != "tomasz@example.com" {
+		t.Errorf("email = %q", who.Email)
 	}
 }
 
@@ -403,7 +404,7 @@ func TestFetchWhoami_Unauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := fetchWhoami(srv.URL, "bad_token")
+	_, err := fetchWhoami(context.Background(), srv.URL, "bad_token")
 	if err == nil {
 		t.Fatal("expected error for 401")
 	}
@@ -615,14 +616,14 @@ func TestFetchWhoami_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := fetchWhoami(srv.URL, "crit_tok")
+	_, err := fetchWhoami(context.Background(), srv.URL, "crit_tok")
 	if err == nil {
 		t.Fatal("expected error for 500")
 	}
 }
 
 func TestFetchWhoami_NetworkError(t *testing.T) {
-	_, _, err := fetchWhoami("http://127.0.0.1:1", "crit_tok")
+	_, err := fetchWhoami(context.Background(), "http://127.0.0.1:1", "crit_tok")
 	if err == nil {
 		t.Fatal("expected error for unreachable server")
 	}
@@ -636,15 +637,15 @@ func TestFetchWhoami_NameOnly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	name, email, err := fetchWhoami(srv.URL, "crit_tok")
+	who, err := fetchWhoami(context.Background(), srv.URL, "crit_tok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != "Tomasz" {
-		t.Errorf("name = %q, want Tomasz", name)
+	if who.Name != "Tomasz" {
+		t.Errorf("name = %q, want Tomasz", who.Name)
 	}
-	if email != "" {
-		t.Errorf("email = %q, want empty", email)
+	if who.Email != "" {
+		t.Errorf("email = %q, want empty", who.Email)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	AuthToken          string   `json:"auth_token,omitempty"`
 	AuthUserName       string   `json:"auth_user_name,omitempty"`
 	AuthUserEmail      string   `json:"auth_user_email,omitempty"`
+	AuthUserID         string   `json:"auth_user_id,omitempty"`
 	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
 	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl"
 }
@@ -283,7 +284,10 @@ func saveGlobalConfig(apply func(m map[string]json.RawMessage) error) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o600)
+	// atomicWriteFile (defined in daemon.go) writes via temp + fsync + rename.
+	// Critical for the global config because it holds the bearer token —
+	// a crash mid-write would otherwise truncate it.
+	return atomicWriteFile(path, data, 0o600)
 }
 
 // gitUserName returns the git-configured user name, or empty string on error.

--- a/github.go
+++ b/github.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 )
 
@@ -26,6 +28,9 @@ type ghComment struct {
 	User      struct {
 		Login string `json:"login"`
 	} `json:"user"`
+	// Note: GitHub's /pulls/.../comments REST endpoint returns only `login`
+	// per user. We resolve the display name lazily via /users/{login} —
+	// see userNameCache.
 	CreatedAt   string `json:"created_at"`
 	InReplyToID int64  `json:"in_reply_to_id"`
 }
@@ -79,8 +84,55 @@ type PRInfo struct {
 }
 
 // prAuthor is used to unmarshal the nested author field from gh output.
+// Name is GitHub's optional display name; we prefer it over Login when set.
 type prAuthor struct {
 	Login string `json:"login"`
+	Name  string `json:"name"`
+}
+
+// displayName returns name when set, falling back to login. Used to convert
+// GitHub-imported author identities into the friendlier display string we
+// pass through to crit-web.
+func displayName(login, name string) string {
+	if strings.TrimSpace(name) != "" {
+		return name
+	}
+	return login
+}
+
+// userNameCache memoizes login → display-name lookups for the duration of a
+// single `crit pull`. The /pulls/.../comments REST payload only returns
+// `login`, so we hit /users/{login} once per unique commenter.
+type userNameCache map[string]string
+
+// lookup returns the display name for a login, fetching from GitHub on cache
+// miss. On any error or missing name, returns login (always a valid fallback).
+//
+// Under `go test`, the network call is skipped entirely — tests that want to
+// exercise display-name resolution should pre-populate the cache before
+// invoking the merge functions.
+func (c userNameCache) lookup(login string) string {
+	if login == "" {
+		return ""
+	}
+	if cached, ok := c[login]; ok {
+		return cached
+	}
+	if testing.Testing() {
+		c[login] = login
+		return login
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "api", "users/"+login, "--jq", ".name // \"\"").Output()
+	if err != nil {
+		c[login] = login
+		return login
+	}
+	name := strings.TrimSpace(string(out))
+	resolved := displayName(login, name)
+	c[login] = resolved
+	return resolved
 }
 
 // prInfoRaw mirrors the gh JSON output shape (author is nested).
@@ -131,7 +183,7 @@ func detectPRInfo() *PRInfo {
 		Additions:    raw.Additions,
 		Deletions:    raw.Deletions,
 		ChangedFiles: raw.ChangedFiles,
-		AuthorLogin:  raw.Author.Login,
+		AuthorLogin:  displayName(raw.Author.Login, raw.Author.Name),
 		CreatedAt:    raw.CreatedAt,
 	}
 }
@@ -297,7 +349,7 @@ func separateRootsAndReplies(ghComments []ghComment) ([]ghComment, map[int64][]g
 }
 
 // appendNewGHReplies adds non-duplicate replies to an existing comment, returning how many were added.
-func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment) int {
+func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, names userNameCache) int {
 	added := 0
 	for _, r := range childReplies {
 		if isDuplicateGHReply(comments[ci].Replies, r.ID) {
@@ -306,7 +358,7 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment) in
 		comments[ci].Replies = append(comments[ci].Replies, Reply{
 			ID:        randomReplyID(),
 			Body:      r.Body,
-			Author:    r.User.Login,
+			Author:    names.lookup(r.User.Login),
 			CreatedAt: r.CreatedAt,
 			GitHubID:  r.ID,
 		})
@@ -316,7 +368,7 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment) in
 }
 
 // mergeRootComment handles a single root ghComment: either deduplicates or creates it.
-func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string) int {
+func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string, names userNameCache) int {
 	cf, ok := cj.Files[gc.Path]
 	if !ok {
 		cf = CritJSONFile{Status: "modified", Comments: []Comment{}}
@@ -327,12 +379,14 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 		startLine = gc.Line
 	}
 
-	if isDuplicateGHComment(cf.Comments, gc.ID, gc.User.Login, startLine, gc.Line, gc.Body) {
+	authorName := names.lookup(gc.User.Login)
+
+	if isDuplicateGHComment(cf.Comments, gc.ID, authorName, startLine, gc.Line, gc.Body) {
 		added := 0
 		if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
 			for ci, c := range cf.Comments {
 				if c.GitHubID == gc.ID {
-					added = appendNewGHReplies(cf.Comments, ci, childReplies)
+					added = appendNewGHReplies(cf.Comments, ci, childReplies, names)
 					break
 				}
 			}
@@ -344,7 +398,7 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 	commentID := randomCommentID()
 	comment := Comment{
 		ID: commentID, StartLine: startLine, EndLine: gc.Line,
-		Body: gc.Body, Author: gc.User.Login, CreatedAt: gc.CreatedAt,
+		Body: gc.Body, Author: authorName, CreatedAt: gc.CreatedAt,
 		UpdatedAt: now, GitHubID: gc.ID,
 	}
 
@@ -354,7 +408,7 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 			comment.Replies = append(comment.Replies, Reply{
 				ID:        randomReplyID(),
 				Body:      r.Body,
-				Author:    r.User.Login,
+				Author:    names.lookup(r.User.Login),
 				CreatedAt: r.CreatedAt,
 				GitHubID:  r.ID,
 			})
@@ -368,7 +422,7 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 }
 
 // mergeOrphanReplies processes replies whose parent was already in cj from a previous pull.
-func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]ghComment) int {
+func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]ghComment, names userNameCache) int {
 	rootIDs := make(map[int64]struct{}, len(roots))
 	for _, gc := range roots {
 		rootIDs[gc.ID] = struct{}{}
@@ -384,7 +438,7 @@ func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]gh
 			continue
 		}
 		cf := cj.Files[filePath]
-		added += appendNewGHReplies(cf.Comments, ci, childReplies)
+		added += appendNewGHReplies(cf.Comments, ci, childReplies, names)
 		cj.Files[filePath] = cf
 	}
 	return added
@@ -395,6 +449,14 @@ func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]gh
 // Handles threading: root comments become top-level Comments, replies become Reply entries.
 // Deduplicates by GitHubID (preferred) or author+lines+body to prevent duplicates from repeated pulls.
 func mergeGHComments(cj *CritJSON, ghComments []ghComment) int {
+	return mergeGHCommentsWithNames(cj, ghComments, make(userNameCache))
+}
+
+// mergeGHCommentsWithNames is the form of mergeGHComments that lets callers
+// supply a pre-populated cache. Production uses mergeGHComments (fresh
+// cache, lazy /users/{login} lookups). Tests can pre-populate to assert on
+// resolved display names without going to the network.
+func mergeGHCommentsWithNames(cj *CritJSON, ghComments []ghComment, names userNameCache) int {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -402,9 +464,9 @@ func mergeGHComments(cj *CritJSON, ghComments []ghComment) int {
 
 	added := 0
 	for _, gc := range roots {
-		added += mergeRootComment(cj, gc, replyMap, now)
+		added += mergeRootComment(cj, gc, replyMap, now, names)
 	}
-	added += mergeOrphanReplies(cj, roots, replyMap)
+	added += mergeOrphanReplies(cj, roots, replyMap, names)
 
 	return added
 }
@@ -779,7 +841,7 @@ func saveCritJSON(critPath string, cj CritJSON) error {
 }
 
 // appendComment adds a comment to the CritJSON struct in memory. Does not write to disk.
-func appendComment(cj *CritJSON, filePath string, startLine, endLine int, body, author string) {
+func appendComment(cj *CritJSON, filePath string, startLine, endLine int, body, author, userID string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -801,6 +863,7 @@ func appendComment(cj *CritJSON, filePath string, startLine, endLine int, body, 
 		Body:      body,
 		Anchor:    anchor,
 		Author:    author,
+		UserID:    userID,
 		CreatedAt: now,
 		UpdatedAt: now,
 	})
@@ -820,7 +883,7 @@ func readAnchorFromDisk(filePath string, startLine, endLine int) string {
 // appendReply adds a reply to an existing comment in the CritJSON struct in memory.
 // Returns an error if the comment ID is not found or is ambiguous across files.
 // Searches both file comments and review_comments.
-func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, filterPath string) error {
+func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve bool, filterPath string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -831,6 +894,7 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
+				UserID:    userID,
 				CreatedAt: now,
 			}
 			cj.ReviewComments[i].Replies = append(cj.ReviewComments[i].Replies, reply)
@@ -858,6 +922,7 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 						ID:        randomReplyID(),
 						Body:      body,
 						Author:    author,
+						UserID:    userID,
 						CreatedAt: now,
 					}
 					cf.Comments[i].Replies = append(cf.Comments[i].Replies, reply)
@@ -888,7 +953,7 @@ func appendReply(cj *CritJSON, commentID, body, author string, resolve bool, fil
 // Creates the review file if it doesn't exist. Appends to existing comments if it does.
 // Works in both git repos and plain directories (file mode).
 // outputDir overrides the default location (repo root or CWD) when non-empty.
-func addCommentToCritJSON(filePath string, startLine, endLine int, body string, author string, outputDir string) error {
+func addCommentToCritJSON(filePath string, startLine, endLine int, body string, author, userID string, outputDir string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
@@ -904,13 +969,13 @@ func addCommentToCritJSON(filePath string, startLine, endLine int, body string, 
 		return err
 	}
 
-	appendComment(&cj, cleaned, startLine, endLine, body, author)
+	appendComment(&cj, cleaned, startLine, endLine, body, author, userID)
 	return saveCritJSON(critPath, cj)
 }
 
 // addReplyToCritJSON adds a reply to an existing comment in the review file.
 // It searches all files for the comment ID. If resolve is true, it also marks the comment as resolved.
-func addReplyToCritJSON(commentID, body, author string, resolve bool, outputDir string, filterPath string) error {
+func addReplyToCritJSON(commentID, body, author, userID string, resolve bool, outputDir string, filterPath string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
@@ -921,7 +986,7 @@ func addReplyToCritJSON(commentID, body, author string, resolve bool, outputDir 
 		return err
 	}
 
-	if err := appendReply(&cj, commentID, body, author, resolve, filterPath); err != nil {
+	if err := appendReply(&cj, commentID, body, author, userID, resolve, filterPath); err != nil {
 		// Only fall back to scanning when the comment genuinely wasn't found.
 		// Don't fall back for ambiguity errors ("found in multiple files").
 		if strings.Contains(err.Error(), "not found") {
@@ -930,7 +995,7 @@ func addReplyToCritJSON(commentID, body, author string, resolve bool, outputDir 
 				if loadErr != nil {
 					return err // return original error
 				}
-				if replyErr := appendReply(&altCJ, commentID, body, author, resolve, filterPath); replyErr != nil {
+				if replyErr := appendReply(&altCJ, commentID, body, author, userID, resolve, filterPath); replyErr != nil {
 					return err // return original error
 				}
 				fmt.Fprintf(os.Stderr, "Note: comment %s found in %s (not the resolved review file)\n", commentID, filepath.Base(altPath))
@@ -1073,7 +1138,7 @@ func (e *BulkCommentEntry) UnmarshalJSON(data []byte) error {
 // bulkAddCommentsToCritJSON applies multiple comments and replies in a single load-save cycle.
 // globalAuthor is used when an entry doesn't specify its own author.
 // outputDir overrides the review file location (empty = centralized storage).
-func processBulkEntry(cj *CritJSON, i int, e BulkCommentEntry, globalAuthor string) error {
+func processBulkEntry(cj *CritJSON, i int, e BulkCommentEntry, globalAuthor, globalUserID string) error {
 	if e.Body == "" {
 		return fmt.Errorf("entry %d: body is required", i)
 	}
@@ -1082,33 +1147,36 @@ func processBulkEntry(cj *CritJSON, i int, e BulkCommentEntry, globalAuthor stri
 	if author == "" {
 		author = globalAuthor
 	}
+	// UserID always comes from the local config — entry-level override would
+	// be a spoof vector. The CLI never trusts a payload-supplied user_id.
+	userID := globalUserID
 
 	if e.ReplyTo != "" {
-		if err := appendReply(cj, e.ReplyTo, e.Body, author, e.Resolve, e.File); err != nil {
+		if err := appendReply(cj, e.ReplyTo, e.Body, author, userID, e.Resolve, e.File); err != nil {
 			return fmt.Errorf("entry %d: %w", i, err)
 		}
 		return nil
 	}
 
 	if e.Scope == "review" || (e.File == "" && e.Path == "" && e.Line <= 0 && e.LineSpec == "") {
-		return processBulkReviewEntry(cj, i, e, author)
+		return processBulkReviewEntry(cj, i, e, author, userID)
 	}
 
-	return processBulkFileOrLineEntry(cj, i, e, author)
+	return processBulkFileOrLineEntry(cj, i, e, author, userID)
 }
 
-func processBulkReviewEntry(cj *CritJSON, i int, e BulkCommentEntry, author string) error {
+func processBulkReviewEntry(cj *CritJSON, i int, e BulkCommentEntry, author, userID string) error {
 	if e.Line > 0 || e.LineSpec != "" {
 		return fmt.Errorf("entry %d: file is required for new comments", i)
 	}
 	if e.Scope != "review" && (e.File != "" || e.Path != "") {
 		return fmt.Errorf("entry %d: file is required for new comments", i)
 	}
-	appendReviewComment(cj, e.Body, author)
+	appendReviewComment(cj, e.Body, author, userID)
 	return nil
 }
 
-func processBulkFileOrLineEntry(cj *CritJSON, i int, e BulkCommentEntry, author string) error {
+func processBulkFileOrLineEntry(cj *CritJSON, i int, e BulkCommentEntry, author, userID string) error {
 	filePath := e.File
 	if filePath == "" {
 		filePath = e.Path
@@ -1123,22 +1191,22 @@ func processBulkFileOrLineEntry(cj *CritJSON, i int, e BulkCommentEntry, author 
 	}
 
 	if e.Scope == "file" {
-		appendFileComment(cj, cleaned, e.Body, author)
+		appendFileComment(cj, cleaned, e.Body, author, userID)
 		return nil
 	}
 
 	if e.Line <= 0 && e.LineSpec == "" {
 		if e.Path != "" && e.File == "" {
-			appendFileComment(cj, cleaned, e.Body, author)
+			appendFileComment(cj, cleaned, e.Body, author, userID)
 			return nil
 		}
 		return fmt.Errorf("entry %d: line must be > 0", i)
 	}
 
-	return processBulkLineComment(cj, i, e, cleaned, author)
+	return processBulkLineComment(cj, i, e, cleaned, author, userID)
 }
 
-func processBulkLineComment(cj *CritJSON, i int, e BulkCommentEntry, cleaned, author string) error {
+func processBulkLineComment(cj *CritJSON, i int, e BulkCommentEntry, cleaned, author, userID string) error {
 	startLine := e.Line
 	endLine := e.EndLine
 
@@ -1157,7 +1225,7 @@ func processBulkLineComment(cj *CritJSON, i int, e BulkCommentEntry, cleaned, au
 		endLine = startLine
 	}
 
-	appendComment(cj, cleaned, startLine, endLine, e.Body, author)
+	appendComment(cj, cleaned, startLine, endLine, e.Body, author, userID)
 	return nil
 }
 
@@ -1180,7 +1248,7 @@ func parseLineSpec(spec string) (start, end int, err error) {
 	return n, n, nil
 }
 
-func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor string, outputDir string) error {
+func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor, globalUserID string, outputDir string) error {
 	if len(entries) == 0 {
 		return fmt.Errorf("no comment entries provided")
 	}
@@ -1196,7 +1264,7 @@ func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor string, 
 	}
 
 	for i, e := range entries {
-		if err := processBulkEntry(&cj, i, e, globalAuthor); err != nil {
+		if err := processBulkEntry(&cj, i, e, globalAuthor, globalUserID); err != nil {
 			return err
 		}
 	}
@@ -1205,7 +1273,7 @@ func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor string, 
 }
 
 // addReviewCommentToCritJSON adds a review-level comment to the review file.
-func addReviewCommentToCritJSON(body, author, outputDir string) error {
+func addReviewCommentToCritJSON(body, author, userID, outputDir string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
@@ -1216,12 +1284,12 @@ func addReviewCommentToCritJSON(body, author, outputDir string) error {
 		return err
 	}
 
-	appendReviewComment(&cj, body, author)
+	appendReviewComment(&cj, body, author, userID)
 	return saveCritJSON(critPath, cj)
 }
 
 // addFileCommentToCritJSON adds a file-level comment to the review file.
-func addFileCommentToCritJSON(filePath, body, author, outputDir string) error {
+func addFileCommentToCritJSON(filePath, body, author, userID, outputDir string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
@@ -1237,12 +1305,12 @@ func addFileCommentToCritJSON(filePath, body, author, outputDir string) error {
 		return err
 	}
 
-	appendFileComment(&cj, cleaned, body, author)
+	appendFileComment(&cj, cleaned, body, author, userID)
 	return saveCritJSON(critPath, cj)
 }
 
 // appendReviewComment adds a review-level comment to the CritJSON struct in memory.
-func appendReviewComment(cj *CritJSON, body, author string) {
+func appendReviewComment(cj *CritJSON, body, author, userID string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -1250,6 +1318,7 @@ func appendReviewComment(cj *CritJSON, body, author string) {
 		ID:        randomReviewCommentID(),
 		Body:      body,
 		Author:    author,
+		UserID:    userID,
 		Scope:     "review",
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -1257,7 +1326,7 @@ func appendReviewComment(cj *CritJSON, body, author string) {
 }
 
 // appendFileComment adds a file-level comment (scope: "file", lines: 0) to the CritJSON struct in memory.
-func appendFileComment(cj *CritJSON, filePath, body, author string) {
+func appendFileComment(cj *CritJSON, filePath, body, author, userID string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -1273,6 +1342,7 @@ func appendFileComment(cj *CritJSON, filePath, body, author string) {
 		ID:        randomCommentID(),
 		Body:      body,
 		Author:    author,
+		UserID:    userID,
 		Scope:     "file",
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/github_test.go
+++ b/github_test.go
@@ -633,7 +633,7 @@ func TestAddCommentToCritJSON_RejectsPathTraversal(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("../../../etc/passwd", 1, 1, "bad", "", "")
+	err := addCommentToCritJSON("../../../etc/passwd", 1, 1, "bad", "", "", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal, got nil")
 	}
@@ -651,7 +651,7 @@ func TestAddCommentToCritJSON_RejectsAbsolutePath(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("/etc/passwd", 1, 1, "bad", "", "")
+	err := addCommentToCritJSON("/etc/passwd", 1, 1, "bad", "", "", "")
 	if err == nil {
 		t.Fatal("expected error for absolute path, got nil")
 	}
@@ -668,7 +668,7 @@ func TestAddCommentToCritJSON_CreatesNewFile(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("main.go", 10, 15, "Fix this bug", "", dir)
+	err := addCommentToCritJSON("main.go", 10, 15, "Fix this bug", "", "", dir)
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -709,10 +709,10 @@ func TestAddCommentToCritJSON_AppendsToExisting(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("main.go", 1, 1, "First", "", dir); err != nil {
+	if err := addCommentToCritJSON("main.go", 1, 1, "First", "", "", dir); err != nil {
 		t.Fatalf("first add: %v", err)
 	}
-	if err := addCommentToCritJSON("main.go", 20, 20, "Second", "", dir); err != nil {
+	if err := addCommentToCritJSON("main.go", 20, 20, "Second", "", "", dir); err != nil {
 		t.Fatalf("second add: %v", err)
 	}
 
@@ -738,8 +738,8 @@ func TestAddCommentToCritJSON_MultipleFiles(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	addCommentToCritJSON("main.go", 1, 1, "Comment on main", "", dir)
-	addCommentToCritJSON("auth.go", 5, 10, "Comment on auth", "", dir)
+	addCommentToCritJSON("main.go", 1, 1, "Comment on main", "", "", dir)
+	addCommentToCritJSON("auth.go", 5, 10, "Comment on auth", "", "", dir)
 
 	data, _ := os.ReadFile(dir + "/.crit.json")
 	var cj CritJSON
@@ -762,7 +762,7 @@ func TestAddCommentToCritJSON_FileMode_NoGitRepo(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("main.go", 5, 5, "File mode comment", "", dir)
+	err := addCommentToCritJSON("main.go", 5, 5, "File mode comment", "", "", dir)
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -795,7 +795,7 @@ func TestAddCommentToCritJSON_FileMode_PathRelativeToCWD(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Path should be stored as given (relative to CWD), not resolved to anything else
-	addCommentToCritJSON("src/auth.go", 10, 10, "comment", "", dir)
+	addCommentToCritJSON("src/auth.go", 10, 10, "comment", "", "", dir)
 
 	data, _ := os.ReadFile(dir + "/.crit.json")
 	var cj CritJSON
@@ -817,7 +817,7 @@ func TestAddCommentToCritJSON_OutputDir(t *testing.T) {
 	os.Chdir(repoDir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("main.go", 1, 1, "custom output dir", "", outputDir); err != nil {
+	if err := addCommentToCritJSON("main.go", 1, 1, "custom output dir", "", "", outputDir); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -886,7 +886,7 @@ func TestAddCommentToCritJSON_RespectsBaseBranchConfig(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("feature.go", 1, 1, "test comment", "", dir); err != nil {
+	if err := addCommentToCritJSON("feature.go", 1, 1, "test comment", "", "", dir); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -922,7 +922,7 @@ func TestAddReplyToCritJSON(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
-	err := addReplyToCritJSON("c1", "Done, fixed it", "agent", false, dir, "")
+	err := addReplyToCritJSON("c1", "Done, fixed it", "", "agent", false, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -958,7 +958,7 @@ func TestAddReplyToCritJSON_WithResolve(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
-	err := addReplyToCritJSON("c1", "Split the function", "agent", true, dir, "")
+	err := addReplyToCritJSON("c1", "Split the function", "agent", "", true, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -987,7 +987,7 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
-	err := addReplyToCritJSON("c99", "reply", "agent", false, dir, "")
+	err := addReplyToCritJSON("c99", "reply", "agent", "", false, dir, "")
 	if err == nil {
 		t.Fatal("expected error for missing comment")
 	}
@@ -1025,7 +1025,7 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, ".crit.json"), localData, 0644)
 
 	// Reply should fall back to the review file containing c_target.
-	err := addReplyToCritJSON("c_target", "Done, fixed", "agent", false, localDir, "")
+	err := addReplyToCritJSON("c_target", "Done, fixed", "", "agent", false, localDir, "")
 	if err != nil {
 		t.Fatalf("expected fallback to find comment, got error: %v", err)
 	}
@@ -1226,7 +1226,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 		{File: "main.go", Line: 3, EndLine: 4, Body: "Extract to function"},
 	}
 
-	err := bulkAddCommentsToCritJSON(entries, "TestBot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "TestBot", "", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1255,7 +1255,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 	replyEntries := []BulkCommentEntry{
 		{ReplyTo: firstCommentID, Body: "Done — added godoc comment", Resolve: true},
 	}
-	err = bulkAddCommentsToCritJSON(replyEntries, "TestBot", dir)
+	err = bulkAddCommentsToCritJSON(replyEntries, "TestBot", "", dir)
 	if err != nil {
 		t.Fatalf("unexpected error on reply: %v", err)
 	}
@@ -1273,7 +1273,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_EmptyBody(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "main.go", Line: 1, Body: ""}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "body is required") {
 		t.Errorf("expected body required error, got: %v", err)
 	}
@@ -1282,7 +1282,7 @@ func TestBulkAddCommentsToCritJSON_EmptyBody(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_MissingFile(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{Line: 1, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "file is required") {
 		t.Errorf("expected file required error, got: %v", err)
 	}
@@ -1291,7 +1291,7 @@ func TestBulkAddCommentsToCritJSON_MissingFile(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_InvalidLine(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "main.go", Line: 0, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "line must be > 0") {
 		t.Errorf("expected line error, got: %v", err)
 	}
@@ -1300,7 +1300,7 @@ func TestBulkAddCommentsToCritJSON_InvalidLine(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_PathTraversal(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "../etc/passwd", Line: 1, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "must be relative") {
 		t.Errorf("expected path traversal error, got: %v", err)
 	}
@@ -1308,7 +1308,7 @@ func TestBulkAddCommentsToCritJSON_PathTraversal(t *testing.T) {
 
 func TestBulkAddCommentsToCritJSON_EmptyEntries(t *testing.T) {
 	dir := initTestRepo(t)
-	err := bulkAddCommentsToCritJSON(nil, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(nil, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "no comment entries") {
 		t.Errorf("expected empty entries error, got: %v", err)
 	}
@@ -1317,7 +1317,7 @@ func TestBulkAddCommentsToCritJSON_EmptyEntries(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_ReplyNotFound(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{ReplyTo: "c99", Body: "reply"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found error, got: %v", err)
 	}
@@ -1333,7 +1333,7 @@ func TestBulkAddCommentsToCritJSON_PerEntryAuthor(t *testing.T) {
 		{File: "main.go", Line: 1, Body: "from global author"},
 		{File: "main.go", Line: 1, Body: "from custom author", Author: "CustomBot"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "GlobalBot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "GlobalBot", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1357,7 +1357,7 @@ func TestBulkAddCommentsToCritJSON_MultipleFiles(t *testing.T) {
 		{File: "a.go", Line: 1, Body: "comment on a"},
 		{File: "b.go", Line: 1, Body: "comment on b"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1404,7 +1404,7 @@ func TestBulkAddCommentsToCritJSON_EndLineDefaultsToLine(t *testing.T) {
 		{File: "main.go", Line: 2, Body: "single line - no end_line"},
 		{File: "main.go", Line: 3, EndLine: 5, Body: "explicit range"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", dir)
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1710,7 +1710,7 @@ func TestAppendReply_ToReviewComment(t *testing.T) {
 		Files: make(map[string]CritJSONFile),
 	}
 
-	err := appendReply(cj, "r0", "done, addressed", "agent", false, "")
+	err := appendReply(cj, "r0", "done, addressed", "", "agent", false, "")
 	if err != nil {
 		t.Fatalf("appendReply to review comment: %v", err)
 	}
@@ -1730,7 +1730,7 @@ func TestAppendReply_ToReviewCommentWithResolve(t *testing.T) {
 		Files: make(map[string]CritJSONFile),
 	}
 
-	err := appendReply(cj, "r0", "fixed", "agent", true, "")
+	err := appendReply(cj, "r0", "fixed", "agent", "", true, "")
 	if err != nil {
 		t.Fatalf("appendReply: %v", err)
 	}
@@ -1743,7 +1743,7 @@ func TestAppendReply_NotFound(t *testing.T) {
 	cj := &CritJSON{
 		Files: make(map[string]CritJSONFile),
 	}
-	err := appendReply(cj, "c99", "reply", "agent", false, "")
+	err := appendReply(cj, "c99", "reply", "agent", "", false, "")
 	if err == nil {
 		t.Fatal("expected error for nonexistent comment")
 	}
@@ -1752,7 +1752,7 @@ func TestAppendReply_NotFound(t *testing.T) {
 func TestAppendReviewComment(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendReviewComment(cj, "general observation", "reviewer")
+	appendReviewComment(cj, "general observation", "reviewer", "")
 
 	if len(cj.ReviewComments) != 1 {
 		t.Fatalf("expected 1 review comment, got %d", len(cj.ReviewComments))
@@ -1771,7 +1771,7 @@ func TestAppendReviewComment(t *testing.T) {
 	}
 
 	// Add another
-	appendReviewComment(cj, "second note", "reviewer")
+	appendReviewComment(cj, "second note", "reviewer", "")
 	if !strings.HasPrefix(cj.ReviewComments[1].ID, "r_") || len(cj.ReviewComments[1].ID) != 8 {
 		t.Errorf("second ID = %q, want r_ prefix + 6 hex chars", cj.ReviewComments[1].ID)
 	}
@@ -1783,7 +1783,7 @@ func TestAppendReviewComment(t *testing.T) {
 func TestAppendFileComment(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendFileComment(cj, "server.go", "needs restructuring", "reviewer")
+	appendFileComment(cj, "server.go", "needs restructuring", "reviewer", "")
 
 	cf, ok := cj.Files["server.go"]
 	if !ok {
@@ -1803,8 +1803,8 @@ func TestAppendFileComment(t *testing.T) {
 func TestAppendComment_IDIncrementsGlobally(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendComment(cj, "main.go", 1, 1, "first", "reviewer")
-	appendComment(cj, "server.go", 5, 5, "second", "reviewer")
+	appendComment(cj, "main.go", 1, 1, "first", "reviewer", "")
+	appendComment(cj, "server.go", 5, 5, "second", "reviewer", "")
 
 	c1 := cj.Files["main.go"].Comments[0]
 	c2 := cj.Files["server.go"].Comments[0]
@@ -1821,7 +1821,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Add a comment via the CLI function
-	err := addCommentToCritJSON("README.md", 1, 1, "fix typo", "reviewer", dir)
+	err := addCommentToCritJSON("README.md", 1, 1, "fix typo", "reviewer", "", dir)
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -1851,7 +1851,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 	}
 
 	// Add a second comment to same file
-	err = addCommentToCritJSON("README.md", 3, 5, "refactor this section", "agent", dir)
+	err = addCommentToCritJSON("README.md", 3, 5, "refactor this section", "agent", "", dir)
 	if err != nil {
 		t.Fatalf("second addCommentToCritJSON: %v", err)
 	}
@@ -1870,7 +1870,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Add a comment first
-	err := addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", dir)
+	err := addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", "", dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1883,7 +1883,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 	commentID := cj.Files["README.md"].Comments[0].ID
 
 	// Add a reply
-	err = addReplyToCritJSON(commentID, "done, fixed", "agent", false, dir, "")
+	err = addReplyToCritJSON(commentID, "done, fixed", "", "agent", false, dir, "")
 	if err != nil {
 		t.Fatalf("addReplyToCritJSON: %v", err)
 	}
@@ -1904,7 +1904,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", dir)
+	addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", "", dir)
 
 	critPath := filepath.Join(dir, ".crit.json")
 	data, _ := os.ReadFile(critPath)
@@ -1912,7 +1912,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 	json.Unmarshal(data, &cj)
 	commentID := cj.Files["README.md"].Comments[0].ID
 
-	err := addReplyToCritJSON(commentID, "done", "agent", true, dir, "")
+	err := addReplyToCritJSON(commentID, "done", "agent", "", true, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1981,7 +1981,7 @@ func TestAddFileCommentToCritJSON_RejectsAbsolutePath(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addFileCommentToCritJSON("/etc/passwd", "test", "author", "")
+	err := addFileCommentToCritJSON("/etc/passwd", "test", "author", "", "")
 	if err == nil {
 		t.Fatal("expected error for absolute path")
 	}
@@ -1993,7 +1993,7 @@ func TestAddFileCommentToCritJSON_RejectsTraversal(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addFileCommentToCritJSON("../outside", "test", "author", "")
+	err := addFileCommentToCritJSON("../outside", "test", "author", "", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal")
 	}
@@ -2005,7 +2005,7 @@ func TestAddReviewCommentToCritJSON_RoundTrip(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addReviewCommentToCritJSON("overall the code is good", "reviewer", dir)
+	err := addReviewCommentToCritJSON("overall the code is good", "reviewer", "", dir)
 	if err != nil {
 		t.Fatalf("addReviewCommentToCritJSON: %v", err)
 	}
@@ -2032,7 +2032,7 @@ func TestClearCritJSON(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a .crit.json
-	addCommentToCritJSON("README.md", 1, 1, "test", "author", dir)
+	addCommentToCritJSON("README.md", 1, 1, "test", "author", "", dir)
 
 	critPath := filepath.Join(dir, ".crit.json")
 	if _, err := os.Stat(critPath); err != nil {
@@ -2083,7 +2083,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
 	t.Run("reply to file comment by random ID", func(t *testing.T) {
-		err := addReplyToCritJSON("c_a3f8b2", "Done, extracted", "agent", false, dir, "")
+		err := addReplyToCritJSON("c_a3f8b2", "Done, extracted", "", "agent", false, dir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2105,7 +2105,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 	})
 
 	t.Run("reply to review comment by random ID", func(t *testing.T) {
-		err := addReplyToCritJSON("r_aabb01", "Acknowledged", "agent", false, dir, "")
+		err := addReplyToCritJSON("r_aabb01", "Acknowledged", "agent", "", false, dir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2128,7 +2128,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 
 	t.Run("review comment reply does not need path disambiguation", func(t *testing.T) {
 		// Review comments are global — no filterPath needed
-		err := addReplyToCritJSON("r_aabb01", "No path needed", "agent", true, dir, "")
+		err := addReplyToCritJSON("r_aabb01", "No path needed", "agent", "", true, dir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2169,7 +2169,7 @@ func TestAppendReply_AmbiguousID(t *testing.T) {
 	}
 
 	t.Run("error without filterPath", func(t *testing.T) {
-		err := appendReply(cj, duplicateID, "done", "agent", false, "")
+		err := appendReply(cj, duplicateID, "done", "agent", "", false, "")
 		if err == nil {
 			t.Fatal("expected disambiguation error")
 		}
@@ -2200,7 +2200,7 @@ func TestAppendReply_AmbiguousID(t *testing.T) {
 			},
 		}
 
-		err := appendReply(cjClean, duplicateID, "done", "agent", false, "a.go")
+		err := appendReply(cjClean, duplicateID, "done", "agent", "", false, "a.go")
 		if err != nil {
 			t.Fatalf("appendReply with filterPath: %v", err)
 		}
@@ -2222,7 +2222,7 @@ func TestAppendReply_AmbiguousID(t *testing.T) {
 			},
 		}
 
-		err := appendReply(cjClean, duplicateID, "done", "agent", false, "nonexistent.go")
+		err := appendReply(cjClean, duplicateID, "done", "agent", "", false, "nonexistent.go")
 		if err == nil {
 			t.Fatal("expected not-found error with wrong filterPath")
 		}
@@ -2241,7 +2241,7 @@ func TestAddCommentToCritJSON_PopulatesAnchor(t *testing.T) {
 	// Write a file with known content.
 	writeFile(t, filepath.Join(dir, "hello.go"), "package main\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n")
 
-	if err := addCommentToCritJSON("hello.go", 3, 4, "Fix this function", "Bot", dir); err != nil {
+	if err := addCommentToCritJSON("hello.go", 3, 4, "Fix this function", "Bot", "", dir); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -2278,7 +2278,7 @@ func TestBulkAddCommentsToCritJSON_PopulatesAnchor(t *testing.T) {
 	entries := []BulkCommentEntry{
 		{File: "server.go", Line: 3, Body: "Why this import?"},
 	}
-	if err := bulkAddCommentsToCritJSON(entries, "Bot", dir); err != nil {
+	if err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir); err != nil {
 		t.Fatalf("bulkAddCommentsToCritJSON: %v", err)
 	}
 
@@ -2308,7 +2308,7 @@ func TestBulkAddCommentsToCritJSON_PopulatesAnchor(t *testing.T) {
 func TestProcessBulkReviewEntry_ReviewScope(t *testing.T) {
 	cj := CritJSON{Files: map[string]CritJSONFile{}}
 	e := BulkCommentEntry{Body: "overall looks good", Scope: "review"}
-	err := processBulkReviewEntry(&cj, 0, e, "reviewer")
+	err := processBulkReviewEntry(&cj, 0, e, "reviewer", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2326,7 +2326,7 @@ func TestProcessBulkReviewEntry_ReviewScope(t *testing.T) {
 func TestProcessBulkReviewEntry_WithLineRejectsNoFile(t *testing.T) {
 	cj := CritJSON{Files: map[string]CritJSONFile{}}
 	e := BulkCommentEntry{Body: "bad", Scope: "review", Line: 5}
-	err := processBulkReviewEntry(&cj, 0, e, "author")
+	err := processBulkReviewEntry(&cj, 0, e, "author", "")
 	if err == nil {
 		t.Error("expected error when review entry has line number")
 	}
@@ -2337,7 +2337,7 @@ func TestProcessBulkReviewEntry_NonReviewScopeWithFile(t *testing.T) {
 	// When scope != "review" but File/Path are set, it errors because
 	// file-scoped comments should go through processBulkFileOrLineEntry.
 	e := BulkCommentEntry{Body: "bad", Scope: "line", File: "test.go"}
-	err := processBulkReviewEntry(&cj, 1, e, "author")
+	err := processBulkReviewEntry(&cj, 1, e, "author", "")
 	if err == nil {
 		t.Error("expected error when non-review scope has file set")
 	}
@@ -2347,7 +2347,7 @@ func TestProcessBulkReviewEntry_NoFileFallsThrough(t *testing.T) {
 	cj := CritJSON{Files: map[string]CritJSONFile{}}
 	// When no file/path is set and scope is not "review", it still adds a review comment.
 	e := BulkCommentEntry{Body: "general feedback", Scope: "line"}
-	err := processBulkReviewEntry(&cj, 0, e, "author")
+	err := processBulkReviewEntry(&cj, 0, e, "author", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2372,7 +2372,7 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 	data, _ := json.Marshal(cj)
 	os.WriteFile(critPath, data, 0644)
 
-	err := addFileCommentToCritJSON("test.go", "file-level feedback", "reviewer", dir)
+	err := addFileCommentToCritJSON("test.go", "file-level feedback", "reviewer", "", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2397,5 +2397,39 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 	}
 	if cf.Comments[0].Scope != "file" {
 		t.Errorf("scope = %q, want file", cf.Comments[0].Scope)
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	for _, tc := range []struct {
+		login, name, want string
+	}{
+		{"alice", "Alice Liddell", "Alice Liddell"},
+		{"alice", "", "alice"},
+		{"alice", "   ", "alice"},
+		{"", "Alice", "Alice"},
+		{"bob", "Bob", "Bob"},
+	} {
+		if got := displayName(tc.login, tc.name); got != tc.want {
+			t.Errorf("displayName(%q, %q) = %q, want %q", tc.login, tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMergeGHComments_UsesDisplayNameFromCache(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{"main.go": {Status: "modified"}}}
+	ghComments := []ghComment{
+		{ID: 100, Path: "main.go", Line: 5, Side: "RIGHT", Body: "looks good",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"},
+			CreatedAt: "2025-01-01T00:00:00Z"},
+	}
+	names := userNameCache{"alice": "Alice Liddell"}
+	if added := mergeGHCommentsWithNames(&cj, ghComments, names); added != 1 {
+		t.Fatalf("added = %d, want 1", added)
+	}
+	if got := cj.Files["main.go"].Comments[0].Author; got != "Alice Liddell" {
+		t.Errorf("Author = %q, want Alice Liddell", got)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -155,10 +156,15 @@ func printQR(url string, showQR bool) {
 	}
 }
 
-func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, sharePaths []string, authToken string, showQR bool) {
+func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, sharePaths []string, authToken, fallbackAuthor string, showQR bool) {
 	localIDs := buildLocalIDSet(existingCfg)
 	localFingerprints, localFingerprintIDs := buildLocalFingerprintIndex(existingCfg)
 	if fetched, err := fetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken); err != nil {
+		if errors.Is(err, errShareUnauthorized) {
+			clearAuthIdentity()
+			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			os.Exit(1)
+		}
 		fmt.Fprintf(os.Stderr, "warning: could not pull remote comments: %v\n", err)
 	} else if len(fetched.NewComments) > 0 || len(fetched.ReplyUpdates) > 0 {
 		if err := mergeWebComments(critPath, fetched.NewComments, fetched.ReplyUpdates); err != nil {
@@ -166,10 +172,14 @@ func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, 
 		}
 	}
 
-	allComments, _ := loadCommentsForUpsert(critPath, sharePaths)
+	allComments, _ := loadCommentsForUpsert(critPath, sharePaths, fallbackAuthor)
 
 	result, err := upsertShareToWeb(existingCfg, files, allComments, authToken)
 	if err != nil {
+		if errors.Is(err, errShareUnauthorized) {
+			clearAuthIdentity()
+			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -186,9 +196,13 @@ func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, 
 	printQR(result.URL, showQR)
 }
 
-func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL, authToken string, showQR bool) {
-	res, err := shareReviewFiles(critPath, files, filePaths, svcURL, authToken)
+func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL, authToken, fallbackAuthor string, showQR bool) {
+	res, err := shareReviewFiles(critPath, files, filePaths, svcURL, authToken, fallbackAuthor)
 	if err != nil {
+		if errors.Is(err, errShareUnauthorized) {
+			clearAuthIdentity()
+			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -197,7 +211,7 @@ func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL,
 		fmt.Fprintf(os.Stderr, "Warning: could not save share state to review file: %v\n", err)
 	}
 
-	initialComments, _ := loadCommentsForUpsert(critPath, filePaths)
+	initialComments, _ := loadCommentsForUpsert(critPath, filePaths, fallbackAuthor)
 	_ = updateShareState(critPath, computeShareHash(files, initialComments), res.ReviewRound)
 
 	fmt.Println(res.URL)
@@ -217,7 +231,12 @@ func runShare(args []string) {
 
 	cfg := loadShareConfig()
 	sf.svcURL = resolveShareURL(sf.svcURL, cfg, defaultShareURL)
-	authToken := resolveAuthToken(cfg)
+	cfg.AuthToken = resolveAuthToken(cfg)
+	// If we have a token but no cached user id, fetch it from /api/auth/whoami
+	// before building the share payload so authenticated comments carry the
+	// user id. Best-effort: failures fall through to anonymous attribution.
+	lazyBackfillAuthUserID(&cfg)
+	authToken := cfg.AuthToken
 
 	files := loadShareFiles(sf.files)
 
@@ -233,11 +252,11 @@ func runShare(args []string) {
 	}
 
 	if existingCfg, ok := loadExistingShareCfg(critPath, sharePaths); ok {
-		runShareExisting(existingCfg, critPath, files, sharePaths, authToken, sf.showQR)
+		runShareExisting(existingCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)
 		return
 	}
 
-	runShareNew(critPath, files, sharePaths, sf.svcURL, authToken, sf.showQR)
+	runShareNew(critPath, files, sharePaths, sf.svcURL, authToken, cfg.Author, sf.showQR)
 }
 
 func parseFetchOutputDir(args []string) string {
@@ -309,6 +328,11 @@ func runFetch(args []string) {
 
 	fetched, err := fetchWebComments(cj.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken)
 	if err != nil {
+		if errors.Is(err, errShareUnauthorized) {
+			clearAuthIdentity()
+			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			os.Exit(1)
+		}
 		fmt.Fprintf(os.Stderr, "Error fetching remote comments: %v\n", err)
 		os.Exit(1)
 	}
@@ -706,6 +730,7 @@ func runPush(args []string) {
 type commentFlags struct {
 	outputDir string
 	author    string
+	userID    string
 	replyTo   string
 	resolve   bool
 	path      string
@@ -780,14 +805,19 @@ func resolveCommentFlags(f *commentFlags) {
 		}
 	}
 
-	// Resolve author: --author flag > config > VCS user.name
+	// Resolve author: --author flag > config > VCS user.name.
+	// Stamp AuthUserID alongside the author so authenticated comments
+	// carry the user identity into the share payload.
+	cfgDir, _ := os.Getwd()
+	if vcs := DetectVCS(""); vcs != nil {
+		cfgDir, _ = vcs.RepoRoot()
+	}
+	cfg := LoadConfig(cfgDir)
 	if f.author == "" {
-		cfgDir, _ := os.Getwd()
-		if vcs := DetectVCS(""); vcs != nil {
-			cfgDir, _ = vcs.RepoRoot()
-		}
-		cfg := LoadConfig(cfgDir)
 		f.author = cfg.Author
+	}
+	if f.userID == "" {
+		f.userID = cfg.AuthUserID
 	}
 }
 
@@ -804,7 +834,7 @@ func runCommentJSON(f commentFlags) {
 		os.Exit(1)
 	}
 
-	if err := bulkAddCommentsToCritJSON(entries, f.author, f.outputDir); err != nil {
+	if err := bulkAddCommentsToCritJSON(entries, f.author, f.userID, f.outputDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -834,7 +864,7 @@ func runCommentReply(f commentFlags) {
 		os.Exit(1)
 	}
 	replyBody := strings.Join(f.args, " ")
-	if err := addReplyToCritJSON(f.replyTo, replyBody, f.author, f.resolve, f.outputDir, f.path); err != nil {
+	if err := addReplyToCritJSON(f.replyTo, replyBody, f.author, f.userID, f.resolve, f.outputDir, f.path); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -877,7 +907,7 @@ func printCommentUsage() {
 	os.Exit(1)
 }
 
-func runCommentLineLevel(loc string, commentArgs []string, author, outputDir string) {
+func runCommentLineLevel(loc string, commentArgs []string, author, userID, outputDir string) {
 	colonIdx := strings.LastIndex(loc, ":")
 	lineSpec := loc[colonIdx+1:]
 	filePath := loc[:colonIdx]
@@ -903,7 +933,7 @@ func runCommentLineLevel(loc string, commentArgs []string, author, outputDir str
 		startLine, endLine = n, n
 	}
 	body := strings.Join(commentArgs[1:], " ")
-	if err := addCommentToCritJSON(filePath, startLine, endLine, body, author, outputDir); err != nil {
+	if err := addCommentToCritJSON(filePath, startLine, endLine, body, author, userID, outputDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -936,7 +966,7 @@ func runComment(args []string) {
 	// 1 arg: review-level comment
 	if len(f.args) == 1 {
 		body := f.args[0]
-		if err := addReviewCommentToCritJSON(body, f.author, f.outputDir); err != nil {
+		if err := addReviewCommentToCritJSON(body, f.author, f.userID, f.outputDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -948,7 +978,7 @@ func runComment(args []string) {
 	loc := f.args[0]
 	colonIdx := strings.LastIndex(loc, ":")
 	if colonIdx > 0 && looksLikeLineSpec(loc[colonIdx+1:]) {
-		runCommentLineLevel(loc, f.args, f.author, f.outputDir)
+		runCommentLineLevel(loc, f.args, f.author, f.userID, f.outputDir)
 		return
 	}
 
@@ -957,7 +987,7 @@ func runComment(args []string) {
 		candidatePath := f.args[0]
 		if fileExistsOnDiskOrSession(candidatePath, f.outputDir) {
 			body := strings.Join(f.args[1:], " ")
-			if err := addFileCommentToCritJSON(candidatePath, body, f.author, f.outputDir); err != nil {
+			if err := addFileCommentToCritJSON(candidatePath, body, f.author, f.userID, f.outputDir); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -309,7 +309,7 @@ func TestHelperProcess_CommentJSON(t *testing.T) {
 func TestRunComment_JSONFlagMixed(t *testing.T) {
 	// Step 1: Create a comment and capture its ID
 	tmp := t.TempDir()
-	err := addCommentToCritJSON("main.go", 1, 1, "comment", "TestBot", tmp)
+	err := addCommentToCritJSON("main.go", 1, 1, "comment", "TestBot", "", tmp)
 	if err != nil {
 		t.Fatalf("setup comment: %v", err)
 	}

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -27,6 +28,7 @@ type Server struct {
 	mux               *http.ServeMux
 	assets            fs.FS
 	shareURL          string
+	authMu            sync.RWMutex // guards authToken + cfg.Auth* fields
 	authToken         string
 	prInfo            *PRInfo
 	prInfoMu          sync.RWMutex
@@ -213,9 +215,9 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"agent_cmd":         s.agentCmd,
 
 		// Auth status
-		"auth_logged_in":  s.authToken != "",
-		"auth_user_name":  s.cfg.AuthUserName,
-		"auth_user_email": s.cfg.AuthUserEmail,
+		"auth_logged_in":  s.authLoggedIn(),
+		"auth_user_name":  s.authUserName(),
+		"auth_user_email": s.authUserEmail(),
 
 		// Review file path
 		"review_path": s.reviewPath,
@@ -356,8 +358,12 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	critPath := s.session.Load().critJSONPath()
-	res, err := shareReviewFiles(critPath, files, filePaths, s.shareURL, s.authToken)
+	res, err := shareReviewFiles(critPath, files, filePaths, s.shareURL, s.authTokenSnapshot(), s.author)
 	if err != nil {
+		if errors.Is(err, errShareUnauthorized) {
+			clearAuthIdentity()
+			s.clearAuthState()
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
@@ -457,7 +463,7 @@ func (s *Server) handleFileComments(w http.ResponseWriter, r *http.Request) {
 		s.session.Load().EnsureFileEntry(path)
 
 		if req.Scope == "file" {
-			c, ok := s.session.Load().AddFileComment(path, req.Body, req.Author)
+			c, ok := s.session.Load().AddFileComment(path, req.Body, req.Author, s.authUserID())
 			if !ok {
 				http.Error(w, "File not found", http.StatusNotFound)
 				return
@@ -472,7 +478,7 @@ func (s *Server) handleFileComments(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		c, ok := s.session.Load().AddComment(path, req.StartLine, req.EndLine, req.Side, req.Body, req.Quote, req.Author)
+		c, ok := s.session.Load().AddComment(path, req.StartLine, req.EndLine, req.Side, req.Body, req.Quote, req.Author, s.authUserID())
 		if !ok {
 			http.Error(w, "File not found", http.StatusNotFound)
 			return
@@ -715,7 +721,7 @@ func handleReplyCRUD(w http.ResponseWriter, r *http.Request, replyID string, ops
 func (s *Server) handleReplyRoute(w http.ResponseWriter, r *http.Request, filePath, commentID, replyID string) {
 	handleReplyCRUD(w, r, replyID, replyOps{
 		add: func(body, author string) (Reply, bool) {
-			return s.session.Load().AddReply(filePath, commentID, body, author)
+			return s.session.Load().AddReply(filePath, commentID, body, author, s.authUserID())
 		},
 		update: func(rid, body string) (Reply, bool) {
 			return s.session.Load().UpdateReply(filePath, commentID, rid, body)
@@ -729,7 +735,7 @@ func (s *Server) handleReplyRoute(w http.ResponseWriter, r *http.Request, filePa
 func (s *Server) handleReviewCommentReplyRoute(w http.ResponseWriter, r *http.Request, commentID, replyID string) {
 	handleReplyCRUD(w, r, replyID, replyOps{
 		add: func(body, author string) (Reply, bool) {
-			return s.session.Load().AddReviewCommentReply(commentID, body, author)
+			return s.session.Load().AddReviewCommentReply(commentID, body, author, s.authUserID())
 		},
 		update: func(rid, body string) (Reply, bool) {
 			return s.session.Load().UpdateReviewCommentReply(commentID, rid, body)
@@ -760,7 +766,7 @@ func (s *Server) handleReviewComments(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Comment body is required", http.StatusBadRequest)
 			return
 		}
-		c := s.session.Load().AddReviewComment(req.Body, req.Author)
+		c := s.session.Load().AddReviewComment(req.Body, req.Author, s.authUserID())
 		w.WriteHeader(http.StatusCreated)
 		writeJSON(w, c)
 
@@ -1382,10 +1388,10 @@ func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
 	author := agentName(s.agentCmd)
 	log.Printf("agent-request %s: completed, posting reply (%d bytes)\nResponse: %s\nStderr: %s", commentID, len(response), response, stderr.String())
 	// Try original path first, then search all files (path may have changed during agent run)
-	_, ok := sess.AddReply(filePath, commentID, response, author)
+	_, ok := sess.AddReply(filePath, commentID, response, author, "")
 	if !ok {
 		if _, actualPath, found := sess.FindCommentByID(commentID, ""); found {
-			_, ok = sess.AddReply(actualPath, commentID, response, author)
+			_, ok = sess.AddReply(actualPath, commentID, response, author, "")
 			if ok {
 				filePath = actualPath
 			}
@@ -1402,6 +1408,46 @@ func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
 		}
 		sess.notify(SSEEvent{Type: "comments-changed"})
 	}
+}
+
+func (s *Server) authTokenSnapshot() string {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.authToken
+}
+
+func (s *Server) authLoggedIn() bool {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.authToken != ""
+}
+
+func (s *Server) authUserID() string {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.cfg.AuthUserID
+}
+
+func (s *Server) authUserName() string {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.cfg.AuthUserName
+}
+
+func (s *Server) authUserEmail() string {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.cfg.AuthUserEmail
+}
+
+func (s *Server) clearAuthState() {
+	s.authMu.Lock()
+	defer s.authMu.Unlock()
+	s.authToken = ""
+	s.cfg.AuthToken = ""
+	s.cfg.AuthUserID = ""
+	s.cfg.AuthUserName = ""
+	s.cfg.AuthUserEmail = ""
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/server_test.go
+++ b/server_test.go
@@ -201,8 +201,8 @@ func TestPostFileComment_FileNotFound(t *testing.T) {
 
 func TestGetFileComments(t *testing.T) {
 	s, session := newTestServer(t)
-	session.AddComment("test.md", 1, 1, "", "one", "", "")
-	session.AddComment("test.md", 2, 2, "", "two", "", "")
+	session.AddComment("test.md", 1, 1, "", "one", "", "", "")
+	session.AddComment("test.md", 2, 2, "", "two", "", "", "")
 
 	req := httptest.NewRequest("GET", "/api/file/comments?path=test.md", nil)
 	w := httptest.NewRecorder()
@@ -222,7 +222,7 @@ func TestGetFileComments(t *testing.T) {
 
 func TestAPIUpdateComment(t *testing.T) {
 	s, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	body := `{"body":"updated"}`
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"?path=test.md", strings.NewReader(body))
@@ -250,7 +250,7 @@ func TestAPIUpdateComment_NotFound(t *testing.T) {
 
 func TestAPIDeleteComment(t *testing.T) {
 	s, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "to delete", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "to delete", "", "", "")
 
 	req := httptest.NewRequest("DELETE", "/api/comment/"+c.ID+"?path=test.md", nil)
 	w := httptest.NewRecorder()
@@ -276,8 +276,8 @@ func TestAPIDeleteComment_NotFound(t *testing.T) {
 
 func TestClearAllComments(t *testing.T) {
 	s, session := newTestServer(t)
-	session.AddComment("test.md", 1, 1, "", "comment 1", "", "")
-	session.AddComment("test.md", 2, 2, "", "comment 2", "", "")
+	session.AddComment("test.md", 1, 1, "", "comment 1", "", "", "")
+	session.AddComment("test.md", 2, 2, "", "comment 2", "", "", "")
 
 	if len(session.GetComments("test.md")) != 2 {
 		t.Fatal("expected 2 comments before clear")
@@ -307,7 +307,7 @@ func TestReviewComments_MethodNotAllowed(t *testing.T) {
 
 func TestFinish(t *testing.T) {
 	s, session := newTestServer(t)
-	session.AddComment("test.md", 1, 1, "", "note", "", "")
+	session.AddComment("test.md", 1, 1, "", "note", "", "", "")
 
 	req := httptest.NewRequest("POST", "/api/finish", nil)
 	w := httptest.NewRecorder()
@@ -352,7 +352,7 @@ func TestFinish_NoComments(t *testing.T) {
 func TestFinish_PromptIncludesFileArgs(t *testing.T) {
 	s, session := newTestServer(t)
 	session.CLIArgs = []string{"test.md"}
-	session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	req := httptest.NewRequest("POST", "/api/finish", nil)
 	w := httptest.NewRecorder()
@@ -372,7 +372,7 @@ func TestFinish_PromptBareGitMode(t *testing.T) {
 	s, session := newTestServer(t)
 	session.Mode = "git"
 	// CLIArgs stays nil — git mode
-	session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	req := httptest.NewRequest("POST", "/api/finish", nil)
 	w := httptest.NewRecorder()
@@ -390,7 +390,7 @@ func TestFinish_PromptBareGitMode(t *testing.T) {
 
 func TestFinish_UnresolvedReturnsPromptWithInstructions(t *testing.T) {
 	s, session := newTestServer(t)
-	session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	req := httptest.NewRequest("POST", "/api/finish", nil)
 	w := httptest.NewRecorder()
@@ -447,7 +447,7 @@ func TestReviewCycle_ApproveReturnsEmptyPrompt(t *testing.T) {
 func TestReviewCycle_UnresolvedReturnsPrompt(t *testing.T) {
 	s, session := newTestServer(t)
 	session.SetAwaitingFirstReview(true)
-	session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	done := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
@@ -1135,7 +1135,7 @@ func TestGetFile_NotInSession_PathTraversal(t *testing.T) {
 
 func TestHandleFinish_PromptIncludesAuthor(t *testing.T) {
 	srv, session := newTestServer(t)
-	session.AddComment(session.Files[0].Path, 1, 1, "", "fix this", "", "")
+	session.AddComment(session.Files[0].Path, 1, 1, "", "fix this", "", "", "")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/finish", nil)
 	w := httptest.NewRecorder()
@@ -1152,7 +1152,7 @@ func TestHandleFinish_PromptIncludesAuthor(t *testing.T) {
 
 func TestHandleFinishEmitsSSEEvent(t *testing.T) {
 	srv, session := newTestServer(t)
-	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "")
+	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "", "")
 
 	// Subscribe before triggering finish
 	ch := session.Subscribe()
@@ -1188,7 +1188,7 @@ func TestHandleFinishEmitsSSEEvent(t *testing.T) {
 
 func TestWaitForEventReturnsOnFinish(t *testing.T) {
 	srv, session := newTestServer(t)
-	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "")
+	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "", "")
 
 	var resp *httptest.ResponseRecorder
 	done := make(chan struct{})
@@ -1222,7 +1222,7 @@ func TestWaitForEventReturnsOnFinish(t *testing.T) {
 
 func TestWaitForEventIgnoresOtherEvents(t *testing.T) {
 	srv, session := newTestServer(t)
-	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "")
+	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "", "")
 
 	done := make(chan struct{})
 	go func() {
@@ -1481,7 +1481,7 @@ func TestGetFilesList_MethodNotAllowed(t *testing.T) {
 
 func TestSessionIncludesReviewComments(t *testing.T) {
 	srv, sess := newTestServer(t)
-	sess.AddReviewComment("general note", "")
+	sess.AddReviewComment("general note", "", "")
 	req := httptest.NewRequest("GET", "/api/session", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -1498,11 +1498,11 @@ func TestSessionIncludesReviewComments(t *testing.T) {
 
 func TestFinishPromptMentionsScopes(t *testing.T) {
 	srv, sess := newTestServer(t)
-	sess.AddReviewComment("address all issues", "")
-	if _, ok := sess.AddFileComment("test.md", "restructure this file", ""); !ok {
+	sess.AddReviewComment("address all issues", "", "")
+	if _, ok := sess.AddFileComment("test.md", "restructure this file", "", ""); !ok {
 		t.Fatal("AddFileComment failed")
 	}
-	if _, ok := sess.AddComment("test.md", 1, 1, "", "bug here", "", ""); !ok {
+	if _, ok := sess.AddComment("test.md", 1, 1, "", "bug here", "", "", ""); !ok {
 		t.Fatal("AddComment failed")
 	}
 	req := httptest.NewRequest("POST", "/api/finish", nil)
@@ -2196,7 +2196,7 @@ func TestSetPRInfo_ConcurrentSafe(t *testing.T) {
 
 func TestFileCommentResolveAPI(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	// Resolve
 	body := `{"resolved": true}`
@@ -2237,7 +2237,7 @@ func TestFileCommentResolveAPI(t *testing.T) {
 
 func TestFileCommentReplyAPI(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	// POST reply
 	body := strings.NewReader(`{"body": "done, fixed", "author": "agent"}`)
@@ -2298,7 +2298,7 @@ func TestFileCommentReplyNotFound(t *testing.T) {
 
 func TestAPIUpdateComment_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	body := `{"body": ""}`
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"?path=test.md", strings.NewReader(body))
@@ -2311,7 +2311,7 @@ func TestAPIUpdateComment_EmptyBody(t *testing.T) {
 
 func TestHandleAgentRequest_NotConfigured(t *testing.T) {
 	srv, session := newTestServer(t)
-	session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	body := strings.NewReader(`{"comment_id": "c1"}`)
 	req := httptest.NewRequest("POST", "/api/agent/request", body)
@@ -2647,7 +2647,7 @@ func TestBuildPlanFeedback(t *testing.T) {
 
 func TestHandleFileCommentResolve(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this bug", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this bug", "", "", "")
 
 	tests := []struct {
 		name       string
@@ -2698,7 +2698,7 @@ func TestHandleFileCommentResolve_MethodNotAllowed(t *testing.T) {
 
 func TestHandleFileCommentResolve_InvalidBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/resolve?path=test.md", strings.NewReader("not json"))
 	w := httptest.NewRecorder()
@@ -2712,7 +2712,7 @@ func TestHandleFileCommentResolve_InvalidBody(t *testing.T) {
 
 func TestHandleReviewCommentResolve(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("general note", "")
+	c := session.AddReviewComment("general note", "", "")
 
 	tests := []struct {
 		name     string
@@ -2752,7 +2752,7 @@ func TestHandleReviewCommentResolve_NotFound(t *testing.T) {
 
 func TestHandleReviewCommentResolve_InvalidBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
+	c := session.AddReviewComment("note", "", "")
 
 	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/resolve", strings.NewReader("not json"))
 	w := httptest.NewRecorder()
@@ -2776,7 +2776,7 @@ func TestHandleReviewCommentResolve_MethodNotAllowed(t *testing.T) {
 
 func TestHandleReviewCommentUpdate_DELETE(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("delete me", "")
+	c := session.AddReviewComment("delete me", "", "")
 
 	req := httptest.NewRequest("DELETE", "/api/review-comment/"+c.ID, nil)
 	w := httptest.NewRecorder()
@@ -2815,7 +2815,7 @@ func TestHandleReviewCommentUpdate_PUT_NotFound(t *testing.T) {
 
 func TestHandleReviewCommentUpdate_PUT_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("original", "")
+	c := session.AddReviewComment("original", "", "")
 
 	body := strings.NewReader(`{"body": ""}`)
 	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID, body)
@@ -2828,7 +2828,7 @@ func TestHandleReviewCommentUpdate_PUT_EmptyBody(t *testing.T) {
 
 func TestHandleReviewCommentUpdate_PUT_InvalidJSON(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("original", "")
+	c := session.AddReviewComment("original", "", "")
 
 	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID, strings.NewReader("not json"))
 	w := httptest.NewRecorder()
@@ -2852,8 +2852,8 @@ func TestHandleReviewCommentUpdate_MethodNotAllowed(t *testing.T) {
 
 func TestHandleReplyCRUD_PUT_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
-	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
+	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent", "")
 
 	body := strings.NewReader(`{"body": ""}`)
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/"+reply.ID+"?path=test.md", body)
@@ -2866,8 +2866,8 @@ func TestHandleReplyCRUD_PUT_EmptyBody(t *testing.T) {
 
 func TestHandleReplyCRUD_PUT_InvalidJSON(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
-	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
+	reply, _ := session.AddReply("test.md", c.ID, "first reply", "agent", "")
 
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/"+reply.ID+"?path=test.md", strings.NewReader("bad"))
 	w := httptest.NewRecorder()
@@ -2879,7 +2879,7 @@ func TestHandleReplyCRUD_PUT_InvalidJSON(t *testing.T) {
 
 func TestHandleReplyCRUD_PUT_NotFound(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	body := strings.NewReader(`{"body": "updated"}`)
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/replies/nonexistent?path=test.md", body)
@@ -2892,7 +2892,7 @@ func TestHandleReplyCRUD_PUT_NotFound(t *testing.T) {
 
 func TestHandleReplyCRUD_DELETE_NotFound(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	req := httptest.NewRequest("DELETE", "/api/comment/"+c.ID+"/replies/nonexistent?path=test.md", nil)
 	w := httptest.NewRecorder()
@@ -2904,7 +2904,7 @@ func TestHandleReplyCRUD_DELETE_NotFound(t *testing.T) {
 
 func TestHandleReplyCRUD_POST_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	body := strings.NewReader(`{"body": "", "author": "agent"}`)
 	req := httptest.NewRequest("POST", "/api/comment/"+c.ID+"/replies?path=test.md", body)
@@ -2917,7 +2917,7 @@ func TestHandleReplyCRUD_POST_EmptyBody(t *testing.T) {
 
 func TestHandleReplyCRUD_POST_InvalidJSON(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	req := httptest.NewRequest("POST", "/api/comment/"+c.ID+"/replies?path=test.md", strings.NewReader("bad json"))
 	w := httptest.NewRecorder()
@@ -2929,7 +2929,7 @@ func TestHandleReplyCRUD_POST_InvalidJSON(t *testing.T) {
 
 func TestHandleReplyCRUD_MethodNotAllowed(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	req := httptest.NewRequest("PATCH", "/api/comment/"+c.ID+"/replies?path=test.md", nil)
 	w := httptest.NewRecorder()
@@ -2943,8 +2943,8 @@ func TestHandleReplyCRUD_MethodNotAllowed(t *testing.T) {
 
 func TestReviewCommentReplyCRUD_PUT_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
-	reply, _ := session.AddReviewCommentReply(c.ID, "reply text", "agent")
+	c := session.AddReviewComment("note", "", "")
+	reply, _ := session.AddReviewCommentReply(c.ID, "reply text", "agent", "")
 
 	body := strings.NewReader(`{"body": ""}`)
 	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/replies/"+reply.ID, body)
@@ -2957,7 +2957,7 @@ func TestReviewCommentReplyCRUD_PUT_EmptyBody(t *testing.T) {
 
 func TestReviewCommentReplyCRUD_PUT_NotFound(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
+	c := session.AddReviewComment("note", "", "")
 
 	body := strings.NewReader(`{"body": "updated"}`)
 	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/replies/nonexistent", body)
@@ -2970,7 +2970,7 @@ func TestReviewCommentReplyCRUD_PUT_NotFound(t *testing.T) {
 
 func TestReviewCommentReplyCRUD_DELETE_NotFound(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
+	c := session.AddReviewComment("note", "", "")
 
 	req := httptest.NewRequest("DELETE", "/api/review-comment/"+c.ID+"/replies/nonexistent", nil)
 	w := httptest.NewRecorder()
@@ -2982,7 +2982,7 @@ func TestReviewCommentReplyCRUD_DELETE_NotFound(t *testing.T) {
 
 func TestReviewCommentReplyCRUD_POST_EmptyBody(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
+	c := session.AddReviewComment("note", "", "")
 
 	body := strings.NewReader(`{"body": "", "author": "agent"}`)
 	req := httptest.NewRequest("POST", "/api/review-comment/"+c.ID+"/replies", body)
@@ -2995,7 +2995,7 @@ func TestReviewCommentReplyCRUD_POST_EmptyBody(t *testing.T) {
 
 func TestReviewCommentReplyCRUD_POST_InvalidJSON(t *testing.T) {
 	srv, session := newTestServer(t)
-	c := session.AddReviewComment("note", "")
+	c := session.AddReviewComment("note", "", "")
 
 	req := httptest.NewRequest("POST", "/api/review-comment/"+c.ID+"/replies", strings.NewReader("bad"))
 	w := httptest.NewRecorder()
@@ -3009,7 +3009,7 @@ func TestReviewCommentReplyCRUD_POST_InvalidJSON(t *testing.T) {
 
 func TestHandleFileCommentUpdate_DELETE(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "delete me", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "delete me", "", "", "")
 
 	req := httptest.NewRequest("DELETE", "/api/comment/"+c.ID+"?path=test.md", nil)
 	w := httptest.NewRecorder()
@@ -3047,7 +3047,7 @@ func TestHandleFileCommentUpdate_PUT_NotFound(t *testing.T) {
 
 func TestHandleFileCommentUpdate_PUT_InvalidJSON(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "original", "", "", "")
 
 	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"?path=test.md", strings.NewReader("bad"))
 	w := httptest.NewRecorder()
@@ -3102,7 +3102,7 @@ func TestHandleHealth_MethodNotAllowed(t *testing.T) {
 
 func TestHandleFinish_AllResolved(t *testing.T) {
 	srv, session := newTestServer(t)
-	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "")
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
 	session.SetCommentResolved("test.md", c.ID, true)
 
 	req := httptest.NewRequest("POST", "/api/finish", nil)

--- a/session.go
+++ b/session.go
@@ -48,6 +48,7 @@ type Reply struct {
 	ID        string `json:"id"`
 	Body      string `json:"body"`
 	Author    string `json:"author,omitempty"`
+	UserID    string `json:"user_id,omitempty"`
 	CreatedAt string `json:"created_at"`
 	GitHubID  int64  `json:"github_id,omitempty"`
 }
@@ -64,6 +65,7 @@ type Comment struct {
 	Anchor         string  `json:"anchor,omitempty"`
 	Drifted        bool    `json:"drifted,omitempty"`
 	Author         string  `json:"author,omitempty"`
+	UserID         string  `json:"user_id,omitempty"`
 	Scope          string  `json:"scope,omitempty"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
@@ -610,7 +612,7 @@ func extractAnchor(content string, startLine, endLine int) string {
 }
 
 // AddComment adds a comment to a specific file.
-func (s *Session) AddComment(filePath string, startLine, endLine int, side, body, quote, author string) (Comment, bool) {
+func (s *Session) AddComment(filePath string, startLine, endLine int, side, body, quote, author, userID string) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	f := s.fileByPathLocked(filePath)
@@ -643,6 +645,7 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 		Quote:       quote,
 		Anchor:      anchor,
 		Author:      author,
+		UserID:      userID,
 		Scope:       "line",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -654,7 +657,7 @@ func (s *Session) AddComment(filePath string, startLine, endLine int, side, body
 }
 
 // AddFileComment adds a file-level comment (not tied to specific lines).
-func (s *Session) AddFileComment(filePath, body, author string) (Comment, bool) {
+func (s *Session) AddFileComment(filePath, body, author, userID string) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	f := s.fileByPathLocked(filePath)
@@ -666,6 +669,7 @@ func (s *Session) AddFileComment(filePath, body, author string) (Comment, bool) 
 		ID:          randomCommentID(),
 		Body:        body,
 		Author:      author,
+		UserID:      userID,
 		Scope:       "file",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -677,7 +681,7 @@ func (s *Session) AddFileComment(filePath, body, author string) (Comment, bool) 
 }
 
 // AddReviewComment adds a review-level comment (not tied to any file).
-func (s *Session) AddReviewComment(body, author string) Comment {
+func (s *Session) AddReviewComment(body, author, userID string) Comment {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -685,6 +689,7 @@ func (s *Session) AddReviewComment(body, author string) Comment {
 		ID:          randomReviewCommentID(),
 		Body:        body,
 		Author:      author,
+		UserID:      userID,
 		Scope:       "review",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -749,7 +754,7 @@ func (s *Session) ResolveReviewComment(id string, resolved bool) (Comment, bool)
 }
 
 // AddReviewCommentReply adds a reply to a review-level comment.
-func (s *Session) AddReviewCommentReply(commentID, body, author string) (Reply, bool) {
+func (s *Session) AddReviewCommentReply(commentID, body, author, userID string) (Reply, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, c := range s.reviewComments {
@@ -759,6 +764,7 @@ func (s *Session) AddReviewCommentReply(commentID, body, author string) (Reply, 
 				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
+				UserID:    userID,
 				CreatedAt: now,
 			}
 			s.reviewComments[i].Replies = append(s.reviewComments[i].Replies, r)
@@ -919,7 +925,7 @@ func (s *Session) RefreshFileContent() {
 }
 
 // AddReply adds a reply to a specific comment on a file.
-func (s *Session) AddReply(filePath, commentID, body, author string) (Reply, bool) {
+func (s *Session) AddReply(filePath, commentID, body, author, userID string) (Reply, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	f := s.fileByPathLocked(filePath)
@@ -933,6 +939,7 @@ func (s *Session) AddReply(filePath, commentID, body, author string) (Reply, boo
 				ID:        randomReplyID(),
 				Body:      body,
 				Author:    author,
+				UserID:    userID,
 				CreatedAt: now,
 			}
 			f.Comments[i].Replies = append(f.Comments[i].Replies, r)

--- a/session_test.go
+++ b/session_test.go
@@ -65,7 +65,7 @@ func TestSession_FileByPath(t *testing.T) {
 
 func TestSession_AddComment(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddComment("plan.md", 1, 3, "", "Rethink this", "", "")
+	c, ok := s.AddComment("plan.md", 1, 3, "", "Rethink this", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -84,7 +84,7 @@ func TestSession_AddComment(t *testing.T) {
 
 func TestSession_AddComment_NonexistentFile(t *testing.T) {
 	s := newTestSession(t)
-	_, ok := s.AddComment("nonexistent.go", 1, 1, "", "test", "", "")
+	_, ok := s.AddComment("nonexistent.go", 1, 1, "", "test", "", "", "")
 	if ok {
 		t.Error("expected AddComment to fail for nonexistent file")
 	}
@@ -92,7 +92,7 @@ func TestSession_AddComment_NonexistentFile(t *testing.T) {
 
 func TestSession_UpdateComment(t *testing.T) {
 	s := newTestSession(t)
-	c, _ := s.AddComment("plan.md", 1, 1, "", "original", "", "")
+	c, _ := s.AddComment("plan.md", 1, 1, "", "original", "", "", "")
 	updated, ok := s.UpdateComment("plan.md", c.ID, "updated body")
 	if !ok {
 		t.Fatal("UpdateComment failed")
@@ -112,7 +112,7 @@ func TestSession_UpdateComment_NotFound(t *testing.T) {
 
 func TestSession_DeleteComment(t *testing.T) {
 	s := newTestSession(t)
-	c, _ := s.AddComment("plan.md", 1, 1, "", "to delete", "", "")
+	c, _ := s.AddComment("plan.md", 1, 1, "", "to delete", "", "", "")
 	if !s.DeleteComment("plan.md", c.ID) {
 		t.Fatal("DeleteComment failed")
 	}
@@ -130,7 +130,7 @@ func TestSession_DeleteComment_NotFound(t *testing.T) {
 
 func TestSession_GetComments_ReturnsCopy(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "test", "", "")
+	s.AddComment("plan.md", 1, 1, "", "test", "", "", "")
 	comments := s.GetComments("plan.md")
 	comments[0].Body = "mutated"
 	if s.GetComments("plan.md")[0].Body == "mutated" {
@@ -140,8 +140,8 @@ func TestSession_GetComments_ReturnsCopy(t *testing.T) {
 
 func TestSession_GetAllComments(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "md comment", "", "")
-	s.AddComment("main.go", 1, 1, "", "go comment", "", "")
+	s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")
+	s.AddComment("main.go", 1, 1, "", "go comment", "", "", "")
 
 	all := s.GetAllComments()
 	if len(all) != 2 {
@@ -154,9 +154,9 @@ func TestSession_GetAllComments(t *testing.T) {
 
 func TestSession_TotalCommentCount(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "one", "", "")
-	s.AddComment("plan.md", 2, 2, "", "two", "", "")
-	s.AddComment("main.go", 1, 1, "", "three", "", "")
+	s.AddComment("plan.md", 1, 1, "", "one", "", "", "")
+	s.AddComment("plan.md", 2, 2, "", "two", "", "", "")
+	s.AddComment("main.go", 1, 1, "", "three", "", "", "")
 
 	if s.TotalCommentCount() != 3 {
 		t.Errorf("TotalCommentCount = %d, want 3", s.TotalCommentCount())
@@ -165,8 +165,8 @@ func TestSession_TotalCommentCount(t *testing.T) {
 
 func TestSession_NewCommentCount(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "new one", "", "")
-	s.AddComment("plan.md", 2, 2, "", "new two", "", "")
+	s.AddComment("plan.md", 1, 1, "", "new one", "", "", "")
+	s.AddComment("plan.md", 2, 2, "", "new two", "", "", "")
 
 	// Simulate carried-forward comments (as happens after round complete)
 	s.mu.Lock()
@@ -231,7 +231,7 @@ func TestSession_UnresolvedCommentCount(t *testing.T) {
 
 func TestSession_WriteFiles(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "fix", "", "")
+	s.AddComment("plan.md", 1, 1, "", "fix", "", "", "")
 
 	flushWrites(s)
 	s.WriteFiles()
@@ -285,7 +285,7 @@ func TestSession_WriteFiles_SharedURLOnly(t *testing.T) {
 
 func TestSession_LoadCritJSON(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "persisted comment", "", "")
+	s.AddComment("plan.md", 1, 1, "", "persisted comment", "", "", "")
 
 	flushWrites(s)
 	s.WriteFiles()
@@ -365,7 +365,7 @@ func TestSession_WriteFiles_PreservesNonSessionFiles(t *testing.T) {
 	}
 
 	// Add a comment on a session file (plan.md) and trigger a write
-	s.AddComment("plan.md", 1, 1, "", "session comment", "", "")
+	s.AddComment("plan.md", 1, 1, "", "session comment", "", "", "")
 	s.WriteFiles()
 
 	// Reload and verify both files are present
@@ -428,8 +428,8 @@ func TestSession_LoadCritJSON_MismatchedHash(t *testing.T) {
 
 func TestSession_SignalRoundComplete(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "fix this", "", "")
-	s.AddComment("main.go", 1, 1, "", "and this", "", "")
+	s.AddComment("plan.md", 1, 1, "", "fix this", "", "", "")
+	s.AddComment("main.go", 1, 1, "", "and this", "", "", "")
 	s.IncrementEdits()
 	s.IncrementEdits()
 
@@ -462,7 +462,7 @@ func TestSession_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c, _ := s.AddComment("plan.md", 1, 1, "", "concurrent", "", "")
+			c, _ := s.AddComment("plan.md", 1, 1, "", "concurrent", "", "", "")
 			s.UpdateComment("plan.md", c.ID, "updated")
 			s.GetComments("plan.md")
 			s.DeleteComment("plan.md", c.ID)
@@ -487,7 +487,7 @@ func TestSession_Subscribe(t *testing.T) {
 
 func TestSession_GetSessionInfo(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "note", "", "")
+	s.AddComment("plan.md", 1, 1, "", "note", "", "", "")
 	s.Files[1].DiffHunks = []DiffHunk{
 		{Lines: []DiffLine{
 			{Type: "add"},
@@ -563,7 +563,7 @@ func TestSession_WriteFiles_OutputDir(t *testing.T) {
 	outDir := t.TempDir()
 	s.OutputDir = outDir
 
-	s.AddComment("plan.md", 1, 1, "", "output dir comment", "", "")
+	s.AddComment("plan.md", 1, 1, "", "output dir comment", "", "", "")
 	flushWrites(s)
 	s.WriteFiles()
 
@@ -593,7 +593,7 @@ func TestSession_LoadCritJSON_OutputDir(t *testing.T) {
 	outDir := t.TempDir()
 	s.OutputDir = outDir
 
-	s.AddComment("plan.md", 1, 1, "", "persisted in output dir", "", "")
+	s.AddComment("plan.md", 1, 1, "", "persisted in output dir", "", "", "")
 	flushWrites(s)
 	s.WriteFiles()
 
@@ -668,8 +668,8 @@ func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
 
 func TestSession_GlobalCommentIDs(t *testing.T) {
 	s := newTestSession(t)
-	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "")
-	c2, _ := s.AddComment("main.go", 1, 1, "", "go comment", "", "")
+	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")
+	c2, _ := s.AddComment("main.go", 1, 1, "", "go comment", "", "", "")
 
 	// IDs are globally unique across files
 	if !strings.HasPrefix(c1.ID, "c_") || len(c1.ID) != 8 {
@@ -963,12 +963,12 @@ func TestChangeBaseBranch_CommentsPreserved(t *testing.T) {
 	}
 
 	// Add a comment on feature.go (should survive base branch change)
-	_, ok := session.AddComment("feature.go", 1, 1, "", "keep this comment", "", "")
+	_, ok := session.AddComment("feature.go", 1, 1, "", "keep this comment", "", "", "")
 	if !ok {
 		t.Fatal("AddComment on feature.go failed")
 	}
 	// Add a comment on prod.go (should be lost when switching base to production)
-	_, ok = session.AddComment("prod.go", 1, 1, "", "will disappear", "", "")
+	_, ok = session.AddComment("prod.go", 1, 1, "", "will disappear", "", "", "")
 	if !ok {
 		t.Fatal("AddComment on prod.go failed")
 	}
@@ -1301,7 +1301,7 @@ func TestAddCommentSetsReviewRound(t *testing.T) {
 	s := newTestSession(t)
 	s.ReviewRound = 2
 
-	c, ok := s.AddComment("plan.md", 1, 1, "", "test body", "", "user")
+	c, ok := s.AddComment("plan.md", 1, 1, "", "test body", "", "user", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -1690,7 +1690,7 @@ func TestSession_AddReply(t *testing.T) {
 		},
 	}
 
-	reply, ok := s.AddReply("test.md", "c1", "Done, fixed it", "agent")
+	reply, ok := s.AddReply("test.md", "c1", "Done, fixed it", "agent", "")
 	if !ok {
 		t.Fatal("AddReply returned false")
 	}
@@ -1728,7 +1728,7 @@ func TestSession_AddReply_UnresolvesComment(t *testing.T) {
 		t.Fatal("expected comment to be resolved before reply")
 	}
 
-	_, ok := s.AddReply("test.md", "c1", "Actually, this needs more work", "reviewer")
+	_, ok := s.AddReply("test.md", "c1", "Actually, this needs more work", "reviewer", "")
 	if !ok {
 		t.Fatal("AddReply returned false")
 	}
@@ -1804,9 +1804,9 @@ func TestSession_AddReply_SequentialIDs(t *testing.T) {
 		},
 	}
 
-	r1, _ := s.AddReply("test.md", "c1", "First reply", "agent")
-	r2, _ := s.AddReply("test.md", "c1", "Second reply", "user")
-	r3, _ := s.AddReply("test.md", "c1", "Third reply", "agent")
+	r1, _ := s.AddReply("test.md", "c1", "First reply", "agent", "")
+	r2, _ := s.AddReply("test.md", "c1", "Second reply", "user", "")
+	r3, _ := s.AddReply("test.md", "c1", "Third reply", "agent", "")
 
 	// All reply IDs should have rp_ prefix and be unique
 	for _, r := range []Reply{r1, r2, r3} {
@@ -1874,7 +1874,7 @@ func TestSession_LoadCritJSON_RestoresReviewRound(t *testing.T) {
 	}
 
 	// New comments should get the restored round number
-	c, ok := s.AddComment("plan.md", 5, 5, "", "round 3 feedback", "", "")
+	c, ok := s.AddComment("plan.md", 5, 5, "", "round 3 feedback", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -2173,7 +2173,7 @@ func TestSession_EnsureFileEntry_ThenAddComment(t *testing.T) {
 	}
 
 	// Now AddComment should work
-	c, ok := s.AddComment("runtime.py", 2, 2, "", "Add docstring", "", "reviewer")
+	c, ok := s.AddComment("runtime.py", 2, 2, "", "Add docstring", "", "reviewer", "")
 	if !ok {
 		t.Fatal("AddComment failed after EnsureFileEntry")
 	}
@@ -2263,7 +2263,7 @@ func TestSession_MergeExternalCritJSON_SyncsUnresolve(t *testing.T) {
 
 func TestCommentScopeDefault(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddComment("plan.md", 1, 1, "", "test body", "", "")
+	c, ok := s.AddComment("plan.md", 1, 1, "", "test body", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -2274,7 +2274,7 @@ func TestCommentScopeDefault(t *testing.T) {
 
 func TestAddFileComment(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddFileComment("plan.md", "this file needs work", "")
+	c, ok := s.AddFileComment("plan.md", "this file needs work", "", "")
 	if !ok {
 		t.Fatal("AddFileComment failed")
 	}
@@ -2292,7 +2292,7 @@ func TestAddFileComment(t *testing.T) {
 
 func TestAddReviewComment(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("please address all issues", "")
+	c := s.AddReviewComment("please address all issues", "", "")
 	if c.Scope != "review" {
 		t.Errorf("expected scope 'review', got %q", c.Scope)
 	}
@@ -2307,7 +2307,7 @@ func TestAddReviewComment(t *testing.T) {
 
 func TestDeleteReviewComment(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("temp", "")
+	c := s.AddReviewComment("temp", "", "")
 	if !s.DeleteReviewComment(c.ID) {
 		t.Fatal("DeleteReviewComment failed")
 	}
@@ -2318,7 +2318,7 @@ func TestDeleteReviewComment(t *testing.T) {
 
 func TestUpdateReviewComment(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("original", "")
+	c := s.AddReviewComment("original", "", "")
 	updated, ok := s.UpdateReviewComment(c.ID, "revised")
 	if !ok {
 		t.Fatal("UpdateReviewComment failed")
@@ -2330,9 +2330,9 @@ func TestUpdateReviewComment(t *testing.T) {
 
 func TestCritJSONIncludesReviewComments(t *testing.T) {
 	s := newTestSession(t)
-	s.AddReviewComment("general feedback", "")
-	s.AddComment("plan.md", 1, 1, "", "line comment", "", "")
-	s.AddFileComment("plan.md", "file comment", "")
+	s.AddReviewComment("general feedback", "", "")
+	s.AddComment("plan.md", 1, 1, "", "line comment", "", "", "")
+	s.AddFileComment("plan.md", "file comment", "", "")
 	s.WriteFiles()
 	data, err := os.ReadFile(s.critJSONPath())
 	if err != nil {
@@ -2356,7 +2356,7 @@ func TestCritJSONIncludesReviewComments(t *testing.T) {
 
 func TestLoadCritJSONRestoresReviewComments(t *testing.T) {
 	s := newTestSession(t)
-	s.AddReviewComment("restored comment", "")
+	s.AddReviewComment("restored comment", "", "")
 	s.WriteFiles()
 	s.reviewComments = nil
 
@@ -2372,9 +2372,9 @@ func TestLoadCritJSONRestoresReviewComments(t *testing.T) {
 
 func TestCommentCountsIncludeReviewComments(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "line", "", "")
-	s.AddFileComment("plan.md", "file", "")
-	s.AddReviewComment("review", "")
+	s.AddComment("plan.md", 1, 1, "", "line", "", "", "")
+	s.AddFileComment("plan.md", "file", "", "")
+	s.AddReviewComment("review", "", "")
 	if got := s.TotalCommentCount(); got != 3 {
 		t.Errorf("TotalCommentCount: expected 3, got %d", got)
 	}
@@ -2385,8 +2385,8 @@ func TestCommentCountsIncludeReviewComments(t *testing.T) {
 
 func TestClearAllCommentsIncludesReview(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "line", "", "")
-	s.AddReviewComment("review", "")
+	s.AddComment("plan.md", 1, 1, "", "line", "", "", "")
+	s.AddReviewComment("review", "", "")
 	s.ClearAllComments()
 	if got := s.TotalCommentCount(); got != 0 {
 		t.Errorf("expected 0 after clear, got %d", got)
@@ -2398,7 +2398,7 @@ func TestClearAllCommentsIncludesReview(t *testing.T) {
 
 func TestReviewCommentsSurviveRound(t *testing.T) {
 	s := newTestSession(t)
-	s.AddReviewComment("carry me forward", "")
+	s.AddReviewComment("carry me forward", "", "")
 	s.WriteFiles()
 
 	// Simulate round: clear in-memory state and reload
@@ -2417,8 +2417,8 @@ func TestReviewCommentsSurviveRound(t *testing.T) {
 
 func TestFileCommentsSurviveRoundWithoutLineMutation(t *testing.T) {
 	s := newTestSession(t)
-	s.AddFileComment("plan.md", "restructure this", "")
-	s.AddComment("plan.md", 1, 1, "", "line comment", "", "")
+	s.AddFileComment("plan.md", "restructure this", "", "")
+	s.AddComment("plan.md", 1, 1, "", "line comment", "", "", "")
 
 	// Simulate round: snapshot previous state
 	s.mu.Lock()
@@ -2475,7 +2475,7 @@ func TestLoadCritJSONDefaultsScope(t *testing.T) {
 
 func TestResolveReviewComment(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "")
+	c := s.AddReviewComment("needs work", "", "")
 	if c.Resolved {
 		t.Error("new review comment should not be resolved")
 	}
@@ -2507,7 +2507,7 @@ func TestResolveReviewComment(t *testing.T) {
 
 func TestResolveReviewCommentAffectsUnresolvedCount(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("review", "")
+	c := s.AddReviewComment("review", "", "")
 	if got := s.UnresolvedCommentCount(); got != 1 {
 		t.Fatalf("expected 1 unresolved, got %d", got)
 	}
@@ -2520,7 +2520,7 @@ func TestResolveReviewCommentAffectsUnresolvedCount(t *testing.T) {
 func TestFileCommentHasReviewRound(t *testing.T) {
 	s := newTestSession(t)
 	s.ReviewRound = 3
-	c, ok := s.AddFileComment("plan.md", "file-level feedback", "")
+	c, ok := s.AddFileComment("plan.md", "file-level feedback", "", "")
 	if !ok {
 		t.Fatal("AddFileComment failed")
 	}
@@ -2532,7 +2532,7 @@ func TestFileCommentHasReviewRound(t *testing.T) {
 func TestReviewCommentHasReviewRound(t *testing.T) {
 	s := newTestSession(t)
 	s.ReviewRound = 2
-	c := s.AddReviewComment("general feedback", "")
+	c := s.AddReviewComment("general feedback", "", "")
 	if c.ReviewRound != 2 {
 		t.Errorf("expected ReviewRound 2, got %d", c.ReviewRound)
 	}
@@ -2540,8 +2540,8 @@ func TestReviewCommentHasReviewRound(t *testing.T) {
 
 func TestAddReviewCommentReply(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "reviewer")
-	reply, ok := s.AddReviewCommentReply(c.ID, "fixed it", "author")
+	c := s.AddReviewComment("needs work", "reviewer", "")
+	reply, ok := s.AddReviewCommentReply(c.ID, "fixed it", "author", "")
 	if !ok {
 		t.Fatal("AddReviewCommentReply failed")
 	}
@@ -2567,7 +2567,7 @@ func TestAddReviewCommentReply(t *testing.T) {
 
 func TestAddReviewCommentReply_NotFound(t *testing.T) {
 	s := newTestSession(t)
-	_, ok := s.AddReviewCommentReply("nonexistent", "body", "author")
+	_, ok := s.AddReviewCommentReply("nonexistent", "body", "author", "")
 	if ok {
 		t.Error("expected AddReviewCommentReply to return false for nonexistent comment")
 	}
@@ -2575,8 +2575,8 @@ func TestAddReviewCommentReply_NotFound(t *testing.T) {
 
 func TestUpdateReviewCommentReply(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "reviewer")
-	reply, _ := s.AddReviewCommentReply(c.ID, "initial reply", "author")
+	c := s.AddReviewComment("needs work", "reviewer", "")
+	reply, _ := s.AddReviewCommentReply(c.ID, "initial reply", "author", "")
 	updated, ok := s.UpdateReviewCommentReply(c.ID, reply.ID, "updated reply")
 	if !ok {
 		t.Fatal("UpdateReviewCommentReply failed")
@@ -2588,7 +2588,7 @@ func TestUpdateReviewCommentReply(t *testing.T) {
 
 func TestUpdateReviewCommentReply_NotFound(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "reviewer")
+	c := s.AddReviewComment("needs work", "reviewer", "")
 	_, ok := s.UpdateReviewCommentReply(c.ID, "nonexistent", "body")
 	if ok {
 		t.Error("expected UpdateReviewCommentReply to return false for nonexistent reply")
@@ -2597,8 +2597,8 @@ func TestUpdateReviewCommentReply_NotFound(t *testing.T) {
 
 func TestDeleteReviewCommentReply(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "reviewer")
-	reply, _ := s.AddReviewCommentReply(c.ID, "to delete", "author")
+	c := s.AddReviewComment("needs work", "reviewer", "")
+	reply, _ := s.AddReviewCommentReply(c.ID, "to delete", "author", "")
 	if !s.DeleteReviewCommentReply(c.ID, reply.ID) {
 		t.Fatal("DeleteReviewCommentReply failed")
 	}
@@ -2610,7 +2610,7 @@ func TestDeleteReviewCommentReply(t *testing.T) {
 
 func TestDeleteReviewCommentReply_NotFound(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("needs work", "reviewer")
+	c := s.AddReviewComment("needs work", "reviewer", "")
 	if s.DeleteReviewCommentReply(c.ID, "nonexistent") {
 		t.Error("expected DeleteReviewCommentReply to return false for nonexistent reply")
 	}
@@ -2895,7 +2895,7 @@ func TestDeleteReviewComment_NotReAddedFromDisk(t *testing.T) {
 	}
 
 	// Add a review comment and write to disk
-	rc := s.AddReviewComment("delete this review comment", "")
+	rc := s.AddReviewComment("delete this review comment", "", "")
 	s.WriteFiles()
 
 	// Verify it's on disk
@@ -2999,8 +2999,8 @@ func TestDeleteReviewCommentReply_NotReAddedFromDisk(t *testing.T) {
 	}
 
 	// Add review comment with a reply, then write to disk
-	rc := s.AddReviewComment("parent review comment", "")
-	reply, ok := s.AddReviewCommentReply(rc.ID, "delete this reply", "agent")
+	rc := s.AddReviewComment("parent review comment", "", "")
+	reply, ok := s.AddReviewCommentReply(rc.ID, "delete this reply", "agent", "")
 	if !ok {
 		t.Fatal("AddReviewCommentReply failed")
 	}
@@ -3093,7 +3093,7 @@ func TestExternalCommentStillMerged(t *testing.T) {
 
 func TestSession_SetCommentResolved(t *testing.T) {
 	s := newTestSession(t)
-	c, _ := s.AddComment("plan.md", 1, 1, "", "needs fix", "", "")
+	c, _ := s.AddComment("plan.md", 1, 1, "", "needs fix", "", "", "")
 
 	// Resolve
 	resolved, ok := s.SetCommentResolved("plan.md", c.ID, true)
@@ -3139,8 +3139,8 @@ func TestSession_SetCommentResolved_NotFound(t *testing.T) {
 
 func TestSession_FindCommentByID(t *testing.T) {
 	s := newTestSession(t)
-	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "")
-	c2, _ := s.AddComment("main.go", 5, 5, "", "go comment", "", "")
+	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")
+	c2, _ := s.AddComment("main.go", 5, 5, "", "go comment", "", "", "")
 
 	// Find with filePath hint
 	found, path, ok := s.FindCommentByID(c1.ID, "plan.md")
@@ -3187,8 +3187,8 @@ func TestSession_ClearAllComments_RemovesCritJSONFromFileList(t *testing.T) {
 	})
 	s.mu.Unlock()
 
-	s.AddComment("plan.md", 1, 1, "", "test", "", "")
-	s.AddReviewComment("review", "")
+	s.AddComment("plan.md", 1, 1, "", "test", "", "", "")
+	s.AddReviewComment("review", "", "")
 
 	if len(s.GetReviewComments()) != 1 {
 		t.Fatal("expected 1 review comment before clear")
@@ -3219,7 +3219,7 @@ func TestSession_ClearAllComments_RemovesCritJSONFromFileList(t *testing.T) {
 
 func TestSession_ClearAllComments_DeletesCritJSONFromDisk(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "test", "", "")
+	s.AddComment("plan.md", 1, 1, "", "test", "", "", "")
 	flushWrites(s)
 	s.WriteFiles()
 
@@ -3238,7 +3238,7 @@ func TestSession_ClearAllComments_DeletesCritJSONFromDisk(t *testing.T) {
 
 func TestSession_HandleExternalDeletion(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "test", "", "")
+	s.AddComment("plan.md", 1, 1, "", "test", "", "", "")
 	flushWrites(s)
 	s.WriteFiles()
 
@@ -3272,9 +3272,9 @@ func TestSession_HandleExternalDeletion_NoMtime(t *testing.T) {
 
 func TestSession_WriteFiles_RoundTrip(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 3, "", "fix formatting", "", "reviewer")
-	s.AddComment("main.go", 2, 2, "RIGHT", "handle error", "func main() {}", "agent")
-	s.AddReviewComment("overall looks good", "reviewer")
+	s.AddComment("plan.md", 1, 3, "", "fix formatting", "", "reviewer", "")
+	s.AddComment("main.go", 2, 2, "RIGHT", "handle error", "func main() {}", "agent", "")
+	s.AddReviewComment("overall looks good", "reviewer", "")
 
 	flushWrites(s)
 	s.WriteFiles()
@@ -3318,7 +3318,7 @@ func TestSession_WriteFiles_RoundTrip(t *testing.T) {
 
 func TestSession_AddComment_PreservesSideAndQuote(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddComment("main.go", 5, 10, "RIGHT", "fix this", "func main() {}", "reviewer")
+	c, ok := s.AddComment("main.go", 5, 10, "RIGHT", "fix this", "func main() {}", "reviewer", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -3354,7 +3354,7 @@ func TestSession_AddComment_PreservesSideAndQuote(t *testing.T) {
 
 func TestSession_WriteFiles_ReviewCommentsPersisted(t *testing.T) {
 	s := newTestSession(t)
-	s.AddReviewComment("general note", "reviewer")
+	s.AddReviewComment("general note", "reviewer", "")
 
 	flushWrites(s)
 	s.WriteFiles()
@@ -3380,7 +3380,7 @@ func TestSession_WriteFiles_ReviewCommentsPersisted(t *testing.T) {
 func TestSession_RandomCommentID_Format(t *testing.T) {
 	s := newTestSession(t)
 
-	c, ok := s.AddComment("plan.md", 1, 1, "", "test", "", "")
+	c, ok := s.AddComment("plan.md", 1, 1, "", "test", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -3389,7 +3389,7 @@ func TestSession_RandomCommentID_Format(t *testing.T) {
 	}
 
 	// Two comments should get different IDs
-	c2, ok := s.AddComment("plan.md", 2, 2, "", "test2", "", "")
+	c2, ok := s.AddComment("plan.md", 2, 2, "", "test2", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -3400,9 +3400,9 @@ func TestSession_RandomCommentID_Format(t *testing.T) {
 
 func TestSession_ClearAllComments(t *testing.T) {
 	s := newTestSession(t)
-	s.AddComment("plan.md", 1, 1, "", "md comment", "", "")
-	s.AddComment("main.go", 1, 1, "", "go comment", "", "")
-	s.AddReviewComment("review comment", "")
+	s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")
+	s.AddComment("main.go", 1, 1, "", "go comment", "", "", "")
+	s.AddReviewComment("review comment", "", "")
 
 	if s.TotalCommentCount() != 3 {
 		t.Fatalf("precondition: expected 3 comments, got %d", s.TotalCommentCount())
@@ -3426,7 +3426,7 @@ func TestSession_ClearAllComments(t *testing.T) {
 
 func TestSession_AddComment_WithSide(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddComment("main.go", 5, 10, "RIGHT", "check this", "", "")
+	c, ok := s.AddComment("main.go", 5, 10, "RIGHT", "check this", "", "", "")
 	if !ok {
 		t.Fatal("AddComment with side failed")
 	}
@@ -3440,7 +3440,7 @@ func TestSession_AddComment_WithSide(t *testing.T) {
 
 func TestSession_WriteFiles_IncludesResolvedComments(t *testing.T) {
 	s := newTestSession(t)
-	c, _ := s.AddComment("plan.md", 1, 1, "", "fix", "", "")
+	c, _ := s.AddComment("plan.md", 1, 1, "", "fix", "", "", "")
 	s.SetCommentResolved("plan.md", c.ID, true)
 
 	flushWrites(s)
@@ -3842,7 +3842,7 @@ func TestAddComment_PopulatesAnchor(t *testing.T) {
 	s := newTestSession(t)
 	// plan.md content: "# Plan\n\n## Step 1\n\nDo the thing\n"
 	// Lines: 1="# Plan", 2="", 3="## Step 1", 4="", 5="Do the thing"
-	c, ok := s.AddComment("plan.md", 3, 5, "", "Rethink this", "", "")
+	c, ok := s.AddComment("plan.md", 3, 5, "", "Rethink this", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -3854,7 +3854,7 @@ func TestAddComment_PopulatesAnchor(t *testing.T) {
 
 func TestAddComment_AnchorSingleLine(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddComment("plan.md", 1, 1, "", "Fix title", "", "")
+	c, ok := s.AddComment("plan.md", 1, 1, "", "Fix title", "", "", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -3865,7 +3865,7 @@ func TestAddComment_AnchorSingleLine(t *testing.T) {
 
 func TestAddComment_NoAnchorForFileComment(t *testing.T) {
 	s := newTestSession(t)
-	c, ok := s.AddFileComment("plan.md", "Overall feedback", "reviewer")
+	c, ok := s.AddFileComment("plan.md", "Overall feedback", "reviewer", "")
 	if !ok {
 		t.Fatal("AddFileComment failed")
 	}
@@ -3876,7 +3876,7 @@ func TestAddComment_NoAnchorForFileComment(t *testing.T) {
 
 func TestAddComment_NoAnchorForReviewComment(t *testing.T) {
 	s := newTestSession(t)
-	c := s.AddReviewComment("General feedback", "reviewer")
+	c := s.AddReviewComment("General feedback", "reviewer", "")
 	if c.Anchor != "" {
 		t.Errorf("review-level comment should not have anchor, got %q", c.Anchor)
 	}
@@ -3924,7 +3924,7 @@ func TestAddComment_OldSideAnchorFromBase(t *testing.T) {
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
-	c, ok := s.AddComment("main.go", 3, 3, "old", "Why was this removed?", "", "reviewer")
+	c, ok := s.AddComment("main.go", 3, 3, "old", "Why was this removed?", "", "reviewer", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}

--- a/share.go
+++ b/share.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -19,6 +20,12 @@ import (
 // defaultShareURL is the production crit-web service URL, used as the fallback
 // when no share URL is configured via flag, env, or config.
 const defaultShareURL = "https://crit.md"
+
+// errShareUnauthorized indicates the share endpoint rejected the bearer token.
+// Callers wrap this and inspect with errors.Is so they can clear the cached
+// auth identity (token + user id + name + email) on top-level share/upsert
+// failures.
+var errShareUnauthorized = errors.New("auth token rejected by share service")
 
 // shareScope computes a hash of sorted file paths, used to detect when
 // share state belongs to a different file set.
@@ -64,8 +71,10 @@ type shareFile struct {
 
 // shareReply represents a reply to include in the shared review.
 type shareReply struct {
-	Body   string `json:"body"`
-	Author string `json:"author_display_name,omitempty"`
+	Body       string `json:"body"`
+	Author     string `json:"author_display_name,omitempty"`
+	UserID     string `json:"user_id,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
 }
 
 // shareComment represents a comment to include in the shared review.
@@ -76,6 +85,7 @@ type shareComment struct {
 	Body        string       `json:"body"`
 	Quote       string       `json:"quote,omitempty"`
 	Author      string       `json:"author_display_name,omitempty"`
+	UserID      string       `json:"user_id,omitempty"`
 	Scope       string       `json:"scope,omitempty"`
 	ReviewRound int          `json:"review_round,omitempty"`
 	Replies     []shareReply `json:"replies,omitempty"`
@@ -118,8 +128,8 @@ type shareReviewFilesResult struct {
 // shareReviewFiles loads comments + cli_args from the review file at critPath
 // and POSTs the files to crit-web. Used by both the CLI (`crit share`) and the
 // server's POST /api/share endpoint so payload wiring stays in one place.
-func shareReviewFiles(critPath string, files []shareFile, filePaths []string, svcURL, authToken string) (shareReviewFilesResult, error) {
-	comments, reviewRound := loadCommentsForShare(critPath, filePaths)
+func shareReviewFiles(critPath string, files []shareFile, filePaths []string, svcURL, authToken, fallbackAuthor string) (shareReviewFilesResult, error) {
+	comments, reviewRound := loadCommentsForShare(critPath, filePaths, fallbackAuthor)
 	cliArgs := loadCliArgsFromReviewFile(critPath)
 
 	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken, cliArgs)
@@ -156,6 +166,9 @@ func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", "", errShareUnauthorized
+	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		var errBody struct {
 			Error string `json:"error"`
@@ -238,27 +251,40 @@ func setBearer(req *http.Request, token string) {
 
 // loadCommentsForShare reads the review file at critPath and returns shareComment entries
 // for the given file paths, plus the review round. Resolved comments are excluded.
-func loadCommentsForShare(critPath string, filePaths []string) ([]shareComment, int) {
-	return loadCommentsFromCritJSON(critPath, filePaths, false, false)
+// fallbackAuthor is used when a comment has no Author set (typically cfg.Author).
+//
+// ExternalID is set on the initial-share path so the server persists it on first
+// insert. This is what enables the round-trip carry-forward of `user_id` on a
+// later PUT/upsert: replace_comments matches incoming attrs.external_id against
+// the existing-by-external_id map and preserves the verified user_id when the
+// re-sharer is anonymous (rules #3/#4 of the attribution table).
+func loadCommentsForShare(critPath string, filePaths []string, fallbackAuthor string) ([]shareComment, int) {
+	return loadCommentsFromCritJSON(critPath, filePaths, false, true, fallbackAuthor)
 }
 
 // loadCommentsForUpsert loads unresolved comments with ExternalID set for
 // round-trip tracking. Resolved comments are excluded — same as initial share.
-func loadCommentsForUpsert(critPath string, filePaths []string) ([]shareComment, int) {
-	return loadCommentsFromCritJSON(critPath, filePaths, false, true)
+func loadCommentsForUpsert(critPath string, filePaths []string, fallbackAuthor string) ([]shareComment, int) {
+	return loadCommentsFromCritJSON(critPath, filePaths, false, true, fallbackAuthor)
 }
 
 // commentToShareComment converts a Comment into a shareComment, applying the
 // includeResolved and setExternalID flags. The filePath and scope fields are
-// set by the caller based on context.
-func commentToShareComment(c Comment, filePath, scope string, includeResolved, setExternalID bool) shareComment {
+// set by the caller based on context. fallbackAuthor is used when c.Author is
+// empty (typically cfg.Author).
+func commentToShareComment(c Comment, filePath, scope, fallbackAuthor string, includeResolved, setExternalID bool) shareComment {
+	author := c.Author
+	if author == "" {
+		author = fallbackAuthor
+	}
 	sc := shareComment{
 		File:      filePath,
 		StartLine: c.StartLine,
 		EndLine:   c.EndLine,
 		Body:      c.Body,
 		Quote:     c.Quote,
-		Author:    c.Author,
+		Author:    author,
+		UserID:    c.UserID,
 		Scope:     scope,
 	}
 	if includeResolved {
@@ -271,7 +297,15 @@ func commentToShareComment(c Comment, filePath, scope string, includeResolved, s
 		sc.ReviewRound = c.ReviewRound
 	}
 	for _, r := range c.Replies {
-		sc.Replies = append(sc.Replies, shareReply{Body: r.Body, Author: r.Author})
+		ra := r.Author
+		if ra == "" {
+			ra = fallbackAuthor
+		}
+		sr := shareReply{Body: r.Body, Author: ra, UserID: r.UserID}
+		if setExternalID {
+			sr.ExternalID = r.ID
+		}
+		sc.Replies = append(sc.Replies, sr)
 	}
 	return sc
 }
@@ -279,8 +313,9 @@ func commentToShareComment(c Comment, filePath, scope string, includeResolved, s
 // loadCommentsFromCritJSON reads the review file at critPath and returns shareComment
 // entries for the given file paths, plus the review round. When includeResolved is true,
 // resolved comments are included. When setExternalID is true, ExternalID is set
-// from the local comment ID for round-trip tracking.
-func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolved, setExternalID bool) ([]shareComment, int) {
+// from the local comment ID for round-trip tracking. fallbackAuthor fills missing
+// Author fields (typically cfg.Author).
+func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolved, setExternalID bool, fallbackAuthor string) ([]shareComment, int) {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
 		return nil, 1
@@ -310,14 +345,14 @@ func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolv
 				continue
 			}
 			scope := c.Scope
-			comments = append(comments, commentToShareComment(c, filePath, scope, includeResolved, setExternalID))
+			comments = append(comments, commentToShareComment(c, filePath, scope, fallbackAuthor, includeResolved, setExternalID))
 		}
 	}
 	for _, c := range cj.ReviewComments {
 		if !includeResolved && c.Resolved {
 			continue
 		}
-		comments = append(comments, commentToShareComment(c, "", "review", includeResolved, setExternalID))
+		comments = append(comments, commentToShareComment(c, "", "review", fallbackAuthor, includeResolved, setExternalID))
 	}
 	return comments, round
 }
@@ -326,9 +361,14 @@ func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolv
 type webReply struct {
 	Body              string `json:"body"`
 	AuthorDisplayName string `json:"author_display_name"`
+	UserID            string `json:"user_id"`
 }
 
 // webComment is the shape of a comment returned by GET /api/reviews/:token/comments.
+// AuthorIdentity is retained for compatibility with existing crit-web responses
+// and is treated as a session-owner token for anonymous web visitors. UserID
+// is the verified user id, set when the comment was authored by a logged-in
+// user (either CLI with bearer token or LiveView while signed in).
 type webComment struct {
 	Body              string     `json:"body"`
 	FilePath          string     `json:"file_path"`
@@ -338,6 +378,8 @@ type webComment struct {
 	Resolved          bool       `json:"resolved"`
 	ExternalID        string     `json:"external_id"`
 	AuthorDisplayName string     `json:"author_display_name"`
+	AuthorIdentity    string     `json:"author_identity"`
+	UserID            string     `json:"user_id"`
 	Quote             string     `json:"quote"`
 	Scope             string     `json:"scope"`
 	Replies           []webReply `json:"replies"`
@@ -415,6 +457,9 @@ func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprin
 	if resp.StatusCode == http.StatusNotFound {
 		return result, nil // review gone
 	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return result, errShareUnauthorized
+	}
 	if resp.StatusCode != http.StatusOK {
 		return result, fmt.Errorf("remote comments returned status %d", resp.StatusCode)
 	}
@@ -425,27 +470,41 @@ func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprin
 	}
 
 	for _, wc := range all {
-		if wc.ExternalID != "" && localIDs[wc.ExternalID] {
-			// Comment exists locally — check for new replies from web
-			if len(wc.Replies) > 0 {
-				result.ReplyUpdates[wc.ExternalID] = wc.Replies
-			}
+		if dropDuplicateWebComment(wc, localIDs, localFingerprints, localFingerprintIDs, result.ReplyUpdates) {
 			continue
-		}
-		if wc.ExternalID == "" {
-			fp := fmt.Sprintf("%s|%s|%d|%d", wc.Body, wc.FilePath, wc.StartLine, wc.EndLine)
-			if localFingerprints[fp] {
-				// Web-authored comment already imported as web-N. Capture
-				// any new replies before discarding the duplicate body.
-				if localID, ok := localFingerprintIDs[fp]; ok && len(wc.Replies) > 0 {
-					result.ReplyUpdates[localID] = wc.Replies
-				}
-				continue
-			}
 		}
 		result.NewComments = append(result.NewComments, wc)
 	}
 	return result, nil
+}
+
+// dropDuplicateWebComment returns true if wc is already represented locally
+// (by external_id or fingerprint match) and therefore should not be appended
+// to NewComments. Any new replies on the duplicate are recorded in updates.
+func dropDuplicateWebComment(
+	wc webComment,
+	localIDs map[string]bool,
+	localFingerprints map[string]bool,
+	localFingerprintIDs map[string]string,
+	updates map[string][]webReply,
+) bool {
+	if wc.ExternalID != "" && localIDs[wc.ExternalID] {
+		if len(wc.Replies) > 0 {
+			updates[wc.ExternalID] = wc.Replies
+		}
+		return true
+	}
+	if wc.ExternalID != "" {
+		return false
+	}
+	fp := fmt.Sprintf("%s|%s|%d|%d", wc.Body, wc.FilePath, wc.StartLine, wc.EndLine)
+	if !localFingerprints[fp] {
+		return false
+	}
+	if localID, ok := localFingerprintIDs[fp]; ok && len(wc.Replies) > 0 {
+		updates[localID] = wc.Replies
+	}
+	return true
 }
 
 // upsertResult holds the response from an upsert (PUT) to crit-web.
@@ -511,7 +570,7 @@ func upsertShareToWeb(cfg CritJSON, files []shareFile, comments []shareComment, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return result, fmt.Errorf("crit-web rejected the request — check your auth_token in config")
+		return result, errShareUnauthorized
 	}
 	if resp.StatusCode >= 400 {
 		return result, fmt.Errorf("upsert failed with status %d", resp.StatusCode)
@@ -623,6 +682,7 @@ func mergeWebComments(critPath string, newComments []webComment, replyUpdates ma
 			replies = append(replies, Reply{
 				Body:   wr.Body,
 				Author: wr.AuthorDisplayName,
+				UserID: wr.UserID,
 			})
 		}
 		c := Comment{
@@ -632,6 +692,7 @@ func mergeWebComments(critPath string, newComments []webComment, replyUpdates ma
 			Body:        wc.Body,
 			Quote:       wc.Quote,
 			Author:      wc.AuthorDisplayName,
+			UserID:      wc.UserID,
 			Scope:       wc.Scope,
 			ReviewRound: wc.ReviewRound,
 			Replies:     replies,
@@ -681,6 +742,7 @@ func mergeRepliesIntoComment(c Comment, webReplies []webReply) Comment {
 		c.Replies = append(c.Replies, Reply{
 			Body:   wr.Body,
 			Author: wr.AuthorDisplayName,
+			UserID: wr.UserID,
 		})
 	}
 	return c

--- a/share_attribution_test.go
+++ b/share_attribution_test.go
@@ -1,0 +1,1057 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedUser creates a user + bearer token on crit-web via the test-only
+// endpoint and returns (token, user_id, name).
+func seedUser(t *testing.T, baseURL, name string) (string, string, string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"name": name})
+	resp, err := http.Post(baseURL+"/api/test/seed-user", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("seed-user request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed-user returned %d", resp.StatusCode)
+	}
+	var out struct {
+		Token  string `json:"token"`
+		UserID string `json:"user_id"`
+		Name   string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decoding seed-user: %v", err)
+	}
+	if out.Token == "" || out.UserID == "" {
+		t.Fatalf("seed-user returned empty fields: %+v", out)
+	}
+	return out.Token, out.UserID, out.Name
+}
+
+// writeProjectConfig writes a .crit.config.json into dir with the given values.
+func writeProjectConfig(t *testing.T, dir string, cfg map[string]any) {
+	t.Helper()
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, ".crit.config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestShareAttributesConfiguredAuthor verifies that when crit is configured
+// with `author: "Alice Smith"`, the local comments shared to crit-web are
+// attributed to "Alice Smith" — NOT the placeholder "imported".
+func TestShareAttributesConfiguredAuthor(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeProjectConfig(t, dir, map[string]any{"author": "Alice Smith"})
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "needs detail", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].AuthorDisplayName != "Alice Smith" {
+		t.Errorf("author_display_name = %q, want %q", comments[0].AuthorDisplayName, "Alice Smith")
+	}
+}
+
+// TestShareAuthAttributesUserIdentity verifies that when sharing with a
+// valid bearer token, comments are server-side-attributed to the
+// authenticated user: author_identity == user.id (uuid), display name
+// from the verified user record (NOT from the payload).
+func TestShareAuthAttributesUserIdentity(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	authToken, userID, userName := seedUser(t, baseURL, "Bob Reviewer")
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Author config intentionally differs from the verified user name to
+	// confirm the server uses its own value, not the payload's.
+	writeProjectConfig(t, dir, map[string]any{"author": "Mallory"})
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					// UserID stamped at write-time as the real CLI flow does
+					// (session.AddComment uses cfg.AuthUserID). Required for
+					// empty payload user_id under auth → null on server.
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "from authenticated user", Scope: "line",
+						UserID:    userID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	cmd := exec.Command(binary, "share", "--share-url", baseURL, "--output", dir, "plan.md")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CRIT_AUTH_TOKEN="+authToken)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crit share failed: %s\n%s", err, out)
+	}
+	output := strings.TrimSpace(string(out))
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	c := comments[0]
+
+	if c.UserID != userID {
+		t.Errorf("user_id = %q, want %q (the authenticated user)", c.UserID, userID)
+	}
+	if c.AuthorDisplayName != userName {
+		t.Errorf("author_display_name = %q, want %q (from verified user, not config)",
+			c.AuthorDisplayName, userName)
+	}
+	if c.UserID == "" {
+		t.Errorf("user_id must be set for authenticated shares")
+	}
+}
+
+// TestShareAuthIgnoresPayloadSpoofedIdentity verifies that when no bearer
+// token is provided, payload-supplied identity fields cannot impersonate
+// a real user. Knowing a user's UUID must not be enough to attribute
+// comments to them.
+func TestShareAuthIgnoresPayloadSpoofedIdentity(t *testing.T) {
+	baseURL := critWebURL(t)
+
+	// Seed a real user just to obtain a real UUID we'll try to spoof.
+	_, victimID, _ := seedUser(t, baseURL, "Victim")
+
+	// Build a payload by hand so we can include the spoofed identity field
+	// that an attacker might add — bypassing the Go CLI which would never
+	// add this field.
+	payload := map[string]any{
+		"files": []map[string]any{
+			{"path": "plan.md", "content": "# Plan\n\nStep 1\n", "status": "modified"},
+		},
+		"comments": []map[string]any{
+			{
+				"file":                "plan.md",
+				"start_line":          3,
+				"end_line":            3,
+				"body":                "spoofed comment",
+				"scope":               "line",
+				"author_display_name": "Victim",
+				// Attacker-supplied — must be ignored.
+				"author_identity": victimID,
+				"author_user_id":  victimID,
+				"user_id":         victimID,
+			},
+		},
+		"review_round": 1,
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(baseURL+"/api/reviews", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		t.Fatalf("share POST returned %d", resp.StatusCode)
+	}
+	var result struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(result.URL, "/")
+	tokenStr := parts[len(parts)-1]
+
+	comments := commentsFromAPI(t, baseURL, tokenStr)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	c := comments[0]
+	if c.UserID == victimID {
+		t.Errorf("SECURITY: anonymous share spoofed user_id to victim %q", victimID)
+	}
+	// New semantics: unauthenticated shares must produce user_id IS NULL
+	// (empty string in the JSON response).
+	if c.UserID != "" {
+		t.Errorf("user_id = %q, want \"\" for unauthenticated share", c.UserID)
+	}
+
+	// And: an unauthenticated share must not result in the review being
+	// linked to the victim's account either. The comment attribution above
+	// is the user-visible signal.
+	_ = fmt.Sprintf("anonymous, got user_id %q", c.UserID)
+}
+
+// TestShareAttrBackwardsCompatNoUserID verifies that an old `.crit.json`
+// written before this feature shipped (no `user_id` field on Comment) still
+// shares cleanly. The omitted field unmarshals to "" — no migration needed.
+func TestShareAttrBackwardsCompatNoUserID(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand-roll JSON without a user_id field — simulates a review file from a
+	// prior CLI version. Field is genuinely absent (not just empty).
+	legacy := `{
+		"review_round": 1,
+		"files": {
+			"plan.md": {
+				"comments": [
+					{
+						"id": "c1",
+						"start_line": 3,
+						"end_line": 3,
+						"body": "from old crit",
+						"scope": "line",
+						"created_at": "2026-01-01T00:00:00Z",
+						"updated_at": "2026-01-01T00:00:00Z"
+					}
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), []byte(legacy), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].UserID != "" {
+		t.Errorf("user_id = %q, want \"\" for legacy comment", comments[0].UserID)
+	}
+}
+
+// TestShareAttrRoundtripPreservesUserID verifies that a comment authored by a
+// logged-in user — and then fetched back into a different CLI workspace —
+// preserves the original `user_id` when the second user re-shares the review
+// anonymously: an existing-by-external_id row keeps its attribution.
+func TestShareAttrRoundtripPreservesUserID(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+
+	// Step 1: Alice (authenticated) shares a review with one comment.
+	aliceToken, aliceID, _ := seedUser(t, baseURL, "Alice Author")
+	dirA := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirA, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dirA, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					// UserID stamped at write-time as the real CLI flow does
+					// (session.AddComment uses cfg.AuthUserID). Required for
+					// empty payload user_id under auth → null on server.
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "alice's note", Scope: "line",
+						UserID:    aliceID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+	cmd := exec.Command(binary, "share", "--share-url", baseURL, "--output", dirA, "plan.md")
+	cmd.Dir = dirA
+	cmd.Env = append(os.Environ(), "CRIT_AUTH_TOKEN="+aliceToken)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("alice share failed: %s\n%s", err, out)
+	}
+	shareOutput := strings.TrimSpace(string(out))
+	logReview(t, shareOutput)
+	token := extractToken(t, shareOutput)
+
+	// Verify the server stamped Alice's user_id on first share.
+	first := commentsFromAPI(t, baseURL, token)
+	if len(first) != 1 {
+		t.Fatalf("first share: expected 1 comment, got %d", len(first))
+	}
+	if first[0].UserID != aliceID {
+		t.Fatalf("first share user_id = %q, want %q", first[0].UserID, aliceID)
+	}
+
+	// Step 2: Alice's same dir re-shares anonymously (no CRIT_AUTH_TOKEN).
+	// .crit.json carries the delete_token so the PUT is authorized; the
+	// re-share itself is anonymous (no bearer). An existing-by-external_id
+	// match must preserve user_id — don't strip it just because the
+	// re-sharer has no bearer token.
+	if err := os.WriteFile(filepath.Join(dirA, "plan.md"), []byte("# Plan\n\nStep 1 revised\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd2 := exec.Command(binary, "share", "--share-url", baseURL, "--output", dirA, "plan.md")
+	cmd2.Dir = dirA
+	// Strip CRIT_AUTH_TOKEN to simulate logged-out re-share.
+	env := os.Environ()
+	filtered := env[:0]
+	for _, e := range env {
+		if !strings.HasPrefix(e, "CRIT_AUTH_TOKEN=") {
+			filtered = append(filtered, e)
+		}
+	}
+	cmd2.Env = filtered
+	out2, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("anonymous re-share failed: %s\n%s", err, out2)
+	}
+
+	// Verify Alice's user_id is preserved.
+	second := commentsFromAPI(t, baseURL, token)
+	var found bool
+	for _, c := range second {
+		if c.Body == "alice's note" {
+			found = true
+			if c.UserID != aliceID {
+				t.Errorf("after re-share, alice's user_id = %q, want %q (must not be cleared by anonymous re-share)",
+					c.UserID, aliceID)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("alice's comment missing after re-share")
+	}
+}
+
+// envWithout returns os.Environ() minus any entries with the given prefixes.
+func envWithout(prefixes ...string) []string {
+	env := os.Environ()
+	out := env[:0]
+outer:
+	for _, e := range env {
+		for _, p := range prefixes {
+			if strings.HasPrefix(e, p) {
+				continue outer
+			}
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// runCritShareEnv runs `crit share` in dir with the given env (caller controls
+// whether CRIT_AUTH_TOKEN/HOME are present). Returns combined output.
+func runCritShareEnv(t *testing.T, binary, baseURL, dir string, extraEnv []string, files ...string) (string, error) {
+	t.Helper()
+	args := append([]string{"share", "--share-url", baseURL, "--output", dir}, files...)
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	cmd.Env = append(envWithout("CRIT_AUTH_TOKEN=", "HOME="), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// TestShareAttrLoginMidFlow — Scenario C: comment 1 written without auth,
+// comment 2 written while authenticated. Server must respect each comment's
+// stored intent: comment 1 stays anonymous, comment 2 is attributed to the
+// authenticated user.
+func TestShareAttrLoginMidFlow(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	authToken, userID, userName := seedUser(t, baseURL, "Mid Flow User")
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n\nStep 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					// Comment 1: written before login → no UserID.
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "anon comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+					// Comment 2: written after login → carries UserID.
+					{ID: "c2", StartLine: 5, EndLine: 5, Body: "authed comment", Scope: "line",
+						UserID:    userID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	output, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + authToken}, "plan.md")
+	if err != nil {
+		t.Fatalf("crit share failed: %v\n%s", err, output)
+	}
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+	byBody := map[string]webComment{}
+	for _, c := range comments {
+		byBody[c.Body] = c
+	}
+	if got := byBody["anon comment"].UserID; got != "" {
+		t.Errorf("anon comment user_id = %q, want \"\" (anonymous intent must be respected even with bearer)", got)
+	}
+	if got := byBody["authed comment"].UserID; got != userID {
+		t.Errorf("authed comment user_id = %q, want %q", got, userID)
+	}
+	if byBody["authed comment"].AuthorDisplayName != userName {
+		t.Errorf("authed comment display_name = %q, want %q", byBody["authed comment"].AuthorDisplayName, userName)
+	}
+}
+
+// TestShareAttrMultiUserRoundtripReply — Scenario D: Alice authed shares,
+// then a web reviewer (separate user) replies. Alice fetches via re-share and
+// verifies the reply carries the web reviewer's identity. Re-sharing again
+// must preserve both Alice's user_id on her parent and the reply's identity.
+func TestShareAttrMultiUserRoundtripReply(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	aliceToken, aliceID, _ := seedUser(t, baseURL, "Alice D")
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "alice parent", Scope: "line",
+						UserID:    aliceID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	// Round 1: Alice authed share (POST).
+	out1, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md")
+	if err != nil {
+		t.Fatalf("alice share failed: %v\n%s", err, out1)
+	}
+	logReview(t, out1)
+	shareTok := extractToken(t, out1)
+
+	// Round 2: re-share with content change so external_id is set on Alice's comment.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 v2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find Alice's comment ID on the web side so we can seed a reply to it.
+	resp, err := http.Get(fmt.Sprintf("%s/api/reviews/%s/comments", baseURL, shareTok))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var raw []struct {
+		ID         string `json:"id"`
+		ExternalID string `json:"external_id"`
+		UserID     string `json:"user_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+	var aliceCommentWebID string
+	for _, c := range raw {
+		if c.ExternalID == "c1" {
+			aliceCommentWebID = c.ID
+			if c.UserID != aliceID {
+				t.Errorf("alice's comment user_id on web = %q, want %q", c.UserID, aliceID)
+			}
+		}
+	}
+	if aliceCommentWebID == "" {
+		t.Fatalf("could not find alice's comment on web: %+v", raw)
+	}
+
+	// Web reviewer adds a reply (seedReply identity is "integration-test"; no user_id).
+	seedReply(t, baseURL, shareTok, aliceCommentWebID, "web reviewer reply")
+
+	// Round 3: Alice re-shares to fetch the reply.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 v3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	cj := readCritJSON(t, dir)
+	var parent *Comment
+	for i := range cj.Files["plan.md"].Comments {
+		c := &cj.Files["plan.md"].Comments[i]
+		if c.ID == "c1" {
+			parent = c
+			break
+		}
+	}
+	if parent == nil {
+		t.Fatal("alice's comment c1 missing after fetch")
+	}
+	if parent.UserID != aliceID {
+		t.Errorf("alice parent user_id = %q, want %q", parent.UserID, aliceID)
+	}
+	var fetchedReply *Reply
+	for i := range parent.Replies {
+		if parent.Replies[i].Body == "web reviewer reply" {
+			fetchedReply = &parent.Replies[i]
+			break
+		}
+	}
+	if fetchedReply == nil {
+		t.Fatalf("web reviewer reply not pulled into local .crit.json: %+v", parent.Replies)
+	}
+
+	// Round 4: Alice re-shares again. Server must preserve Alice's user_id on
+	// her parent and must not strip/replace the reply's stored user_id —
+	// existing-by-external_id rows keep their attribution across re-share.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 v4\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	final := commentsFromAPI(t, baseURL, shareTok)
+	var aliceComment *webComment
+	for i := range final {
+		if final[i].Body == "alice parent" {
+			aliceComment = &final[i]
+		}
+	}
+	if aliceComment == nil {
+		t.Fatal("alice parent missing on web after final re-share")
+	}
+	if aliceComment.UserID != aliceID {
+		t.Errorf("alice parent user_id after re-share = %q, want %q (must not drop on roundtrip)", aliceComment.UserID, aliceID)
+	}
+	var replyAfter *webReply
+	for i := range aliceComment.Replies {
+		if aliceComment.Replies[i].Body == "web reviewer reply" {
+			replyAfter = &aliceComment.Replies[i]
+		}
+	}
+	if replyAfter == nil {
+		t.Fatal("web reviewer reply lost on re-share")
+	}
+	// Lock in: parent's user_id (alice) is preserved across multiple re-shares
+	// — the reply carry-forward logic must not collateral-damage the parent.
+	// We don't constrain the reply's user_id here: the seeded reply had a
+	// NULL user_id, and an authed re-share of a previously-NULL reply may
+	// either keep it NULL or stamp the current user — never some third
+	// foreign id. Both outcomes are acceptable.
+}
+
+// TestShareAttrPutAnonExternalIDMismatch verifies that an anonymous PUT
+// with a payload whose external_id does not match any existing comment
+// drops any spoofed user_id and writes user_id=NULL.
+func TestShareAttrPutAnonExternalIDMismatch(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	_, victimID, _ := seedUser(t, baseURL, "Victim4")
+
+	// First, create a real review with one legitimate comment (anon POST).
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "real comment", Scope: "line",
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+	out1 := critShareCmd(t, binary, baseURL, dir, "plan.md")
+	logReview(t, out1)
+	shareTok := extractToken(t, out1)
+
+	// Read back the .crit.json to grab the share URL + delete_token, then craft
+	// an anonymous PUT manually with a forged external_id + spoofed user_id.
+	cj := readCritJSON(t, dir)
+	if cj.ShareURL == "" || cj.DeleteToken == "" {
+		t.Fatalf("expected share state in .crit.json, got %+v", cj)
+	}
+
+	payload := map[string]any{
+		"delete_token": cj.DeleteToken,
+		"files": []map[string]any{
+			{"path": "plan.md", "content": "# Plan\n\nStep 1 v2\n", "status": "modified"},
+		},
+		"comments": []map[string]any{
+			{
+				"file":       "plan.md",
+				"start_line": 3, "end_line": 3,
+				"body":  "spoof attempt",
+				"scope": "line",
+				// external_id intentionally does not match anything on the server.
+				"external_id":         "forged-no-match",
+				"author_display_name": "Mallory",
+				"user_id":             victimID,
+			},
+		},
+		"review_round": 2,
+	}
+	body, _ := json.Marshal(payload)
+	apiURL := baseURL + "/api/reviews/" + path.Base(cj.ShareURL)
+	req, _ := http.NewRequest(http.MethodPut, apiURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("PUT returned %d", resp.StatusCode)
+	}
+
+	comments := commentsFromAPI(t, baseURL, shareTok)
+	var spoof *webComment
+	for i := range comments {
+		if comments[i].Body == "spoof attempt" {
+			spoof = &comments[i]
+		}
+	}
+	if spoof == nil {
+		t.Fatal("spoof comment missing on web (server should still create it, just without user_id)")
+	}
+	if spoof.UserID == victimID {
+		t.Errorf("SECURITY: anon PUT with mismatched external_id wrote victim user_id %q", victimID)
+	}
+	if spoof.UserID != "" {
+		t.Errorf("user_id = %q, want \"\" for anon PUT no-match", spoof.UserID)
+	}
+}
+
+// TestShareAttrPutAuthPreservesForeignUserID verifies that when an
+// authenticated user re-shares a payload that includes a comment owned
+// by a different user (matched by external_id), the server preserves the
+// original owner's user_id rather than replacing it with the current
+// sharer's id.
+func TestShareAttrPutAuthPreservesForeignUserID(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+
+	bobToken, bobID, _ := seedUser(t, baseURL, "Bob Owner")
+	aliceToken, aliceID, _ := seedUser(t, baseURL, "Alice Sharer")
+
+	// Bob authors and shares the review.
+	dirB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirB, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dirB, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "bob1", StartLine: 3, EndLine: 3, Body: "bob's comment", Scope: "line",
+						UserID:    bobID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+	out1, err := runCritShareEnv(t, binary, baseURL, dirB, []string{"CRIT_AUTH_TOKEN=" + bobToken}, "plan.md")
+	if err != nil {
+		t.Fatalf("bob share: %v\n%s", err, out1)
+	}
+	logReview(t, out1)
+
+	// Re-share once so external_id is set on bob's comment.
+	if err := os.WriteFile(filepath.Join(dirB, "plan.md"), []byte("# Plan\n\nStep 1 v2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dirB, []string{"CRIT_AUTH_TOKEN=" + bobToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	cjB := readCritJSON(t, dirB)
+	if cjB.ShareURL == "" || cjB.DeleteToken == "" {
+		t.Fatalf("missing share state: %+v", cjB)
+	}
+	shareTok := path.Base(cjB.ShareURL)
+
+	// Alice prepares an upsert: same review, includes bob's comment matched by
+	// external_id. Alice's bearer is on the request.
+	payload := map[string]any{
+		"delete_token": cjB.DeleteToken,
+		"files": []map[string]any{
+			{"path": "plan.md", "content": "# Plan\n\nStep 1 v3\n", "status": "modified"},
+		},
+		"comments": []map[string]any{
+			{
+				"file":       "plan.md",
+				"start_line": 3, "end_line": 3,
+				"body":                "bob's comment",
+				"scope":               "line",
+				"external_id":         "bob1",
+				"author_display_name": "Bob Owner",
+				"user_id":             bobID,
+			},
+		},
+		"review_round": 3,
+	}
+	body, _ := json.Marshal(payload)
+	apiURL := baseURL + "/api/reviews/" + path.Base(cjB.ShareURL)
+	req, _ := http.NewRequest(http.MethodPut, apiURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+aliceToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("alice PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("alice PUT returned %d", resp.StatusCode)
+	}
+
+	comments := commentsFromAPI(t, baseURL, shareTok)
+	var bobComment *webComment
+	for i := range comments {
+		if comments[i].Body == "bob's comment" {
+			bobComment = &comments[i]
+		}
+	}
+	if bobComment == nil {
+		t.Fatal("bob's comment missing after alice re-share")
+	}
+	if bobComment.UserID != bobID {
+		t.Errorf("bob's comment user_id = %q, want %q (must not be overwritten by alice's id %q)",
+			bobComment.UserID, bobID, aliceID)
+	}
+}
+
+// TestShareAttrPutAuthExternalIDMismatchDropsSpoof verifies that an
+// authenticated upsert claiming user_id=<other user's id> with no
+// external_id match drops the spoofed id. Because Alice is authenticated
+// and the comment is new, the server may stamp alice.id or write null —
+// either way, bob.id must NOT appear.
+func TestShareAttrPutAuthExternalIDMismatchDropsSpoof(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+
+	aliceToken, aliceID, _ := seedUser(t, baseURL, "Alice Sharer8")
+	_, bobID, _ := seedUser(t, baseURL, "Bob Victim8")
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files:       map[string]CritJSONFile{"plan.md": {}},
+	})
+	out1, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md")
+	if err != nil {
+		t.Fatalf("alice initial share: %v\n%s", err, out1)
+	}
+	logReview(t, out1)
+
+	cj := readCritJSON(t, dir)
+	if cj.ShareURL == "" {
+		t.Fatalf("missing share url after first share: %+v", cj)
+	}
+	shareTok := path.Base(cj.ShareURL)
+
+	payload := map[string]any{
+		"delete_token": cj.DeleteToken,
+		"files": []map[string]any{
+			{"path": "plan.md", "content": "# Plan\n\nStep 1 v2\n", "status": "modified"},
+		},
+		"comments": []map[string]any{
+			{
+				"file":       "plan.md",
+				"start_line": 3, "end_line": 3,
+				"body":                "forged claim",
+				"scope":               "line",
+				"external_id":         "forged-id",
+				"author_display_name": "Bob Victim8",
+				"user_id":             bobID,
+			},
+		},
+		"review_round": 2,
+	}
+	body, _ := json.Marshal(payload)
+	apiURL := baseURL + "/api/reviews/" + path.Base(cj.ShareURL)
+	req, _ := http.NewRequest(http.MethodPut, apiURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+aliceToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("PUT returned %d", resp.StatusCode)
+	}
+
+	comments := commentsFromAPI(t, baseURL, shareTok)
+	var forged *webComment
+	for i := range comments {
+		if comments[i].Body == "forged claim" {
+			forged = &comments[i]
+		}
+	}
+	if forged == nil {
+		t.Fatal("forged comment missing on web")
+	}
+	if forged.UserID == bobID {
+		t.Errorf("SECURITY: auth PUT spoofed bob's user_id %q", bobID)
+	}
+	// Acceptable: either null or alice.id (server's fallback for spoof drops).
+	if forged.UserID != "" && forged.UserID != aliceID {
+		t.Errorf("user_id = %q, want \"\" or %q (alice)", forged.UserID, aliceID)
+	}
+}
+
+// TestShareAttrReplyRoundtripPreservesUserID locks in the Elixir bug fix that
+// replies' user_id values must be preserved across re-shares (not stripped or
+// replaced with the current sharer's id).
+func TestShareAttrReplyRoundtripPreservesUserID(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	aliceToken, aliceID, _ := seedUser(t, baseURL, "Alice Replier")
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{
+						ID: "c1", StartLine: 3, EndLine: 3, Body: "parent", Scope: "line",
+						UserID:    aliceID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z",
+						Replies: []Reply{
+							{ID: "r1", Body: "alice's own reply", Author: "Alice Replier", UserID: aliceID},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Round 1: POST.
+	out1, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md")
+	if err != nil {
+		t.Fatalf("share 1: %v\n%s", err, out1)
+	}
+	logReview(t, out1)
+	shareTok := extractToken(t, out1)
+
+	// Round 2: re-share to set external_id on the reply.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 v2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Round 3: re-share again — bug area is here. Reply's user_id must persist.
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1 v3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCritShareEnv(t, binary, baseURL, dir, []string{"CRIT_AUTH_TOKEN=" + aliceToken}, "plan.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	comments := commentsFromAPI(t, baseURL, shareTok)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 parent comment, got %d", len(comments))
+	}
+	if len(comments[0].Replies) != 1 {
+		t.Fatalf("expected 1 reply, got %d", len(comments[0].Replies))
+	}
+	if comments[0].Replies[0].UserID != aliceID {
+		t.Errorf("reply user_id = %q, want %q (must persist across re-shares)",
+			comments[0].Replies[0].UserID, aliceID)
+	}
+}
+
+// TestShareAttr401ClearsCachedIdentity verifies that when a cached token has
+// been revoked server-side, the lazy whoami backfill on the next `crit share`
+// detects the 401 and removes auth_token / auth_user_id from the global
+// config. Uses a HOME override so the dev config is not touched.
+func TestShareAttr401ClearsCachedIdentity(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	authToken, _, _ := seedUser(t, baseURL, "Revoked User")
+
+	// Pre-populate a fake HOME with auth_token but NO auth_user_id, so the
+	// next share triggers lazyBackfillAuthUserID → whoami → 401.
+	homeDir := t.TempDir()
+	globalCfg := map[string]any{"auth_token": authToken}
+	cfgData, _ := json.MarshalIndent(globalCfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), cfgData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Revoke the token server-side.
+	req, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/auth/token", nil)
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("revoke returned %d", resp.StatusCode)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	args := []string{"share", "--share-url", baseURL, "--output", dir, "plan.md"}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	cmd.Env = append(envWithout("CRIT_AUTH_TOKEN=", "HOME="), "HOME="+homeDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// We don't require non-zero exit — the share may continue anonymously.
+		// The invariant is: cached credentials must be cleared.
+		t.Logf("crit share exit: %v\noutput: %s", err, out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(homeDir, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading cfg after share: %v", err)
+	}
+	var after map[string]any
+	if err := json.Unmarshal(data, &after); err != nil {
+		t.Fatal(err)
+	}
+	if v, has := after["auth_token"]; has && v != "" {
+		t.Errorf("auth_token must be cleared after 401, got %v", v)
+	}
+	if v, has := after["auth_user_id"]; has && v != "" {
+		t.Errorf("auth_user_id must be cleared after 401, got %v", v)
+	}
+}
+
+// TestShareAttrCachedIdentityFromConfigOnly verifies that a cached auth_token
+// + auth_user_id stored in the global config (not env) is used: comments are
+// attributed to the cached user id without setting CRIT_AUTH_TOKEN.
+func TestShareAttrCachedIdentityFromConfigOnly(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+
+	authToken, userID, userName := seedUser(t, baseURL, "Cached User")
+
+	homeDir := t.TempDir()
+	globalCfg := map[string]any{
+		"auth_token":     authToken,
+		"auth_user_id":   userID,
+		"auth_user_name": userName,
+	}
+	cfgData, _ := json.MarshalIndent(globalCfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), cfgData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// .crit.json deliberately has no UserID on the comment; the CLI must stamp
+	// it from the cached config at write-time semantics. For an integration
+	// test we approximate by setting UserID directly (mirrors what `crit
+	// comment` would do at write time when cfg.AuthUserID is set).
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "from cached identity", Scope: "line",
+						UserID:    userID,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+
+	args := []string{"share", "--share-url", baseURL, "--output", dir, "plan.md"}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	cmd.Env = append(envWithout("CRIT_AUTH_TOKEN=", "HOME="), "HOME="+homeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crit share failed: %v\n%s", err, out)
+	}
+	output := strings.TrimSpace(string(out))
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, token)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].UserID != userID {
+		t.Errorf("user_id = %q, want %q (must come from cached config, not env)", comments[0].UserID, userID)
+	}
+	if comments[0].AuthorDisplayName != userName {
+		t.Errorf("display_name = %q, want %q", comments[0].AuthorDisplayName, userName)
+	}
+}

--- a/share_test.go
+++ b/share_test.go
@@ -64,7 +64,7 @@ func TestLoadCommentsForUpsert_ExcludesResolved(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, round := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	comments, round := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 	if round != 1 {
 		t.Errorf("expected round 1, got %d", round)
 	}
@@ -93,7 +93,7 @@ func TestLoadCommentsForUpsert_SetsExternalID(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"main.go"})
+	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"main.go"}, "")
 	if len(comments) != 1 {
 		t.Fatalf("expected 1 comment, got %d", len(comments))
 	}
@@ -120,7 +120,7 @@ func TestLoadCommentsForUpsert_ReviewLevelComments(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 
 	// Should have 2 comments: 1 file-level + 1 unresolved review-level
 	if len(comments) != 2 {
@@ -417,7 +417,7 @@ func TestLoadCommentsForFiles(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
 
 	// Only load unresolved comments for plan.md (c1 and c2, not c3)
-	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 	if round != 2 {
 		t.Errorf("expected round 2, got %d", round)
 	}
@@ -429,13 +429,13 @@ func TestLoadCommentsForFiles(t *testing.T) {
 	}
 
 	// Load for both files — 3 unresolved (c1, c2, c4), not 5 total
-	comments, _ = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md", "other.go"})
+	comments, _ = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md", "other.go"}, "")
 	if len(comments) != 3 {
 		t.Fatalf("expected 3 unresolved comments, got %d", len(comments))
 	}
 
 	// Load for nonexistent file
-	comments, round = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"nope.md"})
+	comments, round = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"nope.md"}, "")
 	if len(comments) != 0 {
 		t.Errorf("expected 0 comments, got %d", len(comments))
 	}
@@ -446,7 +446,7 @@ func TestLoadCommentsForFiles(t *testing.T) {
 
 func TestLoadCommentsForFiles_NoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 	if len(comments) != 0 {
 		t.Errorf("expected 0 comments, got %d", len(comments))
 	}
@@ -1549,7 +1549,7 @@ func TestCommentToShareComment(t *testing.T) {
 			Author:      "Alice",
 			ReviewRound: 2,
 		}
-		sc := commentToShareComment(c, "main.go", "line", false, false)
+		sc := commentToShareComment(c, "main.go", "line", "", false, false)
 		if sc.File != "main.go" {
 			t.Errorf("File = %q, want main.go", sc.File)
 		}
@@ -1575,7 +1575,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("includes resolved when flag set", func(t *testing.T) {
 		c := Comment{Resolved: true}
-		sc := commentToShareComment(c, "", "", true, false)
+		sc := commentToShareComment(c, "", "", "", true, false)
 		if !sc.Resolved {
 			t.Error("expected Resolved=true when includeResolved=true")
 		}
@@ -1583,7 +1583,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("excludes resolved when flag not set", func(t *testing.T) {
 		c := Comment{Resolved: true}
-		sc := commentToShareComment(c, "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", false, false)
 		if sc.Resolved {
 			t.Error("expected Resolved=false when includeResolved=false")
 		}
@@ -1591,7 +1591,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("sets external ID when flag set", func(t *testing.T) {
 		c := Comment{ID: "c123"}
-		sc := commentToShareComment(c, "", "", false, true)
+		sc := commentToShareComment(c, "", "", "", false, true)
 		if sc.ExternalID != "c123" {
 			t.Errorf("ExternalID = %q, want c123", sc.ExternalID)
 		}
@@ -1599,7 +1599,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("omits external ID when flag not set", func(t *testing.T) {
 		c := Comment{ID: "c123"}
-		sc := commentToShareComment(c, "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", false, false)
 		if sc.ExternalID != "" {
 			t.Errorf("ExternalID = %q, want empty", sc.ExternalID)
 		}
@@ -1613,7 +1613,7 @@ func TestCommentToShareComment(t *testing.T) {
 				{Body: "verified", Author: "Alice"},
 			},
 		}
-		sc := commentToShareComment(c, "f.md", "", false, false)
+		sc := commentToShareComment(c, "f.md", "", "", false, false)
 		if len(sc.Replies) != 2 {
 			t.Fatalf("expected 2 replies, got %d", len(sc.Replies))
 		}
@@ -1624,7 +1624,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("review round zero omitted", func(t *testing.T) {
 		c := Comment{ReviewRound: 0}
-		sc := commentToShareComment(c, "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", false, false)
 		if sc.ReviewRound != 0 {
 			t.Errorf("ReviewRound = %d, want 0 (omitted for round 0)", sc.ReviewRound)
 		}

--- a/watch_test.go
+++ b/watch_test.go
@@ -50,7 +50,7 @@ func TestWatchFileMtimes_CommentNotLostOnFileChange(t *testing.T) {
 	go s.watchFileMtimes(stop)
 
 	// Add a comment while the file hasn't changed — this should persist.
-	_, ok := s.AddComment("plan.md", 1, 1, "", "important feedback", "", "tester")
+	_, ok := s.AddComment("plan.md", 1, 1, "", "important feedback", "", "tester", "")
 	if !ok {
 		t.Fatal("AddComment failed")
 	}
@@ -122,7 +122,7 @@ func TestWatchFileMtimes_ConcurrentAddDuringChange(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 20; j++ {
-				s.AddComment("plan.md", 1, 1, "", "concurrent comment", "", "tester")
+				s.AddComment("plan.md", 1, 1, "", "concurrent comment", "", "tester", "")
 				time.Sleep(50 * time.Millisecond)
 			}
 		}()


### PR DESCRIPTION
## Summary

- Each shared comment now carries a cosmetic `author_display_name` (cfg.Author / git / GitHub / "Anonymous" fallback) and a verified `user_id` (stamped from cached `cfg.AuthUserID`). The server is the source of truth on whether to persist `user_id`.
- `~/.crit.config.json` gains `auth_user_id` alongside name/email; lazy-backfilled via `/api/auth/whoami` on first share if missing (5s timeout). Cleared atomically alongside the token via `clearAuthIdentity` on logout or 401.
- `errShareUnauthorized` propagates from `shareFilesToWeb` / `upsertShareToWeb` / `fetchWebComments`; callers clear cached identity and exit.
- Initial POST now sends `external_id` so subsequent PUT upserts can match existing rows server-side.
- `mergeWebComments` preserves fetched `user_id` verbatim — never overwrites with the local sharer's id.
- Server auth state is now mutex-guarded; config writes go through `atomicWriteFile` (temp + fsync + rename) so a crash mid-write can't truncate the bearer token.
- `gh api users/{login}` lookups use `exec.CommandContext` with a 10s timeout to avoid hangs.

Backwards-compatible: `omitempty` on `UserID` means old `.crit.json` files deserialize cleanly and old CLIs talking to a new server resolve to anonymous.

## Review
- [x] Code review: passed (go-expert fresh-eyes pass + targeted fixes for race + atomic-write + ctx timeout)
- [x] Parity audit: N/A (no frontend touched)

## Test plan
- [x] `go test -race -count=1 ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Full crit↔crit-web share integration suite (`./scripts/e2e-share.sh`) — all 24 attribution + share-sync tests pass

See also: https://github.com/tomasz-tomczyk/crit-web/pull/131 (server side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)