### PR TITLE
fix: align light theme with modern GitHub for visible diff highlights

### DIFF
--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -163,8 +163,8 @@
   html:not([data-theme]) {
     /* ---- Brand surfaces ---- */
     --crit-bg-page:     #ffffff;
-    --crit-bg-card:     #f3f4f6;
-    --crit-bg-elevated: #e8eaed;
+    --crit-bg-card:     #f6f8fa;
+    --crit-bg-elevated: #eff2f5;
 
     /* ---- Brand foreground ---- */
     --crit-fg-primary:   #1a1d23;
@@ -181,22 +181,22 @@
     --crit-brand-cta-hover: #3568c8;
 
     /* ---- Editor surfaces (light) ---- */
-    --crit-editor-bg:          #fafafa;
-    --crit-editor-bg-card:     #f5f5f5;
-    --crit-editor-bg-elevated: #eeeeee;
-    --crit-editor-bg-hover:    #e8e8e8;
-    --crit-editor-bg-gutter:   #f0f0f0;
-    --crit-editor-code-bg:     #f5f5f5;
-    --crit-editor-comment-bg:  #f0f6ff;
+    --crit-editor-bg:          #ffffff;
+    --crit-editor-bg-card:     #f6f8fa;
+    --crit-editor-bg-elevated: #eff2f5;
+    --crit-editor-bg-hover:    #eff2f5;
+    --crit-editor-bg-gutter:   #f6f8fa;
+    --crit-editor-code-bg:     #eff1f3;
+    --crit-editor-comment-bg:  #ddf4ff;
 
     /* ---- Editor foreground (light) ---- */
-    --crit-editor-fg:           #24292f;
-    --crit-editor-fg-secondary: #57606a;
-    --crit-editor-fg-muted:     #5a626b;
+    --crit-editor-fg:           #1f2328;
+    --crit-editor-fg-secondary: #59636e;
+    --crit-editor-fg-muted:     #59636e;
 
     /* ---- Editor scrollbar (light) ---- */
     --crit-editor-scrollbar-bg:    #ffffff;
-    --crit-editor-scrollbar-thumb: #d0d0d0;
+    --crit-editor-scrollbar-thumb: #d1d9e0;
 
     /* ---- Semantic colors ---- */
     --crit-green:  #166f30;
@@ -213,14 +213,14 @@
     --crit-shadow: 0 2px 8px rgba(0,0,0,0.08);
 
     /* ---- Diff highlights (light) ---- */
-    --crit-diff-add-bg:       rgba(22, 111, 48, 0.06);
-    --crit-diff-add-line-bg:  rgba(22, 111, 48, 0.14);
-    --crit-diff-del-bg:       rgba(196, 31, 42, 0.04);
-    --crit-diff-del-line-bg:  rgba(196, 31, 42, 0.1);
-    --crit-diff-add-gutter:   rgba(22, 111, 48, 0.1);
-    --crit-diff-del-gutter:   rgba(196, 31, 42, 0.06);
-    --crit-diff-word-add-bg:  rgba(22, 111, 48, 0.15);
-    --crit-diff-word-del-bg:  rgba(196, 31, 42, 0.15);
+    --crit-diff-add-bg:       #dafbe1;
+    --crit-diff-add-line-bg:  #dafbe1;
+    --crit-diff-del-bg:       #ffebe9;
+    --crit-diff-del-line-bg:  #ffebe9;
+    --crit-diff-add-gutter:   #aceebb;
+    --crit-diff-del-gutter:   #ffcecb;
+    --crit-diff-word-add-bg:  #aceebb;
+    --crit-diff-word-del-bg:  #ffcecb;
 
     --crit-comment-range-bg: rgba(210, 153, 34, 0.15);
     --crit-table-stripe: rgba(0, 0, 0, 0.02);
@@ -404,8 +404,8 @@
 [data-theme="light"] {
   /* ---- Brand surfaces ---- */
   --crit-bg-page:     #ffffff;
-  --crit-bg-card:     #f3f4f6;
-  --crit-bg-elevated: #e8eaed;
+  --crit-bg-card:     #f6f8fa;
+  --crit-bg-elevated: #eff2f5;
 
   /* ---- Brand foreground ---- */
   --crit-fg-primary:   #1a1d23;
@@ -422,22 +422,22 @@
   --crit-brand-cta-hover: #3568c8;
 
   /* ---- Editor surfaces (light) ---- */
-  --crit-editor-bg:          #fafafa;
-  --crit-editor-bg-card:     #f5f5f5;
-  --crit-editor-bg-elevated: #eeeeee;
-  --crit-editor-bg-hover:    #e8e8e8;
-  --crit-editor-bg-gutter:   #f0f0f0;
-  --crit-editor-code-bg:     #f5f5f5;
-  --crit-editor-comment-bg:  #f0f6ff;
+  --crit-editor-bg:          #ffffff;
+  --crit-editor-bg-card:     #f6f8fa;
+  --crit-editor-bg-elevated: #eff2f5;
+  --crit-editor-bg-hover:    #eff2f5;
+  --crit-editor-bg-gutter:   #f6f8fa;
+  --crit-editor-code-bg:     #eff1f3;
+  --crit-editor-comment-bg:  #ddf4ff;
 
   /* ---- Editor foreground (light) ---- */
-  --crit-editor-fg:           #24292f;
-  --crit-editor-fg-secondary: #57606a;
-  --crit-editor-fg-muted:     #5a626b;
+  --crit-editor-fg:           #1f2328;
+  --crit-editor-fg-secondary: #59636e;
+  --crit-editor-fg-muted:     #59636e;
 
   /* ---- Editor scrollbar (light) ---- */
   --crit-editor-scrollbar-bg:    #ffffff;
-  --crit-editor-scrollbar-thumb: #d0d0d0;
+  --crit-editor-scrollbar-thumb: #d1d9e0;
 
   /* ---- Semantic colors ---- */
   --crit-green:  #166f30;
@@ -454,14 +454,14 @@
   --crit-shadow: 0 2px 8px rgba(0,0,0,0.08);
 
   /* ---- Diff highlights (light) ---- */
-  --crit-diff-add-bg:       rgba(22, 111, 48, 0.06);
-  --crit-diff-add-line-bg:  rgba(22, 111, 48, 0.14);
-  --crit-diff-del-bg:       rgba(196, 31, 42, 0.04);
-  --crit-diff-del-line-bg:  rgba(196, 31, 42, 0.1);
-  --crit-diff-add-gutter:   rgba(22, 111, 48, 0.1);
-  --crit-diff-del-gutter:   rgba(196, 31, 42, 0.06);
-  --crit-diff-word-add-bg:  rgba(22, 111, 48, 0.15);
-  --crit-diff-word-del-bg:  rgba(196, 31, 42, 0.15);
+  --crit-diff-add-bg:       #dafbe1;
+  --crit-diff-add-line-bg:  #dafbe1;
+  --crit-diff-del-bg:       #ffebe9;
+  --crit-diff-del-line-bg:  #ffebe9;
+  --crit-diff-add-gutter:   #aceebb;
+  --crit-diff-del-gutter:   #ffcecb;
+  --crit-diff-word-add-bg:  #aceebb;
+  --crit-diff-word-del-bg:  #ffcecb;
 
   --crit-comment-range-bg: rgba(210, 153, 34, 0.15);
   --crit-table-stripe: rgba(0, 0, 0, 0.02);
@@ -559,13 +559,13 @@
 /* System light — applies when OS prefers light and no data-theme is set */
 @media (prefers-color-scheme: light) {
   html:not([data-theme]) .hljs{color:#24292e;background:#fff}
-  html:not([data-theme]) .hljs-doctag,html:not([data-theme]) .hljs-keyword,html:not([data-theme]) .hljs-meta .hljs-keyword,html:not([data-theme]) .hljs-template-tag,html:not([data-theme]) .hljs-template-variable,html:not([data-theme]) .hljs-type,html:not([data-theme]) .hljs-variable.language_,html:not([data-theme]) .hljs-tag{color:#b91c28}
+  html:not([data-theme]) .hljs-doctag,html:not([data-theme]) .hljs-keyword,html:not([data-theme]) .hljs-meta .hljs-keyword,html:not([data-theme]) .hljs-template-tag,html:not([data-theme]) .hljs-template-variable,html:not([data-theme]) .hljs-type,html:not([data-theme]) .hljs-variable.language_,html:not([data-theme]) .hljs-tag{color:#cf222e}
   html:not([data-theme]) .hljs-title,html:not([data-theme]) .hljs-title.class_,html:not([data-theme]) .hljs-title.class_.inherited__,html:not([data-theme]) .hljs-title.function_{color:#6f42c1}
-  html:not([data-theme]) .hljs-attr,html:not([data-theme]) .hljs-attribute,html:not([data-theme]) .hljs-literal,html:not([data-theme]) .hljs-meta,html:not([data-theme]) .hljs-number,html:not([data-theme]) .hljs-operator,html:not([data-theme]) .hljs-selector-attr,html:not([data-theme]) .hljs-selector-class,html:not([data-theme]) .hljs-selector-id,html:not([data-theme]) .hljs-variable,html:not([data-theme]) .hljs-params,html:not([data-theme]) .hljs-link,html:not([data-theme]) .hljs-property,html:not([data-theme]) .hljs-char.escape_{color:#0054b5}
+  html:not([data-theme]) .hljs-attr,html:not([data-theme]) .hljs-attribute,html:not([data-theme]) .hljs-literal,html:not([data-theme]) .hljs-meta,html:not([data-theme]) .hljs-number,html:not([data-theme]) .hljs-operator,html:not([data-theme]) .hljs-selector-attr,html:not([data-theme]) .hljs-selector-class,html:not([data-theme]) .hljs-selector-id,html:not([data-theme]) .hljs-variable,html:not([data-theme]) .hljs-params,html:not([data-theme]) .hljs-link,html:not([data-theme]) .hljs-property,html:not([data-theme]) .hljs-char.escape_{color:#005cc5}
   html:not([data-theme]) .hljs-meta .hljs-string,html:not([data-theme]) .hljs-regexp,html:not([data-theme]) .hljs-string{color:#032f62}
-  html:not([data-theme]) .hljs-built_in,html:not([data-theme]) .hljs-symbol{color:#b94600}
-  html:not([data-theme]) .hljs-code,html:not([data-theme]) .hljs-comment,html:not([data-theme]) .hljs-formula{color:#5d6570}
-  html:not([data-theme]) .hljs-name,html:not([data-theme]) .hljs-quote,html:not([data-theme]) .hljs-selector-pseudo,html:not([data-theme]) .hljs-selector-tag{color:#116329}
+  html:not([data-theme]) .hljs-built_in,html:not([data-theme]) .hljs-symbol{color:#953800}
+  html:not([data-theme]) .hljs-code,html:not([data-theme]) .hljs-comment,html:not([data-theme]) .hljs-formula{color:#59636e}
+  html:not([data-theme]) .hljs-name,html:not([data-theme]) .hljs-quote,html:not([data-theme]) .hljs-selector-pseudo,html:not([data-theme]) .hljs-selector-tag{color:#22863a}
   html:not([data-theme]) .hljs-subst{color:#24292e}
   html:not([data-theme]) .hljs-section{color:#005cc5;font-weight:700}
   html:not([data-theme]) .hljs-bullet{color:#735c0f}
@@ -578,13 +578,13 @@
 
 /* Explicit light override */
 [data-theme="light"] .hljs{color:#24292e;background:#fff}
-[data-theme="light"] .hljs-doctag,[data-theme="light"] .hljs-keyword,[data-theme="light"] .hljs-meta .hljs-keyword,[data-theme="light"] .hljs-template-tag,[data-theme="light"] .hljs-template-variable,[data-theme="light"] .hljs-type,[data-theme="light"] .hljs-variable.language_,[data-theme="light"] .hljs-tag{color:#b91c28}
+[data-theme="light"] .hljs-doctag,[data-theme="light"] .hljs-keyword,[data-theme="light"] .hljs-meta .hljs-keyword,[data-theme="light"] .hljs-template-tag,[data-theme="light"] .hljs-template-variable,[data-theme="light"] .hljs-type,[data-theme="light"] .hljs-variable.language_,[data-theme="light"] .hljs-tag{color:#cf222e}
 [data-theme="light"] .hljs-title,[data-theme="light"] .hljs-title.class_,[data-theme="light"] .hljs-title.class_.inherited__,[data-theme="light"] .hljs-title.function_{color:#6f42c1}
-[data-theme="light"] .hljs-attr,[data-theme="light"] .hljs-attribute,[data-theme="light"] .hljs-literal,[data-theme="light"] .hljs-meta,[data-theme="light"] .hljs-number,[data-theme="light"] .hljs-operator,[data-theme="light"] .hljs-selector-attr,[data-theme="light"] .hljs-selector-class,[data-theme="light"] .hljs-selector-id,[data-theme="light"] .hljs-variable,[data-theme="light"] .hljs-params,[data-theme="light"] .hljs-link,[data-theme="light"] .hljs-property,[data-theme="light"] .hljs-char.escape_{color:#0054b5}
+[data-theme="light"] .hljs-attr,[data-theme="light"] .hljs-attribute,[data-theme="light"] .hljs-literal,[data-theme="light"] .hljs-meta,[data-theme="light"] .hljs-number,[data-theme="light"] .hljs-operator,[data-theme="light"] .hljs-selector-attr,[data-theme="light"] .hljs-selector-class,[data-theme="light"] .hljs-selector-id,[data-theme="light"] .hljs-variable,[data-theme="light"] .hljs-params,[data-theme="light"] .hljs-link,[data-theme="light"] .hljs-property,[data-theme="light"] .hljs-char.escape_{color:#005cc5}
 [data-theme="light"] .hljs-meta .hljs-string,[data-theme="light"] .hljs-regexp,[data-theme="light"] .hljs-string{color:#032f62}
-[data-theme="light"] .hljs-built_in,[data-theme="light"] .hljs-symbol{color:#b94600}
-[data-theme="light"] .hljs-code,[data-theme="light"] .hljs-comment,[data-theme="light"] .hljs-formula{color:#5d6570}
-[data-theme="light"] .hljs-name,[data-theme="light"] .hljs-quote,[data-theme="light"] .hljs-selector-pseudo,[data-theme="light"] .hljs-selector-tag{color:#116329}
+[data-theme="light"] .hljs-built_in,[data-theme="light"] .hljs-symbol{color:#953800}
+[data-theme="light"] .hljs-code,[data-theme="light"] .hljs-comment,[data-theme="light"] .hljs-formula{color:#59636e}
+[data-theme="light"] .hljs-name,[data-theme="light"] .hljs-quote,[data-theme="light"] .hljs-selector-pseudo,[data-theme="light"] .hljs-selector-tag{color:#22863a}
 [data-theme="light"] .hljs-subst{color:#24292e}
 [data-theme="light"] .hljs-section{color:#005cc5;font-weight:700}
 [data-theme="light"] .hljs-bullet{color:#735c0f}
@@ -593,3 +593,45 @@
 [data-theme="light"] .hljs-strong{color:#24292e;font-weight:700}
 [data-theme="light"] .hljs-addition{color:#22863a;background-color:#f0fff4}
 [data-theme="light"] .hljs-deletion{color:#b31d28;background-color:#ffeef0}
+
+/* ===== Light-theme AA contrast fixes for diff backgrounds ===== */
+/* Deletion-row gutter line numbers: --crit-editor-fg-muted (#59636e) on #ffcecb fails AA. Darken to fg-default. */
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) .deletion .diff-gutter-num{color:#1f2328}
+}
+[data-theme="light"] .deletion .diff-gutter-num{color:#1f2328}
+
+/* Word-level deletion span (#ffcecb bg): when .diff-word-del is nested inside an
+   .hljs-* color class, the failing groups are keyword (#cf222e), name/quote (#22863a),
+   and comment (#59636e). DOM is .hljs-keyword > .diff-word-del — target the inner span. */
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) .hljs-doctag > .diff-word-del,
+  html:not([data-theme]) .hljs-keyword > .diff-word-del,
+  html:not([data-theme]) .hljs-template-tag > .diff-word-del,
+  html:not([data-theme]) .hljs-template-variable > .diff-word-del,
+  html:not([data-theme]) .hljs-type > .diff-word-del,
+  html:not([data-theme]) .hljs-variable > .diff-word-del,
+  html:not([data-theme]) .hljs-tag > .diff-word-del,
+  html:not([data-theme]) .hljs-name > .diff-word-del,
+  html:not([data-theme]) .hljs-quote > .diff-word-del,
+  html:not([data-theme]) .hljs-selector-pseudo > .diff-word-del,
+  html:not([data-theme]) .hljs-selector-tag > .diff-word-del,
+  html:not([data-theme]) .hljs-code > .diff-word-del,
+  html:not([data-theme]) .hljs-comment > .diff-word-del,
+  html:not([data-theme]) .hljs-formula > .diff-word-del{color:#1f2328}
+}
+[data-theme="light"] .hljs-doctag > .diff-word-del,
+[data-theme="light"] .hljs-keyword > .diff-word-del,
+[data-theme="light"] .hljs-template-tag > .diff-word-del,
+[data-theme="light"] .hljs-template-variable > .diff-word-del,
+[data-theme="light"] .hljs-type > .diff-word-del,
+[data-theme="light"] .hljs-variable > .diff-word-del,
+[data-theme="light"] .hljs-tag > .diff-word-del,
+[data-theme="light"] .hljs-name > .diff-word-del,
+[data-theme="light"] .hljs-quote > .diff-word-del,
+[data-theme="light"] .hljs-selector-pseudo > .diff-word-del,
+[data-theme="light"] .hljs-selector-tag > .diff-word-del,
+[data-theme="light"] .hljs-code > .diff-word-del,
+[data-theme="light"] .hljs-comment > .diff-word-del,
+[data-theme="light"] .hljs-formula > .diff-word-del{color:#1f2328}
+


### PR DESCRIPTION
Closes #384.

## Summary
- Switches light-theme diff highlights from low-alpha rgba overlays to opaque Primer v8 values (`#dafbe1`, `#aceebb`, `#ffebe9`, `#ffcecb`). The faint highlights reported in #384 were technically WCAG AA compliant but visually washed-out — the rgba overlays rendered as near-white on the page bg.
- Aligns the rest of the editor's light tokens (surfaces, fg, hljs syntax) with current Primer v8 — what github.com ships today. The inline hljs theme had drifted from both upstream `github.css` (2021) and from current Primer.
- Three small AA-driven divergences from GH so we still pass the existing axe AA test where GH itself fails: `hljs-built_in` darkened to `#953800`; deletion-row gutter line numbers and `.hljs-* > .diff-word-del` groups darkened to `#1f2328`.
- Dark theme (Tokyo Night) untouched.

See also: tomasz-tomczyk/crit-web#138 (parity mirror).

## Review
- [x] Code review: passed
- [x] Parity audit: matches crit-web/assets/css/app.css

## Test plan
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — pass
- [x] `e2e/tests/accessibility.spec.ts --project=git-mode` — light-theme color-contrast and critical-violations tests PASS (dark-theme test fails pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)