### PR TITLE
feat: distinct "Approved" state for review-finish modal

### DIFF
--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -46,8 +46,10 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     const overlay = page.locator('#waitingOverlay');
     await expect(overlay).toHaveClass(/active/);
 
-    const message = page.locator('#waitingMessage');
-    await expect(message).toContainText('close this browser tab', { timeout: 10_000 });
+    const dialog = page.locator('#waitingDialog');
+    await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(page.locator('#waitingHeading')).toHaveText('Approved');
+    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -273,8 +273,10 @@ test.describe('Multi-Round — Frontend', () => {
     const overlay = page.locator('#waitingOverlay');
     await expect(overlay).toHaveClass(/active/);
 
-    const message = page.locator('#waitingMessage');
-    await expect(message).toContainText('close this browser tab', { timeout: 10_000 });
+    const dialog = page.locator('#waitingDialog');
+    await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(page.locator('#waitingHeading')).toHaveText('Approved');
+    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6268,26 +6268,34 @@
   async function doFinishReview() {
     try {
       const resp = await fetch('/api/finish', { method: 'POST' });
+      if (!resp.ok) throw new Error('finish failed: ' + resp.status);
       const data = await resp.json();
-      const hasComments = !!data.prompt;
-      waitingHasComments = hasComments;
+      const approved = !!data.approved;
+      waitingHasComments = !approved;
       const prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
 
-      document.getElementById('waitingPrompt').textContent = prompt;
+      const dialog = document.getElementById('waitingDialog');
+      const headingEl = document.getElementById('waitingHeading');
+      const messageEl = document.getElementById('waitingMessage');
+      const clipEl = document.getElementById('waitingClipboard');
 
-      if (hasComments) {
-        document.getElementById('waitingMessage').innerHTML =
+      document.getElementById('waitingPrompt').textContent = prompt;
+      clipEl.textContent = 'Copy prompt';
+      clipEl.classList.remove('clipboard-confirm');
+
+      // Replay the success-mark draw animation each time we enter approved state.
+      dialog.classList.remove('approved');
+      if (approved) {
+        void dialog.offsetWidth;
+        dialog.classList.add('approved');
+        headingEl.textContent = 'Approved';
+        messageEl.textContent =
+          'Your agent has been notified \u2014 no further action needed. You can close this tab whenever you\u2019re ready.';
+      } else {
+        headingEl.textContent = 'Review Complete';
+        messageEl.innerHTML =
           'Your agent has been notified. Waiting for updates\u2026' +
           '<span class="waiting-fallback">If your agent wasn\u2019t listening, paste the prompt below.</span>';
-        const clipEl = document.getElementById('waitingClipboard');
-        clipEl.textContent = 'Copy prompt';
-        clipEl.classList.remove('clipboard-confirm');
-      } else {
-        document.getElementById('waitingMessage').textContent =
-          'You can close this browser tab, or leave it open for another round.';
-        const clipEl = document.getElementById('waitingClipboard');
-        clipEl.textContent = 'Copy prompt';
-        clipEl.classList.remove('clipboard-confirm');
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch {}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -155,8 +155,12 @@
 </div>
 
 <div class="waiting-overlay" id="waitingOverlay" role="dialog" aria-modal="true" aria-labelledby="waitingHeading">
-  <div class="waiting-dialog">
-    <div class="waiting-spinner"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+  <div class="waiting-dialog" id="waitingDialog">
+    <div class="waiting-spinner" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    <svg class="success-mark" viewBox="0 0 64 64" aria-hidden="true">
+      <circle class="success-mark-ring" cx="32" cy="32" r="28"/>
+      <path class="success-mark-check" d="M19 33 L28 42 L45 23"/>
+    </svg>
     <h3 id="waitingHeading">Review Complete</h3>
     <p id="waitingMessage"></p>
     <p class="waiting-edits" id="waitingEdits"></p>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1758,10 +1758,10 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   animation: success-check-draw 0.35s cubic-bezier(0.4, 0, 0.2, 1) 0.4s forwards;
 }
 .waiting-dialog.approved .waiting-spinner { display: none; }
-.waiting-dialog.approved .success-mark { display: inline-block; }
 .waiting-dialog.approved #waitingPrompt,
 .waiting-dialog.approved #waitingClipboard { display: none; }
 .waiting-dialog.approved .success-mark {
+  display: inline-block;
   filter: drop-shadow(0 0 0 transparent);
   animation: success-glow 1.6s ease-out 0.7s 1;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1729,6 +1729,64 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   40% { opacity: 1; transform: scale(1.2); }
 }
 
+.success-mark {
+  display: none;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 16px;
+  overflow: visible;
+}
+.success-mark-ring {
+  fill: none;
+  stroke: var(--crit-green);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-dasharray: 176;
+  stroke-dashoffset: 176;
+  transform-origin: 32px 32px;
+  transform: rotate(-90deg);
+  animation: success-ring-draw 0.55s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+.success-mark-check {
+  fill: none;
+  stroke: var(--crit-green);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 40;
+  stroke-dashoffset: 40;
+  animation: success-check-draw 0.35s cubic-bezier(0.4, 0, 0.2, 1) 0.4s forwards;
+}
+.waiting-dialog.approved .waiting-spinner { display: none; }
+.waiting-dialog.approved .success-mark { display: inline-block; }
+.waiting-dialog.approved #waitingPrompt,
+.waiting-dialog.approved #waitingClipboard { display: none; }
+.waiting-dialog.approved .success-mark {
+  filter: drop-shadow(0 0 0 transparent);
+  animation: success-glow 1.6s ease-out 0.7s 1;
+}
+@keyframes success-ring-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes success-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes success-glow {
+  0%   { filter: drop-shadow(0 0 0 transparent); }
+  35%  { filter: drop-shadow(0 0 18px color-mix(in srgb, var(--crit-green) 55%, transparent)); }
+  100% { filter: drop-shadow(0 0 0 transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .success-mark-ring,
+  .success-mark-check {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+  .waiting-dialog.approved .success-mark {
+    animation: none;
+  }
+}
+
 .waiting-dialog .waiting-edits {
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
## Summary

The post-finish modal showed a dot spinner + "Your agent has been notified. Waiting for updates…" in every case, including pure approvals where no further work is expected. The server already returns `approved: bool` from `/api/finish`, but the frontend was ignoring it and inferring "is the agent expected to do work?" from prompt presence — so the resolve-all-then-finish path was misclassified and showed the misleading waiting copy.

Now the modal has two distinct states driven by `data.approved`:

- **Approved** — animated SVG checkmark drawn into a green ring (one-shot, no looping), heading "Approved", conclusive copy. Prompt block + Copy button hidden; the prompt is still auto-copied to the clipboard in `doFinishReview`, so the manual-paste fallback is preserved silently.
- **Waiting** — unchanged: dot spinner, "Review Complete", prompt + Copy button visible.

## Review

- [x] Code review: passed (frontend-expert, no blockers)
- [x] gofmt / golangci-lint / go test -race: clean
- [x] All 35 round-complete E2E tests pass

## Test plan

- [x] Light + dark theme rendering verified via Playwright screenshots
- [x] `e2e/tests/round-complete.spec.ts` and `round-complete.filemode.spec.ts` updated to assert the new `.approved` class + heading
- [x] Existing waiting-state assertions still pass (test for "finish review with comments shows prompt" unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)