### PR TITLE
fix: use 127.0.0.1 in internal HTTP clients to match daemon bind

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -278,7 +278,7 @@ func isDaemonAlive(s sessionEntry) bool {
 	}
 	// HTTP health probe — ensures the port belongs to our daemon, not a reused PID.
 	// We validate the response body to guard against a non-crit process on the same port.
-	resp, err := aliveClient.Get(fmt.Sprintf("http://localhost:%d/api/health", s.Port))
+	resp, err := aliveClient.Get(fmt.Sprintf("http://127.0.0.1:%d/api/health", s.Port))
 	if err != nil {
 		return false
 	}
@@ -299,7 +299,7 @@ func isDaemonAlive(s sessionEntry) bool {
 // Uses a pointer to distinguish "field missing" (older daemon) from "false".
 // When the field is missing, assumes a browser is connected (safe default).
 func daemonHasBrowser(s sessionEntry) bool {
-	resp, err := browserClient.Get(fmt.Sprintf("http://localhost:%d/api/health", s.Port))
+	resp, err := browserClient.Get(fmt.Sprintf("http://127.0.0.1:%d/api/health", s.Port))
 	if err != nil {
 		return true // can't reach daemon, assume browser exists
 	}

--- a/focus_cli.go
+++ b/focus_cli.go
@@ -305,7 +305,7 @@ func probeDaemonFocusReal() *Focus {
 // (nil on any error). Factored out so probeDaemonFocusReal can iterate over
 // every matching daemon without ballooning its complexity.
 func fetchSessionFocus(client *http.Client, port int) *Focus {
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/session", port))
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", port))
 	if err != nil {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -1535,7 +1535,7 @@ func runPlanHook() {
 func waitForDaemonReady(client *http.Client, port int) (statusCode int, body []byte, err error) {
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
-		resp, reqErr := client.Get(fmt.Sprintf("http://localhost:%d/api/session", port))
+		resp, reqErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", port))
 		if reqErr != nil {
 			return 0, nil, fmt.Errorf("could not reach daemon on port %d: %w", port, reqErr)
 		}
@@ -1563,7 +1563,7 @@ func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 	}
 
 	resp, err := client.Post(
-		fmt.Sprintf("http://localhost:%d/api/review-cycle", entry.Port),
+		fmt.Sprintf("http://127.0.0.1:%d/api/review-cycle", entry.Port),
 		"application/json",
 		nil,
 	)
@@ -1711,7 +1711,7 @@ func runReviewClient(entry sessionEntry) (approved bool) {
 	}
 
 	resp, err := client.Post(
-		fmt.Sprintf("http://localhost:%d/api/review-cycle", entry.Port),
+		fmt.Sprintf("http://127.0.0.1:%d/api/review-cycle", entry.Port),
 		"application/json",
 		nil,
 	)


### PR DESCRIPTION
## Summary
- Daemon binds IPv4-only on `127.0.0.1`, but internal HTTP clients used `http://localhost:<port>`.
- On macOS where `localhost` resolves to `::1` first and Go's happy-eyeballs fallback doesn't kick in (resolver config or fast `ECONNREFUSED` on the IPv6 attempt), the client gets connection refused instead of reaching the daemon.
- Switched 5 internal client URLs to `127.0.0.1` (daemon health probes, `waitForDaemonReady`, review-cycle POSTs, `fetchSessionFocus`). User-facing display strings and `openBrowser()` calls keep `localhost` — browsers do their own happy-eyeballs and `localhost` reads better.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] pre-commit hook (gofmt + golangci-lint + tests) passes

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)