### PR TITLE
fix: prevent review comment form re-opening pre-populated after submit

### DIFF
--- a/e2e/tests/review-comments.spec.ts
+++ b/e2e/tests/review-comments.spec.ts
@@ -154,6 +154,18 @@ test.describe('Review-level comments — Git Mode', () => {
     await expect(page.locator('#reviewConversation .comment-card.comment-card-highlight')).toBeVisible();
   });
 
+  test('after submit, form does not re-open pre-populated with submitted text', async ({ page }) => {
+    await page.keyboard.press('Shift+G');
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
+    await textarea.fill('one-shot comment');
+    await page.locator('#reviewConversation .comment-form .btn-primary').click();
+
+    await expect(page.locator('#reviewConversation .comment-card')).toHaveCount(1);
+    // The form must not re-render itself with the just-submitted text.
+    await expect(page.locator('#reviewConversation .comment-form')).toHaveCount(0);
+    await expect(page.locator('.review-conversation-add-more')).toBeVisible();
+  });
+
   test('section can be collapsed and expanded', async ({ page, request }) => {
     await request.post('/api/comments', { data: { body: 'a thread' } });
     await loadPage(page);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5447,6 +5447,11 @@
     reviewCommentSubmitting = false;
     reviewCommentFormActive = false;
     reviewCommentEditingId = null;
+    // Clear the just-submitted textarea so renderReviewConversation's draft
+    // snapshot (line ~5670) doesn't mistake it for in-progress typing and
+    // re-open the form pre-populated with the submitted text.
+    const submittedTa = document.querySelector('#reviewConversation .comment-form[data-form-key="review:new"] textarea');
+    if (submittedTa) submittedTa.value = '';
     updateCommentCount();
     renderReviewConversation();
     renderCommentsPanel();


### PR DESCRIPTION
## Summary
- Review-level comment form was re-rendering pre-populated with the just-submitted text after a successful save, looking like the form duplicated.
- `renderReviewConversation` snapshots any non-empty `review:new` textarea as a "draft to preserve" so SSE/refresh re-renders don't blow away in-progress typing. After submit the textarea still held the submitted text, so the snapshot captured it and re-rendered the form pre-populated.
- Fix clears the `review:new` textarea explicitly in `addReviewComment` before re-rendering. Doesn't affect the editor (separate `formKey`).

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web uses state-driven `formObj.draftBody`, not a DOM-snapshot heuristic — bug doesn't apply)
- [x] Pre-commit: gofmt clean, golangci-lint 0 issues, `go test -race` PASS
- [x] Share integration tests: PASS

## Test plan
- E2E regression test added: `e2e/tests/review-comments.spec.ts` — "after submit, form does not re-open pre-populated with submitted text"
- Verified red without the fix, green with it
- Full review-comments E2E suite (14 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)