### PR TITLE
fix: clean message when running crit on a repo with no changes

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -235,6 +236,33 @@ func resolveVCSOverride(flag, config string) string {
 		return flag
 	}
 	return config
+}
+
+// preflightNoChangedFiles runs the git-mode change detection up front so the
+// CLI can print a clean message instead of failing inside the daemon (issue
+// #438). Returns the user-facing message to print on stderr if there are no
+// changes, or "" if the daemon should proceed normally (changes present, not
+// a VCS repo, or any other detection error — those are surfaced by the
+// daemon's normal init path).
+func preflightNoChangedFiles(sc *serverConfig) string {
+	vcs := DetectVCS(sc.vcsOverride)
+	if vcs == nil {
+		return ""
+	}
+	if sc.baseBranch != "" {
+		vcs.SetDefaultBranchOverride(sc.baseBranch)
+	}
+	root, err := vcs.RepoRoot()
+	if err != nil {
+		return ""
+	}
+	_, _, _, _, derr := detectVCSChanges(vcs, root, sc.ignorePatterns)
+	if !errors.Is(derr, ErrNoChangedFiles) {
+		return ""
+	}
+	return "No changed files found.\n\n" +
+		"  crit              review changed files (needs changes against the base branch)\n" +
+		"  crit <file...>    review specific file(s)\n"
 }
 
 func createSession(sc *serverConfig) (*Session, error) {

--- a/cli_serve_test.go
+++ b/cli_serve_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestPreflightNoChangedFiles_CleanRepo verifies that running crit in a clean
+// git repo with no changes returns the user-facing message instead of letting
+// the daemon spawn and crash with a misleading "could not reach daemon" error.
+// Reproduces issue #438.
+func TestPreflightNoChangedFiles_CleanRepo(t *testing.T) {
+	dir := initTestRepo(t)
+	defaultBranchOnce = sync.Once{}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	sc := &serverConfig{}
+	msg := preflightNoChangedFiles(sc)
+	if msg == "" {
+		t.Fatal("expected a no-changes message, got empty string")
+	}
+	if !strings.Contains(msg, "No changed files found.") {
+		t.Errorf("missing headline; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "crit <file") {
+		t.Errorf("missing file-args hint; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "review changed files") {
+		t.Errorf("missing default-mode explanation; got:\n%s", msg)
+	}
+	if strings.Contains(msg, "plan") {
+		t.Errorf("message should not mention plan mode (internal subcommand); got:\n%s", msg)
+	}
+	// Must not mention daemons, ports, or networking.
+	for _, banned := range []string{"daemon", "port", "connection", "127.0.0.1"} {
+		if strings.Contains(strings.ToLower(msg), banned) {
+			t.Errorf("message mentions %q; should be free of networking/daemon noise:\n%s", banned, msg)
+		}
+	}
+}
+
+// TestPreflightNoChangedFiles_WithChanges verifies the preflight is silent
+// (returns "") when the repo has changes, so the daemon proceeds normally.
+func TestPreflightNoChangedFiles_WithChanges(t *testing.T) {
+	dir := initTestRepo(t)
+	defaultBranchOnce = sync.Once{}
+
+	gitT(t, dir, "checkout", "-b", "feature")
+	writeFile(t, dir+"/README.md", "# Modified\n")
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	sc := &serverConfig{}
+	if msg := preflightNoChangedFiles(sc); msg != "" {
+		t.Errorf("expected empty message when repo has changes, got:\n%s", msg)
+	}
+}
+
+// TestPreflightNoChangedFiles_NotARepo verifies the preflight is silent (so
+// the existing not-a-repo error path in createSession surfaces normally).
+func TestPreflightNoChangedFiles_NotARepo(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	sc := &serverConfig{}
+	if msg := preflightNoChangedFiles(sc); msg != "" {
+		t.Errorf("expected empty message outside a repo, got:\n%s", msg)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1649,6 +1649,16 @@ func runReview(args []string) {
 			go openBrowser(fmt.Sprintf("http://localhost:%d", entry.Port))
 		}
 	} else {
+		// Pre-flight: in default git mode (no files, no focus, no plan), surface
+		// "no changed files" up front instead of letting the daemon spawn, signal
+		// readiness, then crash on init — which leaves the user with a misleading
+		// "could not reach daemon / connection refused" error. See issue #438.
+		if len(sc.files) == 0 && sc.focus == nil && sc.planDir == "" {
+			if msg := preflightNoChangedFiles(sc); msg != "" {
+				fmt.Fprint(os.Stderr, msg)
+				os.Exit(1)
+			}
+		}
 		// Pass raw args to startDaemon — the _serve process parses them itself
 		entry, err = startDaemon(key, args)
 		if err != nil {

--- a/session.go
+++ b/session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,12 @@ import (
 	"sync/atomic"
 	"time"
 )
+
+// ErrNoChangedFiles is returned by detectVCSChanges when the working tree and
+// branch contain no changes against the base ref (or all changes are filtered
+// out by ignore patterns). Callers can detect this via errors.Is to surface a
+// user-friendly message instead of a generic init failure.
+var ErrNoChangedFiles = errors.New("no changed files detected (after applying ignore patterns)")
 
 // lazyFileThreshold is the maximum number of files to eagerly load
 // content and diffs for. Files beyond this threshold are loaded on demand
@@ -369,7 +376,7 @@ func detectVCSChanges(vcs VCS, root string, ignorePatterns []string) (branch, ba
 	changes = filterIgnored(changes, ignorePatterns)
 
 	if len(changes) == 0 {
-		return "", "", "", nil, fmt.Errorf("no changed files detected (after applying ignore patterns)")
+		return "", "", "", nil, ErrNoChangedFiles
 	}
 	return branch, baseRef, resolvedBase, changes, nil
 }


### PR DESCRIPTION
## Summary
- Pre-flight git-mode change detection in the parent before spawning the daemon. If the working tree has no changes against the base ref (after ignore patterns), print a friendly hint and exit 1 — instead of spawning a daemon that signals readiness, fails init, and leaves the client polling a dead port with the misleading "could not reach daemon / connection refused" error.
- New error: `No changed files found.` followed by two recovery hints (`crit` for default mode, `crit <file...>` for explicit files). Internal subcommands kept out of the user-facing copy.
- Promoted the inline "no changed files" string to an exported sentinel `ErrNoChangedFiles` so the preflight can `errors.Is` it.

Closes #438

## Review
- [x] Code review: passed (intent audit clean, go-expert review skipped per user)
- [x] Parity audit: N/A — CLI-only daemon flow, no review-page surface touched

## Test plan
- [x] `go test -race ./...` — full suite green
- [x] `golangci-lint run ./...` — clean
- [x] Manual e2e: clean git repo with no changes → friendly message + exit 1, no daemon spawn
- [x] Manual e2e: repo with changes → daemon spawns normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)