### PR TITLE
fix: skip stack autodetect in file mode; remove CRIT_NO_AUTODETECT

### DIFF
--- a/autodetect_test.go
+++ b/autodetect_test.go
@@ -239,7 +239,7 @@ func TestAutoDetect_WorkingTreeFlag_Bypasses(t *testing.T) {
 
 	// Simulate the boot-path guard inline (avoids spinning up a session).
 	sc := &serverConfig{workingTree: true}
-	if sc.focus == nil && !sc.workingTree && os.Getenv("CRIT_NO_AUTODETECT") != "1" {
+	if sc.focus == nil && !sc.workingTree && len(sc.files) == 0 {
 		// Should be skipped — calling autoDetectStackedFocus here would fire the
 		// stub above and fail the test.
 		_ = autoDetectStackedFocus(&GitVCS{}, dir)
@@ -249,22 +249,26 @@ func TestAutoDetect_WorkingTreeFlag_Bypasses(t *testing.T) {
 	}
 }
 
-func TestAutoDetect_EnvVar_Bypasses(t *testing.T) {
+// TestAutoDetect_FileMode_Bypasses verifies that passing explicit file
+// arguments (file mode) skips autodetect entirely. Regression: PR #391
+// introduced autodetect but didn't gate it on file mode, so `crit some.md`
+// on a stacked branch was silently promoted into range mode and the file
+// argument was thrown away.
+func TestAutoDetect_FileMode_Bypasses(t *testing.T) {
 	dir, _, _ := initStackedRepo(t)
 	chdir(t, dir)
-	t.Setenv("CRIT_NO_AUTODETECT", "1")
 
 	withDetectPRInfo(t, func() *PRInfo {
-		t.Fatal("detectPRInfoFn called despite CRIT_NO_AUTODETECT=1")
+		t.Fatal("detectPRInfoFn called despite file-mode invocation")
 		return nil
 	})
 
-	sc := &serverConfig{}
-	if sc.focus == nil && !sc.workingTree && os.Getenv("CRIT_NO_AUTODETECT") != "1" {
+	sc := &serverConfig{files: []string{"some.md"}}
+	if sc.focus == nil && !sc.workingTree && len(sc.files) == 0 {
 		_ = autoDetectStackedFocus(&GitVCS{}, dir)
 	}
 	if sc.focus != nil {
-		t.Errorf("focus should remain nil under CRIT_NO_AUTODETECT=1, got %+v", sc.focus)
+		t.Errorf("focus should remain nil in file mode, got %+v", sc.focus)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1844,7 +1844,7 @@ type serverConfig struct {
 	remoteFiles bool
 
 	// workingTree forces working-tree mode regardless of stack auto-detection.
-	// Set by --working-tree or CRIT_NO_AUTODETECT=1.
+	// Set by --working-tree.
 	workingTree bool
 }
 
@@ -2081,8 +2081,8 @@ func applySessionOverrides(session *Session, sc *serverConfig) {
 	}
 	// Auto-detect stacked PR / local branch stack when no explicit focus
 	// was requested. Best-effort — any failure falls through to working-tree
-	// mode. Skipped by --working-tree or CRIT_NO_AUTODETECT=1.
-	if sc.focus == nil && !sc.workingTree && os.Getenv("CRIT_NO_AUTODETECT") != "1" {
+	// mode. Skipped in file mode or by --working-tree.
+	if sc.focus == nil && !sc.workingTree && len(sc.files) == 0 {
 		if detected := autoDetectStackedFocus(session.VCS, session.RepoRoot); detected != nil {
 			sc.focus = detected
 		}
@@ -2703,7 +2703,6 @@ Environment:
   CRIT_NO_UPDATE_CHECK        Disable update check on startup
   CRIT_AUTH_TOKEN              Override the auth token (skip login)
   CRIT_NO_INTEGRATION_CHECK   Disable integration staleness check
-  CRIT_NO_AUTODETECT          Skip auto-detection of stacked PR / branch on boot
 
 Configuration:
   Global config:   ~/.crit.config.json


### PR DESCRIPTION
## Summary
- `crit some-file.md` on a stacked branch was being silently promoted into range mode, throwing away the file argument and rebuilding the file list from a SHA range.
- Root cause: the autodetect guard in `applySessionOverrides` (added in #391) didn't check for file mode — only for `--working-tree` and the `CRIT_NO_AUTODETECT` env var.
- Fix: add `len(sc.files) == 0` to the guard so file-mode invocations skip autodetect.
- Also removes `CRIT_NO_AUTODETECT` — unused (no CI, no docs, no scripts referenced it) and redundant with `--working-tree`.

## Review
- [x] Code review: passed (Go-only, no parity/security surface)
- [x] Tests: `go test ./...` clean; `go vet`/`golangci-lint` clean
- [x] Regression test added: `TestAutoDetect_FileMode_Bypasses`

## Test plan
- [x] `crit docs/some-spec.md` from a stacked branch now opens the file (file mode), not the stack range
- [x] `crit` (no args) still autodetects the stack as before
- [x] `crit --working-tree` still bypasses autodetect

🤖 Generated with [Claude Code](https://claude.com/claude-code)