### PR TITLE
feat: give review-level comments a real conceptual home

### DIFF
--- a/e2e/tests/review-comments.filemode.spec.ts
+++ b/e2e/tests/review-comments.filemode.spec.ts
@@ -10,23 +10,20 @@ test.describe('Review-level comments — File Mode', () => {
     await loadPage(page);
   });
 
-  test('G shortcut opens review comment form', async ({ page }) => {
+  test('G shortcut opens review comment form inline', async ({ page }) => {
     await page.keyboard.press('Shift+G');
 
-    const panel = page.locator('#commentsPanel');
-    await expect(panel).not.toHaveClass(/comments-panel-hidden/);
-
-    const form = page.locator('#commentsPanelBody .comment-form textarea');
+    const form = page.locator('#reviewConversation .comment-form textarea');
     await expect(form).toBeVisible();
     await expect(form).toBeFocused();
   });
 
   test('can add a review-level comment via G shortcut', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    await page.locator('#commentsPanelBody .comment-form textarea').fill('File mode general feedback');
-    await page.locator('#commentsPanelBody .comment-form .btn-primary').click();
+    await page.locator('#reviewConversation .comment-form textarea').fill('File mode general feedback');
+    await page.locator('#reviewConversation .comment-form .btn-primary').click();
 
-    const cards = page.locator('#commentsPanelBody .comment-card');
+    const cards = page.locator('#reviewConversation .comment-card');
     await expect(cards).toHaveCount(1);
     await expect(cards.first()).toContainText('File mode general feedback');
   });
@@ -35,57 +32,48 @@ test.describe('Review-level comments — File Mode', () => {
     await request.post('/api/comments', { data: { body: 'api review filemode' } });
     await loadPage(page);
 
-    // Open the comments panel
-    await page.locator('#commentCount').click();
-
-    const panel = page.locator('#commentsPanel');
-    await expect(panel).not.toHaveClass(/comments-panel-hidden/);
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(1);
-    await expect(page.locator('#commentsPanelBody .comment-card').first()).toContainText('api review filemode');
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(1);
+    await expect(page.locator('#reviewConversation .comment-card').first()).toContainText('api review filemode');
   });
 
   test('can delete review comments', async ({ page, request }) => {
     await request.post('/api/comments', { data: { body: 'to delete' } });
     await loadPage(page);
 
-    // Open the comments panel
-    await page.locator('#commentCount').click();
-
-    const card = page.locator('#commentsPanelBody .comment-card').first();
+    const card = page.locator('#reviewConversation .comment-card').first();
     await expect(card).toBeVisible();
     await card.locator('.delete-btn').click();
 
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(0);
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(0);
   });
 
-  test('Add button in panel opens form', async ({ page }) => {
-    // Open the comments panel via keyboard shortcut (no comments yet so badge not visible)
-    await page.keyboard.press('Shift+C');
-    await expect(page.locator('#commentsPanel')).not.toHaveClass(/comments-panel-hidden/);
+  test('empty state composer opens form', async ({ page }) => {
+    const empty = page.locator('.review-conversation-empty');
+    await expect(empty).toBeVisible();
+    await empty.click();
 
-    await page.locator('#panelAddCommentBtn').click();
-
-    const form = page.locator('#commentsPanelBody .comment-form textarea');
+    const form = page.locator('#reviewConversation .comment-form textarea');
     await expect(form).toBeVisible();
+    await expect(form).toBeFocused();
   });
 
   test('Escape closes review comment form', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    const textarea = page.locator('#commentsPanelBody .comment-form textarea');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
     await expect(textarea).toBeVisible();
 
     await textarea.press('Escape');
 
-    await expect(page.locator('#commentsPanelBody .comment-form')).toHaveCount(0);
+    await expect(page.locator('#reviewConversation .comment-form')).toHaveCount(0);
   });
 
   test('Ctrl+Enter submits review comment', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    const textarea = page.locator('#commentsPanelBody .comment-form textarea');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
     await textarea.fill('ctrl+enter filemode');
     await textarea.press('Control+Enter');
 
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(1);
-    await expect(page.locator('#commentsPanelBody .comment-card').first()).toContainText('ctrl+enter filemode');
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(1);
+    await expect(page.locator('#reviewConversation .comment-card').first()).toContainText('ctrl+enter filemode');
   });
 });

--- a/e2e/tests/review-comments.spec.ts
+++ b/e2e/tests/review-comments.spec.ts
@@ -4,29 +4,31 @@ import { clearAllComments, loadPage } from './helpers';
 // ============================================================
 // Review-Level (General) Comments — Git Mode
 // ============================================================
+//
+// As of the Review Conversation refactor: the compose/edit form lives in the
+// inline `#reviewConversation` section at the top of the document, not in the
+// side panel. Cards still mirror in the panel for navigation; clicking a panel
+// card scrolls to the inline section.
 test.describe('Review-level comments — Git Mode', () => {
   test.beforeEach(async ({ request, page }) => {
     await clearAllComments(request);
     await loadPage(page);
   });
 
-  test('G shortcut opens review comment form', async ({ page }) => {
+  test('G shortcut opens review comment form inline', async ({ page }) => {
     await page.keyboard.press('Shift+G');
 
-    const panel = page.locator('#commentsPanel');
-    await expect(panel).not.toHaveClass(/comments-panel-hidden/);
-
-    const form = page.locator('#commentsPanelBody .comment-form textarea');
+    const form = page.locator('#reviewConversation .comment-form textarea');
     await expect(form).toBeVisible();
     await expect(form).toBeFocused();
   });
 
   test('can add a review-level comment via G shortcut', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    await page.locator('#commentsPanelBody .comment-form textarea').fill('General feedback');
-    await page.locator('#commentsPanelBody .comment-form .btn-primary').click();
+    await page.locator('#reviewConversation .comment-form textarea').fill('General feedback');
+    await page.locator('#reviewConversation .comment-form .btn-primary').click();
 
-    const cards = page.locator('#commentsPanelBody .comment-card');
+    const cards = page.locator('#reviewConversation .comment-card');
     await expect(cards).toHaveCount(1);
     await expect(cards.first()).toContainText('General feedback');
   });
@@ -35,58 +37,49 @@ test.describe('Review-level comments — Git Mode', () => {
     await request.post('/api/comments', { data: { body: 'api review comment' } });
     await loadPage(page);
 
-    // Open the comments panel
-    await page.locator('#commentCount').click();
-
-    const panel = page.locator('#commentsPanel');
-    await expect(panel).not.toHaveClass(/comments-panel-hidden/);
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(1);
-    await expect(page.locator('#commentsPanelBody .comment-card').first()).toContainText('api review comment');
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(1);
+    await expect(page.locator('#reviewConversation .comment-card').first()).toContainText('api review comment');
   });
 
   test('can delete review comments', async ({ page, request }) => {
     await request.post('/api/comments', { data: { body: 'to delete' } });
     await loadPage(page);
 
-    // Open the comments panel
-    await page.locator('#commentCount').click();
-
-    const card = page.locator('#commentsPanelBody .comment-card').first();
+    const card = page.locator('#reviewConversation .comment-card').first();
     await expect(card).toBeVisible();
     await card.locator('.delete-btn').click();
 
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(0);
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(0);
   });
 
-  test('Add button in panel opens form', async ({ page }) => {
-    // Open the comments panel via keyboard shortcut (no comments yet so badge not visible)
-    await page.keyboard.press('Shift+C');
-    await expect(page.locator('#commentsPanel')).not.toHaveClass(/comments-panel-hidden/);
+  test('empty state composer opens form', async ({ page }) => {
+    const empty = page.locator('.review-conversation-empty');
+    await expect(empty).toBeVisible();
+    await empty.click();
 
-    await page.locator('#panelAddCommentBtn').click();
-
-    const form = page.locator('#commentsPanelBody .comment-form textarea');
+    const form = page.locator('#reviewConversation .comment-form textarea');
     await expect(form).toBeVisible();
+    await expect(form).toBeFocused();
   });
 
   test('Escape closes review comment form', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    const textarea = page.locator('#commentsPanelBody .comment-form textarea');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
     await expect(textarea).toBeVisible();
 
     await textarea.press('Escape');
 
-    await expect(page.locator('#commentsPanelBody .comment-form')).toHaveCount(0);
+    await expect(page.locator('#reviewConversation .comment-form')).toHaveCount(0);
   });
 
   test('Ctrl+Enter submits review comment', async ({ page }) => {
     await page.keyboard.press('Shift+G');
-    const textarea = page.locator('#commentsPanelBody .comment-form textarea');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
     await textarea.fill('submitted with ctrl+enter');
     await textarea.press('Control+Enter');
 
-    await expect(page.locator('#commentsPanelBody .comment-card')).toHaveCount(1);
-    await expect(page.locator('#commentsPanelBody .comment-card').first()).toContainText('submitted with ctrl+enter');
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(1);
+    await expect(page.locator('#reviewConversation .comment-card').first()).toContainText('submitted with ctrl+enter');
   });
 
   test('review comments included in comment count', async ({ page, request }) => {
@@ -101,23 +94,82 @@ test.describe('Review-level comments — Git Mode', () => {
     await request.post('/api/comments', { data: { body: 'original review' } });
     await loadPage(page);
 
-    // Open the comments panel
-    await page.locator('#commentCount').click();
-
-    const card = page.locator('#commentsPanelBody .comment-card').first();
+    const card = page.locator('#reviewConversation .comment-card').first();
     await expect(card).toBeVisible();
 
-    // Click Edit
     await card.locator('button[title="Edit"]').click();
 
-    const textarea = page.locator('#commentsPanelBody .comment-form textarea');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
     await expect(textarea).toBeVisible();
     await expect(textarea).toHaveValue('original review');
 
     await textarea.clear();
     await textarea.fill('updated review');
-    await page.locator('#commentsPanelBody .comment-form .btn-primary').click();
+    await page.locator('#reviewConversation .comment-form .btn-primary').click();
 
-    await expect(page.locator('#commentsPanelBody .comment-card .comment-body')).toContainText('updated review');
+    await expect(page.locator('#reviewConversation .comment-card .comment-body')).toContainText('updated review');
+  });
+
+  test('file tree has Review conversation row with badge', async ({ page, request }) => {
+    await request.post('/api/comments', { data: { body: 'tree row test' } });
+    await loadPage(page);
+
+    const row = page.locator('.tree-conversation-row');
+    await expect(row).toBeVisible();
+    await expect(row).toContainText('Review conversation');
+    await expect(row.locator('.tree-conversation-badge')).toHaveText('1');
+  });
+
+  test('can reply to a review-level comment', async ({ page, request }) => {
+    await request.post('/api/comments', { data: { body: 'parent thread' } });
+    await loadPage(page);
+
+    const card = page.locator('#reviewConversation .comment-card').first();
+    const replyInput = card.locator('.reply-form .reply-input');
+    await expect(replyInput).toBeVisible();
+    await replyInput.click();
+
+    const textarea = card.locator('.reply-form .reply-textarea');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('a reply');
+    await card.locator('.reply-form .btn-primary').click();
+
+    await expect(card.locator('.reply-body')).toContainText('a reply');
+  });
+
+  test('clicking a panel review-comment card navigates to and flashes the inline card', async ({ page, request }) => {
+    await request.post('/api/comments', { data: { body: 'panel navigation target' } });
+    await loadPage(page);
+
+    // Open the comments panel
+    await page.keyboard.press('Shift+C');
+    await expect(page.locator('#commentsPanel')).not.toHaveClass(/comments-panel-hidden/);
+
+    const panelCard = page.locator('#commentsPanelBody .comment-card').first();
+    await expect(panelCard).toBeVisible();
+    await panelCard.click();
+
+    // Tree row should become active and the inline card should briefly highlight
+    await expect(page.locator('.tree-conversation-row')).toHaveClass(/active/);
+    await expect(page.locator('#reviewConversation .comment-card.comment-card-highlight')).toBeVisible();
+  });
+
+  test('section can be collapsed and expanded', async ({ page, request }) => {
+    await request.post('/api/comments', { data: { body: 'a thread' } });
+    await loadPage(page);
+
+    const section = page.locator('#reviewConversation');
+    const toggle = section.locator('.review-conversation-toggle');
+
+    // Initially expanded — the thread is visible
+    await expect(section.locator('.comment-card')).toBeVisible();
+
+    await toggle.click();
+    await expect(section).toHaveClass(/collapsed/);
+    await expect(section.locator('.comment-card')).toBeHidden();
+
+    await toggle.click();
+    await expect(section).not.toHaveClass(/collapsed/);
+    await expect(section.locator('.comment-card')).toBeVisible();
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1333,10 +1333,32 @@
     tree = collapseCommonPrefixes(tree);
     const body = document.getElementById('fileTreeBody');
     body.innerHTML = '';
+
+    // Review Conversation pseudo-row sits in its own section above FILES.
+    const conversationSection = document.getElementById('treeConversationSection');
+    conversationSection.innerHTML = '';
+    conversationSection.appendChild(buildReviewConversationTreeRow());
+
     renderTreeNode(body, tree, 0, '');
 
     // Set up intersection observer for active file tracking
     setupTreeObserver();
+  }
+
+  function buildReviewConversationTreeRow() {
+    const row = document.createElement('div');
+    row.className = 'tree-conversation-row' + (activeTreePath === REVIEW_CONVERSATION_PATH ? ' active' : '');
+    row.dataset.treePath = REVIEW_CONVERSATION_PATH;
+    let inner =
+      '<span class="tree-conversation-icon">' + ICON_REVIEW_CONVERSATION + '</span>' +
+      '<span class="tree-conversation-name">Review conversation</span>';
+    const unresolved = reviewComments.filter(function(c) { return !c.resolved; }).length;
+    if (unresolved > 0) {
+      inner += '<span class="tree-conversation-badge">' + unresolved + '</span>';
+    }
+    row.innerHTML = inner;
+    row.addEventListener('click', scrollToReviewConversation);
+    return row;
   }
 
   function fileStatusIcon(status) {
@@ -1447,13 +1469,13 @@
   function updateTreeActive(filePath) {
     if (filePath === activeTreePath) return;
     activeTreePath = filePath;
-    const allFiles = document.querySelectorAll('.tree-file');
-    for (let i = 0; i < allFiles.length; i++) {
-      allFiles[i].classList.toggle('active', allFiles[i].dataset.treePath === filePath);
+    const allRows = document.querySelectorAll('.tree-file, .tree-conversation-row');
+    for (let i = 0; i < allRows.length; i++) {
+      allRows[i].classList.toggle('active', allRows[i].dataset.treePath === filePath);
     }
     // Scroll active item into view within the tree panel (manual scroll
     // to avoid scrollIntoView affecting ancestor scroll containers)
-    const activeEl = document.querySelector('.tree-file.active');
+    const activeEl = document.querySelector('.tree-file.active, .tree-conversation-row.active');
     if (activeEl) {
       const panel = document.getElementById('fileTreeBody');
       const rect = activeEl.getBoundingClientRect();
@@ -1519,7 +1541,8 @@
   function setupTreeObserver() {
     if (treeObserver) treeObserver.disconnect();
     const sections = document.querySelectorAll('.file-section[id]');
-    if (sections.length === 0) return;
+    const reviewSection = document.getElementById('reviewConversation');
+    if (sections.length === 0 && !reviewSection) return;
 
     treeObserver = new IntersectionObserver(function(entries) {
       // Skip observer updates briefly after a manual scrollToFile click
@@ -1532,13 +1555,19 @@
           const top = entries[i].boundingClientRect.top;
           if (top < bestTop) {
             bestTop = top;
-            bestPath = entries[i].target.id.replace('file-section-', '');
+            const id = entries[i].target.id;
+            bestPath = id === 'reviewConversation'
+              ? REVIEW_CONVERSATION_PATH
+              : id.replace('file-section-', '');
           }
         }
       }
       if (bestPath) updateTreeActive(bestPath);
     }, { rootMargin: '-60px 0px -70% 0px' });
 
+    if (reviewSection && !reviewSection.hidden) {
+      treeObserver.observe(reviewSection);
+    }
     for (let i = 0; i < sections.length; i++) {
       treeObserver.observe(sections[i]);
     }
@@ -1568,6 +1597,9 @@
 
     // Render mermaid diagrams
     renderMermaidBlocks();
+
+    // Render the inline Review Conversation section above filesContainer
+    renderReviewConversation();
 
     // Re-attach intersection observer for file tree active tracking
     setupTreeObserver();
@@ -4002,6 +4034,13 @@
     return { filePath, startLine, endLine, afterBlockIndex, side };
   }
 
+  function closeEmptyReviewForm() {
+    if (!reviewCommentFormActive || reviewCommentEditingId) return;
+    const ta = document.querySelector('#reviewConversation .comment-form textarea');
+    if (ta && ta.value.trim()) return;
+    cancelReviewCommentForm();
+  }
+
   function closeEmptyForms(exceptKey) {
     const toClose = [];
     activeForms.forEach(function(f) {
@@ -4026,6 +4065,7 @@
       return;
     }
     closeEmptyForms(fk);
+    closeEmptyReviewForm();
     addForm(newForm);
     activeFilePath = newForm.filePath;
     selectionStart = newForm.startLine;
@@ -4050,6 +4090,7 @@
       return;
     }
     closeEmptyForms(fk);
+    closeEmptyReviewForm();
     addForm(newForm);
     renderFileByPath(filePath);
     focusCommentTextarea(newForm.formKey);
@@ -4995,9 +5036,9 @@
       card.appendChild(pending);
     }
 
-    // Reply input
-    if (opts.showReplyInput && filePath) {
-      card.appendChild(createReplyInput(comment.id, filePath));
+    // Reply input (filePath empty/null → review-level reply)
+    if (opts.showReplyInput) {
+      card.appendChild(createReplyInput(comment.id, filePath || ''));
     }
 
     if (pendingAgentRequests.has(comment.id) || isLiveThread(comment)) {
@@ -5334,7 +5375,9 @@
       refreshFileComments(filePath);
     } else {
       await refreshReviewComments();
+      renderReviewConversation();
       renderCommentsPanel();
+      renderFileTree();
     }
   }
 
@@ -5381,6 +5424,9 @@
     reviewCommentFormActive = false;
     reviewCommentEditingId = null;
     updateCommentCount();
+    renderReviewConversation();
+    renderCommentsPanel();
+    renderFileTree();
   }
 
   async function updateReviewComment(id, body) {
@@ -5404,6 +5450,8 @@
     reviewCommentFormActive = false;
     reviewCommentEditingId = null;
     updateCommentCount();
+    renderReviewConversation();
+    renderCommentsPanel();
   }
 
   async function deleteReviewComment(id) {
@@ -5419,39 +5467,34 @@
     }
     if (navCommentId === id) navCommentId = null;
     updateCommentCount();
+    renderReviewConversation();
+    renderCommentsPanel();
+    renderFileTree();
   }
 
   function openReviewCommentForm() {
     // No-op if form is already open
     if (reviewCommentFormActive && !reviewCommentEditingId) return;
-    // Open panel if closed
-    const panel = document.getElementById('commentsPanel');
-    if (panel.classList.contains('comments-panel-hidden')) {
-      panel.classList.remove('comments-panel-hidden');
-      updateTocPosition();
-    }
+    closeEmptyForms(null);
     reviewCommentFormActive = true;
     reviewCommentEditingId = null;
+    renderReviewConversation();
     renderCommentsPanel();
-    // Focus the textarea
+    scrollToReviewConversation();
     requestAnimationFrame(function() {
-      const ta = document.querySelector('#commentsPanelBody textarea');
+      const ta = document.querySelector('#reviewConversation textarea');
       if (ta) ta.focus();
     });
   }
 
   function openReviewCommentEditForm(comment) {
-    // Open panel if closed
-    const panel = document.getElementById('commentsPanel');
-    if (panel.classList.contains('comments-panel-hidden')) {
-      panel.classList.remove('comments-panel-hidden');
-      updateTocPosition();
-    }
     reviewCommentFormActive = true;
     reviewCommentEditingId = comment.id;
+    renderReviewConversation();
     renderCommentsPanel();
+    scrollToReviewConversation();
     requestAnimationFrame(function() {
-      const ta = document.querySelector('#commentsPanelBody textarea');
+      const ta = document.querySelector('#reviewConversation textarea');
       if (ta) ta.focus();
     });
   }
@@ -5459,6 +5502,7 @@
   function cancelReviewCommentForm() {
     reviewCommentFormActive = false;
     reviewCommentEditingId = null;
+    renderReviewConversation();
     renderCommentsPanel();
   }
 
@@ -5502,6 +5546,240 @@
     updateCommentCount();
   }
 
+  // ===== Inline Review Conversation Section (top of document) =====
+
+  const REVIEW_CONVERSATION_PATH = '__review_conversation__';
+  const ICON_REVIEW_CONVERSATION =
+    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v6A1.5 1.5 0 0 1 12.5 11H8.5l-3 2.75V11H3.5A1.5 1.5 0 0 1 2 9.5Z"/>' +
+    '</svg>';
+
+  function createReviewConversationCard(comment) {
+    const isResolved = comment.resolved;
+    const cardClassExtra = [
+      isResolved ? 'resolved-card' : '',
+      comment.carried_forward ? 'carried-forward' : '',
+    ].filter(Boolean).join(' ');
+
+    const parts = buildCommentCard(comment, '', {
+      wrapperClass: 'comment-block',
+      cardClassExtra: cardClassExtra,
+      collapseDefault: isResolved,
+      showLineRef: false,
+      showCarriedForward: true,
+      showReplyInput: true,
+    });
+
+    if (isResolved) {
+      const unresolveBtn = document.createElement('button');
+      unresolveBtn.className = 'resolve-btn resolve-btn--active';
+      unresolveBtn.title = 'Unresolve';
+      unresolveBtn.setAttribute('aria-label', 'Unresolve thread');
+      unresolveBtn.innerHTML = ICON_UNRESOLVE + '<span>Unresolve</span>';
+      unresolveBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        toggleResolveStatus(comment.id, 'review', 'unresolve', null);
+      });
+      parts.actions.appendChild(unresolveBtn);
+    } else {
+      const resolveBtn = document.createElement('button');
+      resolveBtn.className = 'resolve-btn';
+      resolveBtn.title = 'Resolve';
+      resolveBtn.setAttribute('aria-label', 'Resolve thread');
+      resolveBtn.innerHTML = ICON_RESOLVE + '<span>Resolve</span>';
+      resolveBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        toggleResolveStatus(comment.id, 'review', 'resolve', null);
+      });
+      parts.actions.appendChild(resolveBtn);
+    }
+
+    const editBtn = document.createElement('button');
+    editBtn.title = 'Edit';
+    editBtn.innerHTML = ICON_EDIT;
+    editBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      openReviewCommentEditForm(comment);
+    });
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'delete-btn';
+    deleteBtn.title = 'Delete';
+    deleteBtn.innerHTML = ICON_DELETE;
+    deleteBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      deleteReviewComment(comment.id);
+    });
+    parts.actions.appendChild(editBtn);
+    parts.actions.appendChild(deleteBtn);
+
+    return parts.wrapper;
+  }
+
+  // Collapse state — host preference, persisted via cookie like other view prefs.
+  function isReviewConversationCollapsed() {
+    return getCookie('crit-review-conversation-collapsed') === '1';
+  }
+  function setReviewConversationCollapsed(collapsed) {
+    setCookie('crit-review-conversation-collapsed', collapsed ? '1' : '0');
+  }
+
+  const ICON_CHEVRON_DOWN =
+    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">' +
+    '<path d="M4 6l4 4 4-4" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+  function renderReviewConversation() {
+    const section = document.getElementById('reviewConversation');
+    if (!section) return;
+
+    // Hide entirely until session is loaded
+    if (!session || !Array.isArray(files)) {
+      section.hidden = true;
+      return;
+    }
+
+    section.hidden = false;
+    section.innerHTML = '';
+
+    // Match doc layout: file mode centers `.document-wrapper`, so we center the
+    // section too. Git mode renders file-sections full-width, so left-anchor.
+    if (session.mode === 'files') {
+      section.dataset.docLayout = 'centered';
+    } else {
+      delete section.dataset.docLayout;
+    }
+
+    const collapsed = isReviewConversationCollapsed() && !reviewCommentFormActive;
+    section.classList.toggle('collapsed', collapsed);
+
+    // Header — chevron on the left, matching `.tree-folder` and `.comment-card`
+    // collapse conventions elsewhere in the UI.
+    const header = document.createElement('div');
+    header.className = 'review-conversation-header';
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'review-conversation-toggle';
+    toggle.title = collapsed ? 'Expand review conversation' : 'Collapse review conversation';
+    toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    toggle.setAttribute('aria-label', toggle.title);
+    toggle.innerHTML = ICON_CHEVRON_DOWN;
+    toggle.addEventListener('click', function() {
+      setReviewConversationCollapsed(!isReviewConversationCollapsed());
+      renderReviewConversation();
+    });
+    header.appendChild(toggle);
+
+    const headerLabel = document.createElement('span');
+    headerLabel.className = 'icon';
+    headerLabel.innerHTML = ICON_REVIEW_CONVERSATION;
+    header.appendChild(headerLabel);
+
+    const labelText = document.createElement('span');
+    labelText.className = 'label';
+    labelText.textContent = 'Review conversation';
+    header.appendChild(labelText);
+
+    // Match the file-tree badge convention: count unresolved (the "needs attention" signal),
+    // not total. Resolved threads are visible but de-emphasised.
+    const unresolvedCount = reviewComments.filter(function(c) { return !c.resolved; }).length;
+    if (unresolvedCount > 0) {
+      const count = document.createElement('span');
+      count.className = 'count';
+      count.textContent = String(unresolvedCount);
+      header.appendChild(count);
+    }
+    section.appendChild(header);
+
+    if (collapsed) return;
+
+    const body = document.createElement('div');
+    body.className = 'review-conversation-body';
+    section.appendChild(body);
+
+    // Threads (existing comments first; the editor renders inline at the matching position)
+    for (const comment of reviewComments) {
+      if (reviewCommentEditingId === comment.id) {
+        body.appendChild(createReviewCommentEditor(comment));
+      } else {
+        body.appendChild(createReviewConversationCard(comment));
+      }
+    }
+
+    // Footer: new-comment form (when active) | "Add comment" ghost button.
+    // The same button is used for both empty and populated states.
+    if (reviewCommentFormActive && !reviewCommentEditingId) {
+      body.appendChild(createReviewCommentFormUI());
+    } else {
+      const addMore = document.createElement('button');
+      addMore.className = 'review-conversation-add-more';
+      if (reviewComments.length === 0) addMore.classList.add('review-conversation-empty');
+      addMore.type = 'button';
+      addMore.textContent = 'Add comment';
+      addMore.addEventListener('click', function() { openReviewCommentForm(); });
+      body.appendChild(addMore);
+    }
+  }
+
+  function scrollToReviewConversation() {
+    // If the user collapsed it, expand on navigate so the target is visible.
+    if (isReviewConversationCollapsed()) {
+      setReviewConversationCollapsed(false);
+      renderReviewConversation();
+    }
+    const section = document.getElementById('reviewConversation');
+    if (!section) return;
+    ignoreTreeObserverUntil = Date.now() + 200;
+    // Only scroll if the section isn't already comfortably in view —
+    // otherwise clicking the in-view "Add comment" button feels jarring.
+    const rect = section.getBoundingClientRect();
+    const headerOffset = (document.querySelector('.app-header') || {}).offsetHeight || 0;
+    if (rect.top < headerOffset || rect.top > window.innerHeight) {
+      section.scrollIntoView({ block: 'start', behavior: 'instant' });
+    }
+    updateTreeActive(REVIEW_CONVERSATION_PATH);
+  }
+
+  // Scroll to and flash a specific review-level comment card. Mirrors scrollToComment.
+  function scrollToReviewComment(commentId) {
+    if (isReviewConversationCollapsed()) {
+      setReviewConversationCollapsed(false);
+      renderReviewConversation();
+    }
+    const section = document.getElementById('reviewConversation');
+    if (!section) return;
+    const card = section.querySelector('.comment-card[data-comment-id="' + CSS.escape(commentId) + '"]');
+    if (!card) {
+      scrollToReviewConversation();
+      return;
+    }
+    ignoreTreeObserverUntil = Date.now() + 200;
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.remove('comment-card-highlight');
+    void card.offsetWidth;
+    card.classList.add('comment-card-highlight');
+    card.addEventListener('animationend', function() {
+      card.classList.remove('comment-card-highlight');
+    }, { once: true });
+    updateTreeActive(REVIEW_CONVERSATION_PATH);
+  }
+
+  // Build the URL for a reply mutation (edit or delete). filePath empty → review-level.
+  function replyMutationUrl(commentId, replyId, filePath) {
+    return filePath
+      ? '/api/comment/' + commentId + '/replies/' + replyId + '?path=' + enc(filePath)
+      : '/api/review-comment/' + commentId + '/replies/' + replyId;
+  }
+
+  async function refreshAfterReplyChange(filePath) {
+    if (filePath) {
+      refreshFileComments(filePath);
+    } else {
+      await refreshReviewComments();
+      renderReviewConversation();
+      renderCommentsPanel();
+      renderFileTree();
+    }
+  }
+
   async function editReply(commentId, replyId, filePath) {
     const replyEl = document.querySelector('[data-reply-id="' + replyId + '"]');
     if (!replyEl) return;
@@ -5530,23 +5808,24 @@
     btnRow.appendChild(cancelBtn);
     replyEl.appendChild(btnRow);
 
-    cancelBtn.addEventListener('click', () => refreshFileComments(filePath));
+    cancelBtn.addEventListener('click', () => refreshAfterReplyChange(filePath));
     saveBtn.addEventListener('click', async () => {
       const newBody = textarea.value.trim();
       if (!newBody) return;
       try {
-        await fetch('/api/comment/' + commentId + '/replies/' + replyId + '?path=' + enc(filePath), {
+        const res = await fetch(replyMutationUrl(commentId, replyId, filePath), {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ body: newBody })
         });
+        if (!res.ok) throw new Error('Server returned ' + res.status);
       } catch (err) {
         console.error('Error editing reply:', err);
         showMiniToast('Failed to edit reply');
         return;
       }
       userActedThisRound = true;
-      refreshFileComments(filePath);
+      refreshAfterReplyChange(filePath);
     });
 
     bindSubmitCancelKeys(textarea, function() { saveBtn.click(); }, function() { cancelBtn.click(); });
@@ -5554,14 +5833,15 @@
 
   async function deleteReply(commentId, replyId, filePath) {
     try {
-      await fetch('/api/comment/' + commentId + '/replies/' + replyId + '?path=' + enc(filePath), {
+      const res = await fetch(replyMutationUrl(commentId, replyId, filePath), {
         method: 'DELETE'
       });
+      if (!res.ok) throw new Error('Server returned ' + res.status);
       userActedThisRound = true;
     } catch (err) {
       console.error('Error deleting reply:', err);
     }
-    refreshFileComments(filePath);
+    refreshAfterReplyChange(filePath);
   }
 
   function createReplyInput(commentId, filePath) {
@@ -5603,6 +5883,8 @@
 
     function expand() {
       if (form.classList.contains('expanded')) return;
+      closeEmptyReviewForm();
+      closeEmptyForms(null);
       form.classList.add('expanded');
       textarea.value = input.value;
       input.replaceWith(textarea);
@@ -5645,7 +5927,10 @@
       try {
         const payload = { body: body };
         if (configAuthor) payload.author = configAuthor;
-        const res = await fetch('/api/comment/' + commentId + '/replies?path=' + enc(filePath), {
+        const url = filePath
+          ? '/api/comment/' + commentId + '/replies?path=' + enc(filePath)
+          : '/api/review-comment/' + commentId + '/replies';
+        const res = await fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
@@ -5653,25 +5938,27 @@
         if (!res.ok) throw new Error('Server returned ' + res.status);
         userActedThisRound = true;
 
-        // In live threads, also send the reply to the agent
-        const file = getFileByPath(filePath);
-        const comment = file && file.comments ? file.comments.find(function(c) { return c.id === commentId; }) : null;
-        if (comment && (isLiveThread(comment) || pendingAgentRequests.has(commentId))) {
-          pendingAgentRequests.add(commentId);
-          fetch('/api/agent/request', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ comment_id: commentId, file_path: filePath }),
-          }).catch(function(err) {
-            console.error('Error sending reply to agent:', err);
-            pendingAgentRequests.delete(commentId);
-            showMiniToast('Failed to send to agent');
-          });
+        // Live-thread agent dispatch only applies to file-scoped comments.
+        if (filePath) {
+          const file = getFileByPath(filePath);
+          const comment = file && file.comments ? file.comments.find(function(c) { return c.id === commentId; }) : null;
+          if (comment && (isLiveThread(comment) || pendingAgentRequests.has(commentId))) {
+            pendingAgentRequests.add(commentId);
+            fetch('/api/agent/request', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ comment_id: commentId, file_path: filePath }),
+            }).catch(function(err) {
+              console.error('Error sending reply to agent:', err);
+              pendingAgentRequests.delete(commentId);
+              showMiniToast('Failed to send to agent');
+            });
+          }
         }
 
         activeReplyForms.delete(commentId);
         collapse();
-        refreshFileComments(filePath);
+        refreshAfterReplyChange(filePath);
       } catch (err) {
         console.error('Failed to add reply:', err);
         showMiniToast('Failed to save reply');
@@ -5822,50 +6109,13 @@
     });
 
     if (isGeneral) {
-      // General comments: resolve/unresolve, edit, and delete
-      if (isResolved) {
-        const unresolveBtn = document.createElement('button');
-        unresolveBtn.className = 'resolve-btn resolve-btn--active';
-        unresolveBtn.title = 'Unresolve';
-        unresolveBtn.setAttribute('aria-label', 'Unresolve thread');
-        unresolveBtn.innerHTML = ICON_UNRESOLVE + '<span>Unresolve</span>';
-        unresolveBtn.addEventListener('click', function(e) {
-          e.stopPropagation();
-          toggleResolveStatus(comment.id, 'review', 'unresolve', null);
-        });
-        parts.actions.appendChild(unresolveBtn);
-      } else {
-        const resolveBtn = document.createElement('button');
-        resolveBtn.className = 'resolve-btn';
-        resolveBtn.title = 'Resolve';
-        resolveBtn.setAttribute('aria-label', 'Resolve thread');
-        resolveBtn.innerHTML = ICON_RESOLVE + '<span>Resolve</span>';
-        resolveBtn.addEventListener('click', function(e) {
-          e.stopPropagation();
-          toggleResolveStatus(comment.id, 'review', 'resolve', null);
-        });
-        parts.actions.appendChild(resolveBtn);
-      }
-      const editBtn = document.createElement('button');
-      editBtn.title = 'Edit';
-      editBtn.innerHTML = ICON_EDIT;
-      editBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        openReviewCommentEditForm(comment);
-      });
-      const deleteBtn = document.createElement('button');
-      deleteBtn.className = 'delete-btn';
-      deleteBtn.title = 'Delete';
-      deleteBtn.innerHTML = ICON_DELETE;
-      deleteBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        deleteReviewComment(comment.id);
-      });
-      parts.actions.appendChild(editBtn);
-      parts.actions.appendChild(deleteBtn);
-    }
-    // File comments are clickable to scroll to inline location
-    if (!isGeneral) {
+      // General comments are edited/resolved/deleted from the inline
+      // Review Conversation section. Panel cards navigate + flash the inline card,
+      // matching the line-comment behaviour.
+      parts.wrapper.style.cursor = 'pointer';
+      parts.wrapper.addEventListener('click', function() { scrollToReviewComment(comment.id); });
+    } else {
+      // File comments are clickable to scroll to inline location
       parts.wrapper.style.cursor = 'pointer';
       parts.wrapper.addEventListener('click', function(e) {
         // Don't scroll if clicking action buttons
@@ -5924,28 +6174,22 @@
 
     let hasComments = false;
 
-    // Render general comment compose form at the top when active
-    if (reviewCommentFormActive && !reviewCommentEditingId) {
-      body.appendChild(createReviewCommentFormUI());
-    }
-
-    // Render review-level (general) comments first
+    // Render review-level (general) comments first.
+    // Note: the compose/edit form is rendered in the inline Review Conversation
+    // section at the top of the document (see renderReviewConversation), not here.
+    // Cards in the panel are read-only mirrors that link back to the inline section.
     const visibleReviewComments = reviewComments.filter(visibleFilter);
     if (visibleReviewComments.length > 0) {
       hasComments = true;
       const group = document.createElement('div');
       group.className = 'comments-panel-file-group';
 
-      group.appendChild(createFileGroupHeader('Review', visibleReviewComments.length, group));
+      group.appendChild(createFileGroupHeader('Review conversation', visibleReviewComments.length, group));
 
       const cards = document.createElement('div');
       cards.className = 'comments-panel-file-cards';
       for (let j = 0; j < visibleReviewComments.length; j++) {
         const comment = visibleReviewComments[j];
-        if (reviewCommentEditingId === comment.id) {
-          cards.appendChild(createReviewCommentEditor(comment));
-          continue;
-        }
         cards.appendChild(createPanelCommentCard(comment, null));
       }
       group.appendChild(cards);
@@ -6261,7 +6505,6 @@
   }
 
   // ===== General Comment Button (in panel header) =====
-  document.getElementById('panelAddCommentBtn').addEventListener('click', openReviewCommentForm);
 
   // ===== Finish Review =====
   async function doFinishReview() {
@@ -7354,7 +7597,7 @@
 
   function navigateToComment(direction) {
     const panel = document.getElementById('commentsPanel');
-    const container = document.getElementById('filesContainer');
+    const container = document.querySelector('.main-content');
     const cards = Array.from(container.querySelectorAll('.comment-card')).filter(function(card) {
       return !panel || !panel.contains(card);
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,6 +104,7 @@
 
 <div class="main-layout">
   <div class="file-tree-panel" id="fileTreePanel">
+    <div class="tree-section--conversation" id="treeConversationSection"></div>
     <div class="file-tree-header">
       <span class="file-tree-title">Files</span>
       <span class="file-tree-stats" id="fileTreeStats"></span>
@@ -122,6 +123,7 @@
     <div class="file-tree-body" id="fileTreeBody"></div>
   </div>
   <div class="main-content">
+    <div id="reviewConversation" class="review-conversation" hidden></div>
     <div id="filesContainer">
       <div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>
     </div>
@@ -134,7 +136,6 @@
           <span class="comments-panel-count-badge" id="commentsPanelCountBadge">0</span>
         </div>
         <div class="comments-panel-header-actions">
-          <button class="comments-panel-add-btn" id="panelAddCommentBtn" title="Add a general comment (G)">+ Add</button>
           <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
         </div>
       </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2730,18 +2730,6 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
   align-items: center;
   gap: 8px;
 }
-.comments-panel-add-btn {
-  background: none;
-  border: 1px solid var(--crit-border);
-  color: var(--crit-editor-fg-muted);
-  cursor: pointer;
-  font-size: 11px;
-  font-weight: 500;
-  padding: 3px 8px;
-  border-radius: 4px;
-  line-height: 1;
-}
-.comments-panel-add-btn:hover { background: var(--crit-editor-bg-hover); color: var(--crit-editor-fg); border-color: var(--crit-editor-fg-muted); }
 .comments-panel-close {
   background: none;
   border: none;
@@ -4061,4 +4049,202 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+/* ===== Review Conversation (top-of-doc section) ===== */
+/* Linear-inspired: no card chrome around the container, no brand rails.
+   Hierarchy is carried by typography, rhythm, and a hairline divider in
+   the sidebar. */
+.review-conversation {
+  max-width: var(--content-width);
+  margin: 20px 24px 24px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+.review-conversation[data-doc-layout="centered"] { margin: 20px auto 24px; }
+.review-conversation.collapsed .review-conversation-body { display: none; }
+
+.review-conversation-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  user-select: none;
+}
+.review-conversation.collapsed .review-conversation-header { margin-bottom: 0; }
+.review-conversation-toggle {
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  cursor: pointer;
+  padding: 0;
+  width: 18px;
+  height: 18px;
+  margin-left: -2px;
+  border-radius: var(--crit-r-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-toggle svg { width: 12px; height: 12px; }
+.review-conversation-toggle:hover { color: var(--crit-editor-fg); }
+.review-conversation.collapsed .review-conversation-toggle { transform: rotate(-90deg); }
+.review-conversation-header .icon {
+  display: inline-flex;
+  color: var(--crit-editor-fg-muted);
+}
+.review-conversation-header .icon svg {
+  width: 13px;
+  height: 13px;
+}
+.review-conversation-header .label {
+  color: var(--crit-editor-fg);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+.review-conversation-header .count {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--crit-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  background: none;
+  padding: 0;
+  min-width: 0;
+  height: auto;
+  border-radius: 0;
+}
+
+/* Linear's "calm invitation": ghost button with a dashed plus chip that
+   becomes solid on hover. No solid border around the whole button. */
+.review-conversation-add-more {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--crit-editor-fg-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--crit-r-md);
+  padding: 7px 10px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: background var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease),
+              border-color var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-add-more::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--crit-r-sm);
+  border: 1px dashed var(--crit-border-strong);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%23646c85' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
+  transition: border-color var(--crit-dur-fast) var(--crit-ease),
+              border-style var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-add-more:hover::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%2385aaf8' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  border-style: solid;
+  border-color: var(--crit-brand);
+}
+[data-theme="light"] .review-conversation-add-more::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%238892a6' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+}
+[data-theme="light"] .review-conversation-add-more:hover::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%232960bc' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+}
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) .review-conversation-add-more::before {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%238892a6' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  }
+  html:not([data-theme]) .review-conversation-add-more:hover::before {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%232960bc' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  }
+}
+.review-conversation-add-more:hover {
+  background: var(--crit-editor-bg-hover);
+  color: var(--crit-editor-fg);
+  border-color: var(--crit-border);
+}
+
+/* Threads + form inside the section reuse the same renderers — strip the
+   line-anchored 56px gutter so they span the full section width. */
+.review-conversation .comment-block { padding: 0; margin: 0; }
+.review-conversation .comment-block + .comment-block { margin-top: 10px; }
+.review-conversation .comment-form-wrapper { padding-left: 0; }
+
+/* ===== Tree section: review-conversation row sits in its own section
+   above FILES, separated by the file-tree-header's bottom border. ===== */
+.tree-section--conversation {
+  padding: 8px 4px;
+  flex-shrink: 0;
+}
+.tree-conversation-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 28px;
+  padding: 0 10px;
+  margin: 0 4px;
+  cursor: pointer;
+  color: var(--crit-editor-fg-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--crit-r-md);
+  transition: background var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease);
+}
+.tree-conversation-row:hover {
+  background: var(--crit-editor-bg-hover);
+  color: var(--crit-editor-fg);
+}
+.tree-conversation-row.active {
+  background: var(--crit-brand-subtle);
+  color: var(--crit-editor-fg);
+}
+.tree-conversation-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  color: var(--crit-editor-fg-muted);
+  flex-shrink: 0;
+  transition: color var(--crit-dur-fast) var(--crit-ease);
+}
+.tree-conversation-row:hover .tree-conversation-icon,
+.tree-conversation-row.active .tree-conversation-icon {
+  color: var(--crit-editor-fg-secondary);
+}
+.tree-conversation-icon svg { width: 14px; height: 14px; }
+.tree-conversation-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.005em;
+}
+.tree-conversation-badge {
+  font-family: var(--crit-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  background: none;
+  padding: 0;
+}
+.tree-conversation-row.active .tree-conversation-badge {
+  color: var(--crit-brand);
 }

--- a/test/test-diff.sh
+++ b/test/test-diff.sh
@@ -492,6 +492,22 @@ curl -sf -X POST "http://127.0.0.1:$PORT/api/comment/$C4/replies?path=$ENCODED_P
     "author": "reviewer"
   }' > /dev/null
 
+# Seed a couple of review-level (general) comments to exercise the
+# Review Conversation section at the top of the document.
+curl -sf -X POST "http://127.0.0.1:$PORT/api/comments" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "body": "Overall this plan is solid but I think the scope might be too broad for a single round — could we split the SQS migration and the rate-limiting work into separate deliverables?",
+    "author": "reviewer"
+  }' > /dev/null
+
+curl -sf -X POST "http://127.0.0.1:$PORT/api/comments" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "body": "Have we looped in the on-call team about the maintenance window? They'\''ll need to know about the table swap timing.",
+    "author": "reviewer"
+  }' > /dev/null
+
 # Finish the review to write the review file
 REVIEW_FILE=$(curl -sf -X POST "http://127.0.0.1:$PORT/api/finish" | python3 -c "import json, sys; print(json.load(sys.stdin)['review_file'])")
 
@@ -589,6 +605,27 @@ curl -sf -X POST "http://127.0.0.1:$CF_GIT_PORT/api/file/comments?path=$CF_GIT_E
     "start_line": 103, "end_line": 103,
     "body": "[git-mode] Risks: should shift to 112."
   }' > /dev/null
+
+# Seed review-level comments on the git-mode carry-forward instance —
+# exercises the Review Conversation section in git mode.
+curl -sf -X POST "http://127.0.0.1:$CF_GIT_PORT/api/comments" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "body": "[git-mode] General concern: the migration plan keeps pointing at \"Postgres\" without specifying which version. Some of the partitioning syntax assumes 13+.",
+    "author": "reviewer"
+  }' > /dev/null
+
+# Pre-mark one as resolved by toggling via the resolve endpoint.
+RC_RESOLVED=$(curl -sf -X POST "http://127.0.0.1:$CF_GIT_PORT/api/comments" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "body": "[git-mode] Should we capture rollback steps as a runbook in addition to the plan? Easy to miss them under time pressure.",
+    "author": "reviewer"
+  }' | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+
+curl -sf -X PUT "http://127.0.0.1:$CF_GIT_PORT/api/review-comment/$RC_RESOLVED/resolve" \
+  -H 'Content-Type: application/json' \
+  -d '{"resolved": true}' > /dev/null
 
 curl -sf -X POST "http://127.0.0.1:$CF_GIT_PORT/api/finish" > /dev/null
 


### PR DESCRIPTION
## Summary
- Replaces the hidden "+ Add" button in the comments-panel header with a top-of-document **Review conversation** section and a sibling tree-section above FILES in the sidebar.
- Linear-inspired visual treatment: no card chrome, no rails — typography and rhythm carry the hierarchy. Shared ghost "Add comment" button across empty and populated states; auto-closes when an empty review form loses to another comment/reply form.
- Doc-anchored threads behave like line threads: replies, edit/delete, resolve, panel-card click navigates and flashes.
- Section is collapsible (cookie-backed). File mode centers the block; git mode left-anchors at the document edge.
- ] / [ navigation now picks up review-level cards too (was previously skipping them).
- Test fixtures (`test/test-diff.sh`) seed review-level comments in both file-mode and git-mode carry-forward instances; one carry-forward thread is pre-resolved.

Closes #374

## Review
- [x] Code review: passed (3 findings addressed: `]/[` nav scope, `editReply`/`deleteReply` `response.ok` checks, system-light theme variant for the `+` icon)
- [ ] Parity audit: crit-web port to follow in a separate PR

## Test plan
- [x] 20 review-comments e2e tests (git + file mode)
- [x] Adjacent regression suites: comments, multi-form, threading, comment-nav (72 tests pass)
- [x] gofmt clean, golangci-lint clean, go test -race clean
- [x] check-css-vars.sh clean (all 4 theme blocks covered)
- [x] Manual: light + dark + system themes, collapse/expand, panel navigation flash, reply auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)