### PR TITLE
ci: run nix build check on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,16 @@ jobs:
       - name: Run frontend smoke tests
         run: node frontend/test-markdown-patch.mjs
 
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Check Nix package build
+        run: ./scripts/check-nix-build.sh
+
   unit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds the `nix` job (already present in `release.yml`) to `test.yml` so it runs on every PR and push to `main`.
- Catches `vendorHash` drift the moment Go deps change, instead of at release time.

## Test plan
- [ ] CI runs the new `nix` job on this PR and passes.