### PR TITLE
test: cover gaps in atomic write, auth, watch, sapling, parsers

### DIFF
--- a/atomic_write_test.go
+++ b/atomic_write_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Success / perms / overwrite / dir-creation are already covered in
+// daemon_test.go (TestAtomicWriteFile_*). This file adds the missing failure
+// path: a write into a read-only parent must surface an error AND leave no
+// .tmp files behind.
+func TestAtomicWriteFile_FailureLeavesNoTmpFiles(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() == 0 {
+		t.Skip("read-only-dir failure path needs non-root POSIX")
+	}
+	root := t.TempDir()
+	readOnly := filepath.Join(root, "ro")
+	if err := os.MkdirAll(readOnly, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnly, 0o700) })
+
+	target := filepath.Join(readOnly, "x")
+	if err := atomicWriteFile(target, []byte("payload"), 0o644); err == nil {
+		t.Fatal("expected error writing into read-only directory, got nil")
+	}
+	entries, err := os.ReadDir(readOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		t.Errorf("read-only dir should be empty, found %s", e.Name())
+	}
+}

--- a/auth_clear_test.go
+++ b/auth_clear_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestServer_ClearAuthState(t *testing.T) {
+	s := &Server{
+		authToken: "secret-token",
+		cfg: Config{
+			AuthToken:     "secret-token",
+			AuthUserID:    "user-123",
+			AuthUserName:  "Alice",
+			AuthUserEmail: "alice@example.com",
+		},
+	}
+
+	if !s.authLoggedIn() {
+		t.Fatal("precondition: expected authLoggedIn=true")
+	}
+
+	s.clearAuthState()
+
+	if s.authLoggedIn() {
+		t.Error("authLoggedIn still true after clearAuthState")
+	}
+	if got := s.authUserID(); got != "" {
+		t.Errorf("authUserID = %q, want empty", got)
+	}
+	if got := s.authUserName(); got != "" {
+		t.Errorf("authUserName = %q, want empty", got)
+	}
+	if got := s.authUserEmail(); got != "" {
+		t.Errorf("authUserEmail = %q, want empty", got)
+	}
+	if s.cfg.AuthToken != "" {
+		t.Errorf("cfg.AuthToken = %q, want empty", s.cfg.AuthToken)
+	}
+}

--- a/comment_scope_override_test.go
+++ b/comment_scope_override_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommentScopeOverrideFromFlag(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    commentFocusOverride
+		wantErr bool
+	}{
+		{"", scopeOverrideUnset, false},
+		{"layer", scopeOverrideLayer, false},
+		{"full-stack", scopeOverrideFullStack, false},
+		{"full_stack", scopeOverrideFullStack, false},
+		{"working-tree", scopeOverrideWorkingTree, false},
+		{"working_tree", scopeOverrideWorkingTree, false},
+		{"Layer", "", true},      // case-sensitive
+		{"FULL-STACK", "", true}, // case-sensitive
+		{"bogus", "", true},
+		{" layer", "", true}, // no trimming
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := commentScopeOverrideFromFlag(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("commentScopeOverrideFromFlag(%q) = (%q, nil); want error", c.in, got)
+				}
+				if !strings.Contains(err.Error(), "expected layer | full-stack | working-tree") {
+					t.Errorf("error %q does not mention valid values", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("commentScopeOverrideFromFlag(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/parse_fetch_output_dir_test.go
+++ b/parse_fetch_output_dir_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestParseFetchOutputDir(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no args", nil, ""},
+		{"empty slice", []string{}, ""},
+		{"--output long flag", []string{"--output", "/tmp/x"}, "/tmp/x"},
+		{"-o short flag", []string{"-o", "out"}, "out"},
+		{"last value wins", []string{"--output", "first", "-o", "second"}, "second"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseFetchOutputDir(c.args)
+			if got != c.want {
+				t.Errorf("parseFetchOutputDir(%v) = %q, want %q", c.args, got, c.want)
+			}
+		})
+	}
+}

--- a/process_bulk_line_comment_test.go
+++ b/process_bulk_line_comment_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProcessBulkLineComment(t *testing.T) {
+	cases := []struct {
+		name      string
+		entry     BulkCommentEntry
+		wantErr   string
+		wantStart int
+		wantEnd   int
+	}{
+		{
+			name:      "explicit Line and EndLine",
+			entry:     BulkCommentEntry{Body: "x", Line: 10, EndLine: 12},
+			wantStart: 10, wantEnd: 12,
+		},
+		{
+			name:      "Line only defaults EndLine to Line",
+			entry:     BulkCommentEntry{Body: "x", Line: 7},
+			wantStart: 7, wantEnd: 7,
+		},
+		{
+			name:      "LineSpec single number",
+			entry:     BulkCommentEntry{Body: "x", LineSpec: "42"},
+			wantStart: 42, wantEnd: 42,
+		},
+		{
+			name:      "LineSpec range",
+			entry:     BulkCommentEntry{Body: "x", LineSpec: "5-9"},
+			wantStart: 5, wantEnd: 9,
+		},
+		{
+			name:    "LineSpec invalid",
+			entry:   BulkCommentEntry{Body: "x", LineSpec: "not-a-number"},
+			wantErr: "invalid line spec",
+		},
+		{
+			name:    "LineSpec range with non-numeric end",
+			entry:   BulkCommentEntry{Body: "x", LineSpec: "1-bad"},
+			wantErr: "invalid line spec",
+		},
+		{
+			name:    "Line zero rejected",
+			entry:   BulkCommentEntry{Body: "x"},
+			wantErr: "line must be > 0",
+		},
+		{
+			name:    "Line negative rejected",
+			entry:   BulkCommentEntry{Body: "x", Line: -3},
+			wantErr: "line must be > 0",
+		},
+		{
+			name:      "Line set, LineSpec ignored",
+			entry:     BulkCommentEntry{Body: "x", Line: 1, LineSpec: "9-9"},
+			wantStart: 1, wantEnd: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cj := &CritJSON{Files: map[string]CritJSONFile{}}
+			err := processBulkLineComment(cj, 0, c.entry, "f.go", "alice", "u1", inheritedScope{})
+			if c.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			cf, ok := cj.Files["f.go"]
+			if !ok || len(cf.Comments) != 1 {
+				t.Fatalf("expected one comment in f.go, got %+v", cj.Files)
+			}
+			got := cf.Comments[0]
+			if got.StartLine != c.wantStart || got.EndLine != c.wantEnd {
+				t.Errorf("lines = (%d,%d), want (%d,%d)", got.StartLine, got.EndLine, c.wantStart, c.wantEnd)
+			}
+		})
+	}
+}

--- a/sapling_diff_args_test.go
+++ b/sapling_diff_args_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildDiffArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseRef string
+		path    string
+		want    []string
+	}{
+		{"empty base ref omits -r", "", "main.go", []string{"diff", "main.go"}},
+		{"with base ref", "main", "main.go", []string{"diff", "-r", "main", "main.go"}},
+		{"sha base ref", "abc123", "src/x.rs", []string{"diff", "-r", "abc123", "src/x.rs"}},
+		{"path with spaces", "main", "a b/c.go", []string{"diff", "-r", "main", "a b/c.go"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := buildDiffArgs(c.baseRef, c.path)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("buildDiffArgs(%q, %q) = %v, want %v", c.baseRef, c.path, got, c.want)
+			}
+		})
+	}
+}

--- a/watch_refresh_test.go
+++ b/watch_refresh_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeWatchVCS implements only the VCS methods exercised by RefreshDiffs,
+// RefreshFileList, and handleRoundCompleteGit. Other methods inherit zero
+// values from the embedded interface; they will panic if called, which is
+// what we want — surfacing accidentally-exercised paths.
+type fakeWatchVCS struct {
+	VCS
+	mu              sync.Mutex
+	currentBranch   string
+	defaultBranch   string
+	defaultChanges  []FileChange
+	branchChanges   []FileChange
+	diffs           map[string][]DiffHunk
+	numstats        map[string]NumstatEntry
+	diffCalls       int32
+	numstatCalls    int32
+	changedFlsCalls int32
+}
+
+func (f *fakeWatchVCS) CurrentBranch() string { return f.currentBranch }
+func (f *fakeWatchVCS) DefaultBranch() string { return f.defaultBranch }
+
+func (f *fakeWatchVCS) ChangedFilesOnDefaultInDir(_ string) ([]FileChange, error) {
+	atomic.AddInt32(&f.changedFlsCalls, 1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]FileChange, len(f.defaultChanges))
+	copy(out, f.defaultChanges)
+	return out, nil
+}
+
+func (f *fakeWatchVCS) ChangedFilesFromBaseInDir(_, _ string) ([]FileChange, error) {
+	atomic.AddInt32(&f.changedFlsCalls, 1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]FileChange, len(f.branchChanges))
+	copy(out, f.branchChanges)
+	return out, nil
+}
+
+func (f *fakeWatchVCS) FileDiffUnified(path, _, _ string) ([]DiffHunk, error) {
+	atomic.AddInt32(&f.diffCalls, 1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.diffs[path], nil
+}
+
+func (f *fakeWatchVCS) DiffNumstat(_, _ string) (map[string]NumstatEntry, error) {
+	atomic.AddInt32(&f.numstatCalls, 1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]NumstatEntry, len(f.numstats))
+	for k, v := range f.numstats {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func newWatchSession(t *testing.T, v *fakeWatchVCS) *Session {
+	t.Helper()
+	return &Session{
+		VCS:      v,
+		RepoRoot: t.TempDir(),
+		BaseRef:  "origin/main",
+	}
+}
+
+func TestRefreshDiffs_SkipsDeletedAndLazyFiles(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		diffs: map[string][]DiffHunk{
+			"keep.go": {{OldStart: 1, NewStart: 1}},
+			"gone.go": {{OldStart: 5, NewStart: 5}},
+		},
+	}
+	s := newWatchSession(t, v)
+	s.Files = []*FileEntry{
+		{Path: "keep.go", Status: "modified"},
+		{Path: "gone.go", Status: "deleted"},
+		{Path: "lazy.go", Status: "modified", Lazy: true},
+		{Path: "added.go", Status: "added", Content: "new content\n"},
+	}
+
+	s.RefreshDiffs()
+
+	for _, f := range s.Files {
+		switch f.Path {
+		case "keep.go":
+			if len(f.DiffHunks) != 1 {
+				t.Errorf("keep.go: want 1 hunk, got %d", len(f.DiffHunks))
+			}
+		case "gone.go":
+			if f.DiffHunks != nil {
+				t.Errorf("gone.go: should be skipped, got %v", f.DiffHunks)
+			}
+		case "lazy.go":
+			if f.DiffHunks != nil {
+				t.Errorf("lazy.go: should be skipped, got %v", f.DiffHunks)
+			}
+		case "added.go":
+			// new-file hunks come from FileDiffUnifiedNewFile, no VCS call.
+			if len(f.DiffHunks) == 0 {
+				t.Errorf("added.go: expected new-file hunks")
+			}
+		}
+	}
+	if got := atomic.LoadInt32(&v.diffCalls); got != 1 {
+		t.Errorf("FileDiffUnified called %d times, want 1 (only keep.go)", got)
+	}
+}
+
+func TestRefreshFileList_AddsAndRemoves(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []FileChange{
+			{Path: "keep.go", Status: "modified"},
+			{Path: "new.go", Status: "added"},
+		},
+	}
+	s := newWatchSession(t, v)
+
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "keep.go"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "new.go"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := &FileEntry{Path: "keep.go", AbsPath: filepath.Join(s.RepoRoot, "keep.go"), Status: "added"}
+	s.Files = []*FileEntry{
+		original,
+		{Path: "removed.go", AbsPath: filepath.Join(s.RepoRoot, "removed.go"), Status: "modified"},
+	}
+
+	s.RefreshFileList()
+
+	if len(s.Files) != 2 {
+		t.Fatalf("want 2 files, got %d", len(s.Files))
+	}
+	paths := map[string]*FileEntry{}
+	for _, f := range s.Files {
+		paths[f.Path] = f
+	}
+	if _, ok := paths["removed.go"]; ok {
+		t.Error("removed.go should be dropped")
+	}
+	keep := paths["keep.go"]
+	if keep == nil {
+		t.Fatal("keep.go missing")
+	}
+	if keep != original {
+		t.Error("keep.go should reuse the existing FileEntry pointer (preserves comments)")
+	}
+	if keep.Status != "modified" {
+		t.Errorf("keep.go status = %q, want %q (updated under write lock)", keep.Status, "modified")
+	}
+	newF := paths["new.go"]
+	if newF == nil || newF.Status != "added" {
+		t.Errorf("new.go missing or wrong status: %+v", newF)
+	}
+	if newF.Content != "new" {
+		t.Errorf("new.go content = %q, want %q", newF.Content, "new")
+	}
+}
+
+func TestRefreshFileList_LazyThresholdMarksOverflow(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		numstats:      map[string]NumstatEntry{},
+	}
+	// Build > lazyFileThreshold (100) changes.
+	total := lazyFileThreshold + 5
+	for i := 0; i < total; i++ {
+		path := fmt.Sprintf("dir/f%d.go", i)
+		v.branchChanges = append(v.branchChanges, FileChange{Path: path, Status: "modified"})
+		v.numstats[path] = NumstatEntry{Additions: i, Deletions: 0}
+	}
+
+	s := newWatchSession(t, v)
+	s.RefreshFileList()
+
+	if got := atomic.LoadInt32(&v.numstatCalls); got != 1 {
+		t.Errorf("DiffNumstat calls = %d, want 1", got)
+	}
+	lazyCount := 0
+	for _, f := range s.Files {
+		if f.Lazy {
+			lazyCount++
+		}
+	}
+	if lazyCount != total-lazyFileThreshold {
+		t.Errorf("lazy file count = %d, want %d", lazyCount, total-lazyFileThreshold)
+	}
+}
+
+func TestWatch_RefreshDiffsAndFileList_RaceFree(t *testing.T) {
+	t.Parallel()
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []FileChange{
+			{Path: "a.go", Status: "modified"},
+			{Path: "b.go", Status: "modified"},
+		},
+		diffs: map[string][]DiffHunk{
+			"a.go": {{OldStart: 1, NewStart: 1}},
+			"b.go": {{OldStart: 1, NewStart: 1}},
+		},
+	}
+	s := newWatchSession(t, v)
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "a.go"), []byte("aaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "b.go"), []byte("bbb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.Files = []*FileEntry{
+		{Path: "a.go", AbsPath: filepath.Join(s.RepoRoot, "a.go"), Status: "modified"},
+		{Path: "b.go", AbsPath: filepath.Join(s.RepoRoot, "b.go"), Status: "modified"},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); s.RefreshDiffs() }()
+		go func() { defer wg.Done(); s.RefreshFileList() }()
+	}
+	wg.Wait()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, f := range s.Files {
+		if len(f.DiffHunks) == 0 {
+			t.Errorf("file %s missing diff hunks after concurrent refresh", f.Path)
+		}
+	}
+}
+
+func TestHandleRoundCompleteGit_AdvancesRoundAndRefreshes(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []FileChange{
+			{Path: "x.go", Status: "modified"},
+		},
+		diffs: map[string][]DiffHunk{
+			"x.go": {{OldStart: 1, NewStart: 1}},
+		},
+	}
+	s := newWatchSession(t, v)
+	s.ReviewRound = 3
+	s.lastRoundEdits = 4
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "x.go"), []byte("xxx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.Files = []*FileEntry{
+		{Path: "x.go", AbsPath: filepath.Join(s.RepoRoot, "x.go"), Status: "modified"},
+	}
+
+	s.handleRoundCompleteGit()
+
+	if s.ReviewRound != 4 {
+		t.Errorf("ReviewRound = %d, want 4", s.ReviewRound)
+	}
+	if got := atomic.LoadInt32(&v.diffCalls); got == 0 {
+		t.Error("expected RefreshDiffs to call FileDiffUnified")
+	}
+	if got := atomic.LoadInt32(&v.changedFlsCalls); got == 0 {
+		t.Error("expected RefreshFileList to call ChangedFilesFromBaseInDir")
+	}
+}


### PR DESCRIPTION
## Summary
- Add tests for previously-uncovered code paths surfaced by an audit + independent validation pass: atomic-write failure cleanup, auth state clearing, sapling diff-arg construction, comment-scope flag parser, fetch output dir parser, bulk line-comment branches, and concurrent watch refresh under -race.
- Project coverage 67.1% → 68.9%. No production code changes.

## Review
- [x] Code review: passed (0 blockers, 0 warnings)
- [x] Parity audit: N/A (test-only)

## Test plan
- `mise exec -- go test -race -count=1 ./...` — passes
- `mise exec -- go vet ./...` — clean
- Pre-commit hook (gofmt + golangci-lint + tests) passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)