### PR TITLE
fix: hide TOC toggle for single-heading documents

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7286,7 +7286,8 @@
       }
     }
 
-    if (allItems.length === 0) {
+    // A single-heading TOC has nothing to navigate to — hide it.
+    if (allItems.length < 2) {
       hideToc();
       return;
     }


### PR DESCRIPTION
## Summary

A single-entry TOC has nothing to navigate to — it just adds a noop toggle to the header. Hide it when fewer than two headings exist.

Mirrors the same change in `crit-web/assets/js/document-renderer.js` for parity.

## Test plan

- pre-commit hook: gofmt, golangci-lint, go test -race, ESLint, Stylelint, CSS var checker — all pass

See also: tomasz-tomczyk/crit-web#170 (main TOC fix + parity change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)