### PR TITLE
test: stabilize range-mode popover tests against async render

### DIFF
--- a/e2e/tests/focus-picker.rangemode.spec.ts
+++ b/e2e/tests/focus-picker.rangemode.spec.ts
@@ -29,10 +29,12 @@ test('stack chip ✕ exit is visible in range focus', async ({ page }) => {
 test('popover lists feat-a, feat-b, feat-c', async ({ page }) => {
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
-  const popoverText = await page.locator('#stackPopover').textContent();
-  expect(popoverText).toContain('feat-a');
-  expect(popoverText).toContain('feat-b');
-  expect(popoverText).toContain('feat-c');
+  // Popover renders "Loading…" first, then re-renders with stack items
+  // after /api/picker resolves. Wait for an actual stack item before reading text.
+  await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
+  await expect(page.locator('#stackPopover')).toContainText('feat-a');
+  await expect(page.locator('#stackPopover')).toContainText('feat-b');
+  await expect(page.locator('#stackPopover')).toContainText('feat-c');
 });
 
 test('popover renders the default branch as the first entry', async ({ page }) => {
@@ -46,7 +48,13 @@ test('popover renders the default branch as the first entry', async ({ page }) =
 test('popover order is base->head (main, feat-a, feat-b, feat-c)', async ({ page }) => {
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
-  const labels = await page.locator('#stackPopover .stack-popover-item').evaluateAll((els) =>
+  // Wait for the post-/api/picker render — the initial "Loading…" view has no
+  // .stack-popover-item nodes, so reading evaluateAll too soon yields [].
+  const items = page.locator('#stackPopover .stack-popover-item');
+  await expect(items.first()).toBeVisible();
+  // 4 entries expected: main + feat-a/b/c.
+  await expect(items).toHaveCount(4);
+  const labels = await items.evaluateAll((els) =>
     els.map((el) => (el as HTMLElement).innerText.replace(/\s*\(reviewing\)\s*/i, '').replace(/\s*\(full stack\)\s*/i, '').trim())
   );
   // First entry is the default branch label.

--- a/e2e/tests/stack-popover.rangemode.spec.ts
+++ b/e2e/tests/stack-popover.rangemode.spec.ts
@@ -91,6 +91,9 @@ test('default branch is rendered ONCE (no ghost duplicate stack entry)', async (
   // default_sha so each branch appears at most once.
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
+  // Popover initially renders "Loading…"; wait for real items so allTextContents()
+  // doesn't snapshot the empty pre-fetch DOM.
+  await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
   const allLabels = await page.locator('#stackPopover .stack-popover-label').allTextContents();
   const mainCount = allLabels.filter((s) => s.trim() === 'main').length;
   expect(mainCount).toBe(1);
@@ -99,6 +102,8 @@ test('default branch is rendered ONCE (no ghost duplicate stack entry)', async (
 test('non-current entry click switches focus', async ({ page, request }) => {
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
+  // Wait for popover to finish loading before snapshotting button count.
+  await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
   // Pick the first non-default, non-current entry button.
   const buttons = page.locator('#stackPopover button.stack-popover-item:not(.stack-popover-default)');
   const count = await buttons.count();


### PR DESCRIPTION
## Summary

Two range-mode e2e tests intermittently fail in CI with `expect(labels[0]).toMatch(/main/)` receiving `undefined` — the assertion races the popover's async re-render. Surfaced on an unrelated PR (#409, pure git.go diff parsing).

**Root cause:** the stack popover renders a synchronous "Loading…" placeholder, then re-renders `.stack-popover-item` nodes only after `/api/picker` resolves (~2s on slower runners). Tests that snapshot the DOM via `evaluateAll` / `allTextContents` / `count()` immediately after clicking `#stackChipBtn` see the empty placeholder state.

**Fix:** gate the DOM reads on `.stack-popover-item` visibility before snapshotting. On the order assertion, replace the non-retrying `evaluateAll` snapshot with `toHaveCount(4)` so Playwright auto-retries until the popover settles.

Files:
- `e2e/tests/focus-picker.rangemode.spec.ts` — both failing tests (lines 29, 46)
- `e2e/tests/stack-popover.rangemode.spec.ts` — two tests with the same race

Sweep of `e2e/tests/` found no other instances: zero `waitForTimeout`, zero `networkidle`-only waits, only one `evaluateAll` (the failing one).

## Review
- [x] Code review: targeted at demonstrable flake, no over-engineering
- [x] Parity audit: N/A (e2e-only)

## Test plan
- [x] `npx playwright test focus-picker.rangemode.spec.ts stack-popover.rangemode.spec.ts --project=range-mode` → 17/17 pass locally
- [ ] Full CI e2e suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)