### PR TITLE
fix: patch hljs markdown grammar and re-enable for diff view

### DIFF
--- a/copy-deps.js
+++ b/copy-deps.js
@@ -6,12 +6,15 @@ const dest = "frontend";
 // markdown-it
 cpSync("node_modules/markdown-it/dist/markdown-it.min.js", `${dest}/markdown-it.min.js`);
 
-// highlight.js — bundle core + all languages into a single file
+// highlight.js — bundle core + all languages + local patches into a single file.
+// Order: core (defines hljs) → languages (registers 'markdown') → patches
+// (re-registers 'markdown' with crit's fixes). See highlight-markdown-patch.js.
 const core = readFileSync("node_modules/@highlightjs/cdn-assets/highlight.min.js", "utf8");
 const langDir = "node_modules/@highlightjs/cdn-assets/languages";
 const langFiles = readdirSync(langDir).filter(f => f.endsWith(".min.js")).sort();
 const langs = langFiles.map(f => readFileSync(`${langDir}/${f}`, "utf8")).join("\n");
-writeFileSync(`${dest}/highlight.min.js`, core + "\n" + langs);
+const patch = readFileSync(`${dest}/highlight-markdown-patch.js`, "utf8");
+writeFileSync(`${dest}/highlight.min.js`, core + "\n" + langs + "\n" + patch);
 
 // mermaid
 cpSync("node_modules/mermaid/dist/mermaid.min.js", `${dest}/mermaid.min.js`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -406,15 +406,15 @@
     f.diffTooLarge = diffLineCount > 1000;
     f.diffLoaded = !f.diffTooLarge;
 
-    // Pre-highlight code files for diff rendering
-    if (f.fileType === 'code') {
+    // Pre-highlight code and markdown files for diff rendering
+    if (f.fileType === 'code' || f.fileType === 'markdown') {
       f.highlightCache = preHighlightFile(f);
       f.lang = langFromPath(f.path);
+    }
 
-      // In file mode, build line blocks so code files render as document view
-      if (session.mode !== 'git') {
-        f.lineBlocks = buildCodeLineBlocks(f);
-      }
+    // In file mode, build line blocks so code files render as document view
+    if (f.fileType === 'code' && session.mode !== 'git') {
+      f.lineBlocks = buildCodeLineBlocks(f);
     }
 
     // Parse markdown content into line blocks
@@ -747,7 +747,7 @@
   // Pre-highlight file content and return array of highlighted lines (1-indexed).
   // highlightedLines[lineNum] = highlighted HTML for that line.
   function preHighlightFile(file) {
-    if (!file.content || file.fileType !== 'code') return null;
+    if (!file.content) return null;
     const lang = langFromPath(file.path);
     if (!lang || !hljs.getLanguage(lang)) return null;
     try {
@@ -891,9 +891,7 @@
     }
 
     let highlighted = '';
-    // Skip hljs for markdown fences — syntax highlighting (bold headings,
-    // italic emphasis) makes raw markdown source look half-rendered.
-    if (lang && lang !== 'markdown' && lang !== 'md' && hljs.getLanguage(lang)) {
+    if (lang && hljs.getLanguage(lang)) {
       try { highlighted = hljs.highlight(token.content, { language: lang }).value; } catch {}
     }
     if (!highlighted) highlighted = escapeHtml(token.content);

--- a/frontend/highlight-markdown-patch.js
+++ b/frontend/highlight-markdown-patch.js
@@ -1,0 +1,264 @@
+/*
+ * crit-markdown-patch v1 — patched highlight.js markdown grammar.
+ *
+ * Re-registers the 'markdown' language with three upstream bug fixes:
+ *
+ *  - hljs#4279: snake_case identifiers (e.g. flutter_eval, :no_entry:, _id)
+ *    were wrongly italicized because the underscore variant of ITALIC/BOLD
+ *    didn't enforce intraword boundaries. CommonMark requires `_` emphasis
+ *    to be preceded by non-alphanumeric on the open side and followed by
+ *    non-alphanumeric on the close side. Asterisk emphasis is unchanged.
+ *    Reference fix: highlightjs/highlight.js PR #4342 (danvk).
+ *
+ *  - hljs#3719: A bare line of `***` (or `---`, `___`) was being matched as
+ *    BOLD opener instead of HORIZONTAL_RULE because (a) HORIZONTAL_RULE's
+ *    matcher accepted any line starting with 3+ `-`/`*` (substring match,
+ *    not full line) and (b) BOLD came before HORIZONTAL_RULE in contains[].
+ *    Fix: tighten HORIZONTAL_RULE to a full-line match (3+ identical
+ *    `-`, `*`, or `_` characters, optional whitespace) and put it ahead of
+ *    BOLD in the contains[] order.
+ *
+ *  - Italic/bold bleed across code spans: `` `*_id` fields — validate as
+ *    *UUID* before any database query `` was rendering with italic starting
+ *    at the `*` *inside* the backtick code span, eating the rest of the line
+ *    including the closing backtick and the intended `*UUID*`. Root cause:
+ *    in the contains[] array, BOLD/ITALIC were listed *before* CODE, so at
+ *    each scan position hljs tried italic-open first and won, never giving
+ *    the backtick code span a chance. Fix: move CODE before BOLD/ITALIC.
+ *    Plus tightened the asterisk italic/bold patterns to require a closing
+ *    delimiter on the *same line* (no `\n` in content) and to require the
+ *    content to start and end with non-whitespace, per CommonMark
+ *    left/right-flanking rules. This stops asterisk-glob patterns like
+ *    src/[two-stars]/[star].go and similar inside string literals from
+ *    opening an unterminated bold/italic run that bleeds across the line.
+ *
+ * Based on hljs 11.11.1 src/languages/markdown.js. When bumping
+ * @highlightjs/cdn-assets, re-diff this file against the upstream grammar.
+ *
+ * Sentinel: CRIT_MD_PATCH_v1 — used by tests to confirm the patch is bundled.
+ */
+(function () {
+  if (typeof hljs === 'undefined' || !hljs.registerLanguage) return;
+
+  hljs.registerLanguage('markdown', function (hljs) {
+    const regex = hljs.regex;
+
+    const INLINE_HTML = {
+      begin: /<\/?[A-Za-z_]/,
+      end: '>',
+      subLanguage: 'xml',
+      relevance: 0
+    };
+
+    // Fix: hljs#3719 — full-line match required (prevents `***`/`---`/`___`
+    // on their own line from being treated as a BOLD opener).
+    const HORIZONTAL_RULE = {
+      className: 'section',
+      match: /^[ \t]*([-*_])([ \t]*\1){2,}[ \t]*$/m
+    };
+
+    const CODE = {
+      className: 'code',
+      variants: [
+        { begin: '(`{3,})[^`](.|\\n)*?\\1`*[ ]*' },
+        { begin: '(~{3,})[^~](.|\\n)*?\\1~*[ ]*' },
+        { begin: '```', end: '```+[ ]*$' },
+        { begin: '~~~', end: '~~~+[ ]*$' },
+        { begin: '`.+?`' },
+        {
+          begin: '(?=^( {4}|\\t))',
+          contains: [
+            { begin: '^( {4}|\\t)', end: '(\\n)$' }
+          ],
+          relevance: 0
+        }
+      ]
+    };
+
+    const LIST = {
+      className: 'bullet',
+      begin: '^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)',
+      end: '\\s+',
+      excludeEnd: true
+    };
+
+    const LINK_REFERENCE = {
+      begin: /^\[[^\n]+\]:/,
+      returnBegin: true,
+      contains: [
+        { className: 'symbol', begin: /\[/, end: /\]/, excludeBegin: true, excludeEnd: true },
+        { className: 'link', begin: /:\s*/, end: /$/, excludeBegin: true }
+      ]
+    };
+
+    const URL_SCHEME = /[A-Za-z][A-Za-z0-9+.-]*/;
+    const LINK = {
+      variants: [
+        { begin: /\[.+?\]\[.*?\]/, relevance: 0 },
+        { begin: /\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/, relevance: 2 },
+        { begin: regex.concat(/\[.+?\]\(/, URL_SCHEME, /:\/\/.*?\)/), relevance: 2 },
+        { begin: /\[.+?\]\([./?&#].*?\)/, relevance: 1 },
+        { begin: /\[.*?\]\(.*?\)/, relevance: 0 }
+      ],
+      returnBegin: true,
+      contains: [
+        { match: /\[(?=\])/ },
+        { className: 'string', relevance: 0, begin: '\\[', end: '\\]', excludeBegin: true, returnEnd: true },
+        { className: 'link', relevance: 0, begin: '\\]\\(', end: '\\)', excludeBegin: true, excludeEnd: true },
+        { className: 'symbol', relevance: 0, begin: '\\]\\[', end: '\\]', excludeBegin: true, excludeEnd: true }
+      ]
+    };
+
+    // Fix: hljs#4279 — `__..__` underscore-bold must not match intraword
+    // (e.g. `snake__case`). The lookahead in `begin` requires a valid closer
+    // to exist on the same line; otherwise hljs would greedily pair the
+    // opener with end-of-line and falsely bold an unterminated identifier.
+    //
+    // Asterisk variant: also require a closer on the same line so that
+    // unclosed `**` runs (e.g. `**/*.go` inside a string literal) don't
+    // open a bold span that bleeds to end-of-line / next match. Per
+    // CommonMark, an opening `**` must be followed by a non-whitespace
+    // char (already enforced); we additionally require the closer `**`
+    // to appear on the same line (no `\n` between them).
+    const BOLD = {
+      className: 'strong',
+      contains: [], // defined later
+      variants: [
+        {
+          begin: /(?<![A-Za-z0-9])_{2}(?!\s)(?=[^\n]*_{2}(?![A-Za-z0-9]))/,
+          end: /_{2}(?![A-Za-z0-9])/
+        },
+        {
+          // Same-line closer lookahead. `[^\n]*?` is non-greedy and stops at
+          // the first `**` on the line. Without this, `"src/**/*.go"` opens a
+          // bold span and waits for any later `**` to close it.
+          begin: /\*{2}(?!\s)(?=[^\n]*?\*{2})/,
+          end: /\*{2}/
+        }
+      ]
+    };
+
+    // Fix: hljs#4279 — `_..._` underscore-italic must not match intraword
+    // (e.g. `flutter_eval`, `:no_entry:`, `_id`). Same closer-lookahead trick
+    // as BOLD: only open if a valid closer exists on this line; prevents
+    // unterminated `_id` from getting wrapped to end-of-line.
+    //
+    // Asterisk variant: require a closer on the same line, otherwise an
+    // unclosed `*` (e.g. the `*` inside `` `*_id` `` once nested-fence
+    // re-tokenization strips the backticks, or `*.go` after `/`) bleeds
+    // emphasis through the rest of the line. CommonMark allows intraword
+    // `*` (e.g. `un*frigging*believable`), so no word-boundary flank — only
+    // the same-line closer constraint and non-whitespace flanks.
+    const ITALIC = {
+      className: 'emphasis',
+      contains: [], // defined later
+      variants: [
+        {
+          // `(?<!\*)` blocks opening italic on the second `*` of a `**`
+          // sequence — without this, `"src/**/*.go"` opens italic at the
+          // second `*` (next char `/` passes `(?![*\s])`) and pairs with
+          // the later `*` in `*.go`, italicising `*/*`. With it, we never
+          // open italic mid-`**`. The `***bold italic***` case is still
+          // handled because BOLD consumes the outer `**`/`**` first
+          // (BOLD precedes ITALIC in variants, and hljs tries each variant
+          // at every position) and the inner italic opens at a position
+          // that has a non-`*` char before it.
+          // `(?![*\s])` per CommonMark: opener must be followed by
+          // non-whitespace, and we don't want it to be the start of `**`.
+          // `(?=[^\n]*?\*)` requires a closing `*` on the same line.
+          begin: /(?<!\*)\*(?![*\s])(?=[^\n]*?\*)/,
+          end: /\*/
+        },
+        {
+          begin: /(?<![A-Za-z0-9])_(?![_\s])(?=[^\n_]*_(?![A-Za-z0-9]))/,
+          end: /_(?![A-Za-z0-9])/,
+          relevance: 0
+        }
+      ]
+    };
+
+    // 3-level deep nesting is not allowed because it would create confusion
+    // in cases like `***testing***` where we don't know if the last `***`
+    // is starting a new bold/italic or finishing the last one.
+    const BOLD_WITHOUT_ITALIC = hljs.inherit(BOLD, { contains: [] });
+    const ITALIC_WITHOUT_BOLD = hljs.inherit(ITALIC, { contains: [] });
+    BOLD.contains.push(ITALIC_WITHOUT_BOLD);
+    ITALIC.contains.push(BOLD_WITHOUT_ITALIC);
+
+    let CONTAINABLE = [INLINE_HTML, LINK];
+
+    [BOLD, ITALIC, BOLD_WITHOUT_ITALIC, ITALIC_WITHOUT_BOLD].forEach(function (m) {
+      m.contains = m.contains.concat(CONTAINABLE);
+    });
+
+    CONTAINABLE = CONTAINABLE.concat(BOLD, ITALIC);
+
+    // Setext heading content MUST be a paragraph line per CommonMark §4.3 —
+    // not a list item, blockquote, ATX header, indented code block, or HR.
+    // Upstream hljs ignores this, so a YAML frontmatter block like:
+    //   ---
+    //   paths:
+    //     - "src/**/*.go"
+    //     - "internal/*.go"
+    //   ---
+    // matched the trailing `  - "internal/*.go"\n---` as a setext H2,
+    // wrapping the bullet line and the closing fence in `hljs-section`.
+    // The negative lookahead below excludes upper lines that start with
+    // common block-level markers. It does NOT cover every CommonMark case
+    // (HTML blocks, fenced code, link refs), but those are already handled
+    // by other contains[] entries that consume them before HEADER gets a
+    // chance — so in practice this fixes the reported failure modes.
+    const HEADER = {
+      className: 'section',
+      variants: [
+        { begin: '^#{1,6}', end: '$', contains: CONTAINABLE },
+        {
+          begin: '(?=^(?![ \\t]*([-*+>]|#|\\d+[.)])(?:\\s|$))(?! {4}|\\t).+?\\n[=-]{2,}[ \\t]*$)',
+          contains: [
+            { begin: '^[=-]*$' },
+            { begin: '^', end: '\\n', contains: CONTAINABLE }
+          ]
+        }
+      ]
+    };
+
+    const BLOCKQUOTE = {
+      className: 'quote',
+      begin: '^>\\s+',
+      contains: CONTAINABLE,
+      end: '$'
+    };
+
+    const ENTITY = {
+      scope: 'literal',
+      match: /&([a-zA-Z0-9]+|#[0-9]{1,7}|#[Xx][0-9a-fA-F]{1,6});/
+    };
+
+    return {
+      name: 'Markdown',
+      aliases: ['md', 'mkdown', 'mkd'],
+      contains: [
+        HEADER,
+        // Fix: hljs#3719 — HORIZONTAL_RULE must come before BOLD so that a
+        // bare line of `***`/`---`/`___` is consumed as a rule, not a bold
+        // opener that swallows the rest of the document.
+        HORIZONTAL_RULE,
+        INLINE_HTML,
+        // CODE must come before BOLD/ITALIC. hljs tries each contained
+        // pattern at every scan position; whichever matches first wins. With
+        // BOLD/ITALIC ahead of CODE, `*` inside a backtick code span (e.g.
+        // `` `*_id` ``) is consumed by the italic-opener lookahead before
+        // the backtick code span is recognized — italic then bleeds across
+        // the closing backtick to end-of-line.
+        CODE,
+        LIST,
+        BOLD,
+        ITALIC,
+        BLOCKQUOTE,
+        LINK,
+        LINK_REFERENCE,
+        ENTITY
+      ]
+    };
+  });
+})();

--- a/frontend/highlight.min.js
+++ b/frontend/highlight.min.js
@@ -5025,3 +5025,267 @@ beginKeywords:"class interface",end:/\{/,excludeEnd:!0,illegal:/[:($"]/,
 contains:[{beginKeywords:"extends implements"},a]},{beginKeywords:"namespace",
 end:/;/,illegal:/[.']/,contains:[a]},{beginKeywords:"use",end:/;/,contains:[a]
 },{begin:/=>/},n,s]}}})();hljs.registerLanguage("zephir",e)})();
+/*
+ * crit-markdown-patch v1 — patched highlight.js markdown grammar.
+ *
+ * Re-registers the 'markdown' language with three upstream bug fixes:
+ *
+ *  - hljs#4279: snake_case identifiers (e.g. flutter_eval, :no_entry:, _id)
+ *    were wrongly italicized because the underscore variant of ITALIC/BOLD
+ *    didn't enforce intraword boundaries. CommonMark requires `_` emphasis
+ *    to be preceded by non-alphanumeric on the open side and followed by
+ *    non-alphanumeric on the close side. Asterisk emphasis is unchanged.
+ *    Reference fix: highlightjs/highlight.js PR #4342 (danvk).
+ *
+ *  - hljs#3719: A bare line of `***` (or `---`, `___`) was being matched as
+ *    BOLD opener instead of HORIZONTAL_RULE because (a) HORIZONTAL_RULE's
+ *    matcher accepted any line starting with 3+ `-`/`*` (substring match,
+ *    not full line) and (b) BOLD came before HORIZONTAL_RULE in contains[].
+ *    Fix: tighten HORIZONTAL_RULE to a full-line match (3+ identical
+ *    `-`, `*`, or `_` characters, optional whitespace) and put it ahead of
+ *    BOLD in the contains[] order.
+ *
+ *  - Italic/bold bleed across code spans: `` `*_id` fields — validate as
+ *    *UUID* before any database query `` was rendering with italic starting
+ *    at the `*` *inside* the backtick code span, eating the rest of the line
+ *    including the closing backtick and the intended `*UUID*`. Root cause:
+ *    in the contains[] array, BOLD/ITALIC were listed *before* CODE, so at
+ *    each scan position hljs tried italic-open first and won, never giving
+ *    the backtick code span a chance. Fix: move CODE before BOLD/ITALIC.
+ *    Plus tightened the asterisk italic/bold patterns to require a closing
+ *    delimiter on the *same line* (no `\n` in content) and to require the
+ *    content to start and end with non-whitespace, per CommonMark
+ *    left/right-flanking rules. This stops asterisk-glob patterns like
+ *    src/[two-stars]/[star].go and similar inside string literals from
+ *    opening an unterminated bold/italic run that bleeds across the line.
+ *
+ * Based on hljs 11.11.1 src/languages/markdown.js. When bumping
+ * @highlightjs/cdn-assets, re-diff this file against the upstream grammar.
+ *
+ * Sentinel: CRIT_MD_PATCH_v1 — used by tests to confirm the patch is bundled.
+ */
+(function () {
+  if (typeof hljs === 'undefined' || !hljs.registerLanguage) return;
+
+  hljs.registerLanguage('markdown', function (hljs) {
+    const regex = hljs.regex;
+
+    const INLINE_HTML = {
+      begin: /<\/?[A-Za-z_]/,
+      end: '>',
+      subLanguage: 'xml',
+      relevance: 0
+    };
+
+    // Fix: hljs#3719 — full-line match required (prevents `***`/`---`/`___`
+    // on their own line from being treated as a BOLD opener).
+    const HORIZONTAL_RULE = {
+      className: 'section',
+      match: /^[ \t]*([-*_])([ \t]*\1){2,}[ \t]*$/m
+    };
+
+    const CODE = {
+      className: 'code',
+      variants: [
+        { begin: '(`{3,})[^`](.|\\n)*?\\1`*[ ]*' },
+        { begin: '(~{3,})[^~](.|\\n)*?\\1~*[ ]*' },
+        { begin: '```', end: '```+[ ]*$' },
+        { begin: '~~~', end: '~~~+[ ]*$' },
+        { begin: '`.+?`' },
+        {
+          begin: '(?=^( {4}|\\t))',
+          contains: [
+            { begin: '^( {4}|\\t)', end: '(\\n)$' }
+          ],
+          relevance: 0
+        }
+      ]
+    };
+
+    const LIST = {
+      className: 'bullet',
+      begin: '^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)',
+      end: '\\s+',
+      excludeEnd: true
+    };
+
+    const LINK_REFERENCE = {
+      begin: /^\[[^\n]+\]:/,
+      returnBegin: true,
+      contains: [
+        { className: 'symbol', begin: /\[/, end: /\]/, excludeBegin: true, excludeEnd: true },
+        { className: 'link', begin: /:\s*/, end: /$/, excludeBegin: true }
+      ]
+    };
+
+    const URL_SCHEME = /[A-Za-z][A-Za-z0-9+.-]*/;
+    const LINK = {
+      variants: [
+        { begin: /\[.+?\]\[.*?\]/, relevance: 0 },
+        { begin: /\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/, relevance: 2 },
+        { begin: regex.concat(/\[.+?\]\(/, URL_SCHEME, /:\/\/.*?\)/), relevance: 2 },
+        { begin: /\[.+?\]\([./?&#].*?\)/, relevance: 1 },
+        { begin: /\[.*?\]\(.*?\)/, relevance: 0 }
+      ],
+      returnBegin: true,
+      contains: [
+        { match: /\[(?=\])/ },
+        { className: 'string', relevance: 0, begin: '\\[', end: '\\]', excludeBegin: true, returnEnd: true },
+        { className: 'link', relevance: 0, begin: '\\]\\(', end: '\\)', excludeBegin: true, excludeEnd: true },
+        { className: 'symbol', relevance: 0, begin: '\\]\\[', end: '\\]', excludeBegin: true, excludeEnd: true }
+      ]
+    };
+
+    // Fix: hljs#4279 — `__..__` underscore-bold must not match intraword
+    // (e.g. `snake__case`). The lookahead in `begin` requires a valid closer
+    // to exist on the same line; otherwise hljs would greedily pair the
+    // opener with end-of-line and falsely bold an unterminated identifier.
+    //
+    // Asterisk variant: also require a closer on the same line so that
+    // unclosed `**` runs (e.g. `**/*.go` inside a string literal) don't
+    // open a bold span that bleeds to end-of-line / next match. Per
+    // CommonMark, an opening `**` must be followed by a non-whitespace
+    // char (already enforced); we additionally require the closer `**`
+    // to appear on the same line (no `\n` between them).
+    const BOLD = {
+      className: 'strong',
+      contains: [], // defined later
+      variants: [
+        {
+          begin: /(?<![A-Za-z0-9])_{2}(?!\s)(?=[^\n]*_{2}(?![A-Za-z0-9]))/,
+          end: /_{2}(?![A-Za-z0-9])/
+        },
+        {
+          // Same-line closer lookahead. `[^\n]*?` is non-greedy and stops at
+          // the first `**` on the line. Without this, `"src/**/*.go"` opens a
+          // bold span and waits for any later `**` to close it.
+          begin: /\*{2}(?!\s)(?=[^\n]*?\*{2})/,
+          end: /\*{2}/
+        }
+      ]
+    };
+
+    // Fix: hljs#4279 — `_..._` underscore-italic must not match intraword
+    // (e.g. `flutter_eval`, `:no_entry:`, `_id`). Same closer-lookahead trick
+    // as BOLD: only open if a valid closer exists on this line; prevents
+    // unterminated `_id` from getting wrapped to end-of-line.
+    //
+    // Asterisk variant: require a closer on the same line, otherwise an
+    // unclosed `*` (e.g. the `*` inside `` `*_id` `` once nested-fence
+    // re-tokenization strips the backticks, or `*.go` after `/`) bleeds
+    // emphasis through the rest of the line. CommonMark allows intraword
+    // `*` (e.g. `un*frigging*believable`), so no word-boundary flank — only
+    // the same-line closer constraint and non-whitespace flanks.
+    const ITALIC = {
+      className: 'emphasis',
+      contains: [], // defined later
+      variants: [
+        {
+          // `(?<!\*)` blocks opening italic on the second `*` of a `**`
+          // sequence — without this, `"src/**/*.go"` opens italic at the
+          // second `*` (next char `/` passes `(?![*\s])`) and pairs with
+          // the later `*` in `*.go`, italicising `*/*`. With it, we never
+          // open italic mid-`**`. The `***bold italic***` case is still
+          // handled because BOLD consumes the outer `**`/`**` first
+          // (BOLD precedes ITALIC in variants, and hljs tries each variant
+          // at every position) and the inner italic opens at a position
+          // that has a non-`*` char before it.
+          // `(?![*\s])` per CommonMark: opener must be followed by
+          // non-whitespace, and we don't want it to be the start of `**`.
+          // `(?=[^\n]*?\*)` requires a closing `*` on the same line.
+          begin: /(?<!\*)\*(?![*\s])(?=[^\n]*?\*)/,
+          end: /\*/
+        },
+        {
+          begin: /(?<![A-Za-z0-9])_(?![_\s])(?=[^\n_]*_(?![A-Za-z0-9]))/,
+          end: /_(?![A-Za-z0-9])/,
+          relevance: 0
+        }
+      ]
+    };
+
+    // 3-level deep nesting is not allowed because it would create confusion
+    // in cases like `***testing***` where we don't know if the last `***`
+    // is starting a new bold/italic or finishing the last one.
+    const BOLD_WITHOUT_ITALIC = hljs.inherit(BOLD, { contains: [] });
+    const ITALIC_WITHOUT_BOLD = hljs.inherit(ITALIC, { contains: [] });
+    BOLD.contains.push(ITALIC_WITHOUT_BOLD);
+    ITALIC.contains.push(BOLD_WITHOUT_ITALIC);
+
+    let CONTAINABLE = [INLINE_HTML, LINK];
+
+    [BOLD, ITALIC, BOLD_WITHOUT_ITALIC, ITALIC_WITHOUT_BOLD].forEach(function (m) {
+      m.contains = m.contains.concat(CONTAINABLE);
+    });
+
+    CONTAINABLE = CONTAINABLE.concat(BOLD, ITALIC);
+
+    // Setext heading content MUST be a paragraph line per CommonMark §4.3 —
+    // not a list item, blockquote, ATX header, indented code block, or HR.
+    // Upstream hljs ignores this, so a YAML frontmatter block like:
+    //   ---
+    //   paths:
+    //     - "src/**/*.go"
+    //     - "internal/*.go"
+    //   ---
+    // matched the trailing `  - "internal/*.go"\n---` as a setext H2,
+    // wrapping the bullet line and the closing fence in `hljs-section`.
+    // The negative lookahead below excludes upper lines that start with
+    // common block-level markers. It does NOT cover every CommonMark case
+    // (HTML blocks, fenced code, link refs), but those are already handled
+    // by other contains[] entries that consume them before HEADER gets a
+    // chance — so in practice this fixes the reported failure modes.
+    const HEADER = {
+      className: 'section',
+      variants: [
+        { begin: '^#{1,6}', end: '$', contains: CONTAINABLE },
+        {
+          begin: '(?=^(?![ \\t]*([-*+>]|#|\\d+[.)])(?:\\s|$))(?! {4}|\\t).+?\\n[=-]{2,}[ \\t]*$)',
+          contains: [
+            { begin: '^[=-]*$' },
+            { begin: '^', end: '\\n', contains: CONTAINABLE }
+          ]
+        }
+      ]
+    };
+
+    const BLOCKQUOTE = {
+      className: 'quote',
+      begin: '^>\\s+',
+      contains: CONTAINABLE,
+      end: '$'
+    };
+
+    const ENTITY = {
+      scope: 'literal',
+      match: /&([a-zA-Z0-9]+|#[0-9]{1,7}|#[Xx][0-9a-fA-F]{1,6});/
+    };
+
+    return {
+      name: 'Markdown',
+      aliases: ['md', 'mkdown', 'mkd'],
+      contains: [
+        HEADER,
+        // Fix: hljs#3719 — HORIZONTAL_RULE must come before BOLD so that a
+        // bare line of `***`/`---`/`___` is consumed as a rule, not a bold
+        // opener that swallows the rest of the document.
+        HORIZONTAL_RULE,
+        INLINE_HTML,
+        // CODE must come before BOLD/ITALIC. hljs tries each contained
+        // pattern at every scan position; whichever matches first wins. With
+        // BOLD/ITALIC ahead of CODE, `*` inside a backtick code span (e.g.
+        // `` `*_id` ``) is consumed by the italic-opener lookahead before
+        // the backtick code span is recognized — italic then bleeds across
+        // the closing backtick to end-of-line.
+        CODE,
+        LIST,
+        BOLD,
+        ITALIC,
+        BLOCKQUOTE,
+        LINK,
+        LINK_REFERENCE,
+        ENTITY
+      ]
+    };
+  });
+})();

--- a/frontend/test-markdown-patch.mjs
+++ b/frontend/test-markdown-patch.mjs
@@ -1,0 +1,279 @@
+// Smoke test for the patched highlight.js markdown grammar.
+// Run: node frontend/test-markdown-patch.mjs
+//
+// Loads the bundled frontend/highlight.min.js in a sandboxed vm context
+// (the bundle is UMD — checks `module.exports`, `define`, then falls back
+// to `globalThis`/`window`). Then asserts known-bad inputs no longer get
+// wrong spans, and known-good inputs still get the right ones.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import vm from 'node:vm';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bundlePath = resolve(__dirname, 'highlight.min.js');
+const bundle = readFileSync(bundlePath, 'utf8');
+
+const sandbox = {};
+sandbox.window = sandbox;
+sandbox.globalThis = sandbox;
+sandbox.self = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(bundle, sandbox, { filename: 'highlight.min.js' });
+
+const hljs = sandbox.hljs || sandbox.window.hljs;
+if (!hljs) {
+  console.error('FAIL: hljs not exposed on sandbox');
+  process.exit(1);
+}
+if (!hljs.getLanguage('markdown')) {
+  console.error('FAIL: markdown language not registered');
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+
+function check(label, input, predicate) {
+  const out = hljs.highlight(input, { language: 'markdown' }).value;
+  const ok = predicate(out);
+  const status = ok ? 'PASS' : 'FAIL';
+  if (ok) pass++; else fail++;
+  console.log(`${status}: ${label}`);
+  if (!ok) {
+    console.log('  input:    ' + JSON.stringify(input));
+    console.log('  output:   ' + out);
+  }
+}
+
+// Helpers
+const hasEmphasis = (s, frag) =>
+  s.includes(`<span class="hljs-emphasis">${frag}</span>`);
+const containsAnyEmphasisWith = (s, sub) =>
+  /<span class="hljs-emphasis">[^<]*<\/span>/.test(s) &&
+  /<span class="hljs-emphasis">([^<]*)<\/span>/g.exec(s) &&
+  Array.from(s.matchAll(/<span class="hljs-emphasis">([^<]*)<\/span>/g)).some(m => m[1].includes(sub));
+
+// --- hljs#4279: intraword underscore must NOT trigger italic ---
+check(
+  ':no_entry: should not italicize "entry"',
+  ":no_entry:\nI'm not italic.",
+  (out) => !containsAnyEmphasisWith(out, 'entry')
+);
+
+check(
+  'flutter_eval.json should not italicize "eval"',
+  'flutter_eval.json',
+  (out) => !containsAnyEmphasisWith(out, 'eval')
+);
+
+check(
+  '_id should not italicize',
+  'the _id field',
+  (out) => !/<span class="hljs-emphasis">/.test(out)
+);
+
+check(
+  'snake__case should not bold "case"',
+  'snake__case identifier',
+  (out) => !/<span class="hljs-strong">/.test(out)
+);
+
+// --- hljs#3719: bare *** line should be horizontal rule, not bold ---
+check(
+  '*** on its own line is hljs-section (rule), not hljs-strong',
+  'before\n***\nafter',
+  (out) => out.includes('<span class="hljs-section">***</span>') &&
+           !/<span class="hljs-strong">/.test(out)
+);
+
+check(
+  '--- on its own line is hljs-section (rule)',
+  'before\n---\nafter',
+  // It can match either as a rule or as a setext heading underline depending
+  // on context; both are acceptable. What we DON'T want is hljs-strong.
+  (out) => !/<span class="hljs-strong">/.test(out)
+);
+
+check(
+  '___ on its own line is hljs-section (rule), not hljs-strong',
+  'before\n___\nafter',
+  (out) => out.includes('<span class="hljs-section">___</span>') &&
+           !/<span class="hljs-strong">/.test(out)
+);
+
+// --- Regression checks: still highlight legitimate emphasis/strong ---
+check(
+  '**bold text** is still hljs-strong',
+  '**bold text**',
+  (out) => /<span class="hljs-strong">\*\*bold text\*\*<\/span>/.test(out)
+);
+
+check(
+  '*italic text* is still hljs-emphasis',
+  '*italic text*',
+  (out) => /<span class="hljs-emphasis">\*italic text\*<\/span>/.test(out)
+);
+
+check(
+  '_italic_ (whitespace-bounded) is still hljs-emphasis',
+  'this is _italic_ here',
+  (out) => /<span class="hljs-emphasis">_italic_<\/span>/.test(out)
+);
+
+check(
+  '__bold__ (whitespace-bounded) is still hljs-strong',
+  'this is __bold__ here',
+  (out) => /<span class="hljs-strong">__bold__<\/span>/.test(out)
+);
+
+// --- Italic/bold bleed across code spans (notification-plan.md screenshot) ---
+
+// `*_id` should be a code span; surrounding text must NOT be in emphasis.
+check(
+  'backtick code span containing `*_id` is wrapped in hljs-code',
+  '`*_id` fields — validate as *UUID* before any database query',
+  (out) => /<span class="hljs-code">`\*_id`<\/span>/.test(out)
+);
+
+check(
+  '"fields — validate as " (after `*_id`) is NOT inside hljs-emphasis',
+  '`*_id` fields — validate as *UUID* before any database query',
+  (out) => !containsAnyEmphasisWith(out, 'fields')
+);
+
+check(
+  '*UUID* IS still wrapped in hljs-emphasis',
+  '`*_id` fields — validate as *UUID* before any database query',
+  (out) => /<span class="hljs-emphasis">\*UUID\*<\/span>/.test(out)
+);
+
+check(
+  '" before any database query" (after *UUID*) is NOT inside hljs-emphasis',
+  '`*_id` fields — validate as *UUID* before any database query',
+  (out) => !containsAnyEmphasisWith(out, 'database query')
+);
+
+// "src/**/*.go" — neither bold nor italic should match.
+check(
+  '"src/**/*.go" produces no hljs-strong',
+  '"src/**/*.go"',
+  (out) => !/<span class="hljs-strong">/.test(out)
+);
+
+check(
+  '"src/**/*.go" produces no hljs-emphasis',
+  '"src/**/*.go"',
+  (out) => !/<span class="hljs-emphasis">/.test(out)
+);
+
+check(
+  '"internal/*.go" produces no hljs-emphasis',
+  '"internal/*.go"',
+  (out) => !/<span class="hljs-emphasis">/.test(out)
+);
+
+// Multiple code spans on one line.
+check(
+  'two backtick spans both render as hljs-code',
+  'enforce `Content-Type: application/json`; reject `text/plain`',
+  (out) => {
+    const matches = Array.from(out.matchAll(/<span class="hljs-code">`[^`]+`<\/span>/g));
+    return matches.length === 2;
+  }
+);
+
+// `Timestamps — always use *UTC*, never local time` — *UTC* is fine, the
+// rest of the line should not be italicized.
+check(
+  '*UTC* is hljs-emphasis but " never local time" is NOT',
+  'Timestamps — always use *UTC*, never local time',
+  (out) =>
+    /<span class="hljs-emphasis">\*UTC\*<\/span>/.test(out) &&
+    !containsAnyEmphasisWith(out, 'never local time')
+);
+
+// Regression: an unterminated `*` at the end of a string literal must not
+// open italic that bleeds into the rest of the file.
+check(
+  'unterminated trailing `*` does not open hljs-emphasis',
+  'first line has *no closer\nsecond line is plain',
+  (out) => !/<span class="hljs-emphasis">/.test(out)
+);
+
+check(
+  '***bold-italic*** still gets hljs-strong',
+  '***bold-italic***',
+  (out) => /<span class="hljs-strong">/.test(out)
+);
+
+// --- Setext heading must require a paragraph line, not list/HR (CommonMark §4.3) ---
+// Bug: `  - "internal/*.go"\n---` was being matched as setext H2, wrapping the
+// last bullet of YAML frontmatter and the closing `---` fence in hljs-section.
+const yamlFrontmatter = '---\npaths:\n  - "src/**/*.go"\n  - "internal/*.go"\n---';
+
+check(
+  'YAML frontmatter: opening --- is hljs-section',
+  yamlFrontmatter,
+  (out) => /^<span class="hljs-section">---<\/span>/.test(out)
+);
+
+check(
+  'YAML frontmatter: closing --- is hljs-section (HR), not part of setext heading',
+  yamlFrontmatter,
+  (out) => /<span class="hljs-section">---<\/span>$/.test(out)
+);
+
+check(
+  'YAML frontmatter: "src/**/*.go" content is NOT inside any hljs-section span',
+  yamlFrontmatter,
+  (out) => {
+    // Find all hljs-section spans; none should contain the path string.
+    const sections = Array.from(out.matchAll(/<span class="hljs-section">([\s\S]*?)<\/span>/g));
+    return sections.every(m => !m[1].includes('src/') && !m[1].includes('internal/'));
+  }
+);
+
+check(
+  'YAML frontmatter: both `  -` bullets render as hljs-bullet',
+  yamlFrontmatter,
+  (out) => {
+    const bullets = Array.from(out.matchAll(/<span class="hljs-bullet">\s*-<\/span>/g));
+    return bullets.length === 2;
+  }
+);
+
+// Regression: ATX headings still work.
+check(
+  'ATX heading `# Title` is hljs-section',
+  '# Title',
+  (out) => /<span class="hljs-section">#\s*Title<\/span>/.test(out)
+);
+
+// Regression: legitimate setext heading with paragraph line still matches.
+// (Option A keeps setext working when the upper line is a real paragraph.)
+check(
+  'legitimate setext heading `Heading\\n---` still matches as hljs-section',
+  'Heading\n---',
+  (out) => /<span class="hljs-section">/.test(out) && out.includes('Heading')
+);
+
+// Regression: list followed by paragraph break + HR still works.
+check(
+  'list + blank line + --- still produces a horizontal rule',
+  '- item\n\n---',
+  (out) =>
+    /<span class="hljs-bullet">-<\/span>/.test(out) &&
+    /<span class="hljs-section">---<\/span>/.test(out)
+);
+
+// --- Sentinel check: confirm the patch file was bundled ---
+check(
+  'patch sentinel CRIT_MD_PATCH_v1 present in bundle',
+  '',
+  () => bundle.includes('CRIT_MD_PATCH_v1')
+);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -635,3 +635,15 @@
 [data-theme="light"] .hljs-comment > .diff-word-del,
 [data-theme="light"] .hljs-formula > .diff-word-del{color:#1f2328}
 
+/* Whole-line addition rows (#dafbe1 bg): green hljs groups (#22863a) fail AA. Darken to fg-default. */
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) .addition .hljs-name,
+  html:not([data-theme]) .addition .hljs-quote,
+  html:not([data-theme]) .addition .hljs-selector-pseudo,
+  html:not([data-theme]) .addition .hljs-selector-tag{color:#1f2328}
+}
+[data-theme="light"] .addition .hljs-name,
+[data-theme="light"] .addition .hljs-quote,
+[data-theme="light"] .addition .hljs-selector-pseudo,
+[data-theme="light"] .addition .hljs-selector-tag{color:#1f2328}
+

--- a/test/test-plan-copy.md
+++ b/test/test-plan-copy.md
@@ -87,10 +87,6 @@ GET /notifications?limit=20&before=<cursor>
 
 Marks a single notification as read.
 
-### POST /notifications/read-all
-
-Marks all unread notifications as read. Rate limited to 10 requests per minute per user.
-
 ## Worker Design
 
 The delivery worker runs as a separate long-lived process. It reads from the SQS queue
@@ -146,6 +142,13 @@ signed with the user's webhook secret. Receivers should verify this before proce
 - [ ] Integration tests for the delivery pipeline
 - [ ] Runbook: how to inspect and manually retry stuck deliveries
 
+## Monitoring
+
+The worker emits structured JSON logs for every delivery attempt. Key metrics to track:
+- Delivery latency p50/p95/p99 per channel
+- Retry rate per channel
+- Permanently failed delivery rate (should be < 0.1%)
+
 ## Out of Scope
 
 - In-app real-time notifications (WebSockets / SSE) - Phase 2
@@ -160,3 +163,29 @@ signed with the user's webhook secret. Receivers should verify this before proce
 - Is there a maximum size we need to enforce on the `metadata` field? The schema is
   currently unbounded and this should be decided before the migration runs.
 - Do we need a way for users to test their webhook endpoint from the UI?
+
+## Code Standards
+
+The following rules should be saved as `.claude/rules/notification-service.md`:
+
+```markdown
+---
+paths:
+  - "src/**/*.go"
+  - "internal/*.go"
+---
+
+# Notification Service Rules
+
+## Input Validation
+
+- `*_id` fields — validate as *UUID* before any database query
+- Timestamps — always use *UTC*, never local time
+- Request bodies — enforce `Content-Type: application/json`; reject `text/plain`
+
+## Naming Conventions
+
+- REST endpoints: lowercase with hyphens (`/read-all`, not `/readAll`)
+- Database columns: `snake_case` with *descriptive* names
+- Environment variables: `SCREAMING_SNAKE_CASE`
+```


### PR DESCRIPTION
## Summary

Restores markdown syntax highlighting (#375). PR #283 disabled it because hljs's stock grammar produced cascading visual bugs on common markdown content. Rather than ship without the feature, vendor a patched grammar that overrides the upstream registration after load.

`frontend/highlight-markdown-patch.js` re-registers `markdown` with four fixes:

- **hljs#4279** — intraword underscores no longer trigger italic/bold (`snake_case`, `flutter_eval`, `:no_entry:`, `_id` stay plain). Lookbehind/lookahead enforce non-alphanumeric flanks. Asterisk variants unchanged (CommonMark allows intraword `*`).
- **hljs#3719** — bare `***`/`---`/`___` lines render as horizontal rule, not bold. Tightened to full-line match; reordered before BOLD in `contains[]`.
- **Italic bleed across code spans** — moved `CODE` ahead of `BOLD`/`ITALIC` so backtick spans are consumed first. Tightened asterisk patterns to require same-line closer + lookbehind so `**/*.go` (no closing `**`) doesn't open a runaway span.
- **Setext heading false-positives** — YAML frontmatter `---` and list-item-followed-by-`---` no longer match setext heading. Per CommonMark §4.3, setext heading text must be a paragraph (not list/blockquote/ATX/ordered-list/indented code). Tightened the upper-line lookahead.

Wired into the bundle via `copy-deps.js` (appended after upstream languages so it overrides). Markdown files are also now pre-highlighted in diff view (extends the gate at `app.js:410` and `:750`); `buildCodeLineBlocks` stays gated to `code`-only. The `lang === 'markdown'` skip guard in the markdown-it highlight callback is removed.

`frontend/test-markdown-patch.mjs` runs 30 vm-sandboxed assertions covering all four bug classes plus regression checks (`**bold**`, `*italic*`, `***bold-italic***`, ATX headings, legitimate setext, code spans). Run with `node frontend/test-markdown-patch.mjs`.

## Review

- [x] Code review: passed (4 NOTEs, 0 blockers — lookbehind compat documented, upstream tab-in-charclass quirk preserved, setext lookahead O(n) acceptable, test not yet in CI)
- [ ] Parity port to crit-web: in progress on `tomasz-tomczyk/crit-web` branch `fix/hljs-markdown-patches`

## Test plan

- [x] `make test` (`go test -race -count=1 ./...`) — passing
- [x] `node frontend/test-markdown-patch.mjs` — 30/30 passing
- [x] Manual: `make test-diff` rendered the screenshot fixture (nested `\`\`\`markdown` fence, snake_case, YAML frontmatter delimiters) cleanly
- [x] golangci-lint, ESLint (1 pre-existing warning), Stylelint, CSS-vars check — all clean via pre-commit

## Notes

- Lookbehind requires Chrome 62+/Safari 16.4+/Firefox 78+ — fine for crit's audience.
- When a future `@highlightjs/cdn-assets` bump silently changes the upstream grammar, the patch may need re-syncing. The smoke test catches that — consider wiring it into `update-deps` or CI later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)