### PR TITLE
fix: post local replies whose parent has a GitHub ID (#442)

### DIFF
--- a/github_test.go
+++ b/github_test.go
@@ -630,6 +630,57 @@ func TestCollectNewRepliesForPush_NoGitHubRoot(t *testing.T) {
 	}
 }
 
+// TestCollectNewRepliesForPush_ParentSources verifies that local-only replies
+// are collected regardless of how their parent acquired its github_id —
+// whether the parent was imported via `crit pull` or pushed by us in an
+// earlier `crit push`. This pins the fix for issue #442.
+func TestCollectNewRepliesForPush_ParentSources(t *testing.T) {
+	cases := []struct {
+		name        string
+		cf          CritJSONFile
+		wantReplies int
+	}{
+		{
+			name: "parent imported via pull",
+			cf: CritJSONFile{
+				Comments: []Comment{{
+					ID: "c1", GitHubID: 555, StartLine: 1, EndLine: 1, Body: "imported",
+					Replies: []Reply{{ID: "c1-r1", GitHubID: 0, Body: "ack"}},
+				}},
+			},
+			wantReplies: 1,
+		},
+		{
+			name: "parent pushed by us previously",
+			cf: CritJSONFile{
+				Comments: []Comment{{
+					ID: "c1", GitHubID: 777, StartLine: 1, EndLine: 1, Body: "ours",
+					Replies: []Reply{{ID: "c1-r1", GitHubID: 0, Body: "follow-up"}},
+				}},
+			},
+			wantReplies: 1,
+		},
+		{
+			name: "reply already pushed — skipped",
+			cf: CritJSONFile{
+				Comments: []Comment{{
+					ID: "c1", GitHubID: 555, StartLine: 1, EndLine: 1, Body: "imported",
+					Replies: []Reply{{ID: "c1-r1", GitHubID: 999, Body: "synced"}},
+				}},
+			},
+			wantReplies: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectNewRepliesForPush(tc.cf)
+			if len(got) != tc.wantReplies {
+				t.Fatalf("got %d replies, want %d: %+v", len(got), tc.wantReplies, got)
+			}
+		})
+	}
+}
+
 func TestAddCommentToCritJSON_RejectsPathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	if err := exec.Command("git", "init", dir).Run(); err != nil {

--- a/main.go
+++ b/main.go
@@ -800,22 +800,31 @@ func runPushLive(ctx pushContext, b pushBuckets) {
 
 	posted := 0
 	postFailed := false
+	var commentIDs map[string]int64
 	if len(b.Postable) > 0 {
 		ghComments := bucketsToGHComments(b.Postable)
-		commentIDs, err := createGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
+		ids, err := createGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
 		if err != nil {
 			postFailed = true
 			fmt.Fprintf(os.Stderr, "Error posting review: %v\n", err)
 		} else {
 			posted = len(ghComments)
+			commentIDs = ids
+		}
+	}
 
-			// Replies to GitHub-anchored comments only make sense after a
-			// successful review post (so parent IDs are stable).
-			var allReplies []ghReplyForPush
-			for _, cf := range ctx.cj.Files {
-				allReplies = append(allReplies, collectNewRepliesForPush(cf)...)
-			}
-			replyIDs := postPushReplies(ctx.prNumber, allReplies)
+	// Replies to GitHub-anchored comments are independent of whether there
+	// were new top-level comments to post: the parent already has a
+	// github_id (either imported via pull or pushed by us previously), so
+	// the reply can go out regardless. Skip only if the top-level post
+	// failed — parent IDs assigned in this same push wouldn't be stable.
+	if !postFailed {
+		var allReplies []ghReplyForPush
+		for _, cf := range ctx.cj.Files {
+			allReplies = append(allReplies, collectNewRepliesForPush(cf)...)
+		}
+		replyIDs := postPushReplies(ctx.prNumber, allReplies)
+		if len(commentIDs) > 0 || len(replyIDs) > 0 {
 			if uerr := updateCritJSONWithGitHubIDs(ctx.critPath, commentIDs, replyIDs); uerr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update review file with GitHub IDs: %v\n", uerr)
 			}

--- a/roundtrip_integration_test.go
+++ b/roundtrip_integration_test.go
@@ -164,7 +164,6 @@ func TestRoundtrip_PushThenPull_PreservesIDs(t *testing.T) {
 }
 
 func TestRoundtrip_ReplyToRemoteComment(t *testing.T) {
-	t.Skip("blocked on issue #442: crit push doesn't post replies to imported remote comments")
 	e := newRoundtripEnv(t)
 
 	rootID := e.postRemoteComment("sample.go", 19, "please address")
@@ -223,7 +222,6 @@ func TestRoundtrip_ReplyToRemoteComment(t *testing.T) {
 }
 
 func TestRoundtrip_InterleavedReplies(t *testing.T) {
-	t.Skip("blocked on issue #442: crit push skips local replies whose parent has a non-zero github_id (also reproduces when parent's github_id was assigned by our own push)")
 	e := newRoundtripEnv(t)
 
 	// Local root, push it.


### PR DESCRIPTION
Closes #442.

## Problem
\`crit push\` posted nothing when the only local-only items were replies under parents that already had a \`github_id\` — whether from \`crit pull\` (imported) or from a prior push. To the user this looks like "I replied, my reply vanished."

## Root cause
In \`runPushLive\` the entire reply-collection-and-post block was nested inside \`if len(b.Postable) > 0\`. If the push had no new top-level comments, that branch never ran. \`collectNewRepliesForPush\` itself was correct.

## Fix
Hoist reply collection, posting, and ID write-back out of the new-roots conditional. Replies only need \`parent.GitHubID != 0\`, which is independent of whether new top-level comments are also being posted. Guarded by \`!postFailed\` so we don't post replies referencing parent IDs that the same batch failed to create. Idempotency is preserved by the existing \`r.GitHubID == 0\` gate in \`collectNewRepliesForPush\`.

## Tests
- Re-enables \`TestRoundtrip_ReplyToRemoteComment\` and \`TestRoundtrip_InterleavedReplies\` (removed \`t.Skip\` lines from PR #445's harness).
- Adds unit test \`TestCollectNewRepliesForPush_ParentSources\` pinning the three relevant parent states.

## Verification
- Targeted scenarios: PASS
- \`go test ./...\`: PASS
- \`make e2e-roundtrip\`: 10 PASS + 1 SKIP (#446 still skipped, separate fix in flight)
- \`gofmt -l .\`, \`golangci-lint run ./...\`: clean

## Base branch
This PR targets \`pr-roundtrip-harness\` (PR #445), not \`main\`, because the un-skipped tests live on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)