### PR TITLE
fix: strip GIT_* env from test process to prevent worktree corruption

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,9 +1,8 @@
-# Copy node_modules from primary worktree (install once, reuse everywhere)
-[[pre-start]]
-root-deps = "cp -R {{ primary_worktree_path }}/node_modules {{ worktree_path }}/node_modules"
+# Copy gitignored files (node_modules, caches, .env, etc.) from the primary
+# worktree so new worktrees skip cold-start installs. Replaces hand-rolled
+# `cp -R` of node_modules — copy-ignored handles all gitignored paths.
+[[post-start]]
+copy = "wt step copy-ignored"
 
-[[pre-start]]
-e2e-deps = "cp -R {{ primary_worktree_path }}/e2e/node_modules {{ worktree_path }}/e2e/node_modules"
-
-[post-start]
+[[post-start]]
 mise-trust = "mise trust ."

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -8,6 +8,23 @@ import (
 	"testing"
 )
 
+// Strip GIT_* from the test process env so production code paths that exec
+// git (e.g. NewSessionFromGit) don't target the parent repo when tests run
+// inside a git hook (pre-commit's `go test ./...` inherits GIT_DIR /
+// GIT_INDEX_FILE / GIT_WORK_TREE from the commit that triggered it).
+func init() {
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "GIT_") {
+			continue
+		}
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		os.Unsetenv(kv[:eq])
+	}
+}
+
 // initTestRepo creates a temp directory with a git repo and returns the path.
 // The repo has an initial commit on the "main" branch.
 func initTestRepo(t *testing.T) string {
@@ -29,7 +46,23 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	// Strip GIT_* and HOME from the inherited env. When tests run inside a
+	// git hook (e.g. pre-commit's `go test ./...`), git sets GIT_DIR /
+	// GIT_INDEX_FILE / GIT_WORK_TREE for the hook subprocess; without this
+	// filter, every git op below would target the parent repo instead of
+	// the test's tempdir. HOME is filtered so our explicit override below
+	// is unambiguous (exec.Cmd treats duplicate env entries as platform-
+	// dependent).
+	src := os.Environ()
+	env := make([]string, 0, len(src)+2)
+	for _, kv := range src {
+		if strings.HasPrefix(kv, "GIT_") || strings.HasPrefix(kv, "HOME=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
@@ -56,4 +89,23 @@ func flushWrites(s *Session) {
 		s.writeTimer.Stop()
 	}
 	s.mu.Unlock()
+}
+
+// TestGitEnvLeakStripped guards against the testutil_test.go GIT_* env leak
+// that previously corrupted the parent worktree when `go test ./...` was
+// invoked from a pre-commit hook. See the init() and runGit() comments above.
+func TestGitEnvLeakStripped(t *testing.T) {
+	for _, k := range []string{"GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"} {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Fatalf("%s still set after init(): %q", k, v)
+		}
+	}
+	// Even if a test sets GIT_DIR for its own purposes, runGit must not
+	// honor it when operating on its tempdir.
+	t.Setenv("GIT_DIR", "/should/be/ignored")
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf(".git not created in tempdir — GIT_DIR leaked into runGit: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Tests using `runGit` in `testutil_test.go` inherited `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` from the parent process. When `.githooks/pre-commit` ran `go test ./...` during a real `git commit`, every git op inside test helpers targeted the **parent repo** instead of the test's `t.TempDir()` — silently corrupting the active worktree (HEAD renamed to `main`, stray `initial` commits authored by `Test <test@test.com>`, local `user.email/name` overwritten, and via tests that `git config core.worktree`, the bare repo's `core.bare` flipped to `false`).
- Two-layer fix: a process-wide `init()` strips `GIT_*` once (covers production paths like `NewSessionFromGit` that exec git internally); `runGit` also filters `GIT_*` and `HOME` per-call as defense-in-depth.
- Adds `TestGitEnvLeakStripped` to guard against regression.
- Rewrites `.config/wt.toml` to use `wt step copy-ignored` in `post-start` instead of hand-rolled `cp -R` of `node_modules` in `pre-start` — covers all gitignored files, doesn't block worktree creation, keeps wt's approval cache stable across edits.

## Test plan

- [x] `go test ./... -count=1` passes (~29s).
- [x] Reproduced the original bug pre-fix: simulated `git commit` env (`GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` set), then `go test -run 'TestNewSessionFromGitLazyThreshold'` corrupted the worktree as described.
- [x] Same simulation with the fix in place: worktree HEAD/branch/config unchanged, bare repo `bare = true` preserved, no user identity leak.
- [x] Real `git commit` (this PR) ran the full pre-commit hook including `go test ./...` without corruption — the fix self-validates.
- [x] `TestGitEnvLeakStripped` passes.
- [ ] Reviewer: try `wt switch --create some-branch --base main` and confirm `wt step copy-ignored` populates `node_modules` / `e2e/node_modules` from the primary worktree (may require `wt config approvals add` to re-approve the new command string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)