### PR TITLE
refactor: bundled cleanup — wrappers, mustGetwd, browser.go, error surfacing

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func openBrowser(url string) {
+	time.Sleep(200 * time.Millisecond)
+	if tryOpenBrowser(browserCommandSpecs(runtime.GOOS, url, systemIsWSL(), commandExists), runBrowserCommand) {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Warning: could not open browser automatically; open %s manually\n", url)
+}
+
+type browserCommandSpec struct {
+	name string
+	args []string
+}
+
+func tryOpenBrowser(specs []browserCommandSpec, run func(browserCommandSpec) error) bool {
+	for _, spec := range specs {
+		if err := run(spec); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func runBrowserCommand(spec browserCommandSpec) error {
+	return exec.Command(spec.name, spec.args...).Run()
+}
+
+func browserCommandSpecs(goos, url string, isWSL bool, hasCommand func(string) bool) []browserCommandSpec {
+	switch goos {
+	case "darwin":
+		return []browserCommandSpec{{name: "open", args: []string{url}}}
+	case "linux":
+		var specs []browserCommandSpec
+		if isWSL {
+			if hasCommand("wslview") {
+				specs = append(specs, browserCommandSpec{name: "wslview", args: []string{url}})
+			}
+			if hasCommand("powershell.exe") {
+				specs = append(specs, browserCommandSpec{
+					name: "powershell.exe",
+					args: []string{
+						"-NoProfile",
+						"-NonInteractive",
+						"-Command",
+						"Start-Process " + powershellSingleQuote(url),
+					},
+				})
+			}
+			if hasCommand("cmd.exe") {
+				specs = append(specs, browserCommandSpec{
+					name: "cmd.exe",
+					args: []string{"/c", `start "" ` + cmdDoubleQuote(url)},
+				})
+			}
+		}
+		if hasCommand("xdg-open") {
+			specs = append(specs, browserCommandSpec{name: "xdg-open", args: []string{url}})
+		}
+		return specs
+	default:
+		return nil
+	}
+}
+
+func powershellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+func cmdDoubleQuote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func systemIsWSL() bool {
+	versionData, err := os.ReadFile("/proc/version")
+	if err != nil {
+		versionData = nil
+	}
+	return looksLikeWSL(runtime.GOOS, os.Getenv("WSL_DISTRO_NAME"), os.Getenv("WSL_INTEROP"), string(versionData))
+}
+
+func looksLikeWSL(goos, distroName, interop, procVersion string) bool {
+	if goos != "linux" {
+		return false
+	}
+	if distroName != "" || interop != "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(procVersion), "microsoft")
+}
+
+func commandExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}

--- a/focus_cli.go
+++ b/focus_cli.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"regexp"
@@ -321,15 +323,22 @@ func fetchSessionFocus(client *http.Client, port int) *Focus {
 }
 
 // loadCritJSONForOutputDir loads the on-disk CritJSON for the given output dir
-// (or the resolved review path when outputDir is ""). Returns ok=false silently
-// on any failure — the caller falls back to "no scope inheritance".
+// (or the resolved review path when outputDir is ""). A missing review file is
+// the common case and returns ok=false silently. Parse errors and other I/O
+// errors are logged to stderr so a corrupt review file is not papered over by
+// silent fallback to "no scope inheritance".
 func loadCritJSONForOutputDir(outputDir string) (CritJSON, bool) {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: cannot resolve review path: %v\n", err)
 		return CritJSON{}, false
 	}
 	cj, err := loadCritJSON(critPath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return CritJSON{}, false
+		}
+		fmt.Fprintf(os.Stderr, "Warning: cannot read review file %q: %v\n", critPath, err)
 		return CritJSON{}, false
 	}
 	return cj, true

--- a/github.go
+++ b/github.go
@@ -1112,13 +1112,8 @@ func saveCritJSON(critPath string, cj CritJSON) error {
 	return atomicWriteFile(critPath, append(data, '\n'), 0644)
 }
 
-// appendComment adds a comment to the CritJSON struct in memory. Does not write to disk.
-// Defers to appendCommentScoped with no scope inheritance.
-func appendComment(cj *CritJSON, filePath string, startLine, endLine int, body, author, userID string) {
-	appendCommentScoped(cj, filePath, startLine, endLine, body, author, userID, inheritedScope{})
-}
-
-// appendCommentScoped is appendComment with HeadSHA / DiffScope stamping.
+// appendCommentScoped adds a comment to the CritJSON struct in memory with
+// HeadSHA / DiffScope stamping. Does not write to disk.
 // scope.DiffScope == "" produces today's working-tree behavior.
 func appendCommentScoped(cj *CritJSON, filePath string, startLine, endLine int, body, author, userID string, scope inheritedScope) {
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -1229,20 +1224,16 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 	return nil
 }
 
-// addCommentToCritJSON appends a comment to the review file for the given file and line range.
+// addCommentToCritJSONScoped appends a comment to the review file for the given file and line range.
 // Creates the review file if it doesn't exist. Appends to existing comments if it does.
 // Works in both git repos and plain directories (file mode).
 // outputDir overrides the default location (repo root or CWD) when non-empty.
+// scope carries optional HeadSHA / DiffScope stamping; the zero value produces
+// working-tree behavior.
 // userID is documented to support callers that pass an authenticated user; tests
-// pass "" because they don't need that path. The lint exception keeps the signature
-// stable for the API.
+// pass "" because they don't need that path.
 //
 //nolint:unparam // userID is part of the public contract; tests don't exercise it
-func addCommentToCritJSON(filePath string, startLine, endLine int, body string, author, userID string, outputDir string) error {
-	return addCommentToCritJSONScoped(filePath, startLine, endLine, body, author, userID, outputDir, inheritedScope{})
-}
-
-// addCommentToCritJSONScoped is addCommentToCritJSON with scope stamping.
 func addCommentToCritJSONScoped(filePath string, startLine, endLine int, body, author, userID, outputDir string, scope inheritedScope) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
@@ -1542,13 +1533,8 @@ func parseLineSpec(spec string) (start, end int, err error) {
 	return n, n, nil
 }
 
-//nolint:unparam // globalUserID is part of the public contract; tests don't exercise it
-func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor, globalUserID string, outputDir string) error {
-	return bulkAddCommentsToCritJSONScoped(entries, globalAuthor, globalUserID, outputDir, inheritedScope{})
-}
-
-// bulkAddCommentsToCritJSONScoped is bulkAddCommentsToCritJSON with scope stamping
-// applied to every entry.
+// bulkAddCommentsToCritJSONScoped writes a batch of comments to a single review
+// file with scope stamping applied to every entry.
 //
 // Target resolution: a bulk call always writes to a single review file. If any
 // entry uses reply_to and none of the referenced IDs live in the cwd-resolved
@@ -1556,6 +1542,8 @@ func bulkAddCommentsToCritJSON(entries []BulkCommentEntry, globalAuthor, globalU
 // them. New comments in the same bulk ride along. If reply IDs split across
 // multiple review files (or some land in primary and others elsewhere), the
 // call is rejected — callers should split into per-file bulks.
+//
+//nolint:unparam // globalUserID is part of the public contract; tests don't exercise it
 func bulkAddCommentsToCritJSONScoped(entries []BulkCommentEntry, globalAuthor, globalUserID string, outputDir string, scope inheritedScope) error {
 	if len(entries) == 0 {
 		return fmt.Errorf("no comment entries provided")
@@ -1672,12 +1660,8 @@ func cjContainsCommentID(cj *CritJSON, id string) bool {
 	return false
 }
 
-// addReviewCommentToCritJSON adds a review-level comment to the review file.
-func addReviewCommentToCritJSON(body, author, userID, outputDir string) error {
-	return addReviewCommentToCritJSONScoped(body, author, userID, outputDir, inheritedScope{})
-}
-
-// addReviewCommentToCritJSONScoped is addReviewCommentToCritJSON with scope stamping.
+// addReviewCommentToCritJSONScoped adds a review-level comment to the review
+// file with scope stamping.
 func addReviewCommentToCritJSONScoped(body, author, userID, outputDir string, scope inheritedScope) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
@@ -1693,12 +1677,8 @@ func addReviewCommentToCritJSONScoped(body, author, userID, outputDir string, sc
 	return saveCritJSON(critPath, cj)
 }
 
-// addFileCommentToCritJSON adds a file-level comment to the review file.
-func addFileCommentToCritJSON(filePath, body, author, userID, outputDir string) error {
-	return addFileCommentToCritJSONScoped(filePath, body, author, userID, outputDir, inheritedScope{})
-}
-
-// addFileCommentToCritJSONScoped is addFileCommentToCritJSON with scope stamping.
+// addFileCommentToCritJSONScoped adds a file-level comment to the review file
+// with scope stamping.
 func addFileCommentToCritJSONScoped(filePath, body, author, userID, outputDir string, scope inheritedScope) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
@@ -1719,13 +1699,8 @@ func addFileCommentToCritJSONScoped(filePath, body, author, userID, outputDir st
 	return saveCritJSON(critPath, cj)
 }
 
-// appendReviewComment adds a review-level comment to the CritJSON struct in memory.
-// Defers to appendReviewCommentScoped with no scope inheritance.
-func appendReviewComment(cj *CritJSON, body, author, userID string) {
-	appendReviewCommentScoped(cj, body, author, userID, inheritedScope{})
-}
-
-// appendReviewCommentScoped stamps DiffScope/HeadSHA from scope.
+// appendReviewCommentScoped adds a review-level comment to the CritJSON struct
+// in memory, stamping DiffScope/HeadSHA from scope.
 func appendReviewCommentScoped(cj *CritJSON, body, author, userID string, scope inheritedScope) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
@@ -1742,13 +1717,8 @@ func appendReviewCommentScoped(cj *CritJSON, body, author, userID string, scope 
 	cj.ReviewComments = append(cj.ReviewComments, c)
 }
 
-// appendFileComment adds a file-level comment (scope: "file", lines: 0) to the CritJSON struct in memory.
-// Defers to appendFileCommentScoped with no scope inheritance.
-func appendFileComment(cj *CritJSON, filePath, body, author, userID string) {
-	appendFileCommentScoped(cj, filePath, body, author, userID, inheritedScope{})
-}
-
-// appendFileCommentScoped stamps DiffScope/HeadSHA from scope.
+// appendFileCommentScoped adds a file-level comment (scope: "file", lines: 0)
+// to the CritJSON struct in memory, stamping DiffScope/HeadSHA from scope.
 func appendFileCommentScoped(cj *CritJSON, filePath, body, author, userID string, scope inheritedScope) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now

--- a/github_test.go
+++ b/github_test.go
@@ -639,7 +639,7 @@ func TestAddCommentToCritJSON_RejectsPathTraversal(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("../../../etc/passwd", 1, 1, "bad", "", "", "")
+	err := addCommentToCritJSONScoped("../../../etc/passwd", 1, 1, "bad", "", "", "", inheritedScope{})
 	if err == nil {
 		t.Fatal("expected error for path traversal, got nil")
 	}
@@ -657,7 +657,7 @@ func TestAddCommentToCritJSON_RejectsAbsolutePath(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("/etc/passwd", 1, 1, "bad", "", "", "")
+	err := addCommentToCritJSONScoped("/etc/passwd", 1, 1, "bad", "", "", "", inheritedScope{})
 	if err == nil {
 		t.Fatal("expected error for absolute path, got nil")
 	}
@@ -674,7 +674,7 @@ func TestAddCommentToCritJSON_CreatesNewFile(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("main.go", 10, 15, "Fix this bug", "", "", dir)
+	err := addCommentToCritJSONScoped("main.go", 10, 15, "Fix this bug", "", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -715,10 +715,10 @@ func TestAddCommentToCritJSON_AppendsToExisting(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("main.go", 1, 1, "First", "", "", dir); err != nil {
+	if err := addCommentToCritJSONScoped("main.go", 1, 1, "First", "", "", dir, inheritedScope{}); err != nil {
 		t.Fatalf("first add: %v", err)
 	}
-	if err := addCommentToCritJSON("main.go", 20, 20, "Second", "", "", dir); err != nil {
+	if err := addCommentToCritJSONScoped("main.go", 20, 20, "Second", "", "", dir, inheritedScope{}); err != nil {
 		t.Fatalf("second add: %v", err)
 	}
 
@@ -744,8 +744,8 @@ func TestAddCommentToCritJSON_MultipleFiles(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	addCommentToCritJSON("main.go", 1, 1, "Comment on main", "", "", dir)
-	addCommentToCritJSON("auth.go", 5, 10, "Comment on auth", "", "", dir)
+	addCommentToCritJSONScoped("main.go", 1, 1, "Comment on main", "", "", dir, inheritedScope{})
+	addCommentToCritJSONScoped("auth.go", 5, 10, "Comment on auth", "", "", dir, inheritedScope{})
 
 	data, _ := os.ReadFile(dir + "/.crit.json")
 	var cj CritJSON
@@ -768,7 +768,7 @@ func TestAddCommentToCritJSON_FileMode_NoGitRepo(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addCommentToCritJSON("main.go", 5, 5, "File mode comment", "", "", dir)
+	err := addCommentToCritJSONScoped("main.go", 5, 5, "File mode comment", "", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -801,7 +801,7 @@ func TestAddCommentToCritJSON_FileMode_PathRelativeToCWD(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Path should be stored as given (relative to CWD), not resolved to anything else
-	addCommentToCritJSON("src/auth.go", 10, 10, "comment", "", "", dir)
+	addCommentToCritJSONScoped("src/auth.go", 10, 10, "comment", "", "", dir, inheritedScope{})
 
 	data, _ := os.ReadFile(dir + "/.crit.json")
 	var cj CritJSON
@@ -823,7 +823,7 @@ func TestAddCommentToCritJSON_OutputDir(t *testing.T) {
 	os.Chdir(repoDir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("main.go", 1, 1, "custom output dir", "", "", outputDir); err != nil {
+	if err := addCommentToCritJSONScoped("main.go", 1, 1, "custom output dir", "", "", outputDir, inheritedScope{}); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -892,7 +892,7 @@ func TestAddCommentToCritJSON_RespectsBaseBranchConfig(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	if err := addCommentToCritJSON("feature.go", 1, 1, "test comment", "", "", dir); err != nil {
+	if err := addCommentToCritJSONScoped("feature.go", 1, 1, "test comment", "", "", dir, inheritedScope{}); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -1232,7 +1232,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 		{File: "main.go", Line: 3, EndLine: 4, Body: "Extract to function"},
 	}
 
-	err := bulkAddCommentsToCritJSON(entries, "TestBot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "TestBot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1261,7 +1261,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 	replyEntries := []BulkCommentEntry{
 		{ReplyTo: firstCommentID, Body: "Done — added godoc comment", Resolve: true},
 	}
-	err = bulkAddCommentsToCritJSON(replyEntries, "TestBot", "", dir)
+	err = bulkAddCommentsToCritJSONScoped(replyEntries, "TestBot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("unexpected error on reply: %v", err)
 	}
@@ -1279,7 +1279,7 @@ func TestBulkAddCommentsToCritJSON_MixedCommentsAndReplies(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_EmptyBody(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "main.go", Line: 1, Body: ""}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "body is required") {
 		t.Errorf("expected body required error, got: %v", err)
 	}
@@ -1288,7 +1288,7 @@ func TestBulkAddCommentsToCritJSON_EmptyBody(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_MissingFile(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{Line: 1, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "file is required") {
 		t.Errorf("expected file required error, got: %v", err)
 	}
@@ -1297,7 +1297,7 @@ func TestBulkAddCommentsToCritJSON_MissingFile(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_InvalidLine(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "main.go", Line: 0, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "line must be > 0") {
 		t.Errorf("expected line error, got: %v", err)
 	}
@@ -1306,7 +1306,7 @@ func TestBulkAddCommentsToCritJSON_InvalidLine(t *testing.T) {
 func TestBulkAddCommentsToCritJSON_PathTraversal(t *testing.T) {
 	dir := initTestRepo(t)
 	entries := []BulkCommentEntry{{File: "../etc/passwd", Line: 1, Body: "test"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "must be relative") {
 		t.Errorf("expected path traversal error, got: %v", err)
 	}
@@ -1314,7 +1314,7 @@ func TestBulkAddCommentsToCritJSON_PathTraversal(t *testing.T) {
 
 func TestBulkAddCommentsToCritJSON_EmptyEntries(t *testing.T) {
 	dir := initTestRepo(t)
-	err := bulkAddCommentsToCritJSON(nil, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(nil, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "no comment entries") {
 		t.Errorf("expected empty entries error, got: %v", err)
 	}
@@ -1324,7 +1324,7 @@ func TestBulkAddCommentsToCritJSON_ReplyNotFound(t *testing.T) {
 	dir := initTestRepo(t)
 	t.Setenv("HOME", t.TempDir()) // isolate from any real ~/.crit/reviews
 	entries := []BulkCommentEntry{{ReplyTo: "c99", Body: "reply"}}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not found error, got: %v", err)
 	}
@@ -1362,7 +1362,7 @@ func TestBulkAddCommentsToCritJSON_RedirectsRepliesToAltFile(t *testing.T) {
 		{ReplyTo: "c_spec1", Body: "addressed"},
 		{Body: "general note on the spec"}, // new review-level comment, rides along
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1410,9 +1410,9 @@ func TestBulkAddCommentsToCritJSON_RejectsSplitTargets(t *testing.T) {
 
 	// Seed the primary (cwd) review file with a comment.
 	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
-	if err := bulkAddCommentsToCritJSON(
+	if err := bulkAddCommentsToCritJSONScoped(
 		[]BulkCommentEntry{{File: "main.go", Line: 1, Body: "primary comment"}},
-		"Bot", "", dir,
+		"Bot", "", dir, inheritedScope{},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -1431,7 +1431,7 @@ func TestBulkAddCommentsToCritJSON_RejectsSplitTargets(t *testing.T) {
 		{ReplyTo: primaryCommentID, Body: "reply to primary"},
 		{ReplyTo: "c_alt1", Body: "reply to alt"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil {
 		t.Fatal("expected split-target error, got nil")
 	}
@@ -1459,7 +1459,7 @@ func TestBulkAddCommentsToCritJSON_RejectsRepliesAcrossTwoAltFiles(t *testing.T)
 		{ReplyTo: "c_one", Body: "x"},
 		{ReplyTo: "c_two", Body: "y"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err == nil || !strings.Contains(err.Error(), "multiple review files") {
 		t.Fatalf("expected multi-file error, got: %v", err)
 	}
@@ -1475,7 +1475,7 @@ func TestBulkAddCommentsToCritJSON_PerEntryAuthor(t *testing.T) {
 		{File: "main.go", Line: 1, Body: "from global author"},
 		{File: "main.go", Line: 1, Body: "from custom author", Author: "CustomBot"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "GlobalBot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "GlobalBot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1499,7 +1499,7 @@ func TestBulkAddCommentsToCritJSON_MultipleFiles(t *testing.T) {
 		{File: "a.go", Line: 1, Body: "comment on a"},
 		{File: "b.go", Line: 1, Body: "comment on b"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1546,7 +1546,7 @@ func TestBulkAddCommentsToCritJSON_EndLineDefaultsToLine(t *testing.T) {
 		{File: "main.go", Line: 2, Body: "single line - no end_line"},
 		{File: "main.go", Line: 3, EndLine: 5, Body: "explicit range"},
 	}
-	err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir)
+	err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1894,7 +1894,7 @@ func TestAppendReply_NotFound(t *testing.T) {
 func TestAppendReviewComment(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendReviewComment(cj, "general observation", "reviewer", "")
+	appendReviewCommentScoped(cj, "general observation", "reviewer", "", inheritedScope{})
 
 	if len(cj.ReviewComments) != 1 {
 		t.Fatalf("expected 1 review comment, got %d", len(cj.ReviewComments))
@@ -1913,7 +1913,7 @@ func TestAppendReviewComment(t *testing.T) {
 	}
 
 	// Add another
-	appendReviewComment(cj, "second note", "reviewer", "")
+	appendReviewCommentScoped(cj, "second note", "reviewer", "", inheritedScope{})
 	if !strings.HasPrefix(cj.ReviewComments[1].ID, "r_") || len(cj.ReviewComments[1].ID) != 8 {
 		t.Errorf("second ID = %q, want r_ prefix + 6 hex chars", cj.ReviewComments[1].ID)
 	}
@@ -1925,7 +1925,7 @@ func TestAppendReviewComment(t *testing.T) {
 func TestAppendFileComment(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendFileComment(cj, "server.go", "needs restructuring", "reviewer", "")
+	appendFileCommentScoped(cj, "server.go", "needs restructuring", "reviewer", "", inheritedScope{})
 
 	cf, ok := cj.Files["server.go"]
 	if !ok {
@@ -1945,8 +1945,8 @@ func TestAppendFileComment(t *testing.T) {
 func TestAppendComment_IDIncrementsGlobally(t *testing.T) {
 	cj := &CritJSON{Files: make(map[string]CritJSONFile)}
 
-	appendComment(cj, "main.go", 1, 1, "first", "reviewer", "")
-	appendComment(cj, "server.go", 5, 5, "second", "reviewer", "")
+	appendCommentScoped(cj, "main.go", 1, 1, "first", "reviewer", "", inheritedScope{})
+	appendCommentScoped(cj, "server.go", 5, 5, "second", "reviewer", "", inheritedScope{})
 
 	c1 := cj.Files["main.go"].Comments[0]
 	c2 := cj.Files["server.go"].Comments[0]
@@ -1963,7 +1963,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Add a comment via the CLI function
-	err := addCommentToCritJSON("README.md", 1, 1, "fix typo", "reviewer", "", dir)
+	err := addCommentToCritJSONScoped("README.md", 1, 1, "fix typo", "reviewer", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
@@ -1993,7 +1993,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 	}
 
 	// Add a second comment to same file
-	err = addCommentToCritJSON("README.md", 3, 5, "refactor this section", "agent", "", dir)
+	err = addCommentToCritJSONScoped("README.md", 3, 5, "refactor this section", "agent", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("second addCommentToCritJSON: %v", err)
 	}
@@ -2012,7 +2012,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Add a comment first
-	err := addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", "", dir)
+	err := addCommentToCritJSONScoped("README.md", 1, 1, "fix this", "reviewer", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2046,7 +2046,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	addCommentToCritJSON("README.md", 1, 1, "fix this", "reviewer", "", dir)
+	addCommentToCritJSONScoped("README.md", 1, 1, "fix this", "reviewer", "", dir, inheritedScope{})
 
 	critPath := filepath.Join(dir, ".crit.json")
 	data, _ := os.ReadFile(critPath)
@@ -2123,7 +2123,7 @@ func TestAddFileCommentToCritJSON_RejectsAbsolutePath(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addFileCommentToCritJSON("/etc/passwd", "test", "author", "", "")
+	err := addFileCommentToCritJSONScoped("/etc/passwd", "test", "author", "", "", inheritedScope{})
 	if err == nil {
 		t.Fatal("expected error for absolute path")
 	}
@@ -2135,7 +2135,7 @@ func TestAddFileCommentToCritJSON_RejectsTraversal(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addFileCommentToCritJSON("../outside", "test", "author", "", "")
+	err := addFileCommentToCritJSONScoped("../outside", "test", "author", "", "", inheritedScope{})
 	if err == nil {
 		t.Fatal("expected error for path traversal")
 	}
@@ -2147,7 +2147,7 @@ func TestAddReviewCommentToCritJSON_RoundTrip(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	err := addReviewCommentToCritJSON("overall the code is good", "reviewer", "", dir)
+	err := addReviewCommentToCritJSONScoped("overall the code is good", "reviewer", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("addReviewCommentToCritJSON: %v", err)
 	}
@@ -2174,7 +2174,7 @@ func TestClearCritJSON(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a .crit.json
-	addCommentToCritJSON("README.md", 1, 1, "test", "author", "", dir)
+	addCommentToCritJSONScoped("README.md", 1, 1, "test", "author", "", dir, inheritedScope{})
 
 	critPath := filepath.Join(dir, ".crit.json")
 	if _, err := os.Stat(critPath); err != nil {
@@ -2383,7 +2383,7 @@ func TestAddCommentToCritJSON_PopulatesAnchor(t *testing.T) {
 	// Write a file with known content.
 	writeFile(t, filepath.Join(dir, "hello.go"), "package main\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n")
 
-	if err := addCommentToCritJSON("hello.go", 3, 4, "Fix this function", "Bot", "", dir); err != nil {
+	if err := addCommentToCritJSONScoped("hello.go", 3, 4, "Fix this function", "Bot", "", dir, inheritedScope{}); err != nil {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
@@ -2420,7 +2420,7 @@ func TestBulkAddCommentsToCritJSON_PopulatesAnchor(t *testing.T) {
 	entries := []BulkCommentEntry{
 		{File: "server.go", Line: 3, Body: "Why this import?"},
 	}
-	if err := bulkAddCommentsToCritJSON(entries, "Bot", "", dir); err != nil {
+	if err := bulkAddCommentsToCritJSONScoped(entries, "Bot", "", dir, inheritedScope{}); err != nil {
 		t.Fatalf("bulkAddCommentsToCritJSON: %v", err)
 	}
 
@@ -2514,7 +2514,7 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 	data, _ := json.Marshal(cj)
 	os.WriteFile(critPath, data, 0644)
 
-	err := addFileCommentToCritJSON("test.go", "file-level feedback", "reviewer", "", dir)
+	err := addFileCommentToCritJSONScoped("test.go", "file-level feedback", "reviewer", "", dir, inheritedScope{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -135,10 +135,8 @@ func loadShareFiles(paths []string) []shareFile {
 		}
 		relPath := path
 		if filepath.IsAbs(path) {
-			if wd, err := os.Getwd(); err == nil {
-				if rel, err := filepath.Rel(wd, path); err == nil {
-					relPath = rel
-				}
+			if rel, err := filepath.Rel(mustGetwd(), path); err == nil {
+				relPath = rel
 			}
 		}
 		files = append(files, shareFile{Path: relPath, Content: string(content)})
@@ -259,7 +257,12 @@ func runShare(args []string) {
 		sharePaths[i] = f.Path
 	}
 
-	if existingCfg, ok := loadExistingShareCfg(critPath, sharePaths); ok {
+	existingCfg, ok, err := loadExistingShareCfg(critPath, sharePaths)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if ok {
 		runShareExisting(existingCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)
 		return
 	}
@@ -450,7 +453,7 @@ func runInstall(args []string) {
 
 	target := args[0]
 	if target == "all" {
-		cwd, _ := os.Getwd()
+		cwd := mustGetwd()
 		home, _ := os.UserHomeDir()
 		global := isGlobalInstall(cwd, home)
 		for _, name := range availableIntegrations() {
@@ -487,7 +490,7 @@ func runConfig(args []string) {
 		configDir, _ = vcs.RepoRoot()
 	}
 	if configDir == "" {
-		configDir, _ = os.Getwd()
+		configDir = mustGetwd()
 	}
 	cfg := LoadConfig(configDir)
 	fmt.Print(cfg.String())
@@ -954,9 +957,11 @@ func resolveCommentFlags(f *commentFlags) {
 	// Resolve author: --author flag > config > VCS user.name.
 	// Stamp AuthUserID alongside the author so authenticated comments
 	// carry the user identity into the share payload.
-	cfgDir, _ := os.Getwd()
+	cfgDir := mustGetwd()
 	if vcs := DetectVCS(""); vcs != nil {
-		cfgDir, _ = vcs.RepoRoot()
+		if root, err := vcs.RepoRoot(); err == nil {
+			cfgDir = root
+		}
 	}
 	cfg := LoadConfig(cfgDir)
 	if f.author == "" {
@@ -1003,7 +1008,11 @@ func runCommentJSONScoped(f commentFlags, scope inheritedScope) {
 		parts = append(parts, fmt.Sprintf("%d comment%s", comments, plural(comments)))
 	}
 	if replies > 0 {
-		parts = append(parts, fmt.Sprintf("%d repl%s", replies, pluralReply(replies)))
+		word := "replies"
+		if replies == 1 {
+			word = "reply"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", replies, word))
 	}
 	fmt.Printf("Added %s\n", strings.Join(parts, " and "))
 }
@@ -1805,11 +1814,17 @@ func plural(n int) string {
 	return "s"
 }
 
-func pluralReply(n int) string {
-	if n == 1 {
-		return "y"
+// mustGetwd returns the current working directory or aborts the process with a
+// clear diagnostic. Used in CLI paths where every fallback (config dir, repo
+// root) has already failed; if we cannot read the cwd, we genuinely cannot
+// continue.
+func mustGetwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crit: unable to determine current working directory: %v\n", err)
+		os.Exit(1)
 	}
-	return "ies"
+	return wd
 }
 
 // serverConfig holds the resolved configuration for running the server.
@@ -1978,7 +1993,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		repoRoot = configDir
 	}
 	if configDir == "" {
-		configDir, _ = os.Getwd()
+		configDir = mustGetwd()
 	}
 	cfg := LoadConfig(configDir)
 
@@ -2942,7 +2957,7 @@ func installIntegration(name string, force bool) error {
 		return errors.New(strings.TrimRight(b.String(), "\n"))
 	}
 
-	cwd, _ := os.Getwd()
+	cwd := mustGetwd()
 	home, _ := os.UserHomeDir()
 	global := isGlobalInstall(cwd, home)
 
@@ -3015,98 +3030,4 @@ func printUniqueHints(hints []string) {
 		seen[hint] = true
 		fmt.Printf("  %s\n", hint)
 	}
-}
-
-func openBrowser(url string) {
-	time.Sleep(200 * time.Millisecond)
-	if tryOpenBrowser(browserCommandSpecs(runtime.GOOS, url, systemIsWSL(), commandExists), runBrowserCommand) {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "Warning: could not open browser automatically; open %s manually\n", url)
-}
-
-type browserCommandSpec struct {
-	name string
-	args []string
-}
-
-func tryOpenBrowser(specs []browserCommandSpec, run func(browserCommandSpec) error) bool {
-	for _, spec := range specs {
-		if err := run(spec); err == nil {
-			return true
-		}
-	}
-	return false
-}
-
-func runBrowserCommand(spec browserCommandSpec) error {
-	return exec.Command(spec.name, spec.args...).Run()
-}
-
-func browserCommandSpecs(goos, url string, isWSL bool, hasCommand func(string) bool) []browserCommandSpec {
-	switch goos {
-	case "darwin":
-		return []browserCommandSpec{{name: "open", args: []string{url}}}
-	case "linux":
-		var specs []browserCommandSpec
-		if isWSL {
-			if hasCommand("wslview") {
-				specs = append(specs, browserCommandSpec{name: "wslview", args: []string{url}})
-			}
-			if hasCommand("powershell.exe") {
-				specs = append(specs, browserCommandSpec{
-					name: "powershell.exe",
-					args: []string{
-						"-NoProfile",
-						"-NonInteractive",
-						"-Command",
-						"Start-Process " + powershellSingleQuote(url),
-					},
-				})
-			}
-			if hasCommand("cmd.exe") {
-				specs = append(specs, browserCommandSpec{
-					name: "cmd.exe",
-					args: []string{"/c", `start "" ` + cmdDoubleQuote(url)},
-				})
-			}
-		}
-		if hasCommand("xdg-open") {
-			specs = append(specs, browserCommandSpec{name: "xdg-open", args: []string{url}})
-		}
-		return specs
-	default:
-		return nil
-	}
-}
-
-func powershellSingleQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
-}
-
-func cmdDoubleQuote(s string) string {
-	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
-}
-
-func systemIsWSL() bool {
-	versionData, err := os.ReadFile("/proc/version")
-	if err != nil {
-		versionData = nil
-	}
-	return looksLikeWSL(runtime.GOOS, os.Getenv("WSL_DISTRO_NAME"), os.Getenv("WSL_INTEROP"), string(versionData))
-}
-
-func looksLikeWSL(goos, distroName, interop, procVersion string) bool {
-	if goos != "linux" {
-		return false
-	}
-	if distroName != "" || interop != "" {
-		return true
-	}
-	return strings.Contains(strings.ToLower(procVersion), "microsoft")
-}
-
-func commandExists(name string) bool {
-	_, err := exec.LookPath(name)
-	return err == nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -309,7 +309,7 @@ func TestHelperProcess_CommentJSON(t *testing.T) {
 func TestRunComment_JSONFlagMixed(t *testing.T) {
 	// Step 1: Create a comment and capture its ID
 	tmp := t.TempDir()
-	err := addCommentToCritJSON("main.go", 1, 1, "comment", "TestBot", "", tmp)
+	err := addCommentToCritJSONScoped("main.go", 1, 1, "comment", "TestBot", "", tmp, inheritedScope{})
 	if err != nil {
 		t.Fatalf("setup comment: %v", err)
 	}
@@ -1102,25 +1102,6 @@ func TestPlural(t *testing.T) {
 		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
 			if got := plural(tt.n); got != tt.want {
 				t.Errorf("plural(%d) = %q, want %q", tt.n, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestPluralReply(t *testing.T) {
-	tests := []struct {
-		n    int
-		want string
-	}{
-		{0, "ies"},
-		{1, "y"},
-		{2, "ies"},
-		{5, "ies"},
-	}
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
-			if got := pluralReply(tt.n); got != tt.want {
-				t.Errorf("pluralReply(%d) = %q, want %q", tt.n, got, tt.want)
 			}
 		})
 	}

--- a/share.go
+++ b/share.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -590,23 +591,30 @@ func upsertShareToWeb(cfg CritJSON, files []shareFile, comments []shareComment, 
 	return result, nil
 }
 
-// loadExistingShareCfg returns the full CritJSON if a matching share exists (same file scope).
-func loadExistingShareCfg(critPath string, paths []string) (CritJSON, bool) {
+// loadExistingShareCfg returns the full CritJSON if a matching share exists
+// (same file scope). The bool is true only when an existing share is found.
+// A missing review file is reported as (zero, false, nil) so callers can fall
+// back to creating a new share. Parse errors and other I/O errors are surfaced
+// so callers can refuse to clobber a corrupted file.
+func loadExistingShareCfg(critPath string, paths []string) (CritJSON, bool, error) {
 	data, err := os.ReadFile(critPath)
 	if err != nil {
-		return CritJSON{}, false
+		if errors.Is(err, fs.ErrNotExist) {
+			return CritJSON{}, false, nil
+		}
+		return CritJSON{}, false, fmt.Errorf("reading review file %q: %w", critPath, err)
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
-		return CritJSON{}, false
+		return CritJSON{}, false, fmt.Errorf("parsing review file %q: %w", critPath, err)
 	}
 	if cj.ShareURL == "" {
-		return CritJSON{}, false
+		return CritJSON{}, false, nil
 	}
 	if cj.ShareScope != "" && cj.ShareScope != shareScope(paths) {
-		return CritJSON{}, false
+		return CritJSON{}, false, nil
 	}
-	return cj, true
+	return cj, true, nil
 }
 
 // buildLocalIDSet collects all local comment IDs across all files and review comments.
@@ -815,7 +823,7 @@ func loadShareConfig() Config {
 		cfgDir, _ = vcs.RepoRoot()
 	}
 	if cfgDir == "" {
-		cfgDir, _ = os.Getwd()
+		cfgDir = mustGetwd()
 	}
 	return LoadConfig(cfgDir)
 }

--- a/share_test.go
+++ b/share_test.go
@@ -887,7 +887,10 @@ func TestLoadExistingShareCfg(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(critPath, data, 0644)
 
-	cfg, ok := loadExistingShareCfg(critPath, []string{"anything.md"})
+	cfg, ok, err := loadExistingShareCfg(critPath, []string{"anything.md"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -901,7 +904,10 @@ func TestLoadExistingShareCfg(t *testing.T) {
 
 func TestLoadExistingShareCfg_NoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	_, ok := loadExistingShareCfg(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	_, ok, err := loadExistingShareCfg(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	if err != nil {
+		t.Fatalf("missing file should not be an error, got: %v", err)
+	}
 	if ok {
 		t.Error("expected ok=false when no .crit.json exists")
 	}
@@ -914,7 +920,10 @@ func TestLoadExistingShareCfg_NoShareState(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(critPath, data, 0644)
 
-	_, ok := loadExistingShareCfg(critPath, []string{"plan.md"})
+	_, ok, err := loadExistingShareCfg(critPath, []string{"plan.md"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if ok {
 		t.Error("expected ok=false when no share URL set")
 	}
@@ -934,13 +943,19 @@ func TestLoadExistingShareCfg_ScopeMismatch(t *testing.T) {
 	os.WriteFile(critPath, data, 0644)
 
 	// Different file set — should NOT return share state
-	_, ok := loadExistingShareCfg(critPath, []string{"new-plan.md"})
+	_, ok, err := loadExistingShareCfg(critPath, []string{"new-plan.md"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if ok {
 		t.Error("expected ok=false for mismatched scope")
 	}
 
 	// Same file set — should return share state
-	cfg, ok := loadExistingShareCfg(critPath, []string{"old-plan.md"})
+	cfg, ok, err := loadExistingShareCfg(critPath, []string{"old-plan.md"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !ok {
 		t.Fatal("expected ok=true for matching scope")
 	}


### PR DESCRIPTION
## Summary

Bundled refactor PR addressing four small cleanup opportunities surfaced by an audit (separate from #425, which covers the comment-CLI / review-file extraction).

- **Delete 7 unscoped wrapper functions in `github.go`** that were one-line delegates to `*Scoped` variants with `inheritedScope{}`. Removed: `appendComment`, `appendReviewComment`, `appendFileComment`, `addCommentToCritJSON`, `addReviewCommentToCritJSON`, `addFileCommentToCritJSON`, `bulkAddCommentsToCritJSON`. No production callers; tests updated to call the `*Scoped` versions directly. Aligns with `.claude/rules/go.md` which forbids same-signature wrappers.
- **Add `mustGetwd()` helper** and replace 7 ignored-error `os.Getwd()` sites in `main.go` (×6) and `share.go` (×1). Previously these silently kept `""` as cwd on failure, leading to bizarre downstream paths in the unlikely deleted-cwd scenario.
- **Extract `browser.go` from `main.go`**. `browser_test.go` already existed in the package — pure code move, no test changes. Resolves the smell of a test file with no corresponding source file.
- **Distinguish ENOENT from parse/IO errors** in two corruption-tolerant loaders:
  - `share.go` `loadExistingShareCfg` now returns `(CritJSON, bool, error)`. ENOENT → `(zero, false, nil)`; parse/IO → wrapped error so the caller can surface a diagnostic. Single production caller updated.
  - `focus_cli.go` `loadCritJSONForOutputDir` logs parse/IO errors loudly to stderr instead of swallowing them as missing-file. Signature unchanged because the underlying loader synthesizes a fresh struct on ENOENT.
- **Inline `pluralReply`** at its single call site; delete the helper and its test.

## Review

- [x] Code review: passed (fresh go-expert review — 0 blockers, 0 warnings, 3 acceptable notes)
- [x] Parity audit: N/A (no review-page changes)

## Test plan

- \`go build ./...\` clean
- \`go vet ./...\` clean
- \`gofmt -l .\` clean
- \`go test ./...\` passes (35s)
- Pre-commit hooks (golangci-lint, ESLint, Stylelint, CSS-var check) all pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)