### PR TITLE
test: 5 unit tests covering migration, concurrency, partial failure, sentinels

### DIFF
--- a/concurrent_save_test.go
+++ b/concurrent_save_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConcurrentSaveCritJSON_NoCorruption stress-tests the saveCritJSON
+// write path under concurrent writers. Probes gap #23 (concurrent
+// pull/push corruption): if saveCritJSON's atomicity is ever broken,
+// the file will fail to parse mid-run.
+//
+// Production calls saveCritJSON from at least: the daemon's debounced
+// writer, comment_cli direct writes, share/unpublish, and crit pull/push.
+// These can interleave when a daemon and a CLI run at the same time.
+//
+// The test does not assert ordering — last-writer-wins is acceptable.
+// It only asserts that the file is always valid JSON at every observable
+// moment (read-modify-write loop) and at the end.
+func TestConcurrentSaveCritJSON_NoCorruption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review.json")
+
+	// Seed with a non-empty CritJSON so workers have something real to
+	// round-trip. An empty Files map is fine — the marshal/unmarshal pair
+	// is what we want to stress.
+	seed := CritJSON{
+		Branch:  "test",
+		BaseRef: "main",
+		Files: map[string]CritJSONFile{
+			"a.go": {Status: "modified", FileHash: "h1", Comments: []Comment{}},
+		},
+	}
+	if err := saveCritJSON(path, seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	const writers = 4
+	const iters = 50
+
+	var wg sync.WaitGroup
+	var failures atomic.Int64
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Errorf("worker %d read iter %d: %v", id, i, err)
+					failures.Add(1)
+					return
+				}
+				var local CritJSON
+				if err := json.Unmarshal(data, &local); err != nil {
+					t.Errorf("worker %d parse iter %d: %v\n%s", id, i, err, data)
+					failures.Add(1)
+					return
+				}
+				if err := saveCritJSON(path, local); err != nil {
+					t.Errorf("worker %d save iter %d: %v", id, i, err)
+					failures.Add(1)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if failures.Load() > 0 {
+		t.Fatalf("%d worker failures — concurrent save path is not safe", failures.Load())
+	}
+
+	// Final parse must succeed — if atomicity broke, the file will be
+	// truncated, partially written, or contain interleaved bytes.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var final CritJSON
+	if err := json.Unmarshal(data, &final); err != nil {
+		t.Fatalf("FILE CORRUPTED after concurrent saves: %v\n%s", err, data)
+	}
+	if _, ok := final.Files["a.go"]; !ok {
+		t.Errorf("seeded file entry lost: %+v", final.Files)
+	}
+}

--- a/github_test.go
+++ b/github_test.go
@@ -2901,3 +2901,150 @@ func TestUpdateCritJSONWithEditedBodies_StampsLastPushedBody(t *testing.T) {
 		t.Errorf("after stamping, collectEditedForPush returned %d edits, want 0: %+v", len(more), more)
 	}
 }
+
+// TestMergeGHComments_DoesNotValidatePRProvenance pins the current
+// contract for gap #21 (cross-PR cross-pollination). The ghComment shape
+// (see github.go: ghComment struct) carries no PR number or branch ref —
+// the GitHub REST endpoint /pulls/{N}/comments returns comments without
+// any back-reference to the PR they came from.
+//
+// As a result, mergeGHComments cannot reject "foreign" comments at this
+// layer; the PR-scoping defense lives upstream in the caller (which
+// chooses which /pulls/{N}/comments URL to fetch). This test pins the
+// current behavior so a future contract change (adding a defensive check
+// here, or threading PR metadata into ghComment) is a deliberate decision
+// and not an accidental break of merge logic.
+//
+// If you change merge behavior to reject foreign comments, this test
+// should fail and be updated to assert the new contract.
+func TestMergeGHComments_DoesNotValidatePRProvenance(t *testing.T) {
+	cj := CritJSON{
+		Branch:  "feature-A",
+		BaseRef: "main",
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status:   "modified",
+				Comments: []Comment{},
+			},
+		},
+	}
+
+	// Synthetic comments — caller's responsibility to ensure these came
+	// from feature-A's PR, not feature-B's. The merge function has no
+	// way to tell them apart.
+	foreign := []ghComment{
+		{
+			ID: 9999, Path: "main.go", Line: 3, Side: "RIGHT",
+			Body: "comment from a different PR",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "stranger"},
+			CreatedAt: "2025-01-01T00:00:00Z",
+		},
+	}
+
+	added := mergeGHComments(&cj, foreign)
+	if added != 1 {
+		t.Fatalf("merge added = %d, want 1 (merge is metadata-blind by design); "+
+			"if this dropped to 0 because a defense was added, update the test", added)
+	}
+
+	cf := cj.Files["main.go"]
+	if len(cf.Comments) != 1 {
+		t.Fatalf("expected 1 merged comment, got %d", len(cf.Comments))
+	}
+	if cf.Comments[0].Body != "comment from a different PR" {
+		t.Errorf("merged body = %q", cf.Comments[0].Body)
+	}
+
+	// Document the invariant: ghComment carries no PR/branch field, so
+	// merge cannot self-defend. Any cross-PR safety must live in the
+	// fetch path (the caller decides which /pulls/{N}/comments to read).
+	// If this property changes (e.g. ghComment grows a PullRequestURL
+	// field), this test should be updated to assert the new defense.
+}
+
+// TestZeroGitHubID_TreatedAsNotPushed pins gap #26: a comment or reply
+// with GitHubID == 0 must be treated as "not yet pushed" by every
+// predicate that decides whether to send something to GitHub. If 0 ever
+// becomes a legitimate GitHub ID, multiple call sites would need to
+// change in lockstep — this table test serves as a tripwire.
+//
+// Predicates exercised:
+//   - critJSONToGHComments (root push selector): GitHubID==0 → push,
+//     GitHubID!=0 → skip ("already pushed").
+//   - collectNewRepliesForPush (reply push selector): parent must be on
+//     GH (GitHubID!=0) AND reply must be local (GitHubID==0).
+func TestZeroGitHubID_TreatedAsNotPushed(t *testing.T) {
+	t.Run("root_zero_is_pushed", func(t *testing.T) {
+		cj := CritJSON{
+			Files: map[string]CritJSONFile{
+				"a.go": {Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "local-only", GitHubID: 0},
+				}},
+			},
+		}
+		out := critJSONToGHComments(cj)
+		if len(out) != 1 {
+			t.Fatalf("GitHubID==0 root must be pushed; got %d entries", len(out))
+		}
+	})
+
+	t.Run("root_nonzero_is_skipped", func(t *testing.T) {
+		cj := CritJSON{
+			Files: map[string]CritJSONFile{
+				"a.go": {Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "already on GH", GitHubID: 7},
+				}},
+			},
+		}
+		out := critJSONToGHComments(cj)
+		if len(out) != 0 {
+			t.Fatalf("GitHubID!=0 root must be skipped; got %d entries", len(out))
+		}
+	})
+
+	t.Run("reply_with_zero_parent_skipped", func(t *testing.T) {
+		// Parent root is local (GitHubID==0): reply has nothing to attach
+		// to on GitHub, so collectNewRepliesForPush must skip it.
+		cf := CritJSONFile{Comments: []Comment{
+			{ID: "c1", GitHubID: 0, Body: "local root", Replies: []Reply{
+				{ID: "rp1", GitHubID: 0, Body: "local reply"},
+			}},
+		}}
+		got := collectNewRepliesForPush(cf)
+		if len(got) != 0 {
+			t.Fatalf("reply with GitHubID==0 parent must be skipped; got %d", len(got))
+		}
+	})
+
+	t.Run("reply_with_nonzero_parent_zero_self_pushed", func(t *testing.T) {
+		// Parent on GitHub (GitHubID!=0), reply local (GitHubID==0):
+		// must be queued for push.
+		cf := CritJSONFile{Comments: []Comment{
+			{ID: "c1", GitHubID: 100, Body: "remote root", Replies: []Reply{
+				{ID: "rp1", GitHubID: 0, Body: "new local reply"},
+			}},
+		}}
+		got := collectNewRepliesForPush(cf)
+		if len(got) != 1 {
+			t.Fatalf("reply (GitHubID==0, parent!=0) must be queued; got %d", len(got))
+		}
+		if got[0].ParentGHID != 100 || got[0].Body != "new local reply" {
+			t.Errorf("queued reply = %+v", got[0])
+		}
+	})
+
+	t.Run("reply_with_nonzero_parent_nonzero_self_skipped", func(t *testing.T) {
+		// Both parent and reply on GitHub: nothing to do.
+		cf := CritJSONFile{Comments: []Comment{
+			{ID: "c1", GitHubID: 100, Body: "remote root", Replies: []Reply{
+				{ID: "rp1", GitHubID: 200, Body: "remote reply"},
+			}},
+		}}
+		got := collectNewRepliesForPush(cf)
+		if len(got) != 0 {
+			t.Fatalf("reply with GitHubID!=0 must be skipped; got %d", len(got))
+		}
+	})
+}

--- a/push_partial_failure_test.go
+++ b/push_partial_failure_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestPostPushReplies_PartialFailure simulates a `gh api` POST that
+// succeeds for the first reply, fails (HTTP 500) for the second, and
+// succeeds for the third. Probes gap #2 (partial push failure):
+//
+//   - Successfully posted replies must have their GitHubID captured in the
+//     returned replyIDs map (so the on-disk update step can persist them).
+//   - Failed replies must NOT appear in replyIDs (so the next push can
+//     retry only the failed one — re-posting all three would create
+//     duplicates on GitHub).
+//
+// The test wires a fake `gh` binary onto PATH that scripts its responses
+// from a counter file. This is the cleanest mock seam for a function
+// that calls `exec.Command("gh", ...)` directly.
+func TestPostPushReplies_PartialFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-gh shim is a POSIX shell script; not portable to Windows")
+	}
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "counter")
+	if err := os.WriteFile(counter, []byte("0\n"), 0644); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+
+	// Fake gh: increments a counter on each invocation. Returns a JSON id
+	// for calls 1 and 3; exits 1 with a 500-ish error on call 2. Reads
+	// stdin (the payload) but ignores it — postGHReply only cares about
+	// the response body and exit code.
+	fakeGH := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+COUNTER_FILE="` + counter + `"
+n=$(cat "$COUNTER_FILE")
+n=$((n + 1))
+echo "$n" > "$COUNTER_FILE"
+# Drain stdin so the caller's pipe doesn't block.
+cat >/dev/null
+case "$n" in
+  1) echo '{"id": 1001}' ;;
+  2) echo "HTTP 500: server error" >&2; exit 1 ;;
+  3) echo '{"id": 1003}' ;;
+  *) echo '{"id": 9999}' ;;
+esac
+`
+	if err := os.WriteFile(fakeGH, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+
+	replies := []ghReplyForPush{
+		{ParentGHID: 100, Body: "first reply"},
+		{ParentGHID: 200, Body: "second reply (will fail)"},
+		{ParentGHID: 300, Body: "third reply"},
+	}
+
+	got := postPushReplies(42, replies)
+
+	// First reply: parent 100 → id 1001.
+	k1 := replyKey{ParentGHID: 100, BodyPrefix: truncateStr("first reply", 60)}
+	if id, ok := got[k1]; !ok {
+		t.Errorf("missing id for reply 1; map=%v", got)
+	} else if id != 1001 {
+		t.Errorf("reply 1 id = %d, want 1001", id)
+	}
+
+	// Second reply: parent 200 must NOT be in the map (the call failed).
+	// If it leaks in here, a retry would post a duplicate to GitHub.
+	k2 := replyKey{ParentGHID: 200, BodyPrefix: truncateStr("second reply (will fail)", 60)}
+	if id, ok := got[k2]; ok {
+		t.Errorf("failed reply leaked into replyIDs: parent=200 id=%d", id)
+	}
+
+	// Third reply: parent 300 → id 1003. Critical: a failure mid-batch
+	// must not abort the rest of the batch. If postPushReplies gives up
+	// after the 500, this assertion fails.
+	k3 := replyKey{ParentGHID: 300, BodyPrefix: truncateStr("third reply", 60)}
+	if id, ok := got[k3]; !ok {
+		t.Errorf("missing id for reply 3 — partial failure aborted the batch; map=%v", got)
+	} else if id != 1003 {
+		t.Errorf("reply 3 id = %d, want 1003", id)
+	}
+
+	// Sanity: exactly two successful entries.
+	if len(got) != 2 {
+		t.Errorf("len(replyIDs) = %d, want 2; map=%v", len(got), got)
+	}
+}

--- a/session_migration_test.go
+++ b/session_migration_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPreLastPushedBodySchema_ParsesCleanly verifies that a review file
+// written by a pre-#446 crit version (no last_pushed_body fields) parses
+// cleanly into the current CritJSON struct without losing data.
+// Forward-compat probe for the schema migration discussed in issue #446.
+//
+// On this branch (pr-roundtrip-harness), the LastPushedBody field does not
+// yet exist on Comment/Reply. The test still runs as a forward-compat probe:
+// it asserts that the legacy on-disk shape parses, and that re-marshalling
+// does not introduce the field before #446 lands. Once #446 ships, this
+// test should also assert that LastPushedBody is empty after parsing legacy
+// records (so the "empty == in-sync" rule kicks in and no spurious PATCH
+// happens for legacy comments). See TODO below.
+func TestPreLastPushedBodySchema_ParsesCleanly(t *testing.T) {
+	const oldFile = `{
+  "branch": "test",
+  "base_ref": "main",
+  "review_round": 1,
+  "files": {
+    "sample.go": {
+      "status": "modified",
+      "file_hash": "deadbeef",
+      "comments": [
+        {
+          "id": "c_aaaa",
+          "github_id": 12345,
+          "start_line": 1,
+          "end_line": 1,
+          "body": "old comment",
+          "author": "tomasz",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "scope": "line",
+          "created_at": "2025-01-01T00:00:00Z",
+          "updated_at": "2025-01-01T00:00:00Z",
+          "replies": [
+            {
+              "id": "rp_bbbb",
+              "github_id": 67890,
+              "body": "old reply",
+              "author": "reviewer",
+              "user_id": "00000000-0000-0000-0000-000000000002",
+              "created_at": "2025-01-01T00:00:00Z"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+	var cj CritJSON
+	if err := json.Unmarshal([]byte(oldFile), &cj); err != nil {
+		t.Fatalf("legacy review file failed to parse: %v", err)
+	}
+
+	f, ok := cj.Files["sample.go"]
+	if !ok {
+		t.Fatalf("sample.go missing from parsed files: %+v", cj.Files)
+	}
+	if len(f.Comments) != 1 {
+		t.Fatalf("expected 1 comment in sample.go, got %d", len(f.Comments))
+	}
+	c := f.Comments[0]
+	if c.GitHubID != 12345 {
+		t.Errorf("github_id lost: got %d", c.GitHubID)
+	}
+	if c.Body != "old comment" {
+		t.Errorf("body lost: got %q", c.Body)
+	}
+	if c.Author != "tomasz" {
+		t.Errorf("author lost: got %q", c.Author)
+	}
+	if len(c.Replies) != 1 {
+		t.Fatalf("reply lost: %+v", c.Replies)
+	}
+	if c.Replies[0].GitHubID != 67890 {
+		t.Errorf("reply github_id lost: got %d", c.Replies[0].GitHubID)
+	}
+	if c.Replies[0].Body != "old reply" {
+		t.Errorf("reply body lost: got %q", c.Replies[0].Body)
+	}
+
+	// Re-marshal and verify last_pushed_body is absent for legacy-loaded
+	// records. Pre-#446 this passes trivially (the field doesn't exist).
+	// Post-#446 it still passes because LastPushedBody should be omitempty
+	// and stay empty when not present in the source JSON. If #446 lands and
+	// uses a non-omitempty tag or initializes the field on parse, this
+	// assertion will fail and flag the schema bug.
+	out, err := json.Marshal(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), `"last_pushed_body"`) {
+		t.Errorf("re-marshalled legacy comment unexpectedly contains last_pushed_body: %s", out)
+	}
+	outR, err := json.Marshal(&c.Replies[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(outR), `"last_pushed_body"`) {
+		t.Errorf("re-marshalled legacy reply unexpectedly contains last_pushed_body: %s", outR)
+	}
+
+	// TODO(#446): once the LastPushedBody field is added to Comment/Reply,
+	// extend this test to assert:
+	//   - c.LastPushedBody == "" after parsing the legacy file
+	//   - the "empty LastPushedBody == in-sync" rule means a hypothetical
+	//     edited-comment scan returns 0 PATCH candidates for this record
+	// Until then, the assertions above pin the forward-compat contract
+	// (no field invented during parse, no field invented on re-marshal).
+}


### PR DESCRIPTION
## Summary

Adds 5 untagged Go unit tests probing state-corruption invariants that the live-PR roundtrip harness can't reliably exercise (concurrency, schema migration, mocked failures, sentinel handling). No production code changes.

## Tests

- **session_migration_test.go** — `TestPreLastPushedBodySchema_ParsesCleanly`: legacy review file (pre-#446, no `last_pushed_body`) parses cleanly into current `CritJSON` with no data loss; re-marshalling does not invent the field. TODO references #446 for the post-fix assertions (asserting `LastPushedBody == ""` and the empty-as-in-sync rule).
- **concurrent_save_test.go** — `TestConcurrentSaveCritJSON_NoCorruption`: 4 workers x 50 read-modify-write iterations against `saveCritJSON`. Probes the `atomicWriteFile` rename guarantee under daemon/CLI interleaving. Passes (file remains valid JSON throughout).
- **push_partial_failure_test.go** — `TestPostPushReplies_PartialFailure`: fake `gh` shim on `PATH` returns 200/500/200 for three reply POSTs. `postPushReplies` must persist GHIDs for the two successes and **not** leak an entry for the failure (so retries don't dup on GitHub). Passes — confirms the existing partial-failure contract for the reply-push path.
- **github_test.go** — `TestMergeGHComments_DoesNotValidatePRProvenance`: pins the cross-PR-pollination contract (gap-list item 21). `ghComment` carries no PR/branch metadata, so `mergeGHComments` cannot self-defend; cross-PR safety must live upstream in the fetch URL choice. Tripwire test — fails if a defensive check is added later (forcing an intentional contract update).
- **github_test.go** — `TestZeroGitHubID_TreatedAsNotPushed`: table test pinning the `GitHubID == 0` sentinel across `critJSONToGHComments` (root push selector) and `collectNewRepliesForPush` (reply push selector). Tripwire — if 0 ever becomes a legitimate GitHub ID, multiple call sites would need to change in lockstep.

## Test plan

- [x] `go test -race ./...` — all green
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues