### PR TITLE
fix: confirm before discarding non-empty comment draft on Escape

### DIFF
--- a/e2e/tests/draft-autosave.spec.ts
+++ b/e2e/tests/draft-autosave.spec.ts
@@ -165,7 +165,8 @@ test.describe('Draft Autosave', () => {
       expect(keys.length).toBeGreaterThan(0);
     }).toPass({ timeout: 3000 });
 
-    // Press Escape
+    // Press Escape (non-empty draft prompts for confirmation)
+    page.once('dialog', (dialog) => void dialog.accept());
     await textarea.press('Escape');
 
     // Draft should be cleared

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -401,6 +401,70 @@ test.describe('Keyboard Escape Behavior', () => {
     await page.keyboard.press('Escape');
     await expect(page.locator('.kb-nav.focused')).toHaveCount(0);
   });
+
+  test('Escape on non-empty comment form prompts for confirmation', async ({ page }) => {
+    const diffRow = page.locator('.diff-split-row.kb-nav').first();
+    await expect(diffRow).toBeAttached();
+    await diffRow.hover();
+    await page.keyboard.press('c');
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeFocused();
+    await textarea.fill('important draft I do not want to lose');
+
+    // Cancel the confirm — form must stay open with content intact.
+    page.once('dialog', (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      void dialog.dismiss();
+    });
+    await textarea.press('Escape');
+    await expect(page.locator('.comment-form')).toBeVisible();
+    await expect(textarea).toHaveValue('important draft I do not want to lose');
+
+    // Accept the confirm — form should close.
+    page.once('dialog', (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      void dialog.accept();
+    });
+    await textarea.press('Escape');
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+  });
+
+  test('Cancel button on non-empty comment form discards immediately (no confirm)', async ({ page }) => {
+    const diffRow = page.locator('.diff-split-row.kb-nav').first();
+    await expect(diffRow).toBeAttached();
+    await diffRow.hover();
+    await page.keyboard.press('c');
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('draft');
+
+    // Cancel is an explicit, labeled discard action — no prompt.
+    let dialogShown = false;
+    page.once('dialog', () => { dialogShown = true; });
+
+    await page.locator('.comment-form button', { hasText: 'Cancel' }).click();
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+    expect(dialogShown).toBe(false);
+  });
+
+  test('Escape on empty comment form closes silently (no confirm)', async ({ page }) => {
+    const diffRow = page.locator('.diff-split-row.kb-nav').first();
+    await expect(diffRow).toBeAttached();
+    await diffRow.hover();
+    await page.keyboard.press('c');
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeFocused();
+
+    // If a dialog appears, the test fails (we never accept/dismiss).
+    let dialogShown = false;
+    page.once('dialog', () => { dialogShown = true; });
+
+    await textarea.press('Escape');
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+    expect(dialogShown).toBe(false);
+  });
 });
 
 // ============================================================

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4477,8 +4477,14 @@
     const doCancel = opts.onCancel
       ? function() { opts.onCancel(); }
       : function() { cancelComment(formObj); };
+    // Esc is ambiguous (could be a fat-finger), so gate it on a confirm if
+    // there's unsaved content. The Cancel button is an explicit, labeled
+    // discard action — no prompt there (matches GitHub).
+    const doCancelFromEsc = opts.onCancel
+      ? function() { if (confirmDiscardReviewCommentForm()) opts.onCancel(); }
+      : function() { if (confirmDiscardCommentForm(formObj)) cancelComment(formObj); };
 
-    bindSubmitCancelKeys(textarea, doSubmit, doCancel);
+    bindSubmitCancelKeys(textarea, doSubmit, doCancelFromEsc);
 
     if (!opts.onSubmit) {
       textarea.addEventListener('input', function() { debouncedSaveDraft(textarea.value, formObj); });
@@ -4674,6 +4680,24 @@
     updateTreeCommentBadges();
     updateCommentCount();
     return created || null;
+  }
+
+  // Returns true if it's safe to discard the form (form is empty or user
+  // confirmed). Reads the textarea live so unsaved typing is respected even
+  // before the autosave debounce fires.
+  function confirmDiscardCommentForm(formObj) {
+    if (!formObj) return true;
+    const ta = document.querySelector('.comment-form[data-form-key="' + formObj.formKey + '"] textarea');
+    const text = ta ? ta.value : (formObj.draftBody || '');
+    if (!text.trim()) return true;
+    return window.confirm('Discard comment?');
+  }
+
+  function confirmDiscardReviewCommentForm() {
+    const ta = document.querySelector('#reviewConversation .comment-form textarea');
+    const text = ta ? ta.value : '';
+    if (!text.trim()) return true;
+    return window.confirm('Discard comment?');
   }
 
   function cancelComment(formObj) {
@@ -8245,7 +8269,7 @@
         const ta = document.activeElement;
         if (ta && ta.dataset && ta.dataset.formKey) {
           const form = activeForms.find(function(f) { return f.formKey === ta.dataset.formKey; });
-          if (form) cancelComment(form);
+          if (form && confirmDiscardCommentForm(form)) cancelComment(form);
         }
       }
       return;
@@ -8430,8 +8454,13 @@
       }
       case 'Escape': {
         e.preventDefault();
-        if (reviewCommentFormActive) cancelReviewCommentForm();
-        else if (activeForms.length > 0) cancelComment(activeForms[activeForms.length - 1]);
+        if (reviewCommentFormActive) {
+          if (confirmDiscardReviewCommentForm()) cancelReviewCommentForm();
+        }
+        else if (activeForms.length > 0) {
+          const form = activeForms[activeForms.length - 1];
+          if (confirmDiscardCommentForm(form)) cancelComment(form);
+        }
         else if (selectionStart !== null) {
           const clearPath = activeFilePath;
           selectionStart = null;


### PR DESCRIPTION
## Summary
- Esc on a non-empty comment form now prompts `Discard comment?` instead of silently throwing away the draft. Empty form → silent close (unchanged).
- Cancel button discards immediately (matches GitHub).
- Ports the same behavior shipped to crit-web for parity.

## Test plan
- New e2e for Esc-with-content (accept/dismiss), Esc-empty, Cancel-button (no dialog).
- `go build` + `go test ./...` clean.
- Affected e2e suites green (keyboard / draft-autosave / templates).
- See also: tomasz-tomczyk/crit-web#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)