### PR TITLE
style: bump comment input font-size to 14px

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1397,7 +1397,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   background: var(--crit-editor-bg-elevated);
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   cursor: text;
 }
 
@@ -1427,7 +1427,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   background: var(--crit-editor-comment-bg);
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   resize: vertical;
 }
 
@@ -1451,7 +1451,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   border-radius: 4px;
   padding: 6px 8px;
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   resize: vertical;
 }
 


### PR DESCRIPTION
## Summary
- Bumps `.comment-textarea`, `.reply-input`, and expanded `.reply-textarea` from 13px → 14px
- Aligns these with `.comment-body`, `.comment-form textarea`, and `.reply-body`, which were already 14px
- Pure visual; no logic changes

## Test plan
- [ ] Comment edit textarea renders at 14px
- [ ] Reply input (collapsed) renders at 14px
- [ ] Reply textarea (expanded) renders at 14px
- [ ] Cross-repo parity: matched 1:1 with crit-web/

See also: tomasz-tomczyk/crit-web#168

🤖 Generated with [Claude Code](https://claude.com/claude-code)