### PR TITLE
style: align textarea line-height with rendered comment bodies

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1428,6 +1428,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
   font-size: 14px;
+  line-height: 1.6;
   resize: vertical;
 }
 
@@ -1452,6 +1453,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   padding: 6px 8px;
   font-family: var(--crit-font-body);
   font-size: 14px;
+  line-height: 1.6;
   resize: vertical;
 }
 


### PR DESCRIPTION
## Summary
- Reply textarea and edit-comment textarea had no `line-height`, falling back to browser default (`normal`, ~1.15)
- Rendered `.comment-body` and `.reply-body` use 1.6, so wrapped form text looked visibly tighter than the comments above
- Set `line-height: 1.6` on `.reply-form.expanded .reply-textarea` and `.comment-textarea`

## Review
- [x] Parity audit: matches font-size: 14px / line-height: 1.6 already used on rendered bodies and the new-comment textarea
- [x] Pre-commit: gofmt, golangci-lint, tests, eslint, stylelint, css-vars all clean

## Test plan
- [ ] Reply form: type wrapped text, verify spacing matches comment above
- [ ] Edit comment: same check
- [ ] Cross-check with crit-web/ PR — see also: tomasz-tomczyk/crit-web#171

🤖 Generated with [Claude Code](https://claude.com/claude-code)