### PR TITLE
feat: distinct "Approved" state for review-finish modal

### DIFF
--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -141,6 +141,31 @@ test.describe('Markdown Comments — Git Mode', () => {
     await expect(card.locator('.comment-body')).toContainText('Updated text');
   });
 
+  test('Ctrl+Enter saves edits to a comment', async ({ page }) => {
+    const section = mdSection(page);
+
+    // Create a comment first
+    const lineBlock = section.locator('.line-block').first();
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').first().click();
+    await page.locator('.comment-form textarea').fill('Original');
+    await page.locator('.comment-form .btn-primary').click();
+    await expect(section.locator('.comment-card')).toBeVisible();
+
+    // Click Edit
+    await section.locator('.comment-actions button[title="Edit"]').click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toHaveValue('Original');
+    await textarea.fill('Edited via Ctrl+Enter');
+    await textarea.press('Control+Enter');
+
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+    await expect(card.locator('.comment-body')).toContainText('Edited via Ctrl+Enter');
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+  });
+
   test('deleting a comment removes it and updates count', async ({ page }) => {
     const section = mdSection(page);
     const countEl = page.locator('#commentCount');

--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -46,8 +46,10 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     const overlay = page.locator('#waitingOverlay');
     await expect(overlay).toHaveClass(/active/);
 
-    const message = page.locator('#waitingMessage');
-    await expect(message).toContainText('close this browser tab', { timeout: 10_000 });
+    const dialog = page.locator('#waitingDialog');
+    await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(page.locator('#waitingHeading')).toHaveText('Approved');
+    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -273,8 +273,10 @@ test.describe('Multi-Round — Frontend', () => {
     const overlay = page.locator('#waitingOverlay');
     await expect(overlay).toHaveClass(/active/);
 
-    const message = page.locator('#waitingMessage');
-    await expect(message).toContainText('close this browser tab', { timeout: 10_000 });
+    const dialog = page.locator('#waitingDialog');
+    await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(page.locator('#waitingHeading')).toHaveText('Approved');
+    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/threading.spec.ts
+++ b/e2e/tests/threading.spec.ts
@@ -165,6 +165,34 @@ test.describe('Comment Threading', () => {
     await expect(section.locator('.reply-body')).toContainText('Fixed via Ctrl+Enter');
   });
 
+  test('Ctrl+Enter saves edits to a reply', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    const comment = await addComment(request, mdPath, 1, 'Fix this');
+    await request.post(`/api/comment/${comment.id}/replies?path=${encodeURIComponent(mdPath)}`, {
+      data: { body: 'Original reply', author: 'reviewer' },
+    });
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const reply = section.locator('.comment-reply').first();
+    await expect(reply).toBeVisible();
+
+    // Hover to reveal actions, click Edit
+    await reply.hover();
+    await reply.locator('.reply-actions button[title="Edit"]').click();
+
+    const textarea = reply.locator('textarea');
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue('Original reply');
+
+    await textarea.fill('Edited reply via Ctrl+Enter');
+    await textarea.press('Control+Enter');
+
+    await expect(section.locator('.reply-body')).toContainText('Edited reply via Ctrl+Enter');
+    await expect(reply.locator('textarea')).toHaveCount(0);
+  });
+
   test('reply form Cancel collapses without submitting', async ({ page, request }) => {
     const mdPath = await getMdPath(request);
     await addComment(request, mdPath, 1, 'Check this');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6665,27 +6665,32 @@
         throw new Error('Finish review failed: HTTP ' + resp.status);
       }
       const data = await resp.json();
-      // hasComments must be false when the server says approved=true,
-      // even if a prompt is present (e.g. "All comments resolved —
-      // proceed"). Otherwise the user gets the agent-notified
-      // "waiting for updates" UX instead of the approval path.
-      const hasComments = !!data.prompt && !data.approved;
-      waitingHasComments = hasComments;
+      const approved = !!data.approved;
+      waitingHasComments = !approved;
       const prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
 
-      document.getElementById('waitingPrompt').textContent = prompt;
-
+      const dialog = document.getElementById('waitingDialog');
+      const headingEl = document.getElementById('waitingHeading');
+      const messageEl = document.getElementById('waitingMessage');
       const clipEl = document.getElementById('waitingClipboard');
+
+      document.getElementById('waitingPrompt').textContent = prompt;
       clipEl.textContent = 'Copy prompt';
       clipEl.classList.remove('clipboard-confirm');
 
-      if (hasComments) {
-        document.getElementById('waitingMessage').innerHTML =
+      // Replay the success-mark draw animation each time we enter approved state.
+      dialog.classList.remove('approved');
+      if (approved) {
+        void dialog.offsetWidth;
+        dialog.classList.add('approved');
+        headingEl.textContent = 'Approved';
+        messageEl.textContent =
+          'Your agent has been notified \u2014 no further action needed. You can close this tab whenever you\u2019re ready.';
+      } else {
+        headingEl.textContent = 'Review Complete';
+        messageEl.innerHTML =
           'Your agent has been notified. Waiting for updates\u2026' +
           '<span class="waiting-fallback">If your agent wasn\u2019t listening, paste the prompt below.</span>';
-      } else {
-        document.getElementById('waitingMessage').textContent =
-          'You can close this browser tab, or leave it open for another round.';
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch {}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -170,8 +170,12 @@
 </div>
 
 <div class="waiting-overlay" id="waitingOverlay" role="dialog" aria-modal="true" aria-labelledby="waitingHeading">
-  <div class="waiting-dialog">
+  <div class="waiting-dialog" id="waitingDialog">
     <div class="waiting-spinner" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    <svg class="success-mark" viewBox="0 0 64 64" aria-hidden="true">
+      <circle class="success-mark-ring" cx="32" cy="32" r="28"/>
+      <path class="success-mark-check" d="M19 33 L28 42 L45 23"/>
+    </svg>
     <h3 id="waitingHeading">Review Complete</h3>
     <p id="waitingMessage"></p>
     <p class="waiting-edits" id="waitingEdits"></p>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1756,6 +1756,64 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   40% { opacity: 1; transform: scale(1.2); }
 }
 
+.success-mark {
+  display: none;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 16px;
+  overflow: visible;
+}
+.success-mark-ring {
+  fill: none;
+  stroke: var(--crit-green);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-dasharray: 176;
+  stroke-dashoffset: 176;
+  transform-origin: 32px 32px;
+  transform: rotate(-90deg);
+  animation: success-ring-draw 0.55s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+.success-mark-check {
+  fill: none;
+  stroke: var(--crit-green);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 40;
+  stroke-dashoffset: 40;
+  animation: success-check-draw 0.35s cubic-bezier(0.4, 0, 0.2, 1) 0.4s forwards;
+}
+.waiting-dialog.approved .waiting-spinner { display: none; }
+.waiting-dialog.approved #waitingPrompt,
+.waiting-dialog.approved #waitingClipboard { display: none; }
+.waiting-dialog.approved .success-mark {
+  display: inline-block;
+  filter: drop-shadow(0 0 0 transparent);
+  animation: success-glow 1.6s ease-out 0.7s 1;
+}
+@keyframes success-ring-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes success-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes success-glow {
+  0%   { filter: drop-shadow(0 0 0 transparent); }
+  35%  { filter: drop-shadow(0 0 18px color-mix(in srgb, var(--crit-green) 55%, transparent)); }
+  100% { filter: drop-shadow(0 0 0 transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .success-mark-ring,
+  .success-mark-check {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+  .waiting-dialog.approved .success-mark {
+    animation: none;
+  }
+}
+
 .waiting-dialog .waiting-edits {
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- When `/api/finish` returns `approved=true`, the waiting modal now shows an animated success-mark (green ring + check), heading "Approved", and conclusive copy instead of the generic spinner. Prompt block and Copy button are hidden in that state — the prompt is still auto-copied to the clipboard so the manual-paste fallback survives silently.
- `prefers-reduced-motion` disables the draw animations.
- Waiting state (unresolved comments) is unchanged.
- Adds two regression tests for Ctrl+Enter on comment-edit and reply-edit textareas, matching the existing reply-create coverage.

## Test plan
- [ ] `make e2e` — green
- [ ] Approve a review with no comments — see success-mark + "Approved" + conclusive copy
- [ ] Finish a review with unresolved comments — modal still shows spinner + "Waiting for updates"
- [ ] Edit a top-level comment, hit Ctrl+Enter — saves
- [ ] Edit a reply, hit Ctrl+Enter — saves
- [ ] Toggle OS reduced-motion preference — animations disabled, mark still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)