### PR TITLE
chore: post-release audit fixes (Go backend)

### DIFF
--- a/aider_install.go
+++ b/aider_install.go
@@ -98,15 +98,6 @@ func installAiderAt(cwd, home string, force bool) error {
 	return nil
 }
 
-// writeFileMkdir writes data to path, creating parent directories as needed.
-// Use writeFileMkdirAtomic for files where a partial write would be harmful.
-func writeFileMkdir(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o644)
-}
-
 // writeFileMkdirAtomic writes data to path via a same-directory tempfile
 // followed by rename. On POSIX rename is atomic, so a crash mid-write cannot
 // leave a truncated file at path. Parent dirs are created as needed.

--- a/auth.go
+++ b/auth.go
@@ -470,13 +470,15 @@ func lazyBackfillAuthUserID(cfg *Config) {
 // clearAuthIdentity removes the cached token and user identity fields from the
 // global config. Called when the server returns 401 on a share/upsert.
 func clearAuthIdentity() {
-	_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
+	if err := saveGlobalConfig(func(m map[string]json.RawMessage) error {
 		delete(m, "auth_token")
 		delete(m, "auth_user_id")
 		delete(m, "auth_user_name")
 		delete(m, "auth_user_email")
 		return nil
-	})
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to persist credential clear: %v\n", err)
+	}
 }
 
 // errHintAlreadyShown is a sentinel error used by showLoginHint to skip

--- a/config.go
+++ b/config.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 )
 
 // Config holds all configuration values from config files.
@@ -260,11 +262,21 @@ func globalConfigPath() string {
 // It uses map[string]json.RawMessage to preserve unknown keys.
 // The apply function receives the raw map and should set or delete keys as needed.
 // The file is written with 0600 permissions since it may contain auth_token.
+//
+// A sibling lockfile (`<path>.lock`) is held with flock for the duration of the
+// read-modify-write so concurrent crit invocations (e.g. login + lazy backfill)
+// cannot lose updates. flock is released automatically when the process exits.
 func saveGlobalConfig(apply func(m map[string]json.RawMessage) error) error {
 	path := globalConfigPath()
 	if path == "" {
 		return fmt.Errorf("cannot determine home directory")
 	}
+
+	unlock, err := lockGlobalConfig(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 
 	raw := make(map[string]json.RawMessage)
 	if data, err := os.ReadFile(path); err == nil {
@@ -288,6 +300,38 @@ func saveGlobalConfig(apply func(m map[string]json.RawMessage) error) error {
 	// Critical for the global config because it holds the bearer token —
 	// a crash mid-write would otherwise truncate it.
 	return atomicWriteFile(path, data, 0o600)
+}
+
+// lockGlobalConfig acquires an exclusive flock on `<path>.lock`, mirroring the
+// pattern in acquireSessionLock. Returns an unlock func the caller must defer.
+// Retries with exponential backoff up to a 5s deadline.
+func lockGlobalConfig(path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("creating config dir: %w", err)
+	}
+	lockPath := path + ".lock"
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", lockPath, err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	backoff := 50 * time.Millisecond
+	for {
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+			return func() {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+			}, nil
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return nil, fmt.Errorf("could not acquire lock on %s within 5s", lockPath)
+		}
+		time.Sleep(backoff)
+		if backoff < 500*time.Millisecond {
+			backoff *= 2
+		}
+	}
 }
 
 // gitUserName returns the git-configured user name, or empty string on error.

--- a/github.go
+++ b/github.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 )
 
@@ -105,12 +105,26 @@ func displayName(login, name string) string {
 // `login`, so we hit /users/{login} once per unique commenter.
 type userNameCache map[string]string
 
+// fetchGHUserName is the seam used by userNameCache.lookup to resolve a login
+// to a display name via the GitHub API. Tests override this; production code
+// uses the default that shells out to `gh api`.
+var fetchGHUserName = ghAPIUserName
+
+// ghAPIUserName shells out to `gh api users/<login>` and returns the user's
+// display name (empty string if unset).
+func ghAPIUserName(login string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "api", "users/"+login, "--jq", ".name // \"\"").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // lookup returns the display name for a login, fetching from GitHub on cache
-// miss. On any error or missing name, returns login (always a valid fallback).
-//
-// Under `go test`, the network call is skipped entirely — tests that want to
-// exercise display-name resolution should pre-populate the cache before
-// invoking the merge functions.
+// miss. On any error or missing name, returns login (always a valid fallback)
+// and caches that fallback so the warning is logged at most once per login.
 func (c userNameCache) lookup(login string) string {
 	if login == "" {
 		return ""
@@ -118,18 +132,12 @@ func (c userNameCache) lookup(login string) string {
 	if cached, ok := c[login]; ok {
 		return cached
 	}
-	if testing.Testing() {
-		c[login] = login
-		return login
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "users/"+login, "--jq", ".name // \"\"").Output()
+	name, err := fetchGHUserName(login)
 	if err != nil {
+		log.Printf("warning: gh api users/%s: %v", login, err)
 		c[login] = login
 		return login
 	}
-	name := strings.TrimSpace(string(out))
 	resolved := displayName(login, name)
 	c[login] = resolved
 	return resolved

--- a/github_test.go
+++ b/github_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 )
 
+// Avoid shelling out to `gh` during tests. Tests that want to exercise
+// display-name resolution should pre-populate userNameCache directly.
+func init() {
+	fetchGHUserName = func(login string) (string, error) { return "", nil }
+}
+
 func TestMergeGHComments_BasicConversion(t *testing.T) {
 	comments := []ghComment{
 		{

--- a/main.go
+++ b/main.go
@@ -156,13 +156,21 @@ func printQR(url string, showQR bool) {
 	}
 }
 
+// handleShareAuthError clears cached credentials and prints the standard
+// re-auth message to stderr when a share-related call returned 401.
+// It does NOT exit; callers decide whether to exit immediately or fall through
+// (e.g. so a subsequent generic "Error: %v" line still gets printed).
+func handleShareAuthError() {
+	clearAuthIdentity()
+	fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+}
+
 func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, sharePaths []string, authToken, fallbackAuthor string, showQR bool) {
 	localIDs := buildLocalIDSet(existingCfg)
 	localFingerprints, localFingerprintIDs := buildLocalFingerprintIndex(existingCfg)
 	if fetched, err := fetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken); err != nil {
 		if errors.Is(err, errShareUnauthorized) {
-			clearAuthIdentity()
-			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			handleShareAuthError()
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "warning: could not pull remote comments: %v\n", err)
@@ -172,13 +180,12 @@ func runShareExisting(existingCfg CritJSON, critPath string, files []shareFile, 
 		}
 	}
 
-	allComments, _ := loadCommentsForUpsert(critPath, sharePaths, fallbackAuthor)
+	allComments, _ := loadCommentsForShare(critPath, sharePaths, fallbackAuthor)
 
 	result, err := upsertShareToWeb(existingCfg, files, allComments, authToken)
 	if err != nil {
 		if errors.Is(err, errShareUnauthorized) {
-			clearAuthIdentity()
-			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			handleShareAuthError()
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -200,8 +207,7 @@ func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL,
 	res, err := shareReviewFiles(critPath, files, filePaths, svcURL, authToken, fallbackAuthor)
 	if err != nil {
 		if errors.Is(err, errShareUnauthorized) {
-			clearAuthIdentity()
-			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			handleShareAuthError()
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -211,7 +217,7 @@ func runShareNew(critPath string, files []shareFile, filePaths []string, svcURL,
 		fmt.Fprintf(os.Stderr, "Warning: could not save share state to review file: %v\n", err)
 	}
 
-	initialComments, _ := loadCommentsForUpsert(critPath, filePaths, fallbackAuthor)
+	initialComments, _ := loadCommentsForShare(critPath, filePaths, fallbackAuthor)
 	_ = updateShareState(critPath, computeShareHash(files, initialComments), res.ReviewRound)
 
 	fmt.Println(res.URL)
@@ -329,8 +335,7 @@ func runFetch(args []string) {
 	fetched, err := fetchWebComments(cj.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken)
 	if err != nil {
 		if errors.Is(err, errShareUnauthorized) {
-			clearAuthIdentity()
-			fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
+			handleShareAuthError()
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Error fetching remote comments: %v\n", err)

--- a/share.go
+++ b/share.go
@@ -249,22 +249,19 @@ func setBearer(req *http.Request, token string) {
 	}
 }
 
-// loadCommentsForShare reads the review file at critPath and returns shareComment entries
-// for the given file paths, plus the review round. Resolved comments are excluded.
+// loadCommentsForShare reads the review file at critPath and returns unresolved
+// shareComment entries for the given file paths, plus the review round.
 // fallbackAuthor is used when a comment has no Author set (typically cfg.Author).
 //
-// ExternalID is set on the initial-share path so the server persists it on first
-// insert. This is what enables the round-trip carry-forward of `user_id` on a
-// later PUT/upsert: replace_comments matches incoming attrs.external_id against
-// the existing-by-external_id map and preserves the verified user_id when the
+// ExternalID is set so the server persists it on first insert and matches it
+// on subsequent upserts. This enables round-trip carry-forward of `user_id`:
+// replace_comments matches incoming attrs.external_id against the
+// existing-by-external_id map and preserves the verified user_id when the
 // re-sharer is anonymous (rules #3/#4 of the attribution table).
+//
+// Used for both the initial share and the upsert path — they need identical
+// payloads, so they share this loader.
 func loadCommentsForShare(critPath string, filePaths []string, fallbackAuthor string) ([]shareComment, int) {
-	return loadCommentsFromCritJSON(critPath, filePaths, false, true, fallbackAuthor)
-}
-
-// loadCommentsForUpsert loads unresolved comments with ExternalID set for
-// round-trip tracking. Resolved comments are excluded — same as initial share.
-func loadCommentsForUpsert(critPath string, filePaths []string, fallbackAuthor string) ([]shareComment, int) {
 	return loadCommentsFromCritJSON(critPath, filePaths, false, true, fallbackAuthor)
 }
 

--- a/share_test.go
+++ b/share_test.go
@@ -64,7 +64,7 @@ func TestLoadCommentsForUpsert_ExcludesResolved(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, round := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 	if round != 1 {
 		t.Errorf("expected round 1, got %d", round)
 	}
@@ -93,7 +93,7 @@ func TestLoadCommentsForUpsert_SetsExternalID(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"main.go"}, "")
+	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"main.go"}, "")
 	if len(comments) != 1 {
 		t.Fatalf("expected 1 comment, got %d", len(comments))
 	}
@@ -120,7 +120,7 @@ func TestLoadCommentsForUpsert_ReviewLevelComments(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForUpsert(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
 
 	// Should have 2 comments: 1 file-level + 1 unresolved review-level
 	if len(comments) != 2 {


### PR DESCRIPTION
## Summary
Post-v0.10.1 audit fixes for the Go backend.

- **P0** auth: lock global config writes (race on `lazyBackfillAuthUserID`)
- **P0** auth: log `clearAuthIdentity` save failures instead of swallowing
- **P1** main: extract `handleShareAuthError`, dedup 4 copies (divergent exit-vs-fallthrough behavior preserved intentionally)
- **P1** share: collapse identical `loadCommentsForUpsert` into `loadCommentsForShare`
- **P1** aider_install: remove unused `writeFileMkdir`
- **P1** github: replace `testing.Testing()` with `fetchGHUserName` function-variable seam
- **P1** github: log `gh api` failures once per login (cached fallback prevents spam)

## Test plan
- [x] go vet ./...
- [x] go test ./...
- [x] make e2e-share

🤖 Generated with [Claude Code](https://claude.com/claude-code)