### PR TITLE
chore: wire markdown-patch smoke test into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,16 @@ jobs:
       - name: CSS variable validation
         run: bash scripts/check-css-vars.sh
 
+  test-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Run frontend smoke tests
+        run: node frontend/test-markdown-patch.mjs
+
   unit:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ update-deps:
 test:
 	go test ./...
 
+test-frontend:
+	node frontend/test-markdown-patch.mjs
+
 setup-hooks:
 	git config core.hooksPath .githooks
 
@@ -58,4 +61,4 @@ e2e-failed:
 e2e-report:
 	cd e2e && npx playwright show-report
 
-.PHONY: build build-all generate verify-generate update-deps test setup-hooks clean test-diff test-share-sync e2e-share test-daemon test-plan-daemon e2e e2e-failed e2e-report
+.PHONY: build build-all generate verify-generate update-deps test test-frontend setup-hooks clean test-diff test-share-sync e2e-share test-daemon test-plan-daemon e2e e2e-failed e2e-report

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "mermaid": "^11.14.0"
   },
   "scripts": {
-    "update-deps": "bun run copy-deps.js"
+    "update-deps": "bun run copy-deps.js",
+    "test:frontend": "node frontend/test-markdown-patch.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.28.0",


### PR DESCRIPTION
## Summary
- `frontend/test-markdown-patch.mjs` guards the hljs markdown grammar patch (intraword underscore, emoji shortcodes from commit 57c7a3d) but was never invoked.
- Adds `make test-frontend`, `npm run test:frontend`, and a parallel CI job (~5s, no `npm ci` needed).

## Review
- [x] Release audit + independent validation: real P2
- [x] Pre-commit checks: clean

## Test plan
- `node frontend/test-markdown-patch.mjs` → 30/30 pass locally
- New CI job runs alongside existing lint/unit/e2e jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)