### PR TITLE
feat: resizable file-tree and comments-panel sidebars

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/e2e/tests/sidebar-resize.spec.ts
+++ b/e2e/tests/sidebar-resize.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import { addComment, clearAllComments, getMdPath, loadPage } from './helpers';
+
+// ============================================================
+// Sidebar Resize — drag handles + persistence (git mode)
+// ============================================================
+test.describe('Sidebar resize', () => {
+  test.beforeEach(async ({ request, page }) => {
+    await clearAllComments(request);
+    // Reset persisted widths between tests. Cookies hold the settings;
+    // localStorage is cleared too in case future migrations move keys there.
+    await page.context().clearCookies();
+    await page.addInitScript(() => localStorage.clear());
+  });
+
+  // Drag a handle horizontally by `dx` pixels using its current center.
+  async function dragHandle(page: Page, handle: Locator, dx: number) {
+    await handle.scrollIntoViewIfNeeded();
+    const box = (await handle.boundingBox())!;
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + dx, y, { steps: 10 });
+    await page.mouse.up();
+  }
+
+  async function widthOf(panel: Locator): Promise<number> {
+    return (await panel.boundingBox())!.width;
+  }
+
+  // Make the comments panel visible without going through the UI — sidebar
+  // tests shouldn't depend on the comment-icon click path.
+  async function showCommentsPanel(page: Page) {
+    await page.evaluate(() => {
+      document.getElementById('commentsPanel')?.classList.remove('comments-panel-hidden');
+    });
+    await expect(page.locator('#commentsPanel')).toBeVisible();
+  }
+
+  test('file tree default width is 280px when no setting saved', async ({ page }) => {
+    await loadPage(page);
+    await expect.poll(() => widthOf(page.locator('#fileTreePanel'))).toBe(280);
+  });
+
+  test('drag file-tree handle resizes panel and persists across reload', async ({ page }) => {
+    await loadPage(page);
+    const panel = page.locator('#fileTreePanel');
+    const handle = page.locator('#fileTreeResizer');
+    const before = await widthOf(panel);
+
+    await dragHandle(page, handle, 60);
+    await expect.poll(() => widthOf(panel)).toBe(before + 60);
+
+    const afterDrag = await widthOf(panel);
+    await page.reload();
+    await expect.poll(() => widthOf(panel)).toBe(afterDrag);
+  });
+
+  test('file-tree handle clamps to min 180px and grows freely beyond defaults', async ({ page }) => {
+    await loadPage(page);
+    const panel = page.locator('#fileTreePanel');
+    const handle = page.locator('#fileTreeResizer');
+
+    // Drag far left past viewport edge -> clamp at 180.
+    await dragHandle(page, handle, -5000);
+    await expect.poll(() => widthOf(panel)).toBe(180);
+
+    // From 180, drag right by 30 — verify the clamp didn't "stick" the handle.
+    await dragHandle(page, handle, 30);
+    await expect.poll(() => widthOf(panel)).toBe(210);
+
+    // No upper bound: dragging far right grows past the old 600px cap.
+    await dragHandle(page, handle, 600);
+    await expect.poll(() => widthOf(panel)).toBe(810);
+  });
+
+  test('comments-panel resizer is hidden until panel is open, hidden again when closed', async ({ page }) => {
+    await loadPage(page);
+    const handle = page.locator('#commentsPanelResizer');
+    await expect(handle).toBeHidden();
+
+    await showCommentsPanel(page);
+    await expect(handle).toBeVisible();
+
+    await page.evaluate(() => {
+      document.getElementById('commentsPanel')?.classList.add('comments-panel-hidden');
+    });
+    await expect(handle).toBeHidden();
+  });
+
+  test('drag comments-panel handle (left edge) resizes panel and persists', async ({ page }) => {
+    await loadPage(page);
+    await showCommentsPanel(page);
+    const panel = page.locator('#commentsPanel');
+    const handle = page.locator('#commentsPanelResizer');
+    const before = await widthOf(panel);
+
+    // Dragging the LEFT-edge handle leftward grows the panel.
+    await dragHandle(page, handle, -80);
+    await expect.poll(() => widthOf(panel)).toBe(before + 80);
+
+    const after = await widthOf(panel);
+    await page.reload();
+    await showCommentsPanel(page);
+    await expect.poll(() => widthOf(panel)).toBe(after);
+  });
+
+  test('both sidebar widths persist independently across reload', async ({ page }) => {
+    await loadPage(page);
+    await showCommentsPanel(page);
+    const fileTree = page.locator('#fileTreePanel');
+    const comments = page.locator('#commentsPanel');
+
+    await dragHandle(page, page.locator('#fileTreeResizer'), 40);
+    await dragHandle(page, page.locator('#commentsPanelResizer'), -50);
+
+    const ftAfter = await widthOf(fileTree);
+    const cAfter = await widthOf(comments);
+
+    await page.reload();
+    await showCommentsPanel(page);
+    await expect.poll(() => widthOf(fileTree)).toBe(ftAfter);
+    await expect.poll(() => widthOf(comments)).toBe(cAfter);
+  });
+
+  // Sanity: the user-facing path (open panel by clicking comment icon) still
+  // shows the resizer. Kept minimal — sidebar mechanics live in the tests above.
+  test('clicking comment icon opens panel and reveals its resizer', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    await addComment(request, path, 1, 'hello');
+    await loadPage(page);
+    await page.locator('.comment-count-icon').first().click();
+    await expect(page.locator('#commentsPanel')).toBeVisible();
+    await expect(page.locator('#commentsPanelResizer')).toBeVisible();
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -631,6 +631,7 @@
   async function init() {
     initTheme();
     initWidth();
+    initSidebarWidths();
 
     // Measure actual header height and set CSS variable for sticky offsets
     function updateHeaderHeight() {
@@ -7417,6 +7418,68 @@
     if (choice === 'compact') document.documentElement.setAttribute('data-width', 'compact');
     else if (choice === 'wide') document.documentElement.setAttribute('data-width', 'wide');
     else document.documentElement.setAttribute('data-width', 'default');
+  }
+
+  // ===== Sidebar Resize =====
+  // File-tree and comments-panel widths are user-resizable via drag handles.
+  // Persisted as numeric pixels in the consolidated `crit-settings` cookie;
+  // absent = use the CSS default.
+  // Only a minimum is enforced (keeps the handle reachable and the panel usable).
+  // No upper bound — ultrawide users may legitimately want very wide sidebars,
+  // and overflow just adds a horizontal scrollbar.
+  const SIDEBAR_RESIZE = [
+    { handleId: 'fileTreeResizer',     targetId: 'fileTreePanel',  settingKey: 'fileTreeWidth',     min: 180, edge: 'right' },
+    { handleId: 'commentsPanelResizer', targetId: 'commentsPanel', settingKey: 'commentsPanelWidth', min: 300, edge: 'left'  },
+  ];
+
+  function initSidebarWidths() {
+    SIDEBAR_RESIZE.forEach(function(cfg) {
+      const target = document.getElementById(cfg.targetId);
+      if (!target) return;
+      const saved = getSetting(cfg.settingKey, null);
+      if (typeof saved === 'number' && saved >= cfg.min) {
+        target.style.width = saved + 'px';
+      }
+      const handle = document.getElementById(cfg.handleId);
+      if (handle) attachSidebarResizeHandle(handle, target, cfg);
+    });
+  }
+
+  function attachSidebarResizeHandle(handle, target, cfg) {
+    // Pointer events + setPointerCapture: the handle keeps receiving move/up
+    // events even if the pointer leaves the window, devtools opens, or the
+    // user alt-tabs. Avoids the "stuck dragging" leak that document-level
+    // mousemove listeners suffer from.
+    handle.addEventListener('pointerdown', function(e) {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      handle.setPointerCapture(e.pointerId);
+      const startX = e.clientX;
+      const startWidth = target.getBoundingClientRect().width;
+      // For a left-edge handle (comments panel), dragging right shrinks the panel.
+      const dir = cfg.edge === 'left' ? -1 : 1;
+      handle.classList.add('dragging');
+      document.body.classList.add('sidebar-resizing');
+      let lastWidth = startWidth;
+
+      function onMove(ev) {
+        const delta = (ev.clientX - startX) * dir;
+        const w = Math.max(cfg.min, startWidth + delta);
+        target.style.width = w + 'px';
+        lastWidth = w;
+      }
+      function onEnd() {
+        handle.removeEventListener('pointermove', onMove);
+        handle.removeEventListener('pointerup', onEnd);
+        handle.removeEventListener('pointercancel', onEnd);
+        handle.classList.remove('dragging');
+        document.body.classList.remove('sidebar-resizing');
+        setSetting(cfg.settingKey, Math.round(lastWidth));
+      }
+      handle.addEventListener('pointermove', onMove);
+      handle.addEventListener('pointerup', onEnd);
+      handle.addEventListener('pointercancel', onEnd);
+    });
   }
 
   // ===== Update Button =====

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -134,12 +134,14 @@
     </div>
     <div class="file-tree-body" id="fileTreeBody"></div>
   </div>
+  <div class="sidebar-resize-handle" id="fileTreeResizer" aria-hidden="true"></div>
   <div class="main-content">
     <div id="reviewConversation" class="review-conversation" hidden></div>
     <div id="filesContainer">
       <div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>
     </div>
   </div>
+  <div class="sidebar-resize-handle" id="commentsPanelResizer" aria-hidden="true"></div>
   <div class="comments-panel comments-panel-hidden" id="commentsPanel">
     <div class="comments-panel-header">
       <div class="comments-panel-header-row1">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2471,6 +2471,7 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
   .header-context { display: none; }
   .base-branch-picker { display: none; }
   .file-tree-panel { display: none; }
+  .sidebar-resize-handle { display: none !important; }
   #updateBtn { display: none !important; }
   .file-header { padding: 8px 12px; }
   .file-header-toggle { display: none; }
@@ -2496,6 +2497,36 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
 .main-content {
   flex: 1;
   min-width: 0;
+}
+
+/* ===== Sidebar Resize Handles ===== */
+/* Thin draggable strip on the inner edge of each sidebar. Default transparent;
+   the brand-color line on hover/drag is the only visual affordance. Sticky so
+   it tracks the viewport vertically while pages scroll. */
+.sidebar-resize-handle {
+  flex: 0 0 4px;
+  align-self: stretch;
+  cursor: col-resize;
+  position: sticky;
+  top: var(--header-height, 49px);
+  height: calc(100vh - var(--header-height, 49px));
+  z-index: 86;
+  background: transparent;
+  transition: background 0.15s ease;
+}
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle.dragging {
+  background: var(--crit-brand);
+}
+/* Hide the comments-panel resizer when its panel is hidden. */
+.main-layout:has(#commentsPanel.comments-panel-hidden) #commentsPanelResizer {
+  display: none;
+}
+/* Suppress text selection and force resize cursor while dragging. */
+body.sidebar-resizing,
+body.sidebar-resizing * {
+  user-select: none !important;
+  cursor: col-resize !important;
 }
 
 /* ===== File Tree Sidebar ===== */


### PR DESCRIPTION
## Summary

- **Drag handles** on the inner edge of each sidebar (right edge of file-tree, left edge of comments-panel). 4px-wide flex siblings; brand-color line on hover/drag is the only visual affordance.
- **Persisted via `crit-settings`** — new `fileTreeWidth` / `commentsPanelWidth` keys in the consolidated cookie added in #418. Absent = CSS default (280px / 480px).
- **No upper bound** — only a min (180px file-tree, 300px comments) so the handle stays grabbable. Ultrawide users can grow sidebars freely; overflow yields a horizontal scrollbar.
- **Pointer events + `setPointerCapture`** for drag — survives alt-tab, devtools open, pointer-leave-window without leaking the dragging state.

Closes #403

## Review

- [x] Code review: passed (frontend-expert; one drag-interruption blocker fixed by switching from document-level mousemove to captured pointer events)
- [x] Parity audit: N/A — these sidebars are CLI-only

## Test plan

- [x] \`go build\` clean
- [x] \`gofmt -l .\` clean
- [x] \`golangci-lint run ./...\` 0 issues
- [x] Playwright (\`tests/sidebar-resize.spec.ts\`) — 7/7 pass: defaults, drag+persist (each panel, both together), min-clamp + grow-past-default, handle visibility tied to panel state, comment-icon UI path
- [x] Regression: \`file-tree\`, \`comments-panel\`, \`loading\` suites all pass (39 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)