### PR TITLE
fix: PATCH comments and replies whose body was edited (#446)

### DIFF
--- a/github.go
+++ b/github.go
@@ -618,11 +618,12 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, na
 			continue
 		}
 		comments[ci].Replies = append(comments[ci].Replies, Reply{
-			ID:        randomReplyID(),
-			Body:      r.Body,
-			Author:    names.lookup(r.User.Login),
-			CreatedAt: r.CreatedAt,
-			GitHubID:  r.ID,
+			ID:             randomReplyID(),
+			Body:           r.Body,
+			Author:         names.lookup(r.User.Login),
+			CreatedAt:      r.CreatedAt,
+			GitHubID:       r.ID,
+			LastPushedBody: r.Body,
 		})
 		added++
 	}
@@ -663,18 +664,19 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 	comment := stampWithFocus(Comment{
 		ID: commentID, StartLine: startLine, EndLine: gc.Line,
 		Body: gc.Body, Author: authorName, CreatedAt: gc.CreatedAt,
-		UpdatedAt: now, GitHubID: gc.ID,
+		UpdatedAt: now, GitHubID: gc.ID, LastPushedBody: gc.Body,
 	}, scope.asFocus())
 
 	added := 0
 	if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
 		for _, r := range childReplies {
 			comment.Replies = append(comment.Replies, Reply{
-				ID:        randomReplyID(),
-				Body:      r.Body,
-				Author:    names.lookup(r.User.Login),
-				CreatedAt: r.CreatedAt,
-				GitHubID:  r.ID,
+				ID:             randomReplyID(),
+				Body:           r.Body,
+				Author:         names.lookup(r.User.Login),
+				CreatedAt:      r.CreatedAt,
+				GitHubID:       r.ID,
+				LastPushedBody: r.Body,
 			})
 			added++
 		}
@@ -767,6 +769,130 @@ func collectNewRepliesForPush(cf CritJSONFile) []ghReplyForPush {
 		}
 	}
 	return replies
+}
+
+// ghEditForPush represents one already-pushed comment or reply whose local
+// body has diverged from LastPushedBody and therefore needs a PATCH.
+//
+// Path is empty for replies (replies are addressed by GitHubID alone in the
+// GitHub API). For comments it carries the file path so the review file can
+// be updated by location after a successful PATCH.
+type ghEditForPush struct {
+	GitHubID int64
+	Path     string // file path for root comments; empty for replies
+	Body     string
+	IsReply  bool
+}
+
+// collectEditedForPush returns root comments and replies whose local Body
+// differs from LastPushedBody and therefore need a PATCH.
+//
+// Backward-compat rule: a record with GitHubID != 0 but empty LastPushedBody
+// is treated as already-in-sync (treat current Body as last-pushed). This
+// keeps pre-existing review files from re-PATCHing every comment on first
+// push after upgrade. The push paths that successfully POST or PATCH stamp
+// LastPushedBody, so divergence detection only fires for genuine local edits.
+//
+// Resolved comments are skipped (they're not pushable in the new-comment
+// path either; consistent treatment for edits).
+func collectEditedForPush(cj CritJSON) []ghEditForPush {
+	var out []ghEditForPush
+	paths := make([]string, 0, len(cj.Files))
+	for p := range cj.Files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		cf := cj.Files[path]
+		for _, c := range cf.Comments {
+			if c.Resolved {
+				continue
+			}
+			if c.GitHubID != 0 && c.LastPushedBody != "" && c.Body != c.LastPushedBody {
+				out = append(out, ghEditForPush{
+					GitHubID: c.GitHubID,
+					Path:     path,
+					Body:     c.Body,
+				})
+			}
+			for _, r := range c.Replies {
+				if r.GitHubID != 0 && r.LastPushedBody != "" && r.Body != r.LastPushedBody {
+					out = append(out, ghEditForPush{
+						GitHubID: r.GitHubID,
+						Body:     r.Body,
+						IsReply:  true,
+					})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// patchGHComment edits the body of an existing PR review comment via the
+// GitHub API. Works for both root comments and replies — they share the same
+// /pulls/comments/{id} endpoint.
+func patchGHComment(ghID int64, body string) error {
+	payload, err := json.Marshal(map[string]any{"body": body})
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/comments/%d", ghID),
+		"--method", "PATCH",
+		"--input", "-",
+	)
+	cmd.Stdin = bytes.NewReader(payload)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh api patch: %s: %w", string(output), err)
+	}
+	return nil
+}
+
+// updateCritJSONWithEditedBodies stamps LastPushedBody on records that were
+// successfully PATCHed in this push. edited is the slice that was queued for
+// PATCH; succeeded is the subset whose PATCH returned cleanly.
+//
+// Match key for both roots and replies is the GitHubID — it's stable and
+// unique across the review file.
+func updateCritJSONWithEditedBodies(critPath string, succeeded []ghEditForPush) error {
+	if len(succeeded) == 0 {
+		return nil
+	}
+	successByID := make(map[int64]string, len(succeeded))
+	for _, e := range succeeded {
+		successByID[e.GitHubID] = e.Body
+	}
+
+	data, err := os.ReadFile(critPath)
+	if err != nil {
+		return err
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return err
+	}
+	for path, cf := range cj.Files {
+		for i, c := range cf.Comments {
+			if body, ok := successByID[c.GitHubID]; ok && c.GitHubID != 0 {
+				cf.Comments[i].Body = body
+				cf.Comments[i].LastPushedBody = body
+			}
+			for j, r := range c.Replies {
+				if body, ok := successByID[r.GitHubID]; ok && r.GitHubID != 0 {
+					cf.Comments[i].Replies[j].Body = body
+					cf.Comments[i].Replies[j].LastPushedBody = body
+				}
+			}
+		}
+		cj.Files[path] = cf
+	}
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(critPath, append(out, '\n'), 0644)
 }
 
 // postGHReply posts a reply to an existing GitHub PR review comment.
@@ -938,6 +1064,7 @@ func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, r
 				key := fmt.Sprintf("%s:%d", path, c.EndLine)
 				if id, ok := commentIDs[key]; ok {
 					cf.Comments[i].GitHubID = id
+					cf.Comments[i].LastPushedBody = cf.Comments[i].Body
 				}
 			}
 			for j, r := range c.Replies {
@@ -945,6 +1072,7 @@ func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, r
 					rk := replyKey{ParentGHID: cf.Comments[i].GitHubID, BodyPrefix: truncateStr(r.Body, 60)}
 					if id, ok := replyIDs[rk]; ok {
 						cf.Comments[i].Replies[j].GitHubID = id
+						cf.Comments[i].Replies[j].LastPushedBody = cf.Comments[i].Replies[j].Body
 					}
 				}
 			}

--- a/github_test.go
+++ b/github_test.go
@@ -2746,3 +2746,107 @@ func TestParsePRViewJSON_SameRepoPR(t *testing.T) {
 		t.Error("HeadRepoURL empty; want owner/repo URL")
 	}
 }
+
+// TestCollectEditedForPush_DetectsBodyDivergence verifies the diff-detection
+// rules behind the edit-push path (#446):
+//   - root comment with edited body relative to LastPushedBody → enqueued
+//   - reply with edited body relative to LastPushedBody → enqueued
+//   - GitHubID == 0 (never pushed) → not enqueued (handled by POST path)
+//   - GitHubID != 0 but LastPushedBody == "" → not enqueued (legacy idempotency)
+//   - GitHubID != 0 and Body == LastPushedBody → not enqueued
+//   - Resolved comment with edited body → not enqueued
+func TestCollectEditedForPush_DetectsBodyDivergence(t *testing.T) {
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"a.go": {Comments: []Comment{
+				// edited (should be enqueued)
+				{ID: "c1", GitHubID: 100, Body: "edited", LastPushedBody: "original"},
+				// new (no GH ID — POST path handles it)
+				{ID: "c2", GitHubID: 0, Body: "new", LastPushedBody: ""},
+				// legacy: pushed but no LastPushedBody recorded — must not re-PATCH
+				{ID: "c3", GitHubID: 101, Body: "current", LastPushedBody: ""},
+				// in sync
+				{ID: "c4", GitHubID: 102, Body: "same", LastPushedBody: "same"},
+				// resolved, even if edited — skipped
+				{ID: "c5", GitHubID: 103, Body: "edited", LastPushedBody: "original", Resolved: true},
+				// reply edits via parent c6
+				{ID: "c6", GitHubID: 104, Body: "parent", LastPushedBody: "parent", Replies: []Reply{
+					{ID: "r1", GitHubID: 200, Body: "reply edit", LastPushedBody: "reply orig"}, // enqueued
+					{ID: "r2", GitHubID: 0, Body: "new reply", LastPushedBody: ""},              // POST path
+					{ID: "r3", GitHubID: 201, Body: "same", LastPushedBody: ""},                 // legacy, skip
+				}},
+			}},
+		},
+	}
+
+	edits := collectEditedForPush(cj)
+	if len(edits) != 2 {
+		t.Fatalf("collectEditedForPush returned %d edits, want 2: %+v", len(edits), edits)
+	}
+
+	gotIDs := map[int64]string{}
+	for _, e := range edits {
+		gotIDs[e.GitHubID] = e.Body
+	}
+	if gotIDs[100] != "edited" {
+		t.Errorf("expected root c1 (id=100) → 'edited', got %q", gotIDs[100])
+	}
+	if gotIDs[200] != "reply edit" {
+		t.Errorf("expected reply r1 (id=200) → 'reply edit', got %q", gotIDs[200])
+	}
+}
+
+// TestUpdateCritJSONWithEditedBodies_StampsLastPushedBody verifies that after
+// PATCH, the review file is rewritten with the edited body promoted to
+// LastPushedBody so the next push is a no-op.
+func TestUpdateCritJSONWithEditedBodies_StampsLastPushedBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review.json")
+
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"a.go": {Comments: []Comment{{
+				ID: "c1", GitHubID: 500, Body: "edited", LastPushedBody: "original",
+				Replies: []Reply{
+					{ID: "r1", GitHubID: 600, Body: "reply edit", LastPushedBody: "reply orig"},
+				},
+			}}},
+		},
+	}
+	data, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	succeeded := []ghEditForPush{
+		{GitHubID: 500, Body: "edited", Path: "a.go"},
+		{GitHubID: 600, Body: "reply edit", IsReply: true},
+	}
+	if err := updateCritJSONWithEditedBodies(path, succeeded); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got CritJSON
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	c := got.Files["a.go"].Comments[0]
+	if c.LastPushedBody != "edited" {
+		t.Errorf("comment LastPushedBody=%q, want %q", c.LastPushedBody, "edited")
+	}
+	if c.Replies[0].LastPushedBody != "reply edit" {
+		t.Errorf("reply LastPushedBody=%q, want %q", c.Replies[0].LastPushedBody, "reply edit")
+	}
+
+	// Idempotency: re-running collectEditedForPush should now find nothing.
+	if more := collectEditedForPush(got); len(more) != 0 {
+		t.Errorf("after stamping, collectEditedForPush returned %d edits, want 0: %+v", len(more), more)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -822,7 +822,12 @@ func runPushLive(ctx pushContext, b pushBuckets) {
 		}
 	}
 
-	printPushSummary(posted, len(b.FullStack)+len(b.Unmapped), exportPath)
+	// PATCH already-pushed comments/replies whose local body diverged from
+	// LastPushedBody. Independent of the POST path — edits frequently happen
+	// in pushes where there are no new comments to create.
+	patched := pushEditedBodies(ctx)
+
+	printPushSummary(posted, patched, len(b.FullStack)+len(b.Unmapped), exportPath)
 
 	// Exit code: only fail when gh errored AND we have no orphans to fall
 	// back on. Otherwise something useful happened (export written), so
@@ -834,16 +839,48 @@ func runPushLive(ctx pushContext, b pushBuckets) {
 
 // printPushSummary writes the one-line stdout summary describing what
 // happened. Adapts wording to the actual outcome (no orphans, no posts, etc).
-func printPushSummary(posted, orphans int, exportPath string) {
-	if posted == 0 && orphans == 0 {
+func printPushSummary(posted, patched, orphans int, exportPath string) {
+	if posted == 0 && patched == 0 && orphans == 0 {
 		fmt.Println("No comments to push.")
 		return
 	}
 	if exportPath == "" {
+		if patched > 0 {
+			fmt.Printf("Posted %d comments, edited %d.\n", posted, patched)
+			return
+		}
 		fmt.Printf("Posted %d comments.\n", posted)
 		return
 	}
+	if patched > 0 {
+		fmt.Printf("Posted %d comments, edited %d. %d comments exported to %s.\n",
+			posted, patched, orphans, exportPath)
+		return
+	}
 	fmt.Printf("Posted %d comments. %d comments exported to %s.\n", posted, orphans, exportPath)
+}
+
+// pushEditedBodies PATCHes already-pushed comments/replies whose local body
+// diverged from LastPushedBody. Returns the count of records successfully
+// PATCHed and updated in the review file. Failures log to stderr and are
+// excluded from the count, so the next push will retry them.
+func pushEditedBodies(ctx pushContext) int {
+	edits := collectEditedForPush(ctx.cj)
+	if len(edits) == 0 {
+		return 0
+	}
+	succeeded := make([]ghEditForPush, 0, len(edits))
+	for _, e := range edits {
+		if err := patchGHComment(e.GitHubID, e.Body); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to edit comment %d: %v\n", e.GitHubID, err)
+			continue
+		}
+		succeeded = append(succeeded, e)
+	}
+	if uerr := updateCritJSONWithEditedBodies(ctx.critPath, succeeded); uerr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to update review file after edit push: %v\n", uerr)
+	}
+	return len(succeeded)
 }
 
 // fullStackPushGateMessage is the user-facing error string emitted when

--- a/roundtrip_integration_test.go
+++ b/roundtrip_integration_test.go
@@ -409,7 +409,6 @@ func TestRoundtrip_RangeComment(t *testing.T) {
 }
 
 func TestRoundtrip_EditPushedCommentBody(t *testing.T) {
-	t.Skip("blocked on issue #446: crit push silently drops body edits to already-pushed comments")
 	e := newRoundtripEnv(t)
 
 	e.runCrit("comment", "sample.go:19", "original body")

--- a/session.go
+++ b/session.go
@@ -58,6 +58,13 @@ type Reply struct {
 	UserID    string `json:"user_id,omitempty"`
 	CreatedAt string `json:"created_at"`
 	GitHubID  int64  `json:"github_id,omitempty"`
+
+	// LastPushedBody is the Body value at the time of the most recent
+	// successful push (POST or PATCH) to GitHub. Used by `crit push` to
+	// detect locally-edited replies that need a PATCH. Empty on legacy
+	// reply records — treated as "in sync" so existing reviews don't all
+	// re-PATCH on first push after upgrade.
+	LastPushedBody string `json:"last_pushed_body,omitempty"`
 }
 
 // Comment represents a single inline review comment.
@@ -82,6 +89,13 @@ type Comment struct {
 	ReviewRound    int     `json:"review_round,omitempty"`
 	Replies        []Reply `json:"replies,omitempty"`
 	GitHubID       int64   `json:"github_id,omitempty"`
+
+	// LastPushedBody is the Body value at the time of the most recent
+	// successful push (POST or PATCH) to GitHub. Used by `crit push` to
+	// detect locally-edited comments that need a PATCH. Empty on legacy
+	// comment records — treated as "in sync" so existing reviews don't all
+	// re-PATCH on first push after upgrade.
+	LastPushedBody string `json:"last_pushed_body,omitempty"`
 
 	// HeadSHA is the head SHA of the focus when this comment was authored.
 	// Empty for working-tree comments and for pre-feature comments.


### PR DESCRIPTION
Closes #446.

## Problem
\`crit push\` only POSTed new comments and never PATCHed existing ones, so local body edits to already-pushed comments were silently dropped: re-pushing printed \`No comments to push.\` and the remote stayed stale.

## Fix
Track the last-pushed body per comment/reply, and on push PATCH any whose local body diverged.

- **Schema**: \`LastPushedBody string \\\`json:\"last_pushed_body,omitempty\"\\\`\` on both \`Comment\` and \`Reply\` in \`session.go\`. \`omitempty\` keeps old review files backward-compatible.
- **Stamping points**:
  - Pull import (\`mergeRootComment\`, \`appendNewGHReplies\`, inline-reply append) — set \`LastPushedBody = body\` on each imported record.
  - POST success (\`updateCritJSONWithGitHubIDs\`) — set \`LastPushedBody = Body\` alongside the freshly-assigned \`GitHubID\`.
  - PATCH success (new \`updateCritJSONWithEditedBodies\`) — promote the edited body to \`LastPushedBody\`.
- **Diff detection** (\`collectEditedForPush\`): \`GitHubID != 0 && LastPushedBody != \"\" && Body != LastPushedBody\`. Empty \`LastPushedBody\` is treated as in-sync, so legacy review files don't all re-PATCH on first push after upgrade.
- **PATCH dispatch** (\`patchGHComment\`): \`gh api repos/{owner}/{repo}/pulls/comments/{id} --method PATCH\` — same endpoint for roots and replies. Failures log to stderr and exclude that record from the success set so the next push retries.
- **Resolved comments** are skipped (consistent with existing push behavior).
- Push summary now reports \`Posted N comments, edited M.\` when edits occurred.

## Tests
- Re-enables \`TestRoundtrip_EditPushedCommentBody\` (removed \`t.Skip\` line from PR #445's harness).
- Adds unit tests \`TestCollectEditedForPush_DetectsBodyDivergence\` and \`TestUpdateCritJSONWithEditedBodies_StampsLastPushedBody\` covering diff detection + stamping round-trip + idempotent re-detection.

## Verification
- \`TestRoundtrip_EditPushedCommentBody\`: PASS — \`push #2 output: Posted 0 comments, edited 1.\`
- Idempotency trio (\`PushIsIdempotent\`, \`PullIsIdempotent\`, \`PushThenPull_PreservesIDs\`): all PASS — \`omitempty\` + empty-treated-as-in-sync prevents mass re-PATCH.
- \`go test ./...\`: PASS
- \`make e2e-roundtrip\`: 10 PASS + 2 SKIP (#442 reply scenarios — separate fix in flight).
- \`gofmt -l .\`, \`golangci-lint run ./...\`: clean.

## Base branch
Targets \`pr-roundtrip-harness\` (PR #445), not \`main\`, because the un-skipped scenario lives on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)