### PR TITLE
test: wait for PR head sha after force-push in roundtrip harness

### DIFF
--- a/roundtrip_helpers_test.go
+++ b/roundtrip_helpers_test.go
@@ -351,6 +351,36 @@ func (e *roundtripEnv) freshClone() *roundtripEnv {
 	}
 }
 
+// waitForPRHeadSHA polls the PR's head.sha until it matches expected, or
+// fails the test after a timeout. Use after a force-push to give GitHub
+// time to recompute the PR diff before the next push fires; otherwise the
+// next POST /pulls/{N}/comments may be rejected with HTTP 422 because the
+// commit_id no longer matches the PR's recomputed diff.
+func (e *roundtripEnv) waitForPRHeadSHA(expected string) {
+	e.t.Helper()
+	expected = strings.TrimSpace(expected)
+	deadline := time.Now().Add(15 * time.Second)
+	var lastSHA string
+	for time.Now().Before(deadline) {
+		out := mustOutput(e.t, e.workDir, "gh", "api",
+			fmt.Sprintf("repos/%s/pulls/%d", e.repoSlug, e.prNumber))
+		var resp struct {
+			Head struct {
+				SHA string `json:"sha"`
+			} `json:"head"`
+		}
+		if err := json.Unmarshal([]byte(out), &resp); err == nil {
+			lastSHA = resp.Head.SHA
+			if lastSHA == expected {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	e.t.Fatalf("PR head sha did not converge to %s within timeout (last seen: %s)",
+		expected, lastSHA)
+}
+
 func sanitizeName(s string) string {
 	s = strings.ReplaceAll(s, "/", "-")
 	s = strings.ReplaceAll(s, " ", "-")

--- a/roundtrip_integration_test.go
+++ b/roundtrip_integration_test.go
@@ -835,6 +835,13 @@ func TestRoundtrip_AnchorLineDeleted_Outdated(t *testing.T) {
 	mustRun(t, e.workDir, "git", "reset", "--hard", "HEAD~1")
 	mustRun(t, e.workDir, "git", "push", "--force")
 
+	// Wait for GitHub to recompute the PR head sha after the force-push
+	// before issuing more API calls (see issue #456): otherwise the next
+	// `crit push` can race and post against a stale commit_id, getting
+	// rejected with HTTP 422.
+	headSHA := strings.TrimSpace(mustOutput(t, e.workDir, "git", "rev-parse", "HEAD"))
+	e.waitForPRHeadSHA(headSHA)
+
 	e.runCrit("pull")
 	locals := e.allLocalComments()
 	if len(locals) != 1 {


### PR DESCRIPTION
## Summary
- After the test's `git push --force` rewinds the PR head SHA, GitHub takes a moment to recompute the PR diff. If the next `crit push` fires too soon, the new comment's `commit_id` no longer matches the PR's recomputed diff and GitHub rejects with HTTP 422.
- Adds a `waitForPRHeadSHA` helper to `roundtripEnv` that polls `GET /repos/{slug}/pulls/{N}` until `head.sha` matches the local HEAD, with a 15s deadline (no raw `time.Sleep`).
- Calls it from `TestRoundtrip_AnchorLineDeleted_Outdated` after the force-push, before the next `crit pull` / `crit comment` / `crit push`.

Closes #456.

## Review
- [x] Code review: passed (test-only change, behind `e2e_github` build tag)
- [x] Parity audit: N/A (no frontend / no production code touched)

## Test plan
- gofmt clean, go vet clean, golangci-lint clean (default + `e2e_github` tag)
- `go test ./...`: PASS
- Targeted: `./scripts/e2e-roundtrip.sh -run TestRoundtrip_AnchorLineDeleted_Outdated -v` — 7 consecutive PASS
- Full suite: `make e2e-roundtrip` — 2 consecutive PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)