### PR TITLE
fix: tie agent goroutine to daemon shutdown ctx + add runGit helper

### DIFF
--- a/autodetect_test.go
+++ b/autodetect_test.go
@@ -39,27 +39,27 @@ func initStackedRepo(t *testing.T) (dir, aSHA, bSHA string) {
 	t.Helper()
 	dir = initTestRepo(t)
 	// feature-a on top of main.
-	runGit(t, dir, "checkout", "-b", "feature-a")
+	gitT(t, dir, "checkout", "-b", "feature-a")
 	writeFile(t, dir+"/a.txt", "a\n")
-	runGit(t, dir, "add", "a.txt")
-	runGit(t, dir, "commit", "-m", "add a")
-	aSHA = runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "a.txt")
+	gitT(t, dir, "commit", "-m", "add a")
+	aSHA = gitT(t, dir, "rev-parse", "HEAD")
 	// feature-b on top of feature-a.
-	runGit(t, dir, "checkout", "-b", "feature-b")
+	gitT(t, dir, "checkout", "-b", "feature-b")
 	writeFile(t, dir+"/b.txt", "b\n")
-	runGit(t, dir, "add", "b.txt")
-	runGit(t, dir, "commit", "-m", "add b")
-	bSHA = runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "b.txt")
+	gitT(t, dir, "commit", "-m", "add b")
+	bSHA = gitT(t, dir, "rev-parse", "HEAD")
 	return dir, aSHA, bSHA
 }
 
 func TestAutoDetect_NoPR_NoStack(t *testing.T) {
 	dir := initTestRepo(t)
 	// Plain feature branch off main, no other branches in the chain.
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, dir+"/x.txt", "x\n")
-	runGit(t, dir, "add", "x.txt")
-	runGit(t, dir, "commit", "-m", "x")
+	gitT(t, dir, "add", "x.txt")
+	gitT(t, dir, "commit", "-m", "x")
 	chdir(t, dir)
 	withDetectPRInfo(t, func() *PRInfo { return nil })
 
@@ -71,10 +71,10 @@ func TestAutoDetect_NoPR_NoStack(t *testing.T) {
 
 func TestAutoDetect_PRBaseIsDefault(t *testing.T) {
 	dir := initTestRepo(t)
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, dir+"/x.txt", "x\n")
-	runGit(t, dir, "add", "x.txt")
-	runGit(t, dir, "commit", "-m", "x")
+	gitT(t, dir, "add", "x.txt")
+	gitT(t, dir, "commit", "-m", "x")
 	chdir(t, dir)
 
 	withDetectPRInfo(t, func() *PRInfo {
@@ -162,25 +162,25 @@ func TestAutoDetect_LocalStack_DefaultSHAIsLiteralDefaultBranch(t *testing.T) {
 	dir := initTestRepo(t)
 	chdir(t, dir)
 	withDetectPRInfo(t, func() *PRInfo { return nil })
-	mainSHA := runGit(t, dir, "rev-parse", "main")
+	mainSHA := gitT(t, dir, "rev-parse", "main")
 
 	// Three layers above main.
-	runGit(t, dir, "checkout", "-b", "alpha")
+	gitT(t, dir, "checkout", "-b", "alpha")
 	writeFile(t, dir+"/alpha.txt", "alpha\n")
-	runGit(t, dir, "add", "alpha.txt")
-	runGit(t, dir, "commit", "-m", "alpha")
+	gitT(t, dir, "add", "alpha.txt")
+	gitT(t, dir, "commit", "-m", "alpha")
 
-	runGit(t, dir, "checkout", "-b", "beta")
+	gitT(t, dir, "checkout", "-b", "beta")
 	writeFile(t, dir+"/beta.txt", "beta\n")
-	runGit(t, dir, "add", "beta.txt")
-	runGit(t, dir, "commit", "-m", "beta")
-	betaSHA := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "beta.txt")
+	gitT(t, dir, "commit", "-m", "beta")
+	betaSHA := gitT(t, dir, "rev-parse", "HEAD")
 
-	runGit(t, dir, "checkout", "-b", "gamma")
+	gitT(t, dir, "checkout", "-b", "gamma")
 	writeFile(t, dir+"/gamma.txt", "gamma\n")
-	runGit(t, dir, "add", "gamma.txt")
-	runGit(t, dir, "commit", "-m", "gamma")
-	gammaSHA := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "gamma.txt")
+	gitT(t, dir, "commit", "-m", "gamma")
+	gammaSHA := gitT(t, dir, "rev-parse", "HEAD")
 
 	got := autoDetectStackedFocus(&GitVCS{}, dir)
 	if got == nil {
@@ -280,14 +280,14 @@ func TestAutoDetect_FileMode_Bypasses(t *testing.T) {
 // bogus Range focus pinned at that commit.
 func TestAutoDetect_LocalStack_StaleTipFiltered(t *testing.T) {
 	dir := initTestRepo(t)
-	initialSHA := runGit(t, dir, "rev-parse", "HEAD")
+	initialSHA := gitT(t, dir, "rev-parse", "HEAD")
 	// Stale branch left pointing at the initial commit on main.
-	runGit(t, dir, "branch", "stale-merged", initialSHA)
+	gitT(t, dir, "branch", "stale-merged", initialSHA)
 	// Plain feature branch off main — no real stack.
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, dir+"/x.txt", "x\n")
-	runGit(t, dir, "add", "x.txt")
-	runGit(t, dir, "commit", "-m", "x")
+	gitT(t, dir, "add", "x.txt")
+	gitT(t, dir, "commit", "-m", "x")
 	chdir(t, dir)
 	withDetectPRInfo(t, func() *PRInfo { return nil })
 

--- a/config_test.go
+++ b/config_test.go
@@ -378,9 +378,9 @@ func TestLoadConfigAuthorFallsBackToGit(t *testing.T) {
 
 	// Set up a git repo with user.name configured
 	repoDir := t.TempDir()
-	runGit(t, repoDir, "init")
-	runGit(t, repoDir, "config", "user.email", "test@test.com")
-	runGit(t, repoDir, "config", "user.name", "Ada Lovelace")
+	gitT(t, repoDir, "init")
+	gitT(t, repoDir, "config", "user.email", "test@test.com")
+	gitT(t, repoDir, "config", "user.name", "Ada Lovelace")
 
 	// LoadConfig calls git without -C, so we must be inside the repo
 	origDir, _ := os.Getwd()
@@ -429,13 +429,13 @@ func TestNewSessionFromGitWithIgnore(t *testing.T) {
 	defaultBranchOnce = sync.Once{}
 
 	// Create a feature branch with several files
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
 	writeFile(t, filepath.Join(dir, "service.pb.go"), "package main\n// generated\n")
 	writeFile(t, filepath.Join(dir, "vendor", "lib.go"), "package vendor\n")
 	writeFile(t, filepath.Join(dir, "README.md"), "# Updated\n")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add files")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add files")
 
 	// cd into the repo
 	origDir, _ := os.Getwd()

--- a/daemon_e2e_test.go
+++ b/daemon_e2e_test.go
@@ -29,13 +29,13 @@ func TestDaemonLifecycle(t *testing.T) {
 
 	// Create a test repo with a file
 	repoDir := t.TempDir()
-	runGit(t, repoDir, "init")
-	runGit(t, repoDir, "config", "user.email", "test@test.com")
-	runGit(t, repoDir, "config", "user.name", "Test")
-	runGit(t, repoDir, "checkout", "-b", "main")
+	gitT(t, repoDir, "init")
+	gitT(t, repoDir, "config", "user.email", "test@test.com")
+	gitT(t, repoDir, "config", "user.name", "Test")
+	gitT(t, repoDir, "checkout", "-b", "main")
 	writeFile(t, filepath.Join(repoDir, "test.md"), "# Hello\n")
-	runGit(t, repoDir, "add", ".")
-	runGit(t, repoDir, "commit", "-m", "init")
+	gitT(t, repoDir, "add", ".")
+	gitT(t, repoDir, "commit", "-m", "init")
 
 	// Make a change so crit has something to review
 	writeFile(t, filepath.Join(repoDir, "test.md"), "# Hello\n\nWorld\n")

--- a/focus_session_test.go
+++ b/focus_session_test.go
@@ -133,9 +133,9 @@ func TestBucketComments_WorkingTreeKeepsAll(t *testing.T) {
 
 func TestSetFocus_Range_RebuildsFiles(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	commitAt(t, dir, "added.txt", "y\n", "add y")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	s := &Session{
 		RepoRoot:      dir,
@@ -179,9 +179,9 @@ func TestSetFocus_FullStackRequiresDefaultSHA(t *testing.T) {
 
 func TestSetFocus_WorkingTree_ClearsActiveDiffScope(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	commitAt(t, dir, "x.txt", "x\n", "x")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	s := &Session{
 		RepoRoot:      dir,
@@ -215,9 +215,9 @@ func TestSetFocus_WorkingTree_ClearsActiveDiffScope(t *testing.T) {
 // session so the UI can render a "Resume PR" affordance.
 func TestSetFocus_RangeToWorkingTree_StashesLastRangeFocus(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	commitAt(t, dir, "x.txt", "x\n", "x")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	s := &Session{
 		RepoRoot:      dir,

--- a/git.go
+++ b/git.go
@@ -55,10 +55,42 @@ func stripExternalDiffEnv() []string {
 	return out
 }
 
+// runGit runs `git args...` in dir with hardened env (GIT_TERMINAL_PROMPT=0
+// so a misconfigured credential helper can't hang the daemon waiting for tty
+// input) and an optional context for cancellation. Returns stdout bytes; on
+// error, the returned error includes captured stderr.
+//
+// This is a partial migration target: most call sites in this file still use
+// exec.Command directly. New code, and any site that benefits from
+// cancellation, should use runGit. Convert opportunistically.
+func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	// Append rather than replace os.Environ so existing GIT_* config (auth,
+	// SSH agent, etc.) is preserved. GIT_TERMINAL_PROMPT=0 prevents git from
+	// blocking on a credential prompt when run from a daemon with no tty.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		stderrTrim := strings.TrimSpace(stderr.String())
+		if stderrTrim != "" {
+			return stdout.Bytes(), fmt.Errorf("git %s: %w: %s", args[0], err, stderrTrim)
+		}
+		return stdout.Bytes(), fmt.Errorf("git %s: %w", args[0], err)
+	}
+	return stdout.Bytes(), nil
+}
+
 // IsGitRepo returns true if the current directory is inside a git repository.
 func IsGitRepo() bool {
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), "", "rev-parse", "--is-inside-work-tree")
 	if err != nil {
 		return false
 	}
@@ -67,8 +99,7 @@ func IsGitRepo() bool {
 
 // RepoRoot returns the absolute path to the git repository root.
 func RepoRoot() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), "", "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", fmt.Errorf("not a git repository")
 	}
@@ -253,8 +284,7 @@ func ChangedFilesScoped(scope, baseRef string) ([]FileChange, error) {
 
 // changedFilesStaged returns only staged (cached) changes.
 func changedFilesStaged() ([]FileChange, error) {
-	cmd := exec.Command("git", "diff", "--cached", "--name-status")
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), "", "diff", "--cached", "--name-status")
 	if err != nil {
 		return nil, fmt.Errorf("git diff --cached failed: %w", err)
 	}
@@ -263,8 +293,7 @@ func changedFilesStaged() ([]FileChange, error) {
 
 // changedFilesUnstaged returns unstaged modifications plus untracked files.
 func changedFilesUnstaged() ([]FileChange, error) {
-	cmd := exec.Command("git", "diff", "--name-status")
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), "", "diff", "--name-status")
 	if err != nil {
 		return nil, fmt.Errorf("git diff failed: %w", err)
 	}
@@ -286,8 +315,7 @@ func changedFilesBranch(baseRef string) ([]FileChange, error) {
 	if baseRef == "" {
 		return nil, nil
 	}
-	cmd := exec.Command("git", "diff", baseRef+"..HEAD", "--name-status")
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), "", "diff", baseRef+"..HEAD", "--name-status")
 	if err != nil {
 		return nil, fmt.Errorf("git diff %s..HEAD failed: %w", baseRef, err)
 	}
@@ -785,11 +813,7 @@ func untrackedFilesInDir(dir string) ([]FileChange, error) {
 // Paths are relative to the repo root. dir should be the repo root.
 func AllTrackedFiles(dir string) ([]string, error) {
 	// Tracked files
-	cmd := exec.Command("git", "ls-files")
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	out, err := cmd.Output()
+	out, err := runGit(context.Background(), dir, "ls-files")
 	if err != nil {
 		return nil, fmt.Errorf("git ls-files failed: %w", err)
 	}
@@ -807,11 +831,7 @@ func AllTrackedFiles(dir string) ([]string, error) {
 	}
 
 	// Untracked but not gitignored
-	cmd2 := exec.Command("git", "ls-files", "--others", "--exclude-standard")
-	if dir != "" {
-		cmd2.Dir = dir
-	}
-	out2, err := cmd2.Output()
+	out2, err := runGit(context.Background(), dir, "ls-files", "--others", "--exclude-standard")
 	if err != nil {
 		return files, nil //nolint:nilerr // non-fatal: return tracked files only
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -238,10 +238,10 @@ func TestChangedFiles_FeatureBranch(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a feature branch and add a file
-	runGit(t, dir, "checkout", "-b", "feature/test")
+	gitT(t, dir, "checkout", "-b", "feature/test")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "add feature")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "add feature")
 
 	// Also modify a file without committing
 	writeFile(t, filepath.Join(dir, "README.md"), "# Updated")
@@ -271,7 +271,7 @@ func TestFileDiffUnified_RealRepo(t *testing.T) {
 
 	// Modify README.md
 	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n\nNew content\n")
-	runGit(t, dir, "add", "README.md")
+	gitT(t, dir, "add", "README.md")
 
 	hunks, err := fileDiffUnified("README.md", "HEAD", "")
 	if err != nil {
@@ -309,7 +309,7 @@ func TestCurrentBranch_RealRepo(t *testing.T) {
 		t.Errorf("CurrentBranch = %q, want main", branch)
 	}
 
-	runGit(t, dir, "checkout", "-b", "feature/test")
+	gitT(t, dir, "checkout", "-b", "feature/test")
 	branch = CurrentBranch()
 	if branch != "feature/test" {
 		t.Errorf("CurrentBranch = %q, want feature/test", branch)
@@ -375,17 +375,17 @@ func TestRemoteBranches(t *testing.T) {
 
 	// Create a bare remote and push branches
 	bare := t.TempDir()
-	runGit(t, bare, "init", "--bare")
-	runGit(t, dir, "remote", "add", "origin", bare)
-	runGit(t, dir, "push", "origin", "main")
+	gitT(t, bare, "init", "--bare")
+	gitT(t, dir, "remote", "add", "origin", bare)
+	gitT(t, dir, "push", "origin", "main")
 
-	runGit(t, dir, "checkout", "-b", "production")
+	gitT(t, dir, "checkout", "-b", "production")
 	writeFile(t, filepath.Join(dir, "prod.go"), "package main\n")
-	runGit(t, dir, "add", "prod.go")
-	runGit(t, dir, "commit", "-m", "prod")
-	runGit(t, dir, "push", "origin", "production")
+	gitT(t, dir, "add", "prod.go")
+	gitT(t, dir, "commit", "-m", "prod")
+	gitT(t, dir, "push", "origin", "production")
 
-	runGit(t, dir, "checkout", "main")
+	gitT(t, dir, "checkout", "main")
 
 	branches, err := RemoteBranches(dir)
 	if err != nil {
@@ -415,13 +415,13 @@ func TestChangedFilesBranch(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Record the main branch commit as base ref
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Create a feature branch and commit a change
-	runGit(t, dir, "checkout", "-b", "feature/scoped")
+	gitT(t, dir, "checkout", "-b", "feature/scoped")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n\nfunc Feature() {}\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "add feature")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "add feature")
 
 	changes, err := changedFilesBranch(baseRef)
 	if err != nil {
@@ -447,24 +447,24 @@ func TestMergeBase_OriginMain(t *testing.T) {
 
 	// Set up a bare remote and push main
 	bare := t.TempDir()
-	runGit(t, bare, "init", "--bare")
-	runGit(t, dir, "remote", "add", "origin", bare)
-	runGit(t, dir, "push", "origin", "main")
+	gitT(t, bare, "init", "--bare")
+	gitT(t, dir, "remote", "add", "origin", bare)
+	gitT(t, dir, "push", "origin", "main")
 
 	// Record local main's commit
-	localMainSHA := runGit(t, dir, "rev-parse", "main")
+	localMainSHA := gitT(t, dir, "rev-parse", "main")
 
 	// Advance origin/main by committing on main and pushing, then resetting local main back
 	writeFile(t, filepath.Join(dir, "upstream.go"), "package main\n")
-	runGit(t, dir, "add", "upstream.go")
-	runGit(t, dir, "commit", "-m", "upstream commit")
-	runGit(t, dir, "push", "origin", "main")
+	gitT(t, dir, "add", "upstream.go")
+	gitT(t, dir, "commit", "-m", "upstream commit")
+	gitT(t, dir, "push", "origin", "main")
 	// Reset local main back to simulate not fast-forwarding
-	runGit(t, dir, "reset", "--hard", localMainSHA)
+	gitT(t, dir, "reset", "--hard", localMainSHA)
 
 	// Fetch in the original repo so origin/main is ahead of local main
-	runGit(t, dir, "fetch", "origin")
-	originMainSHA := runGit(t, dir, "rev-parse", "origin/main")
+	gitT(t, dir, "fetch", "origin")
+	originMainSHA := gitT(t, dir, "rev-parse", "origin/main")
 
 	// Sanity: origin/main should be ahead of local main
 	if localMainSHA == originMainSHA {
@@ -472,10 +472,10 @@ func TestMergeBase_OriginMain(t *testing.T) {
 	}
 
 	// Create a feature branch based on origin/main (the reporter's workflow)
-	runGit(t, dir, "checkout", "-b", "feature/test", "origin/main")
+	gitT(t, dir, "checkout", "-b", "feature/test", "origin/main")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// MergeBase against "origin/main" should give origin/main's SHA (tight diff)
 	mb, err := MergeBase("origin/main")
@@ -545,9 +545,9 @@ func TestDefaultBaseRef_PrefersOrigin(t *testing.T) {
 
 	// Add a remote and push so refs/remotes/origin/main exists.
 	bare := t.TempDir()
-	runGit(t, bare, "init", "--bare")
-	runGit(t, dir, "remote", "add", "origin", bare)
-	runGit(t, dir, "push", "origin", "main")
+	gitT(t, bare, "init", "--bare")
+	gitT(t, dir, "remote", "add", "origin", bare)
+	gitT(t, dir, "push", "origin", "main")
 
 	defaultBranchOnce = sync.Once{}
 	defaultBranchResult = ""
@@ -574,18 +574,18 @@ func TestMergeBase_FallsBackToOriginWhenLocalMissing(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	bare := t.TempDir()
-	runGit(t, bare, "init", "--bare")
-	runGit(t, dir, "remote", "add", "origin", bare)
-	runGit(t, dir, "push", "origin", "main")
-	originMainSHA := runGit(t, dir, "rev-parse", "origin/main")
+	gitT(t, bare, "init", "--bare")
+	gitT(t, dir, "remote", "add", "origin", bare)
+	gitT(t, dir, "push", "origin", "main")
+	originMainSHA := gitT(t, dir, "rev-parse", "origin/main")
 
-	runGit(t, dir, "checkout", "-b", "feature/no-local-main", "origin/main")
+	gitT(t, dir, "checkout", "-b", "feature/no-local-main", "origin/main")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// Delete local main so only origin/main remains — the bare-repo-worktree case
-	runGit(t, dir, "branch", "-D", "main")
+	gitT(t, dir, "branch", "-D", "main")
 
 	mb, err := MergeBase("main")
 	if err != nil {
@@ -619,7 +619,7 @@ func TestChangedFilesStaged(t *testing.T) {
 
 	// Stage a modification without committing
 	writeFile(t, filepath.Join(dir, "README.md"), "# Staged change")
-	runGit(t, dir, "add", "README.md")
+	gitT(t, dir, "add", "README.md")
 
 	staged, err := changedFilesStaged()
 	if err != nil {
@@ -711,17 +711,17 @@ func TestChangedFilesScoped_Dispatcher(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Create a feature branch with a committed change
-	runGit(t, dir, "checkout", "-b", "feature/dispatch")
+	gitT(t, dir, "checkout", "-b", "feature/dispatch")
 	writeFile(t, filepath.Join(dir, "branch.go"), "package main")
-	runGit(t, dir, "add", "branch.go")
-	runGit(t, dir, "commit", "-m", "branch change")
+	gitT(t, dir, "add", "branch.go")
+	gitT(t, dir, "commit", "-m", "branch change")
 
 	// Stage a file
 	writeFile(t, filepath.Join(dir, "staged.go"), "package main")
-	runGit(t, dir, "add", "staged.go")
+	gitT(t, dir, "add", "staged.go")
 
 	// Leave a file unstaged
 	writeFile(t, filepath.Join(dir, "README.md"), "# Unstaged")
@@ -781,13 +781,13 @@ func TestFileDiffScoped_Branch(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Create feature branch with a change to README.md
-	runGit(t, dir, "checkout", "-b", "feature/diff-scope")
+	gitT(t, dir, "checkout", "-b", "feature/diff-scope")
 	writeFile(t, filepath.Join(dir, "README.md"), "# Modified on branch\n\nNew content\n")
-	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "commit", "-m", "modify readme")
+	gitT(t, dir, "add", "README.md")
+	gitT(t, dir, "commit", "-m", "modify readme")
 
 	hunks, err := FileDiffScoped("README.md", "branch", baseRef, dir)
 	if err != nil {
@@ -806,7 +806,7 @@ func TestFileDiffScoped_Staged(t *testing.T) {
 
 	// Stage a change
 	writeFile(t, filepath.Join(dir, "README.md"), "# Staged content\n")
-	runGit(t, dir, "add", "README.md")
+	gitT(t, dir, "add", "README.md")
 
 	hunks, err := FileDiffScoped("README.md", "staged", "", dir)
 	if err != nil {
@@ -843,7 +843,7 @@ func TestFileDiffScoped_Default(t *testing.T) {
 
 	// Modify and stage a change
 	writeFile(t, filepath.Join(dir, "README.md"), "# Default scope\n")
-	runGit(t, dir, "add", "README.md")
+	gitT(t, dir, "add", "README.md")
 
 	hunks, err := FileDiffScoped("README.md", "", "HEAD", dir)
 	if err != nil {
@@ -875,17 +875,17 @@ func TestFileDiffScoped_DifferentHunksPerScope(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Commit a change on a branch
-	runGit(t, dir, "checkout", "-b", "feature/multi-scope")
+	gitT(t, dir, "checkout", "-b", "feature/multi-scope")
 	writeFile(t, filepath.Join(dir, "README.md"), "# Branch change\n")
-	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "commit", "-m", "branch edit")
+	gitT(t, dir, "add", "README.md")
+	gitT(t, dir, "commit", "-m", "branch edit")
 
 	// Stage a further change
 	writeFile(t, filepath.Join(dir, "README.md"), "# Branch change\n\nStaged line\n")
-	runGit(t, dir, "add", "README.md")
+	gitT(t, dir, "add", "README.md")
 
 	// Make an unstaged change on top
 	writeFile(t, filepath.Join(dir, "README.md"), "# Branch change\n\nStaged line\nUnstaged line\n")
@@ -1027,15 +1027,15 @@ func TestFileDiff_SuppressBlankEmpty(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Enable suppressBlankEmpty
-	runGit(t, dir, "config", "diff.suppressBlankEmpty", "true")
+	gitT(t, dir, "config", "diff.suppressBlankEmpty", "true")
 
 	// File with blank lines between code blocks
 	original := "func A() {\n}\n\nfunc B() {\n\treturn old\n}\n\nfunc C() {\n}\n"
 	modified := "func A() {\n}\n\nfunc B() {\n\treturn new\n}\n\nfunc C() {\n}\n"
 
 	writeFile(t, filepath.Join(dir, "code.go"), original)
-	runGit(t, dir, "add", "code.go")
-	runGit(t, dir, "commit", "-m", "add code")
+	gitT(t, dir, "add", "code.go")
+	gitT(t, dir, "commit", "-m", "add code")
 
 	writeFile(t, filepath.Join(dir, "code.go"), modified)
 
@@ -1202,17 +1202,17 @@ func TestCommitLog(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Record the main branch commit as base ref
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Create a feature branch with two commits
-	runGit(t, dir, "checkout", "-b", "feature/commits")
+	gitT(t, dir, "checkout", "-b", "feature/commits")
 	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
-	runGit(t, dir, "add", "a.go")
-	runGit(t, dir, "commit", "-m", "add function A")
+	gitT(t, dir, "add", "a.go")
+	gitT(t, dir, "commit", "-m", "add function A")
 
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
-	runGit(t, dir, "add", "b.go")
-	runGit(t, dir, "commit", "-m", "add function B")
+	gitT(t, dir, "add", "b.go")
+	gitT(t, dir, "commit", "-m", "add function B")
 
 	commits, err := CommitLog(baseRef, "", dir)
 	if err != nil {
@@ -1267,22 +1267,22 @@ func TestCommitLogEmpty(t *testing.T) {
 
 func TestCommitLog_BetweenSHAs(t *testing.T) {
 	dir := initTestRepo(t)
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
-	runGit(t, dir, "checkout", "-b", "feature/range-head")
+	gitT(t, dir, "checkout", "-b", "feature/range-head")
 	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
-	runGit(t, dir, "add", "a.go")
-	runGit(t, dir, "commit", "-m", "A")
-	shaA := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "a.go")
+	gitT(t, dir, "commit", "-m", "A")
+	shaA := gitT(t, dir, "rev-parse", "HEAD")
 
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
-	runGit(t, dir, "add", "b.go")
-	runGit(t, dir, "commit", "-m", "B")
-	shaB := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "b.go")
+	gitT(t, dir, "commit", "-m", "B")
+	shaB := gitT(t, dir, "rev-parse", "HEAD")
 
 	writeFile(t, filepath.Join(dir, "c.go"), "package main\n\nfunc C() {}\n")
-	runGit(t, dir, "add", "c.go")
-	runGit(t, dir, "commit", "-m", "C")
+	gitT(t, dir, "add", "c.go")
+	gitT(t, dir, "commit", "-m", "C")
 
 	// HEAD is at C; explicit head=B should return only [B, A].
 	commits, err := CommitLog(baseRef, shaB, dir)
@@ -1322,19 +1322,19 @@ func TestChangedFilesForCommit(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Create a feature branch with two commits
-	runGit(t, dir, "checkout", "-b", "feature/commit-files")
+	gitT(t, dir, "checkout", "-b", "feature/commit-files")
 	writeFile(t, filepath.Join(dir, "a.txt"), "hello\n")
-	runGit(t, dir, "add", "a.txt")
-	runGit(t, dir, "commit", "-m", "add a.txt")
+	gitT(t, dir, "add", "a.txt")
+	gitT(t, dir, "commit", "-m", "add a.txt")
 
 	// Second commit: add b.txt and modify a.txt
 	writeFile(t, filepath.Join(dir, "b.txt"), "world\n")
 	writeFile(t, filepath.Join(dir, "a.txt"), "hello modified\n")
-	runGit(t, dir, "add", "a.txt", "b.txt")
-	runGit(t, dir, "commit", "-m", "add b.txt and modify a.txt")
+	gitT(t, dir, "add", "a.txt", "b.txt")
+	gitT(t, dir, "commit", "-m", "add b.txt and modify a.txt")
 
 	// Get HEAD SHA
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	changes, err := ChangedFilesForCommit(sha, dir)
 	if err != nil {
@@ -1361,13 +1361,13 @@ func TestFileDiffForCommit(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Create a feature branch and commit a file
-	runGit(t, dir, "checkout", "-b", "feature/commit-diff")
+	gitT(t, dir, "checkout", "-b", "feature/commit-diff")
 	writeFile(t, filepath.Join(dir, "code.go"), "package main\n\nfunc Hello() {}\n")
-	runGit(t, dir, "add", "code.go")
-	runGit(t, dir, "commit", "-m", "add code.go")
+	gitT(t, dir, "add", "code.go")
+	gitT(t, dir, "commit", "-m", "add code.go")
 
 	// Get HEAD SHA
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	hunks, err := FileDiffForCommit("code.go", sha, dir)
 	if err != nil {
@@ -1397,8 +1397,8 @@ func TestAllTrackedFiles_RealRepo(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "src/main.go"), "package main")
 	writeFile(t, filepath.Join(dir, "src/util.go"), "package main")
 	writeFile(t, filepath.Join(dir, "docs/readme.md"), "# docs")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add files")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add files")
 
 	files, err := AllTrackedFiles(dir)
 	if err != nil {
@@ -1447,8 +1447,8 @@ func TestAllTrackedFiles_ExcludesGitignored(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "app.log"), "log data")
 	writeFile(t, filepath.Join(dir, "build/out.bin"), "binary")
 	writeFile(t, filepath.Join(dir, "keep.txt"), "keep")
-	runGit(t, dir, "add", ".gitignore", "keep.txt")
-	runGit(t, dir, "commit", "-m", "add files")
+	gitT(t, dir, "add", ".gitignore", "keep.txt")
+	gitT(t, dir, "commit", "-m", "add files")
 
 	files, err := AllTrackedFiles(dir)
 	if err != nil {
@@ -1545,15 +1545,15 @@ func TestDiffNumstat(t *testing.T) {
 	dir := initTestRepo(t)
 
 	writeFile(t, filepath.Join(dir, "stats.go"), "package main\n\nfunc hello() {}\n")
-	runGit(t, dir, "add", "stats.go")
-	runGit(t, dir, "commit", "-m", "add stats.go")
-	runGit(t, dir, "checkout", "-b", "feature-numstat")
+	gitT(t, dir, "add", "stats.go")
+	gitT(t, dir, "commit", "-m", "add stats.go")
+	gitT(t, dir, "checkout", "-b", "feature-numstat")
 	writeFile(t, filepath.Join(dir, "stats.go"), "package main\n\nfunc hello() {\n\tfmt.Println(\"hi\")\n}\n\nfunc world() {}\n")
 	writeFile(t, filepath.Join(dir, "newfile.txt"), "line1\nline2\nline3\n")
-	runGit(t, dir, "add", "stats.go", "newfile.txt")
-	runGit(t, dir, "commit", "-m", "modify stats and add newfile")
+	gitT(t, dir, "add", "stats.go", "newfile.txt")
+	gitT(t, dir, "commit", "-m", "modify stats and add newfile")
 
-	base := strings.TrimSpace(runGit(t, dir, "merge-base", "main", "HEAD"))
+	base := strings.TrimSpace(gitT(t, dir, "merge-base", "main", "HEAD"))
 	stats, err := DiffNumstatDir(base, dir)
 	if err != nil {
 		t.Fatalf("DiffNumstat failed: %v", err)
@@ -1576,16 +1576,16 @@ func TestDiffNumstatBinary(t *testing.T) {
 	dir := initTestRepo(t)
 
 	writeFile(t, filepath.Join(dir, "notes.txt"), "hello\n")
-	runGit(t, dir, "add", "notes.txt")
-	runGit(t, dir, "commit", "-m", "add notes")
-	runGit(t, dir, "checkout", "-b", "feature-binary")
+	gitT(t, dir, "add", "notes.txt")
+	gitT(t, dir, "commit", "-m", "add notes")
+	gitT(t, dir, "checkout", "-b", "feature-binary")
 
 	binPath := filepath.Join(dir, "image.png")
 	os.WriteFile(binPath, []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x00}, 0644)
-	runGit(t, dir, "add", "image.png")
-	runGit(t, dir, "commit", "-m", "add binary")
+	gitT(t, dir, "add", "image.png")
+	gitT(t, dir, "commit", "-m", "add binary")
 
-	base := strings.TrimSpace(runGit(t, dir, "merge-base", "main", "HEAD"))
+	base := strings.TrimSpace(gitT(t, dir, "merge-base", "main", "HEAD"))
 	stats, err := DiffNumstatDir(base, dir)
 	if err != nil {
 		t.Fatalf("DiffNumstat failed: %v", err)
@@ -1601,7 +1601,7 @@ func TestDiffNumstatBinary(t *testing.T) {
 func TestFileDiffForCommit_RootCommit(t *testing.T) {
 	dir := initTestRepo(t)
 	// Get the initial (root) commit SHA.
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	hunks, err := FileDiffForCommit("README.md", sha, dir)
 	if err != nil {
@@ -1615,9 +1615,9 @@ func TestFileDiffForCommit_RootCommit(t *testing.T) {
 func TestFileDiffForCommit_NormalCommit(t *testing.T) {
 	dir := initTestRepo(t)
 	writeFile(t, filepath.Join(dir, "README.md"), "# Test\n\nUpdated content\n")
-	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "commit", "-m", "update readme")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "README.md")
+	gitT(t, dir, "commit", "-m", "update readme")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	hunks, err := FileDiffForCommit("README.md", sha, dir)
 	if err != nil {
@@ -1631,9 +1631,9 @@ func TestFileDiffForCommit_NormalCommit(t *testing.T) {
 func TestFileDiffForCommit_FileNotInCommit(t *testing.T) {
 	dir := initTestRepo(t)
 	writeFile(t, filepath.Join(dir, "other.go"), "package main")
-	runGit(t, dir, "add", "other.go")
-	runGit(t, dir, "commit", "-m", "add other")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "other.go")
+	gitT(t, dir, "commit", "-m", "add other")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	// README.md was not changed in this commit.
 	hunks, err := FileDiffForCommit("README.md", sha, dir)

--- a/git_vcs_test.go
+++ b/git_vcs_test.go
@@ -43,9 +43,9 @@ func TestDetectVCS_GitOverride(t *testing.T) {
 func commitAt(t *testing.T, dir, path, content, msg string) string {
 	t.Helper()
 	writeFile(t, filepath.Join(dir, path), content)
-	runGit(t, dir, "add", "-A")
-	runGit(t, dir, "commit", "-m", msg)
-	return runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "-A")
+	gitT(t, dir, "commit", "-m", msg)
+	return gitT(t, dir, "rev-parse", "HEAD")
 }
 
 func sortChanges(in []FileChange) []FileChange {
@@ -56,7 +56,7 @@ func sortChanges(in []FileChange) []FileChange {
 
 func TestChangedFilesBetweenSHAs_AddOneFile(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	head := commitAt(t, dir, "a.txt", "hi", "add a")
 
 	got, err := ChangedFilesBetweenSHAs(base, head, dir)
@@ -72,12 +72,12 @@ func TestChangedFilesBetweenSHAs_AddOneFile(t *testing.T) {
 func TestChangedFilesBetweenSHAs_AddAndModify(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "b.txt", "v1", "add b")
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	writeFile(t, filepath.Join(dir, "a.txt"), "hi")
 	writeFile(t, filepath.Join(dir, "b.txt"), "v2")
-	runGit(t, dir, "add", "-A")
-	runGit(t, dir, "commit", "-m", "add a, modify b")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "-A")
+	gitT(t, dir, "commit", "-m", "add a, modify b")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	got, err := ChangedFilesBetweenSHAs(base, head, dir)
 	if err != nil {
@@ -95,10 +95,10 @@ func TestChangedFilesBetweenSHAs_AddAndModify(t *testing.T) {
 func TestChangedFilesBetweenSHAs_Rename(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "old.go", "package x\n", "add old")
-	base := runGit(t, dir, "rev-parse", "HEAD")
-	runGit(t, dir, "mv", "old.go", "new.go")
-	runGit(t, dir, "commit", "-m", "rename")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "mv", "old.go", "new.go")
+	gitT(t, dir, "commit", "-m", "rename")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	got, err := ChangedFilesBetweenSHAs(base, head, dir)
 	if err != nil {
@@ -112,10 +112,10 @@ func TestChangedFilesBetweenSHAs_Rename(t *testing.T) {
 func TestChangedFilesBetweenSHAs_Deletion(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "c.txt", "x", "add c")
-	base := runGit(t, dir, "rev-parse", "HEAD")
-	runGit(t, dir, "rm", "c.txt")
-	runGit(t, dir, "commit", "-m", "delete c")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "rm", "c.txt")
+	gitT(t, dir, "commit", "-m", "delete c")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	got, err := ChangedFilesBetweenSHAs(base, head, dir)
 	if err != nil {
@@ -129,7 +129,7 @@ func TestChangedFilesBetweenSHAs_Deletion(t *testing.T) {
 
 func TestChangedFilesBetweenSHAs_UntrackedNotIncluded(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	head := commitAt(t, dir, "a.txt", "hi", "add a")
 	// Add an untracked file in the working tree — should NOT appear in range.
 	writeFile(t, filepath.Join(dir, "untracked.txt"), "ignored")
@@ -148,9 +148,9 @@ func TestChangedFilesBetweenSHAs_UntrackedNotIncluded(t *testing.T) {
 func TestFileDiffBetweenSHAs_HappyPath(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "line1\nline2\n", "add a")
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	commitAt(t, dir, "a.txt", "line1\nline2\nline3\n", "modify a")
-	head := runGit(t, dir, "rev-parse", "HEAD")
+	head := gitT(t, dir, "rev-parse", "HEAD")
 
 	hunks, err := FileDiffBetweenSHAs("a.txt", base, head, dir)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestFileDiffBetweenSHAs_HappyPath(t *testing.T) {
 func TestFileDiffBetweenSHAs_IdenticalSHAs(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "line1\n", "add a")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 	hunks, err := FileDiffBetweenSHAs("a.txt", sha, sha, dir)
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +176,7 @@ func TestFileDiffBetweenSHAs_IdenticalSHAs(t *testing.T) {
 
 func TestFileDiffBetweenSHAs_MissingPath(t *testing.T) {
 	dir := initTestRepo(t)
-	base := runGit(t, dir, "rev-parse", "HEAD")
+	base := gitT(t, dir, "rev-parse", "HEAD")
 	head := commitAt(t, dir, "a.txt", "x", "add a")
 	hunks, err := FileDiffBetweenSHAs("does-not-exist.txt", base, head, dir)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestReadFileAtSHA_HappyPath(t *testing.T) {
 	dir := initTestRepo(t)
 	want := "hello world\n"
 	commitAt(t, dir, "a.txt", want, "add a")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	got, err := ReadFileAtSHA(sha, "a.txt", dir)
 	if err != nil {
@@ -205,7 +205,7 @@ func TestReadFileAtSHA_HappyPath(t *testing.T) {
 func TestReadFileAtSHA_MissingPath(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "x", "add a")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	got, err := ReadFileAtSHA(sha, "no-such-file.txt", dir)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestReadFileAtSHA_InvalidRef(t *testing.T) {
 
 func TestHasObject_Existing(t *testing.T) {
 	dir := initTestRepo(t)
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 	if !HasObject(sha, dir) {
 		t.Errorf("HasObject(%q) = false, want true", sha)
 	}
@@ -244,7 +244,7 @@ func TestHasObject_Bogus(t *testing.T) {
 func TestHasObject_NonCommit(t *testing.T) {
 	dir := initTestRepo(t)
 	// Tree SHA of HEAD — not a commit.
-	treeSHA := runGit(t, dir, "rev-parse", "HEAD^{tree}")
+	treeSHA := gitT(t, dir, "rev-parse", "HEAD^{tree}")
 	if HasObject(treeSHA, dir) {
 		t.Errorf("HasObject(tree %s) = true, want false (only commits)", treeSHA)
 	}

--- a/main.go
+++ b/main.go
@@ -2335,6 +2335,11 @@ func runServe(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 
+	// Wire the shutdown ctx into the server so background goroutines (agent
+	// runner, etc.) can be cancelled on SIGINT/SIGTERM/idle-timeout instead of
+	// orphaning subprocesses and racing with WriteFiles.
+	srv.SetShutdownCtx(ctx)
+
 	go func() {
 		if err := httpServer.Serve(listener); err != http.ErrServerClosed {
 			log.Printf("Server error: %v", err)
@@ -2387,6 +2392,10 @@ func runServe(args []string) {
 	if initErr != nil {
 		log.Printf("Error: %v", initErr)
 		srv.SetInitErr(initErr)
+		// Trigger immediate shutdown instead of waiting for SIGINT or the
+		// idle timeout. Without this the daemon would sit in 503-land for up
+		// to an hour after a failed init, burning a port and a process slot.
+		stop()
 		<-ctx.Done()
 		removeSessionFile(key)
 		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -2420,6 +2429,17 @@ func runServe(args []string) {
 
 	removeSessionFile(key)
 	session.Shutdown()
+
+	// Drain in-flight background goroutines (agent subprocess runners) so
+	// their replies land in the session before WriteFiles persists. Capped at
+	// 30s — if an agent is wedged we'd rather lose its reply than hang the
+	// daemon shutdown indefinitely. The agent ctx is parented on this same
+	// shutdown ctx (already Done() above), so the subprocess is being killed
+	// concurrently — most cases drain in milliseconds.
+	if !srv.WaitBackground(30 * time.Second) {
+		log.Printf("Warning: background goroutines did not drain within 30s; proceeding with shutdown")
+	}
+
 	session.WriteFiles()
 
 	if session.ReviewFilePath != "" {

--- a/main.go
+++ b/main.go
@@ -2428,14 +2428,33 @@ func runServe(args []string) {
 	close(watchStop)
 
 	removeSessionFile(key)
+
+	// Order matters here:
+	//   1. session.Shutdown()    — fires the final SSE "server-shutdown" event
+	//                              while clients are still connected.
+	//   2. httpServer.Shutdown() — stops accepting new conns and waits for
+	//                              in-flight handlers to return. This is what
+	//                              gates s.bgWG.Add(1): handleAgentRequest
+	//                              calls Add synchronously inside the handler
+	//                              before responding 202. Once Shutdown
+	//                              returns, no new Add() calls can race with
+	//                              the WaitBackground below — sync.WaitGroup
+	//                              would otherwise panic on Add-during-Wait.
+	//   3. WaitBackground        — drain spawned agent runners so their
+	//                              replies land before WriteFiles persists.
+	//                              Capped at 30s: a wedged agent loses its
+	//                              reply rather than hanging the daemon. The
+	//                              agent ctx is parented on the shutdown ctx
+	//                              (already Done() above), so subprocesses
+	//                              are being killed concurrently — most
+	//                              cases drain in milliseconds.
+	//   4. WriteFiles            — persist final review state.
 	session.Shutdown()
 
-	// Drain in-flight background goroutines (agent subprocess runners) so
-	// their replies land in the session before WriteFiles persists. Capped at
-	// 30s — if an agent is wedged we'd rather lose its reply than hang the
-	// daemon shutdown indefinitely. The agent ctx is parented on this same
-	// shutdown ctx (already Done() above), so the subprocess is being killed
-	// concurrently — most cases drain in milliseconds.
+	shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = httpServer.Shutdown(shutCtx)
+
 	if !srv.WaitBackground(30 * time.Second) {
 		log.Printf("Warning: background goroutines did not drain within 30s; proceeding with shutdown")
 	}
@@ -2445,10 +2464,6 @@ func runServe(args []string) {
 	if session.ReviewFilePath != "" {
 		fmt.Fprintf(os.Stderr, "Review file: %s\n", session.ReviewFilePath)
 	}
-
-	shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_ = httpServer.Shutdown(shutCtx)
 }
 
 func runStatus(args []string) {

--- a/picker_test.go
+++ b/picker_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestResolveDefaultBranchSHA_Git(t *testing.T) {
 	dir := initTestRepo(t)
-	want := runGit(t, dir, "rev-parse", "HEAD")
+	want := gitT(t, dir, "rev-parse", "HEAD")
 	got, err := ResolveDefaultBranchSHA(&GitVCS{}, dir, "main")
 	if err != nil {
 		t.Fatal(err)
@@ -43,8 +43,8 @@ func TestWalkAncestors_Git(t *testing.T) {
 func TestLocalBranchTips_Git(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "x", "a")
-	headBeforeBranch := runGit(t, dir, "rev-parse", "HEAD")
-	runGit(t, dir, "checkout", "-b", "feat-x")
+	headBeforeBranch := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "checkout", "-b", "feat-x")
 	commitAt(t, dir, "b.txt", "y", "b")
 
 	got, err := localBranchTips(&GitVCS{}, dir)
@@ -65,9 +65,9 @@ func TestLocalBranchTips_Git(t *testing.T) {
 
 func TestRemoteBranchTips_Git_ExcludesDefault(t *testing.T) {
 	dir := initTestRepo(t)
-	headSHA := runGit(t, dir, "rev-parse", "HEAD")
-	runGit(t, dir, "update-ref", "refs/remotes/origin/feat-x", headSHA)
-	runGit(t, dir, "update-ref", "refs/remotes/origin/main", headSHA)
+	headSHA := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "update-ref", "refs/remotes/origin/feat-x", headSHA)
+	gitT(t, dir, "update-ref", "refs/remotes/origin/main", headSHA)
 
 	branches, err := remoteBranchTips(&GitVCS{}, dir, "main")
 	if err != nil {
@@ -135,11 +135,11 @@ func TestHandlePicker_MethodNotAllowed(t *testing.T) {
 func TestHandlePicker_StackEntriesIncludeDefaultSHA(t *testing.T) {
 	s, sess := newTestServer(t)
 	dir := initTestRepo(t)
-	defaultSHA := runGit(t, dir, "rev-parse", "HEAD")
+	defaultSHA := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Build a feature branch so the local-branch-tip walker has something
 	// to detect as a stack entry.
-	runGit(t, dir, "checkout", "-b", "feat-a")
+	gitT(t, dir, "checkout", "-b", "feat-a")
 	commitAt(t, dir, "a.txt", "x", "a")
 
 	sess.mu.Lock()
@@ -182,13 +182,13 @@ func TestHandlePicker_DefaultSHAIsLiteralDefaultBranch(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Three layers above main: alpha → beta → gamma.
-	runGit(t, dir, "checkout", "-b", "alpha")
+	gitT(t, dir, "checkout", "-b", "alpha")
 	commitAt(t, dir, "a.txt", "a", "alpha")
 
-	runGit(t, dir, "checkout", "-b", "beta")
+	gitT(t, dir, "checkout", "-b", "beta")
 	commitAt(t, dir, "b.txt", "b", "beta")
 
-	runGit(t, dir, "checkout", "-b", "gamma")
+	gitT(t, dir, "checkout", "-b", "gamma")
 	commitAt(t, dir, "c.txt", "c", "gamma")
 
 	sess.mu.Lock()
@@ -211,7 +211,7 @@ func TestHandlePicker_DefaultSHAIsLiteralDefaultBranch(t *testing.T) {
 	if len(resp.Stack) < 2 {
 		t.Fatalf("expected 2+ stack entries, got %d: %+v", len(resp.Stack), resp.Stack)
 	}
-	mainSHA := runGit(t, dir, "rev-parse", "main")
+	mainSHA := gitT(t, dir, "rev-parse", "main")
 	for _, e := range resp.Stack {
 		if e.DefaultSHA != mainSHA {
 			t.Errorf("entry %q default_sha=%q want main (literal default) %q", e.Label, e.DefaultSHA, mainSHA)
@@ -227,15 +227,15 @@ func TestDetectStack_ExcludesStaleBranchesBeforeMergeBase(t *testing.T) {
 	dir := initTestRepo(t)
 	// Main commit M1, then a stale branch points here.
 	m1 := commitAt(t, dir, "m1.txt", "1", "m1")
-	runGit(t, dir, "branch", "old", m1)
+	gitT(t, dir, "branch", "old", m1)
 	// Main advances to M2 — this is what feature branches off of.
 	commitAt(t, dir, "m2.txt", "2", "m2")
 	// Feature branch off main@M2 with two commits F1, F2.
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "checkout", "-b", "feat")
 	f1 := commitAt(t, dir, "f1.txt", "f1", "f1")
 	f2 := commitAt(t, dir, "f2.txt", "f2", "f2")
 	// Also park a branch on F1 so a legitimate post-merge-base entry shows up.
-	runGit(t, dir, "branch", "feat-f1", f1)
+	gitT(t, dir, "branch", "feat-f1", f1)
 
 	stack, err := detectStack(&GitVCS{}, dir, nil)
 	if err != nil {
@@ -270,11 +270,11 @@ func TestDetectStack_IncludesPostMergeBaseBranchTips(t *testing.T) {
 	// Main at M.
 	commitAt(t, dir, "m.txt", "m", "m")
 	// Feature branch with two commits A, B.
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "checkout", "-b", "feat")
 	a := commitAt(t, dir, "a.txt", "a", "a")
-	runGit(t, dir, "branch", "feat-a", a)
+	gitT(t, dir, "branch", "feat-a", a)
 	b := commitAt(t, dir, "b.txt", "b", "b")
-	runGit(t, dir, "branch", "feat-b", b)
+	gitT(t, dir, "branch", "feat-b", b)
 
 	stack, err := detectStack(&GitVCS{}, dir, nil)
 	if err != nil {
@@ -302,15 +302,15 @@ func TestDetectStack_DropsNakedCommitsBehindBranch(t *testing.T) {
 	dir := initTestRepo(t)
 	// Diverge "staging" from the default branch and pile noise commits on
 	// it (e.g. unrelated tickets that landed on staging).
-	runGit(t, dir, "checkout", "-b", "staging")
+	gitT(t, dir, "checkout", "-b", "staging")
 	commitAt(t, dir, "n1.txt", "n1", "[ABC-100] noise one")
 	commitAt(t, dir, "n2.txt", "n2", "[ABC-101] noise two")
 	commitAt(t, dir, "n3.txt", "n3", "[ABC-102] noise three")
 	// Parent feature branch on top of staging.
-	runGit(t, dir, "checkout", "-b", "feat-parent")
+	gitT(t, dir, "checkout", "-b", "feat-parent")
 	commitAt(t, dir, "p.txt", "p", "feat-parent commit")
 	// Current branch on top of feat-parent.
-	runGit(t, dir, "checkout", "-b", "feat-current")
+	gitT(t, dir, "checkout", "-b", "feat-current")
 	commitAt(t, dir, "c.txt", "c", "feat-current commit")
 
 	stack, err := detectStack(&GitVCS{}, dir, nil)
@@ -348,13 +348,13 @@ func TestDetectStack_DropsNakedCommitsBehindBranch(t *testing.T) {
 func TestDetectStack_KeepsNakedCommitsAheadOfNearestBranch(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "m.txt", "m", "main")
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "checkout", "-b", "feat")
 	commitAt(t, dir, "f.txt", "f", "feat tip")
-	featTipSHA := runGit(t, dir, "rev-parse", "HEAD")
+	featTipSHA := gitT(t, dir, "rev-parse", "HEAD")
 	// Detach HEAD so subsequent commits don't drag the feat ref forward —
 	// we want feat to stay an older branch-tip ancestor while new naked
 	// commits land on top.
-	runGit(t, dir, "checkout", "--detach", featTipSHA)
+	gitT(t, dir, "checkout", "--detach", featTipSHA)
 	commitAt(t, dir, "w1.txt", "w1", "wip one")
 	commitAt(t, dir, "w2.txt", "w2", "wip two")
 
@@ -388,10 +388,10 @@ func TestDetectStack_KeepsNakedCommitsAheadOfNearestBranch(t *testing.T) {
 func TestDetectStack_DefaultBranchAsRoot(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "m1.txt", "1", "m1")
-	mergeBase := runGit(t, dir, "rev-parse", "HEAD")
+	mergeBase := gitT(t, dir, "rev-parse", "HEAD")
 	// Park a stale branch on the merge-base SHA — should still be excluded.
-	runGit(t, dir, "branch", "stale-at-base", mergeBase)
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "branch", "stale-at-base", mergeBase)
+	gitT(t, dir, "checkout", "-b", "feat")
 	commitAt(t, dir, "f.txt", "f", "f")
 
 	stack, err := detectStack(&GitVCS{}, dir, nil)

--- a/server.go
+++ b/server.go
@@ -156,9 +156,6 @@ func (s *Server) withReady(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// SetSession attaches a fully initialized session and marks the server as ready.
-// Uses atomic.Pointer to ensure the session pointer is visible to all goroutines
-// immediately after store, which is critical on weakly-ordered architectures (ARM64).
 // SetShutdownCtx wires the daemon's signal-handled context into the server so
 // background goroutines can react to shutdown. Call this once during daemon
 // startup, before any handler can fire. Tests that don't run a real daemon may
@@ -196,6 +193,9 @@ func (s *Server) WaitBackground(timeout time.Duration) bool {
 	}
 }
 
+// SetSession attaches a fully initialized session and marks the server as ready.
+// Uses atomic.Pointer to ensure the session pointer is visible to all goroutines
+// immediately after store, which is critical on weakly-ordered architectures (ARM64).
 func (s *Server) SetSession(session *Session) {
 	s.session.Store(session)
 }

--- a/server.go
+++ b/server.go
@@ -52,6 +52,16 @@ type Server struct {
 	reviewPath        string
 	cliArgs           []string     // positional file args; flags (--pr, --range, etc.) are not preserved
 	prList            *prListCache // 60s cache for picker "Other PRs"
+
+	// shutdownCtx is the daemon's signal-handled context; child operations
+	// (e.g. runAgentCmd subprocesses) derive their context from this so a
+	// SIGINT/SIGTERM/idle-timeout cancels them instead of leaking. Set via
+	// SetShutdownCtx; nil in tests, in which case a background context is used.
+	shutdownCtx context.Context
+	// bgWG tracks long-running background goroutines (e.g. agent subprocess
+	// runners) that must complete before the daemon writes the review file
+	// during shutdown. The shutdown path Wait()s on this with a timeout.
+	bgWG sync.WaitGroup
 }
 
 // NewServer creates a Server with the given session and configuration.
@@ -149,6 +159,43 @@ func (s *Server) withReady(next http.HandlerFunc) http.HandlerFunc {
 // SetSession attaches a fully initialized session and marks the server as ready.
 // Uses atomic.Pointer to ensure the session pointer is visible to all goroutines
 // immediately after store, which is critical on weakly-ordered architectures (ARM64).
+// SetShutdownCtx wires the daemon's signal-handled context into the server so
+// background goroutines can react to shutdown. Call this once during daemon
+// startup, before any handler can fire. Tests that don't run a real daemon may
+// leave it unset; effectiveCtx then falls back to context.Background().
+func (s *Server) SetShutdownCtx(ctx context.Context) {
+	s.shutdownCtx = ctx
+}
+
+// effectiveCtx returns the daemon shutdown ctx if set, otherwise a background
+// ctx. Used by background goroutines so test paths (which don't run a real
+// daemon and never call SetShutdownCtx) keep working.
+func (s *Server) effectiveCtx() context.Context {
+	if s.shutdownCtx != nil {
+		return s.shutdownCtx
+	}
+	return context.Background()
+}
+
+// WaitBackground blocks until all tracked background goroutines (currently:
+// agent subprocess runners) have returned, or until timeout elapses. Returns
+// true on clean drain, false on timeout. Called from the daemon shutdown path
+// to give in-flight agent runs a chance to post their replies before
+// session.WriteFiles() persists the final state.
+func (s *Server) WaitBackground(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		s.bgWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 func (s *Server) SetSession(session *Session) {
 	s.session.Store(session)
 }
@@ -1398,8 +1445,14 @@ func (s *Server) handleAgentRequest(w http.ResponseWriter, r *http.Request) {
 
 	prompt := buildAgentPrompt(comment, filePath)
 
-	// Run agent command asynchronously
-	go s.runAgentCmd(prompt, comment.ID, filePath)
+	// Run agent command asynchronously. Tracked via bgWG so the daemon
+	// shutdown path can wait for the reply to be posted before WriteFiles
+	// persists the final review state.
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		s.runAgentCmd(prompt, comment.ID, filePath)
+	}()
 
 	w.WriteHeader(http.StatusAccepted)
 	writeJSON(w, map[string]any{
@@ -1442,7 +1495,11 @@ func buildAgentPrompt(c Comment, filePath string) string {
 // If agent_cmd contains {prompt}, the placeholder is replaced with the prompt
 // as a single argument. Otherwise, the prompt is piped via stdin.
 func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	// Parent on the daemon shutdown ctx so SIGINT/SIGTERM/idle-timeout kills
+	// the agent subprocess instead of orphaning it (the subprocess has its
+	// own session id via daemonSysProcAttr). Tests that don't wire a shutdown
+	// ctx fall back to context.Background() — same behavior as before.
+	ctx, cancel := context.WithTimeout(s.effectiveCtx(), 10*time.Minute)
 	defer cancel()
 
 	parts := strings.Fields(s.agentCmd)
@@ -1498,6 +1555,14 @@ func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
 	if !ok {
 		log.Printf("agent-request %s: failed to add reply (comment not found in file %q)", commentID, filePath)
 	} else {
+		// On shutdown, skip the refresh fan-out: the SSE subscribers are gone
+		// and we're about to WriteFiles. The reply is already in the session
+		// (added by AddReply above) and will be persisted.
+		select {
+		case <-s.effectiveCtx().Done():
+			return
+		default:
+		}
 		// Re-read content (and file list/diffs in git mode) so next fetch returns updated data
 		sess.RefreshFileContent()
 		if sess.Mode == "git" {

--- a/server_agent_test.go
+++ b/server_agent_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleAgentRequest_NoAgentConfigured(t *testing.T) {
@@ -163,5 +165,72 @@ func TestRunAgentCmd_StdinFallback(t *testing.T) {
 	}
 	if replies[0].Author != "cat" {
 		t.Errorf("reply author = %q, want 'cat'", replies[0].Author)
+	}
+}
+
+// TestRunAgentCmd_CancelledByShutdownCtx verifies that the agent subprocess
+// is terminated when the daemon's shutdown ctx is cancelled — regression
+// guard for the orphaned-subprocess bug.
+func TestRunAgentCmd_CancelledByShutdownCtx(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, session := newTestServer(t)
+	session.RepoRoot = dir
+	// Sleep longer than the test timeout would tolerate; we'll cancel mid-run.
+	s.agentCmd = "sleep 30"
+
+	session.mu.Lock()
+	session.Files[0].Comments = []Comment{
+		{ID: "c1", StartLine: 1, EndLine: 1, Body: "test", Author: "reviewer", Scope: "line"},
+	}
+	session.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.SetShutdownCtx(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		s.runAgentCmd("prompt", "c1", session.Files[0].Path)
+		close(done)
+	}()
+
+	// Give the subprocess a moment to spawn, then cancel.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Good: cancel killed the subprocess and runAgentCmd returned promptly.
+	case <-time.After(5 * time.Second):
+		t.Fatal("runAgentCmd did not return within 5s of shutdown ctx cancel — subprocess orphaned")
+	}
+}
+
+// TestWaitBackground_TimesOut verifies WaitBackground returns false when
+// background goroutines exceed the timeout, and true on clean drain.
+func TestWaitBackground_TimesOut(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	// Clean drain: no work outstanding.
+	if !s.WaitBackground(50 * time.Millisecond) {
+		t.Error("WaitBackground returned false with no outstanding work")
+	}
+
+	// Wedged goroutine: should time out.
+	release := make(chan struct{})
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		<-release
+	}()
+	if s.WaitBackground(50 * time.Millisecond) {
+		t.Error("WaitBackground returned true while a goroutine was still running")
+	}
+	close(release)
+	if !s.WaitBackground(time.Second) {
+		t.Error("WaitBackground did not drain after the goroutine exited")
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1394,8 +1394,8 @@ func TestGetFile_NotInSession_NotOnDisk(t *testing.T) {
 func TestGetFilesList(t *testing.T) {
 	dir := initTestRepo(t)
 	writeFile(t, filepath.Join(dir, "src/main.go"), "package main")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add file")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add file")
 
 	session := &Session{
 		Mode:          "git",
@@ -1457,8 +1457,8 @@ func TestGetFilesList_RespectsIgnorePatterns(t *testing.T) {
 	dir := initTestRepo(t)
 	writeFile(t, filepath.Join(dir, "main.go"), "package main")
 	writeFile(t, filepath.Join(dir, "debug.log"), "log data")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add files")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add files")
 
 	session := &Session{
 		Mode:           "git",
@@ -2476,10 +2476,10 @@ func TestHandleCommits_MethodNotAllowed(t *testing.T) {
 func TestHandleCommits_GitMode(t *testing.T) {
 	dir := initTestRepo(t)
 	// Create a feature branch with a commit.
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "new.go"), "package main")
-	runGit(t, dir, "add", "new.go")
-	runGit(t, dir, "commit", "-m", "add new file")
+	gitT(t, dir, "add", "new.go")
+	gitT(t, dir, "commit", "-m", "add new file")
 
 	session := &Session{
 		Mode:        "git",
@@ -3433,10 +3433,10 @@ func TestHandleConfig_WithAuthToken(t *testing.T) {
 
 func TestHandleSession_WithScope(t *testing.T) {
 	dir := initTestRepo(t)
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "new.go"), "package main\n")
-	runGit(t, dir, "add", "new.go")
-	runGit(t, dir, "commit", "-m", "add new file")
+	gitT(t, dir, "add", "new.go")
+	gitT(t, dir, "commit", "-m", "add new file")
 
 	session := &Session{
 		Mode:        "git",
@@ -3553,11 +3553,11 @@ func TestHandleFile_MethodNotAllowed(t *testing.T) {
 
 func TestHandleSession_WithCommit(t *testing.T) {
 	dir := initTestRepo(t)
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "new.go"), "package main\n")
-	runGit(t, dir, "add", "new.go")
-	runGit(t, dir, "commit", "-m", "add new file")
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "new.go")
+	gitT(t, dir, "commit", "-m", "add new file")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	session := &Session{
 		Mode:        "git",

--- a/session_test.go
+++ b/session_test.go
@@ -699,8 +699,8 @@ func TestNewSessionFromGit_SubdirectoryCwd(t *testing.T) {
 
 	// Create a file in a subdirectory and commit it
 	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add src/main.go")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add src/main.go")
 
 	// Make an unstaged modification (the kind that shows in git diff HEAD)
 	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n\nfunc main() {}\n")
@@ -788,16 +788,16 @@ func TestNewSessionFromGit_BaseBranchParam(t *testing.T) {
 	}()
 
 	// Create a second branch "base" that acts as our custom base
-	runGit(t, dir, "checkout", "-b", "base")
+	gitT(t, dir, "checkout", "-b", "base")
 	writeFile(t, filepath.Join(dir, "base.go"), "package main\n")
-	runGit(t, dir, "add", "base.go")
-	runGit(t, dir, "commit", "-m", "base branch commit")
+	gitT(t, dir, "add", "base.go")
+	gitT(t, dir, "commit", "-m", "base branch commit")
 
 	// Now create a feature branch off "base" with a new file
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// Set the override — this is how resolveServerConfig() wires --base-branch
 	defaultBranchOverride = "base"
@@ -850,16 +850,16 @@ func TestChangeBaseBranch(t *testing.T) {
 
 	// main has: main.go
 	// Create "production" branch off main with extra files
-	runGit(t, dir, "checkout", "-b", "production")
+	gitT(t, dir, "checkout", "-b", "production")
 	writeFile(t, filepath.Join(dir, "prod.go"), "package main\n")
-	runGit(t, dir, "add", "prod.go")
-	runGit(t, dir, "commit", "-m", "production commit")
+	gitT(t, dir, "add", "prod.go")
+	gitT(t, dir, "commit", "-m", "production commit")
 
 	// Create feature branch off production
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// Create session with default base (main)
 	session, err := NewSessionFromGit(nil)
@@ -945,16 +945,16 @@ func TestChangeBaseBranch_CommentsPreserved(t *testing.T) {
 
 	// main has: README.md (initial commit)
 	// Create "production" branch with prod.go
-	runGit(t, dir, "checkout", "-b", "production")
+	gitT(t, dir, "checkout", "-b", "production")
 	writeFile(t, filepath.Join(dir, "prod.go"), "package main\n")
-	runGit(t, dir, "add", "prod.go")
-	runGit(t, dir, "commit", "-m", "production commit")
+	gitT(t, dir, "add", "prod.go")
+	gitT(t, dir, "commit", "-m", "production commit")
 
 	// Create feature branch with feature.go
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\nfunc Feature() {}\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// Create session (base=main, so both prod.go and feature.go appear)
 	session, err := NewSessionFromGit(nil)
@@ -1027,16 +1027,16 @@ func TestNewSessionFromFiles_BaseBranch(t *testing.T) {
 	}()
 
 	// Create a "base" branch with one file
-	runGit(t, dir, "checkout", "-b", "base")
+	gitT(t, dir, "checkout", "-b", "base")
 	writeFile(t, filepath.Join(dir, "base.go"), "package main\n")
-	runGit(t, dir, "add", "base.go")
-	runGit(t, dir, "commit", "-m", "base branch commit")
+	gitT(t, dir, "add", "base.go")
+	gitT(t, dir, "commit", "-m", "base branch commit")
 
 	// Create a "feature" branch off "base" with an additional file
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "feature.go"), "package main\n")
-	runGit(t, dir, "add", "feature.go")
-	runGit(t, dir, "commit", "-m", "feature commit")
+	gitT(t, dir, "add", "feature.go")
+	gitT(t, dir, "commit", "-m", "feature commit")
 
 	// Set the override — same mechanism as resolveServerConfig()
 	defaultBranchOverride = "base"
@@ -1363,7 +1363,7 @@ func TestFileDiffUnified_ColorConfigDoesNotBreakParsing(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Set color.diff=always in the repo config (simulates a user's gitconfig)
-	runGit(t, dir, "config", "color.diff", "always")
+	gitT(t, dir, "config", "color.diff", "always")
 
 	// Modify a file to create a diff
 	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n\nNew content\n")
@@ -2620,14 +2620,14 @@ func TestEnsureLoaded(t *testing.T) {
 	dir := initTestRepo(t)
 
 	writeFile(t, filepath.Join(dir, "lazy.go"), "package main\n\nfunc lazy() {}\n")
-	runGit(t, dir, "add", "lazy.go")
-	runGit(t, dir, "commit", "-m", "add lazy.go")
-	runGit(t, dir, "checkout", "-b", "feature-lazy")
+	gitT(t, dir, "add", "lazy.go")
+	gitT(t, dir, "commit", "-m", "add lazy.go")
+	gitT(t, dir, "checkout", "-b", "feature-lazy")
 	writeFile(t, filepath.Join(dir, "lazy.go"), "package main\n\nfunc lazy() {\n\tfmt.Println(\"loaded\")\n}\n")
-	runGit(t, dir, "add", "lazy.go")
-	runGit(t, dir, "commit", "-m", "modify lazy.go")
+	gitT(t, dir, "add", "lazy.go")
+	gitT(t, dir, "commit", "-m", "modify lazy.go")
 
-	base := strings.TrimSpace(runGit(t, dir, "merge-base", "main", "HEAD"))
+	base := strings.TrimSpace(gitT(t, dir, "merge-base", "main", "HEAD"))
 
 	fe := &FileEntry{
 		Path:    "lazy.go",
@@ -2688,13 +2688,13 @@ func TestNewSessionFromGitLazyThreshold(t *testing.T) {
 	defaultBranchOverride = ""
 	defer func() { defaultBranchOverride = "" }()
 
-	runGit(t, dir, "checkout", "-b", "feature-many-files")
+	gitT(t, dir, "checkout", "-b", "feature-many-files")
 	for i := 0; i < 120; i++ {
 		name := fmt.Sprintf("file%03d.go", i)
 		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("package main\n// file %d\n", i))
 	}
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add 120 files")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add 120 files")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -2737,12 +2737,12 @@ func TestNewSessionFromGitUnderThreshold(t *testing.T) {
 	defaultBranchOverride = ""
 	defer func() { defaultBranchOverride = "" }()
 
-	runGit(t, dir, "checkout", "-b", "feature-few-files")
+	gitT(t, dir, "checkout", "-b", "feature-few-files")
 	for i := 0; i < 5; i++ {
 		writeFile(t, filepath.Join(dir, fmt.Sprintf("small%d.go", i)), "package main\n")
 	}
-	runGit(t, dir, "add", ".")
-	runGit(t, dir, "commit", "-m", "add 5 files")
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add 5 files")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -2766,12 +2766,12 @@ func TestNewSessionFromGitUnderThreshold(t *testing.T) {
 func TestGetFileSnapshotLazy(t *testing.T) {
 	dir := initTestRepo(t)
 
-	runGit(t, dir, "checkout", "-b", "feature-snap")
+	gitT(t, dir, "checkout", "-b", "feature-snap")
 	writeFile(t, filepath.Join(dir, "snap.go"), "package main\nfunc snap() {}\n")
-	runGit(t, dir, "add", "snap.go")
-	runGit(t, dir, "commit", "-m", "add snap.go")
+	gitT(t, dir, "add", "snap.go")
+	gitT(t, dir, "commit", "-m", "add snap.go")
 
-	base := strings.TrimSpace(runGit(t, dir, "merge-base", "main", "HEAD"))
+	base := strings.TrimSpace(gitT(t, dir, "merge-base", "main", "HEAD"))
 
 	s := &Session{
 		Mode:     "git",
@@ -3567,10 +3567,10 @@ func TestCreateSession_LoadsShareFromReviewPath(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Create a file on a feature branch so git mode detects changes.
-	runGit(t, dir, "checkout", "-b", "feat-share")
+	gitT(t, dir, "checkout", "-b", "feat-share")
 	writeFile(t, filepath.Join(dir, "new.md"), "# New\n\nContent\n")
-	runGit(t, dir, "add", "new.md")
-	runGit(t, dir, "commit", "-m", "add new.md")
+	gitT(t, dir, "add", "new.md")
+	gitT(t, dir, "commit", "-m", "add new.md")
 
 	// Prepare a review file with share state.
 	reviewPath := filepath.Join(t.TempDir(), "review.json")
@@ -3890,15 +3890,15 @@ func TestAddComment_OldSideAnchorFromBase(t *testing.T) {
 	// Create a file on the base branch with known content.
 	goPath := filepath.Join(dir, "main.go")
 	writeFile(t, goPath, "package main\n\nfunc deleted() {\n\t// old code\n}\n")
-	runGit(t, dir, "add", "main.go")
-	runGit(t, dir, "commit", "-m", "add main.go")
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "add main.go")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
 	// Create feature branch and modify the file (removing the old function).
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "checkout", "-b", "feat")
 	writeFile(t, goPath, "package main\n\nfunc newFunc() {\n\t// new code\n}\n")
-	runGit(t, dir, "add", "main.go")
-	runGit(t, dir, "commit", "-m", "replace function")
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "replace function")
 
 	s := &Session{
 		Mode:        "git",
@@ -4259,7 +4259,7 @@ func TestAvailableScopes_EmptyBaseRef(t *testing.T) {
 	dir := initTestRepo(t)
 	// Create a file and stage it.
 	writeFile(t, filepath.Join(dir, "staged.go"), "package main")
-	runGit(t, dir, "add", "staged.go")
+	gitT(t, dir, "add", "staged.go")
 
 	// Use a real GitVCS pointed at the test repo.
 	// Need to chdir for GitVCS to work.
@@ -4626,7 +4626,7 @@ func TestScopedHunks_NilVCS(t *testing.T) {
 func TestScopedHunks_AddedFile(t *testing.T) {
 	dir := initTestRepo(t)
 	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
-	runGit(t, dir, "add", "new.go")
+	gitT(t, dir, "add", "new.go")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -4658,10 +4658,10 @@ func TestScopedHunks_UntrackedFile(t *testing.T) {
 
 func TestGetSessionInfoScoped_GitBranchScope(t *testing.T) {
 	dir := initTestRepo(t)
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
-	runGit(t, dir, "add", "new.go")
-	runGit(t, dir, "commit", "-m", "add new file")
+	gitT(t, dir, "add", "new.go")
+	gitT(t, dir, "commit", "-m", "add new file")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -4701,17 +4701,17 @@ func TestGetSessionInfoScoped_GitBranchScope(t *testing.T) {
 
 func TestGetSessionInfoScoped_CommitScope(t *testing.T) {
 	dir := initTestRepo(t)
-	runGit(t, dir, "checkout", "-b", "feature")
+	gitT(t, dir, "checkout", "-b", "feature")
 	writeFile(t, filepath.Join(dir, "new.go"), "package main\n\nfunc main() {}\n")
-	runGit(t, dir, "add", "new.go")
-	runGit(t, dir, "commit", "-m", "add new file")
+	gitT(t, dir, "add", "new.go")
+	gitT(t, dir, "commit", "-m", "add new file")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
 	// Get the commit SHA.
-	sha := runGit(t, dir, "rev-parse", "HEAD")
+	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	s := &Session{
 		Mode:        "git",
@@ -4732,21 +4732,21 @@ func TestGetSessionInfoScoped_CommitScope(t *testing.T) {
 
 func TestSession_GetCommits_RangeMode(t *testing.T) {
 	dir := initTestRepo(t)
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
-	runGit(t, dir, "checkout", "-b", "feature/get-commits-range")
+	gitT(t, dir, "checkout", "-b", "feature/get-commits-range")
 	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
-	runGit(t, dir, "add", "a.go")
-	runGit(t, dir, "commit", "-m", "A")
+	gitT(t, dir, "add", "a.go")
+	gitT(t, dir, "commit", "-m", "A")
 
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
-	runGit(t, dir, "add", "b.go")
-	runGit(t, dir, "commit", "-m", "B")
-	shaB := runGit(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "add", "b.go")
+	gitT(t, dir, "commit", "-m", "B")
+	shaB := gitT(t, dir, "rev-parse", "HEAD")
 
 	writeFile(t, filepath.Join(dir, "c.go"), "package main\n\nfunc C() {}\n")
-	runGit(t, dir, "add", "c.go")
-	runGit(t, dir, "commit", "-m", "C")
+	gitT(t, dir, "add", "c.go")
+	gitT(t, dir, "commit", "-m", "C")
 
 	// Session is in range mode focused on A..B; git HEAD is C.
 	s := &Session{
@@ -4779,16 +4779,16 @@ func TestSession_GetCommits_RangeMode(t *testing.T) {
 
 func TestSession_GetCommits_WorkingTreeMode(t *testing.T) {
 	dir := initTestRepo(t)
-	baseRef := runGit(t, dir, "rev-parse", "HEAD")
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
 
-	runGit(t, dir, "checkout", "-b", "feature/get-commits-wt")
+	gitT(t, dir, "checkout", "-b", "feature/get-commits-wt")
 	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
-	runGit(t, dir, "add", "a.go")
-	runGit(t, dir, "commit", "-m", "A")
+	gitT(t, dir, "add", "a.go")
+	gitT(t, dir, "commit", "-m", "A")
 
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
-	runGit(t, dir, "add", "b.go")
-	runGit(t, dir, "commit", "-m", "B")
+	gitT(t, dir, "add", "b.go")
+	gitT(t, dir, "commit", "-m", "B")
 
 	s := &Session{
 		Mode:        "git",

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -30,19 +30,19 @@ func init() {
 func initTestRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	runGit(t, dir, "init")
-	runGit(t, dir, "config", "user.email", "test@test.com")
-	runGit(t, dir, "config", "user.name", "Test")
+	gitT(t, dir, "init")
+	gitT(t, dir, "config", "user.email", "test@test.com")
+	gitT(t, dir, "config", "user.name", "Test")
 	// Create initial commit
 	writeFile(t, filepath.Join(dir, "README.md"), "# Test")
-	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "commit", "-m", "initial")
+	gitT(t, dir, "add", "README.md")
+	gitT(t, dir, "commit", "-m", "initial")
 	// Ensure default branch is "main"
-	runGit(t, dir, "branch", "-M", "main")
+	gitT(t, dir, "branch", "-M", "main")
 	return dir
 }
 
-func runGit(t *testing.T, dir string, args ...string) string {
+func gitT(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
@@ -104,7 +104,7 @@ func TestGitEnvLeakStripped(t *testing.T) {
 	// honor it when operating on its tempdir.
 	t.Setenv("GIT_DIR", "/should/be/ignored")
 	dir := t.TempDir()
-	runGit(t, dir, "init")
+	gitT(t, dir, "init")
 	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
 		t.Fatalf(".git not created in tempdir — GIT_DIR leaked into runGit: %v", err)
 	}

--- a/watch_test.go
+++ b/watch_test.go
@@ -401,10 +401,10 @@ func TestWatchGit_SkipsGitStatusWhenNotWaiting(t *testing.T) {
 	dir := initTestRepo(t)
 
 	// Create a feature branch so we have a known base
-	runGit(t, dir, "checkout", "-b", "feat")
+	gitT(t, dir, "checkout", "-b", "feat")
 	writeFile(t, filepath.Join(dir, "file.go"), "package main\n")
-	runGit(t, dir, "add", "file.go")
-	runGit(t, dir, "commit", "-m", "add file")
+	gitT(t, dir, "add", "file.go")
+	gitT(t, dir, "commit", "-m", "add file")
 
 	s := &Session{
 		Mode:        "git",


### PR DESCRIPTION
## Summary

Two coupled correctness fixes for the daemon's shutdown path. They ship together because the second is groundwork for cancellable git work and shares one mental model with the first.

### 1. Daemon shutdown safety for the agent goroutine

`runAgentCmd` was creating its own `context.WithTimeout(context.Background(), 10*time.Minute)` and was launched bare (`go s.runAgentCmd(...)`), unparented from the daemon's signal-handled context. On SIGINT/SIGTERM/idle-timeout the agent subprocess (Setsid via `daemonSysProcAttr`) kept running, burning LLM API tokens until its 10-minute budget elapsed, and then called `AddReply` / `RefreshFileList` / `RefreshDiffs` / `notify` on a session whose watcher and SSE goroutines were already gone — after `WriteFiles` had run.

- `Server` gains `shutdownCtx` and `bgWG` fields plus `SetShutdownCtx`, `effectiveCtx`, `WaitBackground` helpers.
- `runServe` calls `srv.SetShutdownCtx(ctx)` immediately after wiring the signal context.
- `handleAgentRequest` wraps its goroutine with `bgWG.Add/Done`.
- `runAgentCmd` derives its 10-min timeout from `effectiveCtx()`; skips the post-run refresh fan-out if the shutdown ctx is already done (the reply is still added in-memory and persisted by the subsequent `WriteFiles`).
- The shutdown path now runs in this order: `session.Shutdown()` (final SSE) → `httpServer.Shutdown` (drains in-flight handlers, gates further `bgWG.Add` calls) → `WaitBackground(30s)` (drains spawned agent runners) → `WriteFiles`.
- On `initErr`, `runServe` calls `stop()` immediately instead of `<-ctx.Done()`. Without this the daemon would sit in 503-land for up to an hour after a failed init, holding a port and a process slot.

### 2. `runGit` helper

`git.go` had ~42 `exec.Command("git", ...)` call sites with no shared place to add cross-cutting concerns (ctx cancellation, env hardening, stderr capture).

Added `runGit(ctx, dir, args...) ([]byte, error)` that uses `exec.CommandContext`, sets dir, appends `GIT_TERMINAL_PROMPT=0` to the env (prevents the daemon from blocking on a credential prompt with no tty), and includes captured stderr in the returned error.

Converted the high-traffic call sites: `IsGitRepo`, `RepoRoot`, `AllTrackedFiles` (used by `handleFilesList`), `changedFilesStaged`, `changedFilesUnstaged`, `changedFilesBranch`. Migration is intentionally partial — the helper docstring notes other call sites should be converted opportunistically.

The pre-existing test helper named `runGit` (in `testutil_test.go`) was renamed to `gitT` to free the name; purely mechanical, all `_test.go` updated in one pass.

## Review

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] `go test -race -count=1 ./...` passing

## Test plan

- Added `TestRunAgentCmd_CancelledByShutdownCtx` — verifies agent subprocess is terminated within 5s of shutdown ctx cancel (regression guard for orphaned subprocess bug).
- Added `TestWaitBackground_TimesOut` — verifies the wait helper drains cleanly when idle and times out as configured when goroutines are wedged.
- Existing agent / handler / git tests continue to pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)