### PR TITLE
fix: route crit comment --json bulk to alt review file by reply ID

### DIFF
--- a/github.go
+++ b/github.go
@@ -1306,6 +1306,9 @@ func findReviewFileByCommentID(commentID string, excludePath string) (string, er
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("comment %q not found in any review file", commentID)
+		}
 		return "", err
 	}
 
@@ -1545,28 +1548,127 @@ func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor, globalU
 
 // bulkAddCommentsToCritJSONScoped is bulkAddCommentsToCritJSON with scope stamping
 // applied to every entry.
+//
+// Target resolution: a bulk call always writes to a single review file. If any
+// entry uses reply_to and none of the referenced IDs live in the cwd-resolved
+// primary file, the entire bulk is redirected to the alt file that contains
+// them. New comments in the same bulk ride along. If reply IDs split across
+// multiple review files (or some land in primary and others elsewhere), the
+// call is rejected — callers should split into per-file bulks.
 func bulkAddCommentsToCritJSONScoped(entries []BulkCommentEntry, globalAuthor, globalUserID string, outputDir string, scope inheritedScope) error {
 	if len(entries) == 0 {
 		return fmt.Errorf("no comment entries provided")
 	}
 
-	critPath, err := resolveReviewPath(outputDir)
+	primaryPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
 	}
 
-	cj, err := loadCritJSON(critPath)
+	primary, err := loadCritJSON(primaryPath)
+	if err != nil {
+		return err
+	}
+
+	targetPath, targetCJ, redirected, err := resolveBulkTarget(entries, primaryPath, primary)
 	if err != nil {
 		return err
 	}
 
 	for i, e := range entries {
-		if err := processBulkEntry(&cj, i, e, globalAuthor, globalUserID, scope); err != nil {
+		if err := processBulkEntry(&targetCJ, i, e, globalAuthor, globalUserID, scope); err != nil {
 			return err
 		}
 	}
 
-	return saveCritJSON(critPath, cj)
+	if err := saveCritJSON(targetPath, targetCJ); err != nil {
+		return err
+	}
+	if redirected {
+		fmt.Fprintf(os.Stderr, "Note: replies routed to %s (not the cwd-resolved review file)\n", filepath.Base(targetPath))
+	}
+	return nil
+}
+
+// resolveBulkTarget picks the single review file that this bulk call should
+// write to. Returns the path, the loaded CritJSON to mutate, and whether the
+// target differs from the cwd-resolved primary.
+func resolveBulkTarget(entries []BulkCommentEntry, primaryPath string, primary CritJSON) (string, CritJSON, bool, error) {
+	var replyIDs []string
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if e.ReplyTo == "" || seen[e.ReplyTo] {
+			continue
+		}
+		seen[e.ReplyTo] = true
+		replyIDs = append(replyIDs, e.ReplyTo)
+	}
+
+	if len(replyIDs) == 0 {
+		return primaryPath, primary, false, nil
+	}
+
+	var inPrimary, missing []string
+	for _, id := range replyIDs {
+		if cjContainsCommentID(&primary, id) {
+			inPrimary = append(inPrimary, id)
+		} else {
+			missing = append(missing, id)
+		}
+	}
+
+	if len(missing) == 0 {
+		return primaryPath, primary, false, nil
+	}
+	if len(inPrimary) > 0 {
+		return "", CritJSON{}, false, fmt.Errorf(
+			"bulk targets multiple review files: %v exist in %s, but %v do not — split into per-file bulks",
+			inPrimary, filepath.Base(primaryPath), missing,
+		)
+	}
+
+	// None in primary — every reply ID must live in the same alt file.
+	var altPath string
+	for _, id := range missing {
+		path, err := findReviewFileByCommentID(id, primaryPath)
+		if err != nil {
+			return "", CritJSON{}, false, fmt.Errorf("reply target %s: %w", id, err)
+		}
+		if altPath == "" {
+			altPath = path
+			continue
+		}
+		if path != altPath {
+			return "", CritJSON{}, false, fmt.Errorf(
+				"bulk targets multiple review files: %s in %s, %s in %s — split into per-file bulks",
+				missing[0], filepath.Base(altPath), id, filepath.Base(path),
+			)
+		}
+	}
+
+	altCJ, err := loadCritJSON(altPath)
+	if err != nil {
+		return "", CritJSON{}, false, fmt.Errorf("load %s: %w", filepath.Base(altPath), err)
+	}
+	return altPath, altCJ, true, nil
+}
+
+// cjContainsCommentID reports whether the given comment ID exists in the
+// in-memory CritJSON, across review-level and per-file comments.
+func cjContainsCommentID(cj *CritJSON, id string) bool {
+	for _, c := range cj.ReviewComments {
+		if c.ID == id {
+			return true
+		}
+	}
+	for _, cf := range cj.Files {
+		for _, c := range cf.Comments {
+			if c.ID == id {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // addReviewCommentToCritJSON adds a review-level comment to the review file.

--- a/github_test.go
+++ b/github_test.go
@@ -1322,10 +1322,146 @@ func TestBulkAddCommentsToCritJSON_EmptyEntries(t *testing.T) {
 
 func TestBulkAddCommentsToCritJSON_ReplyNotFound(t *testing.T) {
 	dir := initTestRepo(t)
+	t.Setenv("HOME", t.TempDir()) // isolate from any real ~/.crit/reviews
 	entries := []BulkCommentEntry{{ReplyTo: "c99", Body: "reply"}}
 	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found error, got: %v", err)
+	}
+}
+
+// writeAltReviewFile writes a CritJSON to ~/.crit/reviews/<name>.json under
+// the (presumed test-stubbed) HOME, returning its path. Used to set up a sibling
+// review file that the bulk fallback should discover via findReviewFileByCommentID.
+func writeAltReviewFile(t *testing.T, name string, cj CritJSON) string {
+	t.Helper()
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".crit", "reviews")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name+".json")
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBulkAddCommentsToCritJSON_RedirectsRepliesToAltFile(t *testing.T) {
+	dir := initTestRepo(t)
+	t.Setenv("HOME", t.TempDir())
+
+	altPath := writeAltReviewFile(t, "alt_review", CritJSON{
+		Files: map[string]CritJSONFile{
+			"spec.md": {Comments: []Comment{{ID: "c_spec1", StartLine: 1, EndLine: 1, Body: "original"}}},
+		},
+	})
+
+	entries := []BulkCommentEntry{
+		{ReplyTo: "c_spec1", Body: "addressed"},
+		{Body: "general note on the spec"}, // new review-level comment, rides along
+	}
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Primary (cwd-resolved) file should be untouched / empty.
+	primaryPath := filepath.Join(dir, ".crit.json")
+	if data, err := os.ReadFile(primaryPath); err == nil {
+		var cj CritJSON
+		json.Unmarshal(data, &cj)
+		for _, cf := range cj.Files {
+			if len(cf.Comments) > 0 {
+				t.Errorf("primary file should not have been modified, found %d comments", len(cf.Comments))
+			}
+		}
+		if len(cj.ReviewComments) > 0 {
+			t.Errorf("primary file should not have review comments, got %d", len(cj.ReviewComments))
+		}
+	}
+
+	// Alt file should have the reply on c_spec1 plus the new review comment.
+	altData, err := os.ReadFile(altPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var alt CritJSON
+	if err := json.Unmarshal(altData, &alt); err != nil {
+		t.Fatal(err)
+	}
+	cf := alt.Files["spec.md"]
+	if len(cf.Comments) != 1 || len(cf.Comments[0].Replies) != 1 {
+		t.Fatalf("expected 1 reply on c_spec1, got comments=%d replies=%d",
+			len(cf.Comments), len(cf.Comments[0].Replies))
+	}
+	if cf.Comments[0].Replies[0].Body != "addressed" {
+		t.Errorf("reply body = %q", cf.Comments[0].Replies[0].Body)
+	}
+	if len(alt.ReviewComments) != 1 || alt.ReviewComments[0].Body != "general note on the spec" {
+		t.Errorf("expected new review comment in alt file, got %+v", alt.ReviewComments)
+	}
+}
+
+func TestBulkAddCommentsToCritJSON_RejectsSplitTargets(t *testing.T) {
+	dir := initTestRepo(t)
+	t.Setenv("HOME", t.TempDir())
+
+	// Seed the primary (cwd) review file with a comment.
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	if err := bulkAddCommentsToCritJSON(
+		[]BulkCommentEntry{{File: "main.go", Line: 1, Body: "primary comment"}},
+		"Bot", "", dir,
+	); err != nil {
+		t.Fatal(err)
+	}
+	primaryCJ := readCritJSON(t, dir)
+	primaryCommentID := primaryCJ.Files["main.go"].Comments[0].ID
+
+	// Alt review file with a different comment ID.
+	writeAltReviewFile(t, "alt_review", CritJSON{
+		Files: map[string]CritJSONFile{
+			"spec.md": {Comments: []Comment{{ID: "c_alt1", StartLine: 1, EndLine: 1, Body: "alt"}}},
+		},
+	})
+
+	// Bulk that mixes a primary-file reply with an alt-file reply → rejected.
+	entries := []BulkCommentEntry{
+		{ReplyTo: primaryCommentID, Body: "reply to primary"},
+		{ReplyTo: "c_alt1", Body: "reply to alt"},
+	}
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	if err == nil {
+		t.Fatal("expected split-target error, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple review files") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBulkAddCommentsToCritJSON_RejectsRepliesAcrossTwoAltFiles(t *testing.T) {
+	dir := initTestRepo(t)
+	t.Setenv("HOME", t.TempDir())
+
+	writeAltReviewFile(t, "alt_one", CritJSON{
+		Files: map[string]CritJSONFile{
+			"a.md": {Comments: []Comment{{ID: "c_one", StartLine: 1, EndLine: 1, Body: "a"}}},
+		},
+	})
+	writeAltReviewFile(t, "alt_two", CritJSON{
+		Files: map[string]CritJSONFile{
+			"b.md": {Comments: []Comment{{ID: "c_two", StartLine: 1, EndLine: 1, Body: "b"}}},
+		},
+	})
+
+	entries := []BulkCommentEntry{
+		{ReplyTo: "c_one", Body: "x"},
+		{ReplyTo: "c_two", Body: "y"},
+	}
+	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	if err == nil || !strings.Contains(err.Error(), "multiple review files") {
+		t.Fatalf("expected multi-file error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

When `crit comment --json` runs from a cwd whose resolved review file doesn't contain the comment IDs being replied to, the bulk write silently lands in the wrong review file (or no-ops on missing IDs). The singular `crit comment --reply-to` path already scans `~/.crit/reviews/` for the ID via `findReviewFileByCommentID`; this extends the same defensive fallback to `--json`.

A bulk call now writes to a single target file, chosen by:
- no `reply_to` entries → cwd-resolved primary (unchanged)
- all reply IDs present in primary → primary (unchanged)
- all reply IDs converge on one alt review file under `~/.crit/reviews/` → entire bulk redirects there (new comments ride along), with a one-line stderr note
- reply IDs split across files → rejected with `bulk targets multiple review files: ...` so the caller can split the call

Also makes `findReviewFileByCommentID` return the canonical `not found in any review file` error when `~/.crit/reviews/` doesn't exist, instead of a raw `os.ReadDir` error.

## Test plan
- [x] `go test ./...` (full suite) — pass
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests cover: redirect to alt file (replies + new comments ride along), split-target rejection (primary + alt), split-target rejection (two alts), missing `~/.crit/reviews/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)