### PR TITLE
fix: expand hljs language coverage via alias resolution

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -476,6 +476,27 @@ func Reverse(s string) string {
 GOFILE
 git add utils.go
 
+# Stage a new Gherkin feature file (exercises hljs alias resolution for .feature)
+cat > login.feature << 'GHERKIN'
+Feature: User login
+  As a registered user
+  I want to log in to my account
+  So that I can access my dashboard
+
+  Scenario: Successful login with valid credentials
+    Given I am on the login page
+    When I enter "alice@example.com" and "secret123"
+    And I click the "Sign in" button
+    Then I should see the dashboard
+    And I should see "Welcome back, Alice"
+
+  Scenario: Failed login with invalid password
+    Given I am on the login page
+    When I enter "alice@example.com" and "wrong"
+    Then I should see an error message
+GHERKIN
+git add login.feature
+
 # === Unstaged changes (working tree only) ===
 # Create an untracked file
 cat > config.yaml << 'EOF'

--- a/e2e/tests/file-tree.spec.ts
+++ b/e2e/tests/file-tree.spec.ts
@@ -16,9 +16,9 @@ test.describe('File Tree — Git Mode', () => {
 
   test('file tree lists all files from the session', async ({ page }) => {
     // Git fixture has: plan.md, server.go, handler.js, deleted.txt, routes.go (committed)
-    // + utils.go (staged), config.yaml (untracked) = 7 total
+    // + utils.go, login.feature (staged), config.yaml (untracked) = 8 total
     const treeFiles = page.locator('.tree-file');
-    await expect(treeFiles).toHaveCount(7);
+    await expect(treeFiles).toHaveCount(8);
   });
 
   test('file tree shows correct file names', async ({ page }) => {
@@ -39,7 +39,7 @@ test.describe('File Tree — Git Mode', () => {
   test('file tree header shows file count', async ({ page }) => {
     const stats = page.locator('#fileTreeStats');
     await expect(stats).toBeVisible();
-    await expect(stats).toContainText('6');
+    await expect(stats).toContainText('7');
   });
 
   test('file tree header shows addition stats', async ({ page }) => {
@@ -113,9 +113,9 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file status icons have correct classes', async ({ page }) => {
-    // plan.md, handler.js, and config.yaml (untracked) are added
+    // plan.md, handler.js, login.feature, and config.yaml (untracked) are added
     const addedIcons = page.locator('.tree-file-status-icon.added');
-    await expect(addedIcons).toHaveCount(3);
+    await expect(addedIcons).toHaveCount(4);
 
     // server.go, routes.go, and utils.go (staged modification) are modified
     const modifiedIcons = page.locator('.tree-file-status-icon.modified');

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -48,9 +48,9 @@ test.describe('Scope Toggle', () => {
   test('switching to staged scope shows only staged files', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'staged');
-    // Staged: utils.go only
+    // Staged: utils.go, login.feature
     await expect(async () => {
-      await expect(page.locator('.file-section')).toHaveCount(1);
+      await expect(page.locator('.file-section')).toHaveCount(2);
     }).toPass({ timeout: 5000 });
     await expect(page.locator('.file-section', { hasText: 'utils.go' })).toBeVisible();
   });
@@ -68,7 +68,7 @@ test.describe('Scope Toggle', () => {
   test('switching back to all scope restores full file list', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'staged');
-    await expect(page.locator('.file-section')).toHaveCount(1);
+    await expect(page.locator('.file-section')).toHaveCount(2);
     await switchScope(page, 'all');
     await expect(async () => {
       const count = await page.locator('.file-section').count();
@@ -86,17 +86,17 @@ test.describe('Scope Toggle', () => {
   test('scope persists across page reload', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'staged');
-    await expect(page.locator('.file-section')).toHaveCount(1);
+    await expect(page.locator('.file-section')).toHaveCount(2);
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="staged"]')).toHaveClass(/active/);
-    await expect(page.locator('.file-section')).toHaveCount(1);
+    await expect(page.locator('.file-section')).toHaveCount(2);
   });
 
   test('file tree updates when scope changes', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'staged');
-    await expect(page.locator('.tree-file')).toHaveCount(1);
+    await expect(page.locator('.tree-file')).toHaveCount(2);
     await expect(page.locator('.tree-file-name', { hasText: 'utils.go' })).toBeVisible();
   });
 

--- a/e2e/tests/syntax-highlighting.spec.ts
+++ b/e2e/tests/syntax-highlighting.spec.ts
@@ -67,6 +67,25 @@ test.describe('Syntax Highlighting — Split Mode', () => {
   });
 });
 
+test.describe('Syntax Highlighting — hljs alias resolution', () => {
+  test('Gherkin .feature file gets syntax highlighting (hljs alias)', async ({ page }) => {
+    await loadPage(page);
+    const section = page.locator('#file-section-login\\.feature');
+    await expect(section).toBeVisible();
+
+    const additionLine = section.locator('.diff-split-side.addition .diff-content').first();
+    await expect(additionLine).toBeVisible();
+
+    // Gherkin keywords (Feature, Scenario, Given, When, Then) should be tokenized.
+    const spanCount = await additionLine.locator('span').count();
+    expect(spanCount).toBeGreaterThan(0);
+
+    // Confirm hljs class is present somewhere in the section's diff content.
+    const anyHljsClass = await section.locator('.diff-content span[class*="hljs-"]').first();
+    await expect(anyHljsClass).toBeVisible();
+  });
+});
+
 test.describe('Syntax Highlighting — Unified Mode', () => {
   test('Go file has syntax-highlighted code in unified diff', async ({ page }) => {
     await loadPage(page);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -708,24 +708,40 @@
   }
 
   // ===== Syntax Highlighting for Diffs =====
+  // Most extensions are resolved via hljs's built-in alias system
+  // (e.g. .feature → gherkin, .md → markdown, .tsx → typescript, .toml → ini,
+  // .scss → scss, .h/.hpp → c/cpp, .yml → yaml, .kt → kotlin, .rb → ruby,
+  // .dockerfile → dockerfile, .makefile → makefile). Only extensions that hljs
+  // does NOT cover via aliases need entries here.
+  const EXT_OVERRIDES = {
+    tf: 'hcl',         // Terraform — hljs has no .tf alias
+    htm: 'xml',        // hljs aliases html but not htm
+    svg: 'xml',
+    cs: 'csharp',
+    sh: 'bash',
+    zig: 'zig',        // not a built-in alias in our bundle
+    md: 'markdown',    // normalize: callers compare lang against 'markdown'
+  };
+  // Files identified by basename rather than extension.
+  const BASENAME_LANG = {
+    dockerfile: 'dockerfile',
+    makefile: 'makefile',
+    gemfile: 'ruby',
+    rakefile: 'ruby',
+  };
   function langFromPath(filePath) {
-    const ext = (filePath || '').split('.').pop().toLowerCase();
-    const map = {
-      js: 'javascript', jsx: 'javascript', ts: 'typescript', tsx: 'typescript',
-      go: 'go', py: 'python', rb: 'ruby', rs: 'rust',
-      sql: 'sql', sh: 'bash', bash: 'bash', zsh: 'bash',
-      json: 'json', yaml: 'yaml', yml: 'yaml',
-      html: 'xml', htm: 'xml', xml: 'xml', svg: 'xml',
-      css: 'css', scss: 'css', less: 'css',
-      ex: 'elixir', exs: 'elixir',
-      md: 'markdown', java: 'java', kt: 'kotlin',
-      c: 'c', h: 'c', cpp: 'cpp', hpp: 'cpp',
-      cs: 'csharp', swift: 'swift', php: 'php',
-      r: 'r', lua: 'lua', zig: 'zig', nim: 'nim',
-      toml: 'ini', ini: 'ini', dockerfile: 'dockerfile',
-      makefile: 'makefile', tf: 'hcl',
-    };
-    return map[ext] || null;
+    if (!filePath) return null;
+    const base = filePath.split('/').pop() || '';
+    const baseLower = base.toLowerCase();
+    // Pure basename (no extension) — Dockerfile, Makefile, etc.
+    if (!baseLower.includes('.') && BASENAME_LANG[baseLower]) {
+      return BASENAME_LANG[baseLower];
+    }
+    const ext = baseLower.includes('.') ? baseLower.split('.').pop() : '';
+    if (ext && EXT_OVERRIDES[ext]) return EXT_OVERRIDES[ext];
+    if (ext && hljs.getLanguage(ext)) return ext;
+    // Fall back to basename match (catches Dockerfile.something edge cases too).
+    return BASENAME_LANG[baseLower] || null;
   }
 
   // Pre-highlight file content and return array of highlighted lines (1-indexed).


### PR DESCRIPTION
## Summary
- Replace hand-curated extension→language map in `langFromPath` with `hljs.getLanguage()` alias resolution plus a small override map for extensions hljs doesn't alias (`tf`, `htm`, `svg`, `cs`, `sh`, `zig`, `md`).
- Adds basename detection for extensionless files: `Dockerfile`, `Makefile`, `Gemfile`, `Rakefile`.
- Picks up Gherkin (`.feature`) and many other languages that were already bundled in `highlight.min.js` via `copy-deps.js` but unreachable through the dispatcher.
- Note: keeps the intentional `lang !== 'markdown'` guard at `app.js:880` (avoids messy nested ` ```markdown ` rendering when reviewing a top-level `.md` file). Hence `md → markdown` stays in the override map so downstream `lang === 'markdown'` comparisons keep working.

Related to #375.

## Review
- [x] Code review: passed
- [x] Parity audit: paired with tomasz-tomczyk/crit-web#136

## Test plan
- [x] New E2E test in `e2e/tests/syntax-highlighting.spec.ts` asserts hljs spans render on a `.feature` file
- [x] Sample Gherkin file added to `e2e/setup-fixtures.sh`
- [x] Updated dependent file-count assertions in `file-tree.spec.ts` and `scope-toggle.spec.ts`
- [x] Full git-mode E2E suite: 457 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)