### PR TITLE
fix: keep SSE alive past idle timeout (Safari "Connection lost")

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,6 +22,10 @@ import (
 	"rsc.io/qr"
 )
 
+// sseHeartbeatInterval is the cadence for SSE keepalive comments. It's a var
+// so tests can shrink it. 30s comfortably under the server's 60s IdleTimeout.
+var sseHeartbeatInterval = 30 * time.Second
+
 // Server handles HTTP requests for the crit review UI.
 type Server struct {
 	session           atomic.Pointer[Session]
@@ -1049,6 +1053,10 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	flusher.Flush()
 
+	// Safari won't fire EventSource.onopen until it sees a body byte.
+	fmt.Fprint(w, ":\n\n")
+	flusher.Flush()
+
 	sess := s.session.Load()
 	sess.BrowserConnect()
 	defer sess.BrowserDisconnect()
@@ -1056,10 +1064,16 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ch := sess.Subscribe()
 	defer sess.Unsubscribe(ch)
 
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-heartbeat.C:
+			fmt.Fprint(w, ":\n\n")
+			flusher.Flush()
 		case event, ok := <-ch:
 			if !ok {
 				return

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3517,5 +3518,56 @@ func TestHandleFiles_PathTraversal_DotDot(t *testing.T) {
 	// Should return 400 or 403.
 	if w.Code == 200 {
 		t.Error("path traversal should not return 200")
+	}
+}
+
+// TestEvents_SafariCompat verifies the SSE stream sends an immediate `:\n\n`
+// comment frame (so Safari fires onopen) and continues sending heartbeats so
+// the connection isn't closed by the server's IdleTimeout. Both behaviors are
+// invisible to the user when working but produce "Could not connect" errors
+// in Safari when missing.
+func TestEvents_SafariCompat(t *testing.T) {
+	prev := sseHeartbeatInterval
+	sseHeartbeatInterval = 50 * time.Millisecond
+	t.Cleanup(func() { sseHeartbeatInterval = prev })
+
+	srv, _ := newTestServer(t)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	buf := make([]byte, 3)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		t.Fatalf("reading initial frame: %v", err)
+	}
+	if string(buf) != ":\n\n" {
+		t.Errorf("initial frame = %q, want %q (Safari needs a body byte before onopen fires)", buf, ":\n\n")
+	}
+
+	heartbeat := make([]byte, 3)
+	if _, err := io.ReadFull(resp.Body, heartbeat); err != nil {
+		t.Fatalf("reading heartbeat frame: %v", err)
+	}
+	if string(heartbeat) != ":\n\n" {
+		t.Errorf("heartbeat frame = %q, want %q", heartbeat, ":\n\n")
 	}
 }


### PR DESCRIPTION
## Summary
- Send an initial `:\n\n` SSE comment so `EventSource.onopen` fires immediately (Safari delays this until the first body byte).
- Add a 30s heartbeat ticker so the stream isn't closed by the server's 60s `IdleTimeout`.

## Why
Safari was surfacing repeated "Could not connect to the server" errors on the review page. Root cause was idle SSE connections hitting the server's `IdleTimeout: 60s` — Chromium and Firefox auto-reconnect more silently, which is why this looked Safari-specific even though the root cause affected all browsers.

## Review
- [x] Code review: passed
- [x] go-expert agent assessed perf cost: negligible (~0.1 syscalls/sec per connection, no allocations, no extra goroutine).

## Test plan
- [x] New unit test `TestEvents_SafariCompat` asserts the initial `:\n\n` frame and heartbeat (with `sseHeartbeatInterval` shrunk to 50ms).
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` clean
- [x] `go test -race -count=1 ./...` passes (46s)
- [x] Manual verification in Safari via Docker container: stream stayed connected past 60s, no console errors, `crit comment` propagated via SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)