### PR TITLE
fix: persist verified user_id on auth login

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -92,19 +92,16 @@ func runAuthLogin(args []string) {
 		os.Exit(1)
 	}
 
-	// Cache user identity for the settings panel
-	if token.UserName != "" || token.UserEmail != "" {
-		_ = saveGlobalConfig(func(m map[string]json.RawMessage) error {
-			if token.UserName != "" {
-				name, _ := json.Marshal(token.UserName)
-				m["auth_user_name"] = name
-			}
-			if token.UserEmail != "" {
-				email, _ := json.Marshal(token.UserEmail)
-				m["auth_user_email"] = email
-			}
-			return nil
-		})
+	if err := saveAuthIdentity(token); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to persist auth identity: %v\n", err)
+	}
+
+	// If the server didn't return a user_id (older crit-web), fetch it now via
+	// /api/auth/whoami so the daemon doesn't need to backfill on first share.
+	if token.UserID == "" {
+		freshCfg := loadShareConfig()
+		freshCfg.AuthToken = token.AccessToken
+		lazyBackfillAuthUserID(&freshCfg)
 	}
 
 	greeting := "Logged in."
@@ -172,6 +169,7 @@ func requestDeviceCode(serverURL string) (deviceCodeResponse, error) {
 // tokenResponse holds a successful response from POST /api/device/token.
 type tokenResponse struct {
 	AccessToken string `json:"access_token"`
+	UserID      string `json:"user_id"`
 	UserName    string `json:"user_name"`
 	UserEmail   string `json:"user_email"`
 }
@@ -283,6 +281,28 @@ func clearSpinner(dots int) {
 	if dots > 0 {
 		fmt.Fprint(os.Stderr, "\r"+strings.Repeat(" ", dots+2)+"\r")
 	}
+}
+
+// saveAuthIdentity persists the user identity fields from a token response
+// to the global config. All three fields (auth_user_id, auth_user_name,
+// auth_user_email) are rewritten together so a stale value from a previous
+// account cannot survive a re-login: missing fields in the response remove
+// the corresponding key from disk rather than leaving it untouched.
+func saveAuthIdentity(token tokenResponse) error {
+	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		writeOrDelete := func(key, value string) {
+			if value == "" {
+				delete(m, key)
+				return
+			}
+			raw, _ := json.Marshal(value)
+			m[key] = raw
+		}
+		writeOrDelete("auth_user_id", token.UserID)
+		writeOrDelete("auth_user_name", token.UserName)
+		writeOrDelete("auth_user_email", token.UserEmail)
+		return nil
+	})
 }
 
 // saveAuthToken writes the auth_token to the global config file.

--- a/auth_test.go
+++ b/auth_test.go
@@ -726,3 +726,124 @@ func TestPollForToken_Integration(t *testing.T) {
 		t.Errorf("server received %d requests, want 3", got)
 	}
 }
+
+// TestSaveAuthIdentity_OverwritesStaleFields verifies that re-login replaces
+// every identity field, even when the new token response omits some of them.
+// This guards against the prod regression where a previous account's
+// auth_user_id survived a login as a different user, causing the daemon to
+// stamp the wrong user_id into shared comments.
+func TestSaveAuthIdentity_OverwritesStaleFields(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed config with stale identity from a previous login (different user).
+	initial := `{
+		"auth_token": "old_token",
+		"auth_user_id": "old-uuid",
+		"auth_user_name": "Old User",
+		"auth_user_email": "old@example.com"
+	}`
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// New login as a different user.
+	newToken := tokenResponse{
+		AccessToken: "new_token",
+		UserID:      "new-uuid",
+		UserName:    "New User",
+		UserEmail:   "new@example.com",
+	}
+	if err := saveAuthIdentity(newToken); err != nil {
+		t.Fatalf("saveAuthIdentity: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+
+	check := func(key, want string) {
+		t.Helper()
+		var got string
+		json.Unmarshal(raw[key], &got)
+		if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	check("auth_user_id", "new-uuid")
+	check("auth_user_name", "New User")
+	check("auth_user_email", "new@example.com")
+}
+
+// TestSaveAuthIdentity_RemovesFieldsAbsentFromResponse verifies that when the
+// server returns an empty user_id (older crit-web), the existing key is
+// removed from disk rather than silently retained — otherwise the daemon
+// would keep stamping the previous user's id forever.
+func TestSaveAuthIdentity_RemovesFieldsAbsentFromResponse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initial := `{
+		"auth_user_id": "stale-uuid",
+		"auth_user_name": "Stale User",
+		"auth_user_email": "stale@example.com"
+	}`
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Older server: only returns user_name; no user_id, no user_email.
+	if err := saveAuthIdentity(tokenResponse{
+		AccessToken: "tok",
+		UserName:    "Just Name",
+	}); err != nil {
+		t.Fatalf("saveAuthIdentity: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+
+	if _, ok := raw["auth_user_id"]; ok {
+		t.Error("auth_user_id should be removed when token response omits it")
+	}
+	if _, ok := raw["auth_user_email"]; ok {
+		t.Error("auth_user_email should be removed when token response omits it")
+	}
+	var name string
+	json.Unmarshal(raw["auth_user_name"], &name)
+	if name != "Just Name" {
+		t.Errorf("auth_user_name = %q, want Just Name", name)
+	}
+}
+
+// TestPollDeviceToken_ParsesUserID verifies the new user_id field on the
+// token response is decoded into tokenResponse.UserID.
+func TestPollDeviceToken_ParsesUserID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "crit_xyz",
+			"token_type":   "bearer",
+			"user_id":      "abc-123",
+			"user_name":    "tomasz",
+			"user_email":   "me@example.com",
+		})
+	}))
+	defer srv.Close()
+
+	result, err := pollDeviceToken(srv.URL, "dc_test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.token.UserID != "abc-123" {
+		t.Errorf("user_id = %q, want abc-123", result.token.UserID)
+	}
+	if result.token.UserEmail != "me@example.com" {
+		t.Errorf("user_email = %q, want me@example.com", result.token.UserEmail)
+	}
+}


### PR DESCRIPTION
## Summary

Two attribution bugs surfaced from a prod miss where shared comments came back with `user_id = nil` and `author_identity = "imported"` even though the user was logged in:

1. **`crit auth login` never saved `auth_user_id`** — the device-flow token response only carried `access_token`, `user_name`, `user_email`. The daemon then stamped comments with a blank user_id and the server wrote them as imported. Fixed in companion crit-web PR #141 (server now returns `user_id`); this PR consumes it.

2. **Stale identity survived re-login** — the existing code wrote `auth_user_name`/`auth_user_email` one at a time, so when a user logged in as account B after previously using account A, A's `auth_user_id` (and any field B's response omitted) stayed on disk. The payload then contained user A's id while the bearer token authenticated as user B; the server treated the mismatch as anonymous.

## Changes

- Add `UserID` to `tokenResponse`.
- Extract `saveAuthIdentity()` that rewrites all three identity fields **atomically**: missing fields delete the key on disk so a stale value cannot survive a re-login.
- Belt-and-braces: when the response omits `user_id` (older crit-web), fall through to `lazyBackfillAuthUserID()` which fetches via whoami.

## Migration

Existing logged-in users need to log out + log in to pick up the verified `user_id`. Comments authored before then stay anonymous on the server (intentional — the explicit re-login is the migration).

## Review
- [x] Code review: passed inline; new tests cover the regression
- [x] Parity audit: N/A (no frontend touched)

## Test plan
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — clean
- [x] New tests: `TestSaveAuthIdentity_OverwritesStaleFields` (the prod regression), `TestSaveAuthIdentity_RemovesFieldsAbsentFromResponse`, `TestPollDeviceToken_ParsesUserID`
- [x] Full crit↔crit-web share integration suite (`./scripts/e2e-share.sh`) — all tests pass

Follow-up: #392 (consolidate the five overlapping author/identity config fields).

See also: tomasz-tomczyk/crit-web#141 (server side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)