### PR TITLE
fix: prefer origin/<default> as diff base over stale local branch

### DIFF
--- a/git.go
+++ b/git.go
@@ -94,6 +94,27 @@ func getDefaultBranchOverride() string {
 	return defaultBranchOverride
 }
 
+// defaultBaseRef returns the best ref to use as the diff base for the
+// auto-detected default branch. Prefers `origin/<defaultBranch>` when that
+// remote-tracking ref exists locally, otherwise falls back to the bare local
+// branch name. The remote ref is preferred because the local default branch
+// is often stale relative to upstream — leading to misleading diffs that
+// include commits already merged on the remote.
+//
+// If the user has set a base-branch override (via config or CLI), this
+// function honors it as-is, since the user has explicitly chosen a ref.
+func defaultBaseRef() string {
+	branch := DefaultBranch()
+	if getDefaultBranchOverride() != "" {
+		return branch
+	}
+	remote := "origin/" + branch
+	if exec.Command("git", "rev-parse", "--verify", "refs/remotes/"+remote).Run() == nil {
+		return remote
+	}
+	return branch
+}
+
 func detectDefaultBranch() string {
 	// Try remote HEAD first
 	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
@@ -415,8 +436,7 @@ func changedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
 }
 
 func changedFilesOnFeature() ([]FileChange, error) {
-	defaultBranch := DefaultBranch()
-	mergeBase, err := MergeBase(defaultBranch)
+	mergeBase, err := MergeBase(defaultBaseRef())
 	if err != nil {
 		// Fallback to HEAD diff if merge-base fails
 		return changedFilesOnDefault()

--- a/git_test.go
+++ b/git_test.go
@@ -525,6 +525,44 @@ func TestMergeBase_OriginMain(t *testing.T) {
 	}
 }
 
+// TestDefaultBaseRef_PrefersOrigin verifies that when origin/<defaultBranch>
+// exists, defaultBaseRef returns it instead of the bare local name. This is
+// the fix for https://github.com/tomasz-tomczyk/crit/issues/377 — auto-detect
+// should diff against the remote-tracking ref so a stale local main doesn't
+// produce a bloated diff.
+func TestDefaultBaseRef_PrefersOrigin(t *testing.T) {
+	dir := initTestRepo(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// No remote yet — should fall back to the bare local name.
+	defaultBranchOnce = sync.Once{}
+	defaultBranchResult = ""
+	if got := defaultBaseRef(); got != "main" {
+		t.Errorf("without remote: defaultBaseRef() = %q, want %q", got, "main")
+	}
+
+	// Add a remote and push so refs/remotes/origin/main exists.
+	bare := t.TempDir()
+	runGit(t, bare, "init", "--bare")
+	runGit(t, dir, "remote", "add", "origin", bare)
+	runGit(t, dir, "push", "origin", "main")
+
+	defaultBranchOnce = sync.Once{}
+	defaultBranchResult = ""
+	if got := defaultBaseRef(); got != "origin/main" {
+		t.Errorf("with remote: defaultBaseRef() = %q, want %q", got, "origin/main")
+	}
+
+	// Override should suppress remote preference — user picked the ref.
+	setDefaultBranchOverride("custom")
+	defer setDefaultBranchOverride("")
+	if got := defaultBaseRef(); got != "custom" {
+		t.Errorf("with override: defaultBaseRef() = %q, want %q", got, "custom")
+	}
+}
+
 func TestChangedFilesBranch_EmptyBaseRef(t *testing.T) {
 	dir := initTestRepo(t)
 	origDir, _ := os.Getwd()

--- a/git_vcs.go
+++ b/git_vcs.go
@@ -25,6 +25,8 @@ func (g *GitVCS) GetDefaultBranchOverride() string { return getDefaultBranchOver
 
 func (g *GitVCS) MergeBase(ref string) (string, error) { return MergeBase(ref) }
 
+func (g *GitVCS) DefaultBaseRef() string { return defaultBaseRef() }
+
 func (g *GitVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
 	return changedFilesOnDefaultInDir(dir)
 }

--- a/github.go
+++ b/github.go
@@ -819,7 +819,7 @@ func loadCritJSON(critPath string) (CritJSON, error) {
 		cfg := LoadConfig(filepath.Dir(critPath))
 		base := cfg.BaseBranch
 		if base == "" {
-			base = DefaultBranch()
+			base = defaultBaseRef()
 		}
 		baseRef, _ := MergeBase(base)
 		cj = CritJSON{

--- a/main.go
+++ b/main.go
@@ -557,7 +557,7 @@ func runPull(args []string) {
 		cfg := LoadConfig("")
 		base := cfg.BaseBranch
 		if base == "" {
-			base = DefaultBranch()
+			base = defaultBaseRef()
 		}
 		cj.BaseRef, _ = MergeBase(base)
 		cj.ReviewRound = 1

--- a/sapling.go
+++ b/sapling.go
@@ -83,6 +83,10 @@ func (s *SaplingVCS) GetDefaultBranchOverride() string {
 	return s.overrideBranch
 }
 
+// DefaultBaseRef returns the default branch as-is. Sapling has no
+// origin/<branch>-style remote tracking refs analogous to git.
+func (s *SaplingVCS) DefaultBaseRef() string { return s.DefaultBranch() }
+
 // MergeBase returns the common ancestor between the working copy and ref.
 func (s *SaplingVCS) MergeBase(ref string) (string, error) {
 	revset := fmt.Sprintf("ancestor(., %s)", ref)

--- a/session.go
+++ b/session.go
@@ -313,7 +313,7 @@ func detectVCSChanges(vcs VCS, root string, ignorePatterns []string) (branch, ba
 	branch = vcs.CurrentBranch()
 	resolvedBase = vcs.DefaultBranch()
 	if branch != resolvedBase {
-		baseRef, _ = vcs.MergeBase(resolvedBase)
+		baseRef, _ = vcs.MergeBase(vcs.DefaultBaseRef())
 	}
 
 	if baseRef != "" {
@@ -429,7 +429,7 @@ func resolveGitContext() (root, branch, baseRef, baseBranchName string, vcs VCS)
 	resolvedBase := vcs.DefaultBranch()
 	baseBranchName = resolvedBase
 	if branch != resolvedBase {
-		baseRef, _ = vcs.MergeBase(resolvedBase)
+		baseRef, _ = vcs.MergeBase(vcs.DefaultBaseRef())
 	}
 	return root, branch, baseRef, baseBranchName, vcs
 }

--- a/vcs.go
+++ b/vcs.go
@@ -33,6 +33,12 @@ type VCS interface {
 	// MergeBase returns the merge-base commit between HEAD and the given ref.
 	MergeBase(ref string) (string, error)
 
+	// DefaultBaseRef returns the best ref to use as the diff base for the
+	// auto-detected default branch. For git, prefers `origin/<branch>` when
+	// the remote-tracking ref exists locally, since the local default branch
+	// is often stale. For Sapling, returns the default branch as-is.
+	DefaultBaseRef() string
+
 	// ChangedFilesOnDefaultInDir returns changed files when on the default branch.
 	ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error)
 


### PR DESCRIPTION
## Summary
- Auto-detected default branch now uses `origin/<branch>` for merge-base when the remote-tracking ref exists, instead of the bare local name.
- Local `main` is often stale relative to `origin/main` (e.g. when feature branches are based on `origin/main` after a fetch but before a `main` fast-forward), producing diffs bloated with already-merged upstream commits.
- New `defaultBaseRef()` helper threaded through `detectVCSChanges`, `resolveGitContext`, `changedFilesOnFeature`, and the `crit pull` codepaths. The `base_branch` config override is unchanged — already accepts `origin/main`.
- VCS interface gains `DefaultBaseRef()`; Sapling backend returns the bare default (no equivalent remote convention).

Closes #377

## Review
- [x] Code review: passed (no blockers)
- [x] Parity audit: N/A (Go-only)

## Test plan
- New `TestDefaultBaseRef_PrefersOrigin` covers no-remote, with-remote, and override paths
- Existing `TestMergeBase_OriginMain` (the issue reporter's exact workflow) still passes
- Full `go test -race -count=1 ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)