### PR TITLE
Change comment submit button text to 'Add comment'

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4054,7 +4054,7 @@
     return createCommentFormUI({
       formObj: formObj,
       headerText: formObj.editingId ? 'Editing comment' : 'Comment',
-      submitText: formObj.editingId ? 'Update' : 'Submit',
+      submitText: formObj.editingId ? 'Update' : 'Comment',
       initialBody: initialBody,
       autoFocus: false
     });
@@ -4524,7 +4524,7 @@
     return createCommentFormUI({
       formObj: formObj,
       headerText: (formObj.editingId ? 'Editing comment on ' : 'Comment on ') + lineRef,
-      submitText: formObj.editingId ? 'Update' : 'Submit',
+      submitText: formObj.editingId ? 'Update' : 'Comment',
       initialBody: initialBody,
       autoFocus: false
     });
@@ -5470,7 +5470,7 @@
     return createCommentFormUI({
       formObj: formObj,
       headerText: 'Comment',
-      submitText: 'Submit',
+      submitText: 'Comment',
       initialBody: '',
       autoFocus: false,
       onSubmit: function(body) { addReviewComment(body); },
@@ -7805,7 +7805,7 @@
         { key: '<kbd>e</kbd>', action: 'Edit comment on focused block' },
         { key: '<kbd>d</kbd>', action: 'Delete comment on focused block' },
         { key: '<kbd>G</kbd>', action: 'General comment' },
-        { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Submit comment' },
+        { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Comment' },
       ]},
       { label: 'Review', shortcuts: [
         { key: '<kbd>Shift</kbd>+<kbd>F</kbd>', action: 'Finish review' },


### PR DESCRIPTION
Hi,

When I write a comment, I need to press the "submit" button to submit my comment.
First time I've used it, I thought to myself "but I don't want to submit my review yet", and I think about it every time now 🙃 

Can the button be renamed to "add comment", "comment", or something like that so it will feel like "I'm just done with this part, but not with the whole review"?

Thanks! :) 
