### PR TITLE
refactor: consolidate atomic-file-write helpers

### DIFF
--- a/aider_install.go
+++ b/aider_install.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -71,13 +70,13 @@ func installAiderAt(cwd, home string, force bool) error {
 		if _, statErr := os.Stat(paths.conventionsDest); statErr == nil {
 			fmt.Printf("  Skipped:   %s (already exists, use --force to overwrite)\n", paths.conventionsDest)
 		} else {
-			if err := writeFileMkdirAtomic(paths.conventionsDest, data); err != nil {
+			if err := atomicWriteFile(paths.conventionsDest, data, 0o644); err != nil {
 				return fmt.Errorf("writing %s: %w", paths.conventionsDest, err)
 			}
 			fmt.Printf("  Installed: %s\n", paths.conventionsDest)
 		}
 	} else {
-		if err := writeFileMkdirAtomic(paths.conventionsDest, data); err != nil {
+		if err := atomicWriteFile(paths.conventionsDest, data, 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", paths.conventionsDest, err)
 		}
 		fmt.Printf("  Installed: %s\n", paths.conventionsDest)
@@ -91,40 +90,6 @@ func installAiderAt(cwd, home string, force bool) error {
 	fmt.Printf("  Updated:   %s (added %s under read:)\n", paths.confPath, paths.readEntry)
 	fmt.Println("  Aider will load the crit conventions on next start")
 	fmt.Println()
-	return nil
-}
-
-// writeFileMkdirAtomic writes data to path via a same-directory tempfile
-// followed by rename. On POSIX rename is atomic, so a crash mid-write cannot
-// leave a truncated file at path. Parent dirs are created as needed.
-func writeFileMkdirAtomic(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	tmp := filepath.Join(dir, filepath.Base(path)+".tmp."+strconv.Itoa(os.Getpid()))
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
 	return nil
 }
 
@@ -159,7 +124,7 @@ func mergeAiderConfFile(path, readEntry string) error {
 		return err
 	}
 
-	return writeFileMkdirAtomic(path, merged)
+	return atomicWriteFile(path, merged, 0o644)
 }
 
 // mergeAiderConfYAML returns the YAML bytes resulting from merging readEntry

--- a/aider_install_test.go
+++ b/aider_install_test.go
@@ -486,14 +486,15 @@ func TestMergeAiderConfFile_MalformedLeavesFileUntouched(t *testing.T) {
 	}
 }
 
-func TestWriteFileMkdirAtomic_CleansUpTempfile(t *testing.T) {
-	// Atomic write: after a successful rename, no .tmp.* siblings should
+func TestAiderInstallAtomicWrite_CleansUpTempfile(t *testing.T) {
+	// Atomic write: after a successful rename, no tempfile siblings should
 	// remain. This indirectly proves rename happened (and didn't leave a
-	// half-written file behind).
+	// half-written file behind). Covers the aider install code path which
+	// now routes through the canonical atomicWriteFile helper.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "file.yml")
 
-	if err := writeFileMkdirAtomic(path, []byte("hello\n")); err != nil {
+	if err := atomicWriteFile(path, []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(path)
@@ -509,7 +510,7 @@ func TestWriteFileMkdirAtomic_CleansUpTempfile(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, e := range entries {
-		if strings.Contains(e.Name(), ".tmp.") {
+		if strings.Contains(e.Name(), ".tmp") {
 			t.Errorf("leftover tempfile: %s", e.Name())
 		}
 	}

--- a/atomic_write.go
+++ b/atomic_write.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to the target path atomically using a
+// same-directory tempfile + fsync + rename. On POSIX rename is atomic, so a
+// crash mid-write cannot leave a truncated file at target. Parent
+// directories are created with mode 0700 if missing. The final file is
+// chmod'd to perm regardless of umask.
+//
+// Used as the canonical write path for review files (saveCritJSON), session
+// state (writeSessionFile), config (saveConfigFile), plan-session mappings
+// (savePlanSlug), and aider integration files (installAider). Keep this
+// function's signature stable — multiple call sites depend on it.
+func atomicWriteFile(target string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename temp file to target: %w", err)
+	}
+	return nil
+}

--- a/daemon.go
+++ b/daemon.go
@@ -108,44 +108,6 @@ func reviewFilePath(key string) (string, error) {
 	return filepath.Join(dir, key+".json"), nil
 }
 
-// atomicWriteFile writes data to the target path atomically using temp file + fsync + rename.
-func atomicWriteFile(target string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(target)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dir, err)
-	}
-
-	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	tmpName := tmp.Name()
-
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return fmt.Errorf("write temp file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return fmt.Errorf("sync temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("close temp file: %w", err)
-	}
-	if err := os.Chmod(tmpName, perm); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-	if err := os.Rename(tmpName, target); err != nil {
-		os.Remove(tmpName)
-		return fmt.Errorf("rename temp file to target: %w", err)
-	}
-	return nil
-}
-
 // writeSessionFile writes a session entry to ~/.crit/sessions/<key>.json.
 func writeSessionFile(key string, entry sessionEntry) error {
 	path, err := sessionFilePath(key)

--- a/plans.go
+++ b/plans.go
@@ -259,14 +259,12 @@ func savePlanSlug(sessionID, slug string) error {
 		return err
 	}
 
-	// Atomic write via temp file + rename to prevent partial writes.
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, out, 0644); err != nil {
-		return fmt.Errorf("writing plan sessions temp file: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("renaming plan sessions temp file: %w", err)
+	// Route through atomicWriteFile (atomic_write.go) so we get fsync
+	// before rename. Without fsync, a power loss between rename and the
+	// kernel flushing the data block leaves a zero-byte file on disk
+	// (the inode is renamed but the data was never written).
+	if err := atomicWriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("writing plan sessions: %w", err)
 	}
 	return nil
 }

--- a/review_file.go
+++ b/review_file.go
@@ -157,10 +157,7 @@ func saveCritJSON(critPath string, cj CritJSON) error {
 	if err != nil {
 		return fmt.Errorf("marshaling review file: %w", err)
 	}
-	// Ensure parent directory exists (centralized path may not exist yet).
-	if err := os.MkdirAll(filepath.Dir(critPath), 0700); err != nil {
-		return fmt.Errorf("creating review directory: %w", err)
-	}
+	// atomicWriteFile (atomic_write.go) handles MkdirAll internally.
 	return atomicWriteFile(critPath, append(data, '\n'), 0644)
 }
 


### PR DESCRIPTION
## Summary

Three independent atomic-file-write helpers had drifted across the codebase. This PR consolidates them into one canonical helper and fixes a real durability bug along the way.

- **Move `atomicWriteFile`** from `daemon.go` to a dedicated `atomic_write.go`. No behavior change — better location, given it's used by review files, config, sessions, plans, and aider integration.
- **Delete `writeFileMkdirAtomic`** in `aider_install.go`. Replace its three call sites with `atomicWriteFile(path, data, 0o644)`. The old helper hardcoded perm via `O_CREATE` flags and skipped `Chmod`; the canonical helper now guarantees `0o644` regardless of umask.
- **Durability fix in `plans.savePlanSessions`**: was using inline `os.WriteFile + os.Rename` with no `fsync`. On power loss between the rename and the kernel flushing the data block, the inode rename committed but the data did not — leaving a zero-byte plan-sessions file at the target. Now routes through `atomicWriteFile` (temp + write + fsync + rename). The advisory `flock` around the function is preserved.
- **Drop redundant `os.MkdirAll`** in `saveCritJSON` — `atomicWriteFile` already creates the parent directory.

### Hidden assumptions verified

- `writeFileMkdirAtomic`'s call sites (CONVENTIONS.md, .aider.conf.yml) only ever wanted `0o644`. No executables, so no perm regression.
- Old helper used `MkdirAll(0o755)`; canonical uses `0o700`. Parent dirs (`./.crit/`, `~`) already exist in practice — no observable change.
- Tempfile naming changed from `.tmp.<pid>` to `os.CreateTemp` random suffix. Test `TestAiderInstallAtomicWrite_CleansUpTempfile` updated to assert no `.tmp` siblings remain.

## Review
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` passes (54.8s)
- [x] Pre-commit hook passes (gofmt, lint, tests, ESLint, Stylelint, CSS vars)

## Test plan
- Existing `daemon_test.go` `atomicWriteFile` tests still pass (unchanged surface)
- Aider install atomic write test renamed + retargeted to canonical helper
- Plan-session save path exercised by existing `plans_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)