### PR TITLE
feat: per-round timeline backend (Stage 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Review session files (generated at runtime)
 *.comments.json
 *.review.md
+/.crit/
 
 # Dependencies
 node_modules/

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -431,7 +431,7 @@ func runServe(args []string) {
 	}
 	if sc.outputDir != "" {
 		abs, _ := filepath.Abs(sc.outputDir)
-		sc.reviewPath = filepath.Join(abs, ".crit.json")
+		sc.reviewPath = filepath.Join(abs, ".crit")
 	} else {
 		sc.reviewPath, _ = reviewFilePath(key)
 	}
@@ -596,6 +596,6 @@ func runServe(args []string) {
 	session.WriteFiles()
 
 	if session.ReviewFilePath != "" {
-		fmt.Fprintf(os.Stderr, "Review file: %s\n", session.ReviewFilePath)
+		fmt.Fprintf(os.Stderr, "Review file: %s\n", reviewPathsFor(session.ReviewFilePath).Review)
 	}
 }

--- a/comment_cli.go
+++ b/comment_cli.go
@@ -76,6 +76,12 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 			if resolve {
 				cj.ReviewComments[i].Resolved = true
 				cj.ReviewComments[i].ResolvedRound = cj.ReviewRound
+			} else {
+				// Match HTTP AddReviewCommentReply semantics: a non-resolving
+				// reply unresolves a previously-resolved comment so the new
+				// reply doesn't get hidden by the resolution filter.
+				cj.ReviewComments[i].Resolved = false
+				cj.ReviewComments[i].ResolvedRound = 0
 			}
 			return nil
 		}
@@ -106,6 +112,12 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 					if resolve {
 						cf.Comments[i].Resolved = true
 						cf.Comments[i].ResolvedRound = cj.ReviewRound
+					} else {
+						// Match HTTP AddReply semantics: a non-resolving reply
+						// unresolves a previously-resolved comment so the new
+						// reply doesn't get hidden by the resolution filter.
+						cf.Comments[i].Resolved = false
+						cf.Comments[i].ResolvedRound = 0
 					}
 					cj.Files[filePath] = cf
 				}

--- a/comment_cli.go
+++ b/comment_cli.go
@@ -75,6 +75,7 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 			cj.ReviewComments[i].UpdatedAt = now
 			if resolve {
 				cj.ReviewComments[i].Resolved = true
+				cj.ReviewComments[i].ResolvedRound = cj.ReviewRound
 			}
 			return nil
 		}
@@ -104,6 +105,7 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 					cf.Comments[i].UpdatedAt = now
 					if resolve {
 						cf.Comments[i].Resolved = true
+						cf.Comments[i].ResolvedRound = cj.ReviewRound
 					}
 					cj.Files[filePath] = cf
 				}

--- a/comment_cli.go
+++ b/comment_cli.go
@@ -64,11 +64,12 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 	for i, c := range cj.ReviewComments {
 		if c.ID == commentID {
 			reply := Reply{
-				ID:        randomReplyID(),
-				Body:      body,
-				Author:    author,
-				UserID:    userID,
-				CreatedAt: now,
+				ID:          randomReplyID(),
+				Body:        body,
+				Author:      author,
+				UserID:      userID,
+				CreatedAt:   now,
+				ReviewRound: cj.ReviewRound,
 			}
 			cj.ReviewComments[i].Replies = append(cj.ReviewComments[i].Replies, reply)
 			cj.ReviewComments[i].UpdatedAt = now
@@ -92,11 +93,12 @@ func appendReply(cj *CritJSON, commentID, body, author, userID string, resolve b
 				if !found {
 					found = true
 					reply := Reply{
-						ID:        randomReplyID(),
-						Body:      body,
-						Author:    author,
-						UserID:    userID,
-						CreatedAt: now,
+						ID:          randomReplyID(),
+						Body:        body,
+						Author:      author,
+						UserID:      userID,
+						CreatedAt:   now,
+						ReviewRound: cj.ReviewRound,
 					}
 					cf.Comments[i].Replies = append(cf.Comments[i].Replies, reply)
 					cf.Comments[i].UpdatedAt = now

--- a/comment_scope_test.go
+++ b/comment_scope_test.go
@@ -18,7 +18,7 @@ func withDaemonFocus(t *testing.T, focus *Focus) {
 func writeReviewFileWithScope(t *testing.T, dir, scope string) {
 	t.Helper()
 	cj := CritJSON{ActiveDiffScope: scope, Files: map[string]CritJSONFile{}}
-	if err := saveCritJSON(filepath.Join(dir, ".crit.json"), cj); err != nil {
+	if err := saveCritJSON(filepath.Join(dir, ".crit"), cj); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -130,7 +130,7 @@ func TestRunComment_StampsScopeFromDaemon_LineLevel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cj, err := loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, err := loadCritJSON(filepath.Join(dir, ".crit"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestRunComment_NoStampWithoutDaemonAndDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cj, _ := loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, _ := loadCritJSON(filepath.Join(dir, ".crit"))
 	cf := cj.Files["foo.go"]
 	if cf.Comments[0].HeadSHA != "" || cf.Comments[0].DiffScope != "" {
 		t.Errorf("expected no stamping in working-tree mode, got %+v", cf.Comments[0])

--- a/concurrent_save_test.go
+++ b/concurrent_save_test.go
@@ -49,7 +49,7 @@ func TestConcurrentSaveCritJSON_NoCorruption(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for i := 0; i < iters; i++ {
-				data, err := os.ReadFile(path)
+				data, err := os.ReadFile(reviewPathsFor(path).Review)
 				if err != nil {
 					t.Errorf("worker %d read iter %d: %v", id, i, err)
 					failures.Add(1)
@@ -77,7 +77,7 @@ func TestConcurrentSaveCritJSON_NoCorruption(t *testing.T) {
 
 	// Final parse must succeed — if atomicity broke, the file will be
 	// truncated, partially written, or contain interleaved bytes.
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(reviewPathsFor(path).Review)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -99,13 +99,15 @@ func reviewsDir() (string, error) {
 	return filepath.Join(home, ".crit", "reviews"), nil
 }
 
-// reviewFilePath returns the full path for a review data file.
+// reviewFilePath returns the v4 review identity path: a folder named <key>
+// (no extension) under ~/.crit/reviews/. The actual JSON files live inside as
+// <key>/review.json and <key>/snapshots.json — see reviewPathsFor.
 func reviewFilePath(key string) (string, error) {
 	dir, err := reviewsDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, key+".json"), nil
+	return filepath.Join(dir, key), nil
 }
 
 // writeSessionFile writes a session entry to ~/.crit/sessions/<key>.json.

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -853,7 +853,7 @@ func TestReviewFilePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reviewFilePath: %v", err)
 	}
-	want := filepath.Join(home, ".crit", "reviews", "mykey123456.json")
+	want := filepath.Join(home, ".crit", "reviews", "mykey123456")
 	if path != want {
 		t.Errorf("path = %q, want %q", path, want)
 	}

--- a/focus_session_test.go
+++ b/focus_session_test.go
@@ -235,6 +235,11 @@ func TestSetFocus_PostSetSession_PreservesComments(t *testing.T) {
 		t.Errorf("comments after focus change = %+v; want one seeded comment", got.Comments)
 	}
 
+	// Drain any debounced WriteFiles scheduled by SetFocus before
+	// reading on-disk state — otherwise the debounce goroutine and the
+	// test reader race on s.Files / RoundSnapshots.
+	flushWrites(s)
+
 	// And on-disk state survived (no silent overwrite).
 	cj2, err := loadCritJSON(identity)
 	if err != nil {

--- a/focus_session_test.go
+++ b/focus_session_test.go
@@ -162,6 +162,89 @@ func TestSetFocus_Range_RebuildsFiles(t *testing.T) {
 	}
 }
 
+// TestSetFocus_PostSetSession_PreservesComments is a regression test for B1
+// (review). Background: loadCritJSON checks Session.sessionStarted and bails
+// out post-SetSession; SetFocus calls it at runtime to repopulate per-file
+// Comments after the file list is rebuilt. With the guard active, that
+// reload was silently a no-op so any focus change wiped on-disk comments
+// from the in-memory session — and the next scheduleWrite would persist
+// the empty slate back to disk.
+//
+// SetFocus must use the Locked variant of loadCritJSON, which skips the
+// guard because the caller already holds s.mu. This test pins that
+// behavior: after SetSession marks the session started, switching focus
+// must keep comments visible on the new file list.
+func TestSetFocus_PostSetSession_PreservesComments(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	commitAt(t, dir, "added.txt", "first\nsecond\n", "add file")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		RepoRoot:      dir,
+		OutputDir:     dir,
+		VCS:           &GitVCS{},
+		Branch:        "main",
+		subscribers:   make(map[chan SSEEvent]struct{}),
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	// First focus: range mode. SetFocus runs the constructor-time path
+	// (sessionStarted == 0), so this populates on-disk state cleanly.
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a comment directly on disk so the next SetFocus has something to reload.
+	identity := filepath.Join(dir, ".crit")
+	cj, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf := cj.Files["added.txt"]
+	cf.Comments = []Comment{{ID: "c1", Body: "seeded", StartLine: 1, EndLine: 1, Scope: "line"}}
+	if cj.Files == nil {
+		cj.Files = map[string]CritJSONFile{}
+	}
+	cj.Files["added.txt"] = cf
+	if err := saveCritJSON(identity, cj); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate Server.SetSession: flip the started flag. Any subsequent
+	// loadCritJSON via the public entry point would no-op.
+	s.sessionStarted.Store(1)
+
+	// Toggle focus. The internal reload path must use loadCritJSONLocked
+	// and pull the seeded comment back into s.Files.
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeFullStack, DefaultSHA: base}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got *FileEntry
+	for _, f := range s.Files {
+		if f.Path == "added.txt" {
+			got = f
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("added.txt missing from rebuilt s.Files: %+v", s.Files)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].ID != "c1" {
+		t.Errorf("comments after focus change = %+v; want one seeded comment", got.Comments)
+	}
+
+	// And on-disk state survived (no silent overwrite).
+	cj2, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs := cj2.Files["added.txt"].Comments; len(cs) != 1 || cs[0].ID != "c1" {
+		t.Errorf("disk comments after focus change = %+v; want one seeded comment", cs)
+	}
+}
+
 func TestSetFocus_FullStackRequiresDefaultSHA(t *testing.T) {
 	dir := t.TempDir()
 	s := &Session{

--- a/focus_session_test.go
+++ b/focus_session_test.go
@@ -28,7 +28,7 @@ func TestPersistActiveDiffScope_RoundTrips(t *testing.T) {
 	if err := s.persistActiveDiffScope("layer"); err != nil {
 		t.Fatal(err)
 	}
-	cj, err := loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, err := loadCritJSON(filepath.Join(dir, ".crit"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestPersistActiveDiffScope_RoundTrips(t *testing.T) {
 	if err := s.persistActiveDiffScope(""); err != nil {
 		t.Fatal(err)
 	}
-	cj, _ = loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, _ = loadCritJSON(filepath.Join(dir, ".crit"))
 	if cj.ActiveDiffScope != "" {
 		t.Errorf("after persist(\"\"), got %q (should be cleared)", cj.ActiveDiffScope)
 	}
@@ -156,7 +156,7 @@ func TestSetFocus_Range_RebuildsFiles(t *testing.T) {
 	}
 
 	// On-disk ActiveDiffScope was persisted.
-	cj, _ := loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, _ := loadCritJSON(filepath.Join(dir, ".crit"))
 	if cj.ActiveDiffScope != "layer" {
 		t.Errorf("disk ActiveDiffScope = %q, want layer", cj.ActiveDiffScope)
 	}
@@ -195,7 +195,7 @@ func TestSetFocus_WorkingTree_ClearsActiveDiffScope(t *testing.T) {
 	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
 		t.Fatal(err)
 	}
-	cj, _ := loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, _ := loadCritJSON(filepath.Join(dir, ".crit"))
 	if cj.ActiveDiffScope != "layer" {
 		t.Fatalf("setup: ActiveDiffScope=%q want layer", cj.ActiveDiffScope)
 	}
@@ -204,7 +204,7 @@ func TestSetFocus_WorkingTree_ClearsActiveDiffScope(t *testing.T) {
 	if err := s.SetFocus(Focus{Kind: FocusWorkingTree}); err != nil {
 		t.Fatal(err)
 	}
-	cj, _ = loadCritJSON(filepath.Join(dir, ".crit.json"))
+	cj, _ = loadCritJSON(filepath.Join(dir, ".crit"))
 	if cj.ActiveDiffScope != "" {
 		t.Errorf("on-disk ActiveDiffScope=%q want empty", cj.ActiveDiffScope)
 	}

--- a/github.go
+++ b/github.go
@@ -1061,7 +1061,7 @@ type replyKey struct {
 // commentIDs maps "path:endLine" -> GitHubID for root comments.
 // replyIDs maps replyKey -> GitHubID for replies.
 func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, replyIDs map[replyKey]int64) error {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return err
 	}
@@ -1096,7 +1096,7 @@ func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, r
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(critPath, append(out, '\n'), 0644)
+	return atomicWriteFile(reviewPathsFor(critPath).Review, append(out, '\n'), 0644)
 }
 
 // truncateStr returns the first n runes of s, or all of s if shorter.

--- a/github_test.go
+++ b/github_test.go
@@ -1155,6 +1155,34 @@ func TestFindReviewFileByCommentID_InReviewComments(t *testing.T) {
 	}
 }
 
+func TestFindReviewFileByCommentID_FolderForm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	reviewDir := filepath.Join(home, ".crit", "reviews")
+	folder := filepath.Join(reviewDir, "key1")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cj := CritJSON{
+		ReviewComments: []Comment{{ID: "r_folder1", Body: "From folder"}},
+		Files:          map[string]CritJSONFile{},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(filepath.Join(folder, "review.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findReviewFileByCommentID("r_folder1", "/excluded.json")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != folder {
+		t.Errorf("got %q, want folder identity %q", got, folder)
+	}
+}
+
 func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
 	cj := CritJSON{
 		Files: map[string]CritJSONFile{

--- a/github_test.go
+++ b/github_test.go
@@ -730,7 +730,7 @@ func TestAddCommentToCritJSON_CreatesNewFile(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json/review.json")
+	data, err := os.ReadFile(dir + "/.crit/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestAddCommentToCritJSON_AppendsToExisting(t *testing.T) {
 		t.Fatalf("second add: %v", err)
 	}
 
-	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
+	data, _ := os.ReadFile(dir + "/.crit/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -798,7 +798,7 @@ func TestAddCommentToCritJSON_MultipleFiles(t *testing.T) {
 	addCommentToCritJSONScoped("main.go", 1, 1, "Comment on main", "", "", dir, inheritedScope{})
 	addCommentToCritJSONScoped("auth.go", 5, 10, "Comment on auth", "", "", dir, inheritedScope{})
 
-	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
+	data, _ := os.ReadFile(dir + "/.crit/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -824,7 +824,7 @@ func TestAddCommentToCritJSON_FileMode_NoGitRepo(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json/review.json")
+	data, err := os.ReadFile(dir + "/.crit/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestAddCommentToCritJSON_FileMode_PathRelativeToCWD(t *testing.T) {
 	// Path should be stored as given (relative to CWD), not resolved to anything else
 	addCommentToCritJSONScoped("src/auth.go", 10, 10, "comment", "", "", dir, inheritedScope{})
 
-	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
+	data, _ := os.ReadFile(dir + "/.crit/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -884,7 +884,7 @@ func TestAddCommentToCritJSON_OutputDir(t *testing.T) {
 	}
 
 	// Should be in outputDir
-	data, err := os.ReadFile(outputDir + "/.crit.json/review.json")
+	data, err := os.ReadFile(outputDir + "/.crit/review.json")
 	if err != nil {
 		t.Fatalf("expected .crit.json in outputDir: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestAddCommentToCritJSON_RespectsBaseBranchConfig(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json/review.json")
+	data, err := os.ReadFile(dir + "/.crit/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -977,14 +977,14 @@ func TestAddReplyToCritJSON(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c1", "Done, fixed it", "", "agent", false, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -1013,14 +1013,14 @@ func TestAddReplyToCritJSON_WithResolve(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c1", "Split the function", "agent", "", true, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -1042,7 +1042,7 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c99", "reply", "agent", "", false, dir, "")
 	if err == nil {
@@ -1079,7 +1079,7 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	localDir := t.TempDir()
 	localCJ := CritJSON{Branch: "other", ReviewRound: 1, Files: map[string]CritJSONFile{}}
 	localData, _ := json.MarshalIndent(localCJ, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(localDir, ".crit.json", "review.json")), localData, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(localDir, ".crit", "review.json")), localData, 0644)
 
 	// Reply should fall back to the review file containing c_target.
 	err := addReplyToCritJSON("c_target", "Done, fixed", "", "agent", false, localDir, "")
@@ -1102,7 +1102,7 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	}
 
 	// Verify the local file was NOT modified.
-	localData2, _ := os.ReadFile(filepath.Join(localDir, ".crit.json", "review.json"))
+	localData2, _ := os.ReadFile(filepath.Join(localDir, ".crit", "review.json"))
 	var localResult CritJSON
 	json.Unmarshal(localData2, &localResult)
 	if len(localResult.Files) != 0 {
@@ -1205,7 +1205,7 @@ func TestCritJSONToGHComments_SkipsAlreadyPushed(t *testing.T) {
 
 func TestUpdateCritJSONWithGitHubIDs(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	cj := CritJSON{
 		Branch: "main", BaseRef: "abc123", ReviewRound: 1,
@@ -1247,7 +1247,7 @@ func TestUpdateCritJSONWithGitHubIDs(t *testing.T) {
 
 func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	cj := CritJSON{
 		Branch: "main", ReviewRound: 1,
@@ -1289,7 +1289,7 @@ func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
 // readCritJSON is a test helper that reads and parses .crit.json from the given directory.
 func readCritJSON(t *testing.T, dir string) CritJSON {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
 	}
@@ -1449,7 +1449,7 @@ func TestBulkAddCommentsToCritJSON_RedirectsRepliesToAltFile(t *testing.T) {
 	}
 
 	// Primary (cwd-resolved) file should be untouched / empty.
-	primaryPath := filepath.Join(dir, ".crit.json")
+	primaryPath := filepath.Join(dir, ".crit")
 	if data, err := os.ReadFile(primaryPath); err == nil {
 		var cj CritJSON
 		json.Unmarshal(data, &cj)
@@ -1807,7 +1807,7 @@ func TestCreateGHReview_IDMapping(t *testing.T) {
 // that matches pushed replies back to their .crit.json entries.
 func TestUpdateCritJSONWithGitHubIDs_ReplyMapping(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	cj := CritJSON{
 		Branch: "feature", BaseRef: "abc", ReviewRound: 1,
@@ -2063,7 +2063,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 	}
 
 	// Read back and verify
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
@@ -2112,7 +2112,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 	}
 
 	// Read to get the comment ID
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	data, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
@@ -2142,7 +2142,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 
 	addCommentToCritJSONScoped("README.md", 1, 1, "fix this", "reviewer", "", dir, inheritedScope{})
 
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	data, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
@@ -2246,7 +2246,7 @@ func TestAddReviewCommentToCritJSON_RoundTrip(t *testing.T) {
 		t.Fatalf("addReviewCommentToCritJSON: %v", err)
 	}
 
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatal(err)
@@ -2270,7 +2270,7 @@ func TestClearCritJSON(t *testing.T) {
 	// Create a .crit.json
 	addCommentToCritJSONScoped("README.md", 1, 1, "test", "author", "", dir, inheritedScope{})
 
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	if _, err := os.Stat(critPath); err != nil {
 		t.Fatal("expected .crit.json to exist")
 	}
@@ -2316,7 +2316,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	t.Run("reply to file comment by random ID", func(t *testing.T) {
 		err := addReplyToCritJSON("c_a3f8b2", "Done, extracted", "", "agent", false, dir, "")
@@ -2324,7 +2324,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2346,7 +2346,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2369,7 +2369,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2604,7 +2604,7 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 		BaseRef: "abc",
 		Files:   map[string]CritJSONFile{},
 	}
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	data, _ := json.Marshal(cj)
 	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 

--- a/github_test.go
+++ b/github_test.go
@@ -730,7 +730,7 @@ func TestAddCommentToCritJSON_CreatesNewFile(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json")
+	data, err := os.ReadFile(dir + "/.crit.json/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestAddCommentToCritJSON_AppendsToExisting(t *testing.T) {
 		t.Fatalf("second add: %v", err)
 	}
 
-	data, _ := os.ReadFile(dir + "/.crit.json")
+	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -798,7 +798,7 @@ func TestAddCommentToCritJSON_MultipleFiles(t *testing.T) {
 	addCommentToCritJSONScoped("main.go", 1, 1, "Comment on main", "", "", dir, inheritedScope{})
 	addCommentToCritJSONScoped("auth.go", 5, 10, "Comment on auth", "", "", dir, inheritedScope{})
 
-	data, _ := os.ReadFile(dir + "/.crit.json")
+	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -824,7 +824,7 @@ func TestAddCommentToCritJSON_FileMode_NoGitRepo(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json")
+	data, err := os.ReadFile(dir + "/.crit.json/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestAddCommentToCritJSON_FileMode_PathRelativeToCWD(t *testing.T) {
 	// Path should be stored as given (relative to CWD), not resolved to anything else
 	addCommentToCritJSONScoped("src/auth.go", 10, 10, "comment", "", "", dir, inheritedScope{})
 
-	data, _ := os.ReadFile(dir + "/.crit.json")
+	data, _ := os.ReadFile(dir + "/.crit.json/review.json")
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -884,7 +884,7 @@ func TestAddCommentToCritJSON_OutputDir(t *testing.T) {
 	}
 
 	// Should be in outputDir
-	data, err := os.ReadFile(outputDir + "/.crit.json")
+	data, err := os.ReadFile(outputDir + "/.crit.json/review.json")
 	if err != nil {
 		t.Fatalf("expected .crit.json in outputDir: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestAddCommentToCritJSON_RespectsBaseBranchConfig(t *testing.T) {
 		t.Fatalf("addCommentToCritJSON: %v", err)
 	}
 
-	data, err := os.ReadFile(dir + "/.crit.json")
+	data, err := os.ReadFile(dir + "/.crit.json/review.json")
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -977,14 +977,14 @@ func TestAddReplyToCritJSON(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c1", "Done, fixed it", "", "agent", false, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -1013,14 +1013,14 @@ func TestAddReplyToCritJSON_WithResolve(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c1", "Split the function", "agent", "", true, dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -1042,7 +1042,7 @@ func TestAddReplyToCritJSON_NotFound(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	err := addReplyToCritJSON("c99", "reply", "agent", "", false, dir, "")
 	if err == nil {
@@ -1079,7 +1079,7 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	localDir := t.TempDir()
 	localCJ := CritJSON{Branch: "other", ReviewRound: 1, Files: map[string]CritJSONFile{}}
 	localData, _ := json.MarshalIndent(localCJ, "", "  ")
-	os.WriteFile(filepath.Join(localDir, ".crit.json"), localData, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(localDir, ".crit.json", "review.json")), localData, 0644)
 
 	// Reply should fall back to the review file containing c_target.
 	err := addReplyToCritJSON("c_target", "Done, fixed", "", "agent", false, localDir, "")
@@ -1088,7 +1088,9 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	}
 
 	// Verify reply was written to the correct review file.
-	data, _ := os.ReadFile(filepath.Join(reviewDir, "correct.json"))
+	// addReplyToCritJSON migrated the seeded flat correct.json into the v4
+	// folder layout, so the canonical read is correct.json/review.json.
+	data, _ := os.ReadFile(filepath.Join(reviewDir, "correct.json", "review.json"))
 	var result CritJSON
 	json.Unmarshal(data, &result)
 	comments := result.Files["main.go"].Comments
@@ -1100,7 +1102,7 @@ func TestAddReplyToCritJSON_FallbackByCommentID(t *testing.T) {
 	}
 
 	// Verify the local file was NOT modified.
-	localData2, _ := os.ReadFile(filepath.Join(localDir, ".crit.json"))
+	localData2, _ := os.ReadFile(filepath.Join(localDir, ".crit.json", "review.json"))
 	var localResult CritJSON
 	json.Unmarshal(localData2, &localResult)
 	if len(localResult.Files) != 0 {
@@ -1190,7 +1192,7 @@ func TestUpdateCritJSONWithGitHubIDs(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	idMap := map[string]int64{
 		"main.go:5":  111,
@@ -1202,7 +1204,7 @@ func TestUpdateCritJSONWithGitHubIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, _ := os.ReadFile(critPath)
+	result, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var got CritJSON
 	json.Unmarshal(result, &got)
 
@@ -1235,7 +1237,7 @@ func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	replyIDs := map[replyKey]int64{
 		{ParentGHID: 100, BodyPrefix: "Done, fixed it"}: 201,
@@ -1246,7 +1248,7 @@ func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, _ := os.ReadFile(critPath)
+	result, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var got CritJSON
 	json.Unmarshal(result, &got)
 
@@ -1259,7 +1261,7 @@ func TestUpdateCritJSONWithGitHubIDs_Replies(t *testing.T) {
 // readCritJSON is a test helper that reads and parses .crit.json from the given directory.
 func readCritJSON(t *testing.T, dir string) CritJSON {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, err := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
 	}
@@ -1434,7 +1436,8 @@ func TestBulkAddCommentsToCritJSON_RedirectsRepliesToAltFile(t *testing.T) {
 	}
 
 	// Alt file should have the reply on c_spec1 plus the new review comment.
-	altData, err := os.ReadFile(altPath)
+	// addReplyToCritJSON migrated alt_review.json into the v4 folder layout.
+	altData, err := os.ReadFile(reviewPathsFor(altPath).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1796,7 +1799,7 @@ func TestUpdateCritJSONWithGitHubIDs_ReplyMapping(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, append(data, '\n'), 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), append(data, '\n'), 0644)
 
 	commentIDs := map[string]int64{} // no new root comments
 	replyIDs := map[replyKey]int64{
@@ -1808,7 +1811,7 @@ func TestUpdateCritJSONWithGitHubIDs_ReplyMapping(t *testing.T) {
 	}
 
 	// Re-read and verify
-	data, _ = os.ReadFile(critPath)
+	data, _ = os.ReadFile(reviewPathsFor(critPath).Review)
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -2033,7 +2036,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 
 	// Read back and verify
 	critPath := filepath.Join(dir, ".crit.json")
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
 	}
@@ -2061,7 +2064,7 @@ func TestAddCommentToCritJSON_RoundTrip(t *testing.T) {
 		t.Fatalf("second addCommentToCritJSON: %v", err)
 	}
 
-	data, _ = os.ReadFile(critPath)
+	data, _ = os.ReadFile(reviewPathsFor(critPath).Review)
 	json.Unmarshal(data, &cj)
 	if len(cj.Files["README.md"].Comments) != 2 {
 		t.Errorf("expected 2 comments after second add, got %d", len(cj.Files["README.md"].Comments))
@@ -2082,7 +2085,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 
 	// Read to get the comment ID
 	critPath := filepath.Join(dir, ".crit.json")
-	data, _ := os.ReadFile(critPath)
+	data, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	commentID := cj.Files["README.md"].Comments[0].ID
@@ -2093,7 +2096,7 @@ func TestAddReplyToCritJSON_RoundTrip(t *testing.T) {
 		t.Fatalf("addReplyToCritJSON: %v", err)
 	}
 
-	data, _ = os.ReadFile(critPath)
+	data, _ = os.ReadFile(reviewPathsFor(critPath).Review)
 	json.Unmarshal(data, &cj)
 	if len(cj.Files["README.md"].Comments[0].Replies) != 1 {
 		t.Fatalf("expected 1 reply, got %d", len(cj.Files["README.md"].Comments[0].Replies))
@@ -2112,7 +2115,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 	addCommentToCritJSONScoped("README.md", 1, 1, "fix this", "reviewer", "", dir, inheritedScope{})
 
 	critPath := filepath.Join(dir, ".crit.json")
-	data, _ := os.ReadFile(critPath)
+	data, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	commentID := cj.Files["README.md"].Comments[0].ID
@@ -2122,7 +2125,7 @@ func TestAddReplyToCritJSON_WithResolve_ViaFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, _ = os.ReadFile(critPath)
+	data, _ = os.ReadFile(reviewPathsFor(critPath).Review)
 	json.Unmarshal(data, &cj)
 	if !cj.Files["README.md"].Comments[0].Resolved {
 		t.Error("expected comment to be resolved after reply with resolve=true")
@@ -2216,7 +2219,7 @@ func TestAddReviewCommentToCritJSON_RoundTrip(t *testing.T) {
 	}
 
 	critPath := filepath.Join(dir, ".crit.json")
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2285,7 +2288,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	t.Run("reply to file comment by random ID", func(t *testing.T) {
 		err := addReplyToCritJSON("c_a3f8b2", "Done, extracted", "", "agent", false, dir, "")
@@ -2293,7 +2296,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2315,7 +2318,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2338,7 +2341,7 @@ func TestAddReplyToCritJSON_RandomIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+		data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 		var result CritJSON
 		json.Unmarshal(data, &result)
 
@@ -2451,7 +2454,7 @@ func TestAddCommentToCritJSON_PopulatesAnchor(t *testing.T) {
 	}
 
 	critPath, _ := resolveReviewPath(dir)
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatalf("read review file: %v", err)
 	}
@@ -2488,7 +2491,7 @@ func TestBulkAddCommentsToCritJSON_PopulatesAnchor(t *testing.T) {
 	}
 
 	critPath, _ := resolveReviewPath(dir)
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatalf("read review file: %v", err)
 	}
@@ -2575,7 +2578,7 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 	}
 	critPath := filepath.Join(dir, ".crit.json")
 	data, _ := json.Marshal(cj)
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	err := addFileCommentToCritJSONScoped("test.go", "file-level feedback", "reviewer", "", dir, inheritedScope{})
 	if err != nil {
@@ -2583,7 +2586,7 @@ func TestAddFileCommentToCritJSON_Success(t *testing.T) {
 	}
 
 	// Re-read and verify.
-	data, err = os.ReadFile(critPath)
+	data, err = os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -315,7 +315,7 @@ func runFetch(args []string) {
 
 	if len(fetched.NewComments) == 0 && len(fetched.ReplyUpdates) == 0 {
 		fmt.Println("No new comments.")
-		fmt.Printf("Review file: %s\n", critPath)
+		fmt.Printf("Review file: %s\n", reviewPathsFor(critPath).Review)
 		return
 	}
 
@@ -332,7 +332,7 @@ func runFetch(args []string) {
 		}
 		fmt.Printf("Updated %d comment(s) with %d new reply(ies).\n", len(fetched.ReplyUpdates), replyCount)
 	}
-	fmt.Printf("Review file: %s\n", critPath)
+	fmt.Printf("Review file: %s\n", reviewPathsFor(critPath).Review)
 }
 
 func runUnpublish(args []string) {
@@ -1953,7 +1953,7 @@ func runStatus(args []string) {
 	}
 
 	revExists := false
-	if _, statErr := os.Stat(revPath); statErr == nil {
+	if _, statErr := os.Stat(reviewPathsFor(revPath).Review); statErr == nil {
 		revExists = true
 	}
 
@@ -1969,7 +1969,7 @@ func printStatusJSON(vcsName, branch, revPath string, revExists bool, session *s
 	result := map[string]interface{}{
 		"vcs":                vcsName,
 		"branch":             branch,
-		"review_file":        revPath,
+		"review_file":        reviewPathsFor(revPath).Review,
 		"review_file_exists": revExists,
 	}
 	daemon := map[string]interface{}{"running": false}
@@ -1989,7 +1989,7 @@ func printStatusJSON(vcsName, branch, revPath string, revExists bool, session *s
 }
 
 func addReviewStats(result map[string]interface{}, revPath string) {
-	data, err := os.ReadFile(revPath)
+	data, err := os.ReadFile(reviewPathsFor(revPath).Review)
 	if err != nil {
 		return
 	}
@@ -2012,7 +2012,7 @@ func printStatusHuman(vcsName, branch, revPath string, revExists bool, session *
 	if branch != "" {
 		fmt.Printf("Branch:      %s\n", branch)
 	}
-	fmt.Printf("Review file: %s\n", revPath)
+	fmt.Printf("Review file: %s\n", reviewPathsFor(revPath).Review)
 	if session != nil {
 		fmt.Printf("Daemon:      running (PID %d, port %d)\n", session.PID, session.Port)
 	} else {
@@ -2021,7 +2021,7 @@ func printStatusHuman(vcsName, branch, revPath string, revExists bool, session *
 	if !revExists {
 		return
 	}
-	data, err := os.ReadFile(revPath)
+	data, err := os.ReadFile(reviewPathsFor(revPath).Review)
 	if err != nil {
 		return
 	}
@@ -2136,8 +2136,10 @@ func findStaleReviews(revDir string, days int) []staleReview {
 		name := de.Name()
 
 		if de.IsDir() {
-			// v4 folder-form review (or orphan snapshots-only folder).
-			key := name
+			// MIGRATION-REMOVAL: pre-fix early-v4 folders kept a stray .json
+			// extension on the folder name. Strip it for the session-key
+			// lookup; the standard load path will rename the folder on access.
+			key := strings.TrimSuffix(name, ".json")
 			if activeSessions[key] {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -1406,7 +1406,7 @@ func backgroundCleanup() {
 func deleteStaleReviewsSilent(stale []staleReview) {
 	sessDir, _ := sessionsDir()
 	for _, s := range stale {
-		if os.Remove(s.path) != nil {
+		if !removeStaleReviewPath(s.path) {
 			continue
 		}
 		if sessDir != "" {
@@ -1417,12 +1417,35 @@ func deleteStaleReviewsSilent(stale []staleReview) {
 	}
 }
 
+// removeStaleReviewPath removes a review identity, supporting both the v4
+// folder layout (RemoveAll) and v3 flat *.json files (Remove + sibling
+// sidecar). MIGRATION-REMOVAL: the flat-file branch can be deleted once the
+// migration shim is removed.
+func removeStaleReviewPath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return os.RemoveAll(path) == nil
+	}
+	// MIGRATION-REMOVAL: v3 flat-file fallback.
+	if err := os.Remove(path); err != nil {
+		return false
+	}
+	_ = os.Remove(path + ".snapshots.json")
+	return true
+}
+
 // cleanupOnApproval deletes the review file when the review is approved
 // and cleanup is enabled.
 func cleanupOnApproval(approved bool, reviewPath string, cleanupEnabled bool) {
-	if approved && cleanupEnabled && reviewPath != "" {
-		os.Remove(reviewPath)
+	if !(approved && cleanupEnabled && reviewPath != "") {
+		return
 	}
+	// In v4 the review identity is a folder; remove it whole. The
+	// MIGRATION-REMOVAL fallback handles v3 flat reviews still on disk.
+	_ = removeStaleReviewPath(reviewPath)
 }
 
 func runPlan(args []string) {
@@ -2110,10 +2133,28 @@ func findStaleReviews(revDir string, days int) []staleReview {
 
 	var stale []staleReview
 	for _, de := range entries {
-		if !strings.HasSuffix(de.Name(), ".json") {
+		name := de.Name()
+
+		if de.IsDir() {
+			// v4 folder-form review (or orphan snapshots-only folder).
+			key := name
+			if activeSessions[key] {
+				continue
+			}
+			if sr, ok := checkStaleReviewFolder(revDir, de, key, cutoff); ok {
+				stale = append(stale, sr)
+			}
 			continue
 		}
-		key := strings.TrimSuffix(de.Name(), ".json")
+
+		// MIGRATION-REMOVAL: legacy v3 flat *.json file. Treat as a stale
+		// candidate so cleanup wipes it (and any sibling sidecar) the next
+		// time crit runs. After the migration removal release this branch
+		// goes away.
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		key := strings.TrimSuffix(name, ".json")
 		if activeSessions[key] {
 			continue
 		}
@@ -2122,6 +2163,70 @@ func findStaleReviews(revDir string, days int) []staleReview {
 		}
 	}
 	return stale
+}
+
+// checkStaleReviewFolder evaluates a directory entry inside the reviews dir.
+// It is a v4-native staleness check for folder-form reviews. Three possible
+// outcomes:
+//
+//  1. The folder contains review.json: read it, parse UpdatedAt, fall back
+//     to file mtime if missing. Stale if the timestamp is before cutoff.
+//  2. The folder lacks review.json but contains snapshots.json: it's an
+//     orphan-snapshots folder (e.g. a crashed migration or a deleted review
+//     left behind a sidecar). Stale if folder mtime is before cutoff.
+//  3. Empty / unrecognized contents: skip.
+func checkStaleReviewFolder(revDir string, de os.DirEntry, key string, cutoff time.Time) (staleReview, bool) {
+	folder := filepath.Join(revDir, de.Name())
+	reviewPath := filepath.Join(folder, "review.json")
+
+	if data, readErr := os.ReadFile(reviewPath); readErr == nil {
+		var cj CritJSON
+		var updatedAt time.Time
+		var branch string
+		var commentCount int
+		if json.Unmarshal(data, &cj) == nil {
+			branch = cj.Branch
+			if t, parseErr := time.Parse(time.RFC3339, cj.UpdatedAt); parseErr == nil {
+				updatedAt = t
+			}
+			for _, f := range cj.Files {
+				commentCount += len(f.Comments)
+			}
+			commentCount += len(cj.ReviewComments)
+		}
+		if updatedAt.IsZero() {
+			if info, statErr := os.Stat(reviewPath); statErr == nil {
+				updatedAt = info.ModTime()
+			}
+		}
+		if !updatedAt.Before(cutoff) {
+			return staleReview{}, false
+		}
+		return staleReview{
+			key:      key,
+			path:     folder,
+			branch:   branch,
+			age:      time.Since(updatedAt),
+			comments: commentCount,
+		}, true
+	}
+
+	// review.json missing — check for orphan snapshots folder.
+	if _, err := os.Stat(filepath.Join(folder, "snapshots.json")); err != nil {
+		return staleReview{}, false
+	}
+	info, err := de.Info()
+	if err != nil {
+		return staleReview{}, false
+	}
+	if !info.ModTime().Before(cutoff) {
+		return staleReview{}, false
+	}
+	return staleReview{
+		key:  key,
+		path: folder,
+		age:  time.Since(info.ModTime()),
+	}, true
 }
 
 func buildActiveSessionSet() map[string]bool {
@@ -2191,8 +2296,8 @@ func deleteStaleReviews(stale []staleReview) int {
 	sessDir, _ := sessionsDir()
 	deleted := 0
 	for _, s := range stale {
-		if err := os.Remove(s.path); err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting %s: %v\n", s.path, err)
+		if !removeStaleReviewPath(s.path) {
+			fmt.Fprintf(os.Stderr, "Error deleting %s: directory not empty or path missing\n", s.path)
 			continue
 		}
 		deleted++

--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func runFetch(args []string) {
 		os.Exit(1)
 	}
 
-	data, readErr := os.ReadFile(critPath)
+	data, readErr := os.ReadFile(reviewPathsFor(critPath).Review)
 	if readErr != nil {
 		fmt.Fprintln(os.Stderr, "Error: no review file found. Run `crit share` first.")
 		os.Exit(1)
@@ -370,7 +370,7 @@ func runUnpublish(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error: no review file found. Nothing to unpublish.")
 		os.Exit(1)
@@ -541,7 +541,7 @@ func runPull(args []string) {
 		os.Exit(1)
 	}
 	var cj CritJSON
-	if data, readErr := os.ReadFile(critPath); readErr == nil {
+	if data, readErr := os.ReadFile(reviewPathsFor(critPath).Review); readErr == nil {
 		if jsonErr := json.Unmarshal(data, &cj); jsonErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: existing review file is invalid, starting fresh: %v\n", jsonErr)
 		}
@@ -738,7 +738,7 @@ func loadPushContext(args []string) pushContext {
 	// checkout can still find the right file by branch via the redirect.
 	var cj CritJSON
 	cwdFileExists := true
-	data, readErr := os.ReadFile(critPath)
+	data, readErr := os.ReadFile(reviewPathsFor(critPath).Review)
 	if readErr != nil {
 		if !os.IsNotExist(readErr) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", readErr)

--- a/main_test.go
+++ b/main_test.go
@@ -313,7 +313,7 @@ func TestRunComment_JSONFlagMixed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup comment: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmp, ".crit.json"))
+	data, err := os.ReadFile(filepath.Join(tmp, ".crit.json", "review.json"))
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -1054,7 +1054,7 @@ func TestFetch_PrintsReviewFilePath(t *testing.T) {
 				t.Fatal(err)
 			}
 			critPath := filepath.Join(tmpDir, ".crit.json")
-			if err := os.WriteFile(critPath, data, 0o644); err != nil {
+			if err := os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644); err != nil {
 				t.Fatal(err)
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -856,6 +856,127 @@ func TestFindStaleReviews(t *testing.T) {
 	}
 }
 
+func TestFindStaleReviews_FolderForm(t *testing.T) {
+	dir := t.TempDir()
+
+	// Folder-form review with stale updated_at.
+	oldTime := time.Now().Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	staleFolder := filepath.Join(dir, "stalekey1")
+	if err := os.MkdirAll(staleFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cj := CritJSON{
+		Branch:      "old-branch",
+		UpdatedAt:   oldTime,
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"main.go": {Comments: []Comment{{ID: "c1"}}},
+		},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(filepath.Join(staleFolder, "review.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar present too.
+	if err := os.WriteFile(filepath.Join(staleFolder, "snapshots.json"), []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recent folder-form review.
+	recentFolder := filepath.Join(dir, "recentkey")
+	if err := os.MkdirAll(recentFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recentCJ := CritJSON{
+		Branch:      "recent-branch",
+		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+		ReviewRound: 1,
+		Files:       map[string]CritJSONFile{},
+	}
+	recentData, _ := json.MarshalIndent(recentCJ, "", "  ")
+	if err := os.WriteFile(filepath.Join(recentFolder, "review.json"), recentData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := findStaleReviews(dir, 7)
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale review, got %d (%+v)", len(stale), stale)
+	}
+	if stale[0].branch != "old-branch" {
+		t.Errorf("branch = %q", stale[0].branch)
+	}
+	if stale[0].comments != 1 {
+		t.Errorf("comments = %d", stale[0].comments)
+	}
+	if stale[0].path != staleFolder {
+		t.Errorf("path = %q, want folder identity %q", stale[0].path, staleFolder)
+	}
+}
+
+func TestFindStaleReviews_OrphanSnapshotsFolder(t *testing.T) {
+	dir := t.TempDir()
+	orphan := filepath.Join(dir, "orphan1")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// snapshots.json without a sibling review.json.
+	if err := os.WriteFile(filepath.Join(orphan, "snapshots.json"), []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Age the folder mtime past the cutoff.
+	old := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(orphan, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := findStaleReviews(dir, 7)
+	if len(stale) != 1 {
+		t.Fatalf("expected orphan folder collected, got %d entries: %+v", len(stale), stale)
+	}
+	if stale[0].path != orphan {
+		t.Errorf("path = %q, want orphan folder %q", stale[0].path, orphan)
+	}
+}
+
+func TestDeleteStaleReviews_FolderForm(t *testing.T) {
+	dir := t.TempDir()
+	folder := filepath.Join(dir, "key1")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, "review.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, "snapshots.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted := deleteStaleReviews([]staleReview{{key: "key1", path: folder}})
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+	if _, err := os.Stat(folder); !os.IsNotExist(err) {
+		t.Errorf("folder not removed: err=%v", err)
+	}
+}
+
+func TestCleanupOnApproval_RemovesFolderForm(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, ".crit.json")
+	if err := saveCritJSON(identity, CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSnapshotsFile(reviewPathsFor(identity).Snapshots, SnapshotsFile{RoundSnapshots: map[string]map[int]RoundSnapshot{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupOnApproval(true, identity, true)
+
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Errorf("folder not removed: err=%v", err)
+	}
+}
+
 func TestDeleteStaleReviews(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.json")

--- a/main_test.go
+++ b/main_test.go
@@ -313,7 +313,7 @@ func TestRunComment_JSONFlagMixed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup comment: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(tmp, ".crit.json", "review.json"))
+	data, err := os.ReadFile(filepath.Join(tmp, ".crit", "review.json"))
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -962,7 +962,7 @@ func TestDeleteStaleReviews_FolderForm(t *testing.T) {
 
 func TestCleanupOnApproval_RemovesFolderForm(t *testing.T) {
 	dir := t.TempDir()
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	if err := saveCritJSON(identity, CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1174,7 +1174,7 @@ func TestFetch_PrintsReviewFilePath(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			critPath := filepath.Join(tmpDir, ".crit.json")
+			critPath := filepath.Join(tmpDir, ".crit")
 			if err := os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644); err != nil {
 				t.Fatal(err)
 			}

--- a/reply_round_test.go
+++ b/reply_round_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRepliesAtOrBeforeRound_HidesFutureReplies covers the unit-level
+// reply-filter helper: a reply authored in R2 must be hidden when viewing R1,
+// while replies at or before R1 must be retained.
+func TestRepliesAtOrBeforeRound_HidesFutureReplies(t *testing.T) {
+	parentRound := 1
+	replies := []Reply{
+		{ID: "rp1", ReviewRound: 1},
+		{ID: "rp2", ReviewRound: 2},
+		{ID: "rp3", ReviewRound: 3},
+	}
+	got := repliesAtOrBeforeRound(replies, 1, parentRound)
+	if len(got) != 1 || got[0].ID != "rp1" {
+		t.Fatalf("expected only rp1 at round<=1, got %+v", got)
+	}
+}
+
+// TestRepliesAtOrBeforeRound_VisibleAtOwnRound: a reply authored at R1 is
+// visible when viewing R1.
+func TestRepliesAtOrBeforeRound_VisibleAtOwnRound(t *testing.T) {
+	got := repliesAtOrBeforeRound([]Reply{{ID: "rp1", ReviewRound: 1}}, 1, 1)
+	if len(got) != 1 {
+		t.Fatalf("reply at own round must be visible, got %+v", got)
+	}
+}
+
+// TestRepliesAtOrBeforeRound_LegacyFallsBackToParent: a reply with no
+// ReviewRound set (zero value, e.g. from review files written before the
+// field existed) inherits its parent's round. So a legacy reply on a
+// parent authored at R1 is visible from R1 onward.
+func TestRepliesAtOrBeforeRound_LegacyFallsBackToParent(t *testing.T) {
+	replies := []Reply{{ID: "rp_legacy"}} // ReviewRound == 0
+	if got := repliesAtOrBeforeRound(replies, 1, 1); len(got) != 1 {
+		t.Errorf("legacy reply on R1 parent must be visible at R1, got %+v", got)
+	}
+	if got := repliesAtOrBeforeRound(replies, 0, 1); len(got) != 0 {
+		// round=0 is invalid for callers, but the helper is reached only
+		// from commentsAtOrBeforeRound which short-circuits round<=0.
+		// Sanity: when parent's effective round (1) > requested (0), hide.
+		t.Errorf("legacy reply must be hidden when round<parent, got %+v", got)
+	}
+	// Legacy reply on R2 parent must be hidden at R1.
+	if got := repliesAtOrBeforeRound(replies, 1, 2); len(got) != 0 {
+		t.Errorf("legacy reply on R2 parent must be hidden at R1, got %+v", got)
+	}
+}
+
+// TestRepliesAtOrBeforeRound_Chain: a multi-round reply chain on the same
+// parent should be progressively revealed as the viewer scrubs forward.
+func TestRepliesAtOrBeforeRound_Chain(t *testing.T) {
+	replies := []Reply{
+		{ID: "rp1", ReviewRound: 1},
+		{ID: "rp2", ReviewRound: 2},
+		{ID: "rp3", ReviewRound: 3},
+	}
+	for _, tc := range []struct {
+		round, want int
+	}{
+		{1, 1}, {2, 2}, {3, 3}, {4, 3},
+	} {
+		got := repliesAtOrBeforeRound(replies, tc.round, 1)
+		if len(got) != tc.want {
+			t.Errorf("round=%d: want %d replies, got %d (%+v)", tc.round, tc.want, len(got), got)
+		}
+	}
+}
+
+// TestCommentsAtOrBeforeRound_FiltersFutureReplies: the top-level filter
+// keeps R1 parents but drops their R2 replies when scoping to round=1.
+func TestCommentsAtOrBeforeRound_FiltersFutureReplies(t *testing.T) {
+	cs := []Comment{
+		{
+			ID:          "c1",
+			ReviewRound: 1,
+			Replies: []Reply{
+				{ID: "rp1", ReviewRound: 1},
+				{ID: "rp2", ReviewRound: 2},
+			},
+		},
+	}
+	got := commentsAtOrBeforeRound(cs, 1)
+	if len(got) != 1 {
+		t.Fatalf("expected parent comment retained, got %+v", got)
+	}
+	if len(got[0].Replies) != 1 || got[0].Replies[0].ID != "rp1" {
+		t.Errorf("expected only rp1 at round=1, got %+v", got[0].Replies)
+	}
+	// Original input must not be mutated.
+	if len(cs[0].Replies) != 2 {
+		t.Errorf("input replies mutated: %+v", cs[0].Replies)
+	}
+}
+
+// TestReply_RoundTripJSON guards that the new ReviewRound field round-trips
+// cleanly through encoding/json with the expected wire name and omitempty.
+func TestReply_RoundTripJSON(t *testing.T) {
+	in := Reply{ID: "rp1", Body: "hi", CreatedAt: "now", ReviewRound: 2}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `"review_round":2`; !strings.Contains(string(data), want) {
+		t.Errorf("missing %s in %s", want, data)
+	}
+	var out Reply
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.ReviewRound != 2 {
+		t.Errorf("round did not round-trip: got %d", out.ReviewRound)
+	}
+
+	// Zero value must omit the field on the wire (legacy/back-compat shape).
+	zero, _ := json.Marshal(Reply{ID: "rp0", Body: "x", CreatedAt: "now"})
+	if strings.Contains(string(zero), "review_round") {
+		t.Errorf("expected review_round omitted when zero, got %s", zero)
+	}
+}
+
+// TestHandleFileComments_RoundFiltersReplies covers the HTTP path: a reply
+// authored at R2 must not appear in /api/file/comments?round=1, but must
+// appear at round=2.
+func TestHandleFileComments_RoundFiltersReplies(t *testing.T) {
+	s, sess := newRoundsTestServer(t)
+	sess.Files[0].Comments = []Comment{
+		{
+			ID: "c1", ReviewRound: 1, Body: "parent",
+			Replies: []Reply{
+				{ID: "rp1", ReviewRound: 1, Body: "early"},
+				{ID: "rp2", ReviewRound: 2, Body: "late"},
+			},
+		},
+	}
+
+	// At round=1, only the early reply is visible.
+	req := httptest.NewRequest("GET", "/api/file/comments?path=test.md&round=1", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("round=1 status=%d body=%s", w.Code, w.Body.String())
+	}
+	var r1 []Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &r1); err != nil {
+		t.Fatal(err)
+	}
+	if len(r1) != 1 || len(r1[0].Replies) != 1 || r1[0].Replies[0].ID != "rp1" {
+		t.Fatalf("round=1 expected single reply rp1, got %+v", r1)
+	}
+
+	// At round=2, both replies are visible.
+	req = httptest.NewRequest("GET", "/api/file/comments?path=test.md&round=2", nil)
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("round=2 status=%d body=%s", w.Code, w.Body.String())
+	}
+	var r2 []Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &r2); err != nil {
+		t.Fatal(err)
+	}
+	if len(r2) != 1 || len(r2[0].Replies) != 2 {
+		t.Fatalf("round=2 expected both replies, got %+v", r2)
+	}
+}
+
+// TestSession_AddReply_StampsReviewRound: the in-memory reply-add path must
+// stamp the current Session.ReviewRound onto the reply.
+func TestSession_AddReply_StampsReviewRound(t *testing.T) {
+	_, sess := newTestServer(t)
+	sess.Files[0].Comments = []Comment{{ID: "c1", ReviewRound: 1}}
+	sess.ReviewRound = 3
+
+	r, ok := sess.AddReply("test.md", "c1", "reply body", "alice", "")
+	if !ok {
+		t.Fatal("AddReply returned !ok")
+	}
+	if r.ReviewRound != 3 {
+		t.Errorf("expected reply ReviewRound=3, got %d", r.ReviewRound)
+	}
+	if got := sess.Files[0].Comments[0].Replies[0].ReviewRound; got != 3 {
+		t.Errorf("persisted reply round=%d, want 3", got)
+	}
+}
+
+// TestAppendReply_StampsCritJSONReviewRound: the headless CLI path stamps the
+// reply with cj.ReviewRound (the persisted on-disk value) since it has no
+// live Session.
+func TestAppendReply_StampsCritJSONReviewRound(t *testing.T) {
+	cj := &CritJSON{
+		ReviewRound: 4,
+		Files: map[string]CritJSONFile{
+			"a.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", ReviewRound: 1, Body: "x"},
+				},
+			},
+		},
+	}
+	if err := appendReply(cj, "c1", "reply", "agent", "", false, ""); err != nil {
+		t.Fatalf("appendReply: %v", err)
+	}
+	got := cj.Files["a.go"].Comments[0].Replies[0].ReviewRound
+	if got != 4 {
+		t.Errorf("expected reply ReviewRound=4 (from cj.ReviewRound), got %d", got)
+	}
+
+	// Review-level comment path.
+	cj2 := &CritJSON{
+		ReviewRound:    7,
+		ReviewComments: []Comment{{ID: "r0", Scope: "review"}},
+		Files:          map[string]CritJSONFile{},
+	}
+	if err := appendReply(cj2, "r0", "ack", "agent", "", false, ""); err != nil {
+		t.Fatalf("appendReply review: %v", err)
+	}
+	if cj2.ReviewComments[0].Replies[0].ReviewRound != 7 {
+		t.Errorf("expected review reply ReviewRound=7, got %d", cj2.ReviewComments[0].Replies[0].ReviewRound)
+	}
+}
+
+// TestSession_AddReviewCommentReply_StampsReviewRound mirrors the file-comment
+// test for review-level comments.
+func TestSession_AddReviewCommentReply_StampsReviewRound(t *testing.T) {
+	_, sess := newTestServer(t)
+	sess.ReviewRound = 5
+	parent := sess.AddReviewComment("parent body", "alice", "")
+
+	r, ok := sess.AddReviewCommentReply(parent.ID, "reply", "alice", "")
+	if !ok {
+		t.Fatal("AddReviewCommentReply returned !ok")
+	}
+	if r.ReviewRound != 5 {
+		t.Errorf("expected reply ReviewRound=5, got %d", r.ReviewRound)
+	}
+}

--- a/resolved_round_test.go
+++ b/resolved_round_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestResolveStampsResolvedRound_HTTP verifies that resolving a file comment
+// via PUT /api/comment/{id}/resolve sets ResolvedRound to the current
+// session.ReviewRound at the moment of mutation, and clears it back to 0
+// when the comment is unresolved.
+func TestResolveStampsResolvedRound_HTTP(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
+
+	// Advance to round 3 before resolving — the field should record 3, not 1.
+	session.mu.Lock()
+	session.ReviewRound = 3
+	session.mu.Unlock()
+
+	req := httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/resolve?path=test.md", strings.NewReader(`{"resolved": true}`))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("PUT resolve: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Resolved {
+		t.Fatal("expected resolved=true")
+	}
+	if got.ResolvedRound != 3 {
+		t.Errorf("ResolvedRound = %d, want 3", got.ResolvedRound)
+	}
+
+	// Unresolve clears to 0.
+	req = httptest.NewRequest("PUT", "/api/comment/"+c.ID+"/resolve?path=test.md", strings.NewReader(`{"resolved": false}`))
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("PUT unresolve: status = %d", w.Code)
+	}
+	var cleared Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &cleared); err != nil {
+		t.Fatal(err)
+	}
+	if cleared.Resolved {
+		t.Fatal("expected resolved=false after unresolve")
+	}
+	if cleared.ResolvedRound != 0 {
+		t.Errorf("ResolvedRound after unresolve = %d, want 0", cleared.ResolvedRound)
+	}
+}
+
+// TestResolveReviewCommentStampsResolvedRound_HTTP covers the review-level
+// resolve path.
+func TestResolveReviewCommentStampsResolvedRound_HTTP(t *testing.T) {
+	srv, session := newTestServer(t)
+	c := session.AddReviewComment("review note", "alice", "")
+
+	session.mu.Lock()
+	session.ReviewRound = 4
+	session.mu.Unlock()
+
+	req := httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/resolve", strings.NewReader(`{"resolved": true}`))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("PUT resolve: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ResolvedRound != 4 {
+		t.Errorf("ResolvedRound = %d, want 4", got.ResolvedRound)
+	}
+
+	// Unresolve clears.
+	req = httptest.NewRequest("PUT", "/api/review-comment/"+c.ID+"/resolve", strings.NewReader(`{"resolved": false}`))
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("PUT unresolve: status = %d", w.Code)
+	}
+	var cleared Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &cleared); err != nil {
+		t.Fatal(err)
+	}
+	if cleared.ResolvedRound != 0 {
+		t.Errorf("ResolvedRound after unresolve = %d, want 0", cleared.ResolvedRound)
+	}
+}
+
+// TestReplyResolveStampsResolvedRound_CLI exercises `crit comment --reply-to
+// <id> --resolve <body>` via appendReply, asserting that the parent comment's
+// ResolvedRound is set from cj.ReviewRound at the time of the call.
+func TestReplyResolveStampsResolvedRound_CLI(t *testing.T) {
+	cj := CritJSON{
+		ReviewRound: 5,
+		Files: map[string]CritJSONFile{
+			"a.md": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", StartLine: 1, EndLine: 1, Body: "open", ReviewRound: 1},
+				},
+			},
+		},
+	}
+	if err := appendReply(&cj, "c1", "done", "alice", "", true, ""); err != nil {
+		t.Fatal(err)
+	}
+	got := cj.Files["a.md"].Comments[0]
+	if !got.Resolved {
+		t.Fatal("expected resolved=true after --resolve")
+	}
+	if got.ResolvedRound != 5 {
+		t.Errorf("ResolvedRound = %d, want 5", got.ResolvedRound)
+	}
+	if len(got.Replies) != 1 {
+		t.Fatalf("expected 1 reply, got %d", len(got.Replies))
+	}
+}
+
+// TestReplyResolveReviewLevel_CLI covers reply --resolve against a
+// review-level comment.
+func TestReplyResolveReviewLevel_CLI(t *testing.T) {
+	cj := CritJSON{
+		ReviewRound: 7,
+		ReviewComments: []Comment{
+			{ID: "r1", Body: "review note", ReviewRound: 1, Scope: "review"},
+		},
+		Files: map[string]CritJSONFile{},
+	}
+	if err := appendReply(&cj, "r1", "addressed", "alice", "", true, ""); err != nil {
+		t.Fatal(err)
+	}
+	got := cj.ReviewComments[0]
+	if !got.Resolved || got.ResolvedRound != 7 {
+		t.Errorf("ResolvedRound=%d resolved=%v, want 7/true", got.ResolvedRound, got.Resolved)
+	}
+}
+
+// TestAddReplyClearsResolvedRound asserts that adding a reply (which
+// re-opens a resolved comment by setting Resolved=false) also zeroes
+// ResolvedRound, mirroring the documented clearing semantics.
+func TestAddReplyClearsResolvedRound(t *testing.T) {
+	srv, session := newTestServer(t)
+	c, _ := session.AddComment("test.md", 1, 1, "", "fix this", "", "", "")
+
+	// First, resolve at round 2.
+	session.mu.Lock()
+	session.ReviewRound = 2
+	session.mu.Unlock()
+	if _, ok := session.SetCommentResolved("test.md", c.ID, true); !ok {
+		t.Fatal("SetCommentResolved failed")
+	}
+
+	// Now add a reply — should re-open and zero the round.
+	body := strings.NewReader(`{"body": "actually not done", "author": "bob"}`)
+	req := httptest.NewRequest("POST", "/api/comment/"+c.ID+"/replies?path=test.md", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 201 {
+		t.Fatalf("POST reply: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Inspect parent state.
+	session.mu.RLock()
+	got := session.Files[0].Comments[0]
+	session.mu.RUnlock()
+	if got.Resolved {
+		t.Error("expected Resolved=false after reply")
+	}
+	if got.ResolvedRound != 0 {
+		t.Errorf("ResolvedRound after re-open = %d, want 0", got.ResolvedRound)
+	}
+}

--- a/resolved_round_test.go
+++ b/resolved_round_test.go
@@ -145,6 +145,64 @@ func TestReplyResolveReviewLevel_CLI(t *testing.T) {
 	}
 }
 
+// TestAppendReply_NonResolvingClearsResolved is a regression test for
+// review W1: the CLI appendReply path must mirror the HTTP AddReply path
+// and clear Resolved/ResolvedRound when adding a reply to an already-
+// resolved comment, otherwise the new reply gets hidden by the resolution
+// filter and the data semantics diverge between writers.
+func TestAppendReply_NonResolvingClearsResolved(t *testing.T) {
+	t.Run("file_comment", func(t *testing.T) {
+		cj := CritJSON{
+			ReviewRound: 4,
+			Files: map[string]CritJSONFile{
+				"a.md": {
+					Status: "modified",
+					Comments: []Comment{
+						{
+							ID: "c1", StartLine: 1, EndLine: 1, Body: "open", ReviewRound: 1,
+							Resolved: true, ResolvedRound: 2,
+						},
+					},
+				},
+			},
+		}
+		if err := appendReply(&cj, "c1", "actually not done", "alice", "", false, ""); err != nil {
+			t.Fatal(err)
+		}
+		got := cj.Files["a.md"].Comments[0]
+		if got.Resolved {
+			t.Error("expected Resolved=false after non-resolving reply")
+		}
+		if got.ResolvedRound != 0 {
+			t.Errorf("ResolvedRound = %d, want 0", got.ResolvedRound)
+		}
+		if len(got.Replies) != 1 {
+			t.Errorf("expected 1 reply, got %d", len(got.Replies))
+		}
+	})
+
+	t.Run("review_comment", func(t *testing.T) {
+		cj := CritJSON{
+			ReviewRound: 4,
+			ReviewComments: []Comment{
+				{ID: "r1", Body: "review note", ReviewRound: 1, Scope: "review",
+					Resolved: true, ResolvedRound: 2},
+			},
+			Files: map[string]CritJSONFile{},
+		}
+		if err := appendReply(&cj, "r1", "actually not done", "alice", "", false, ""); err != nil {
+			t.Fatal(err)
+		}
+		got := cj.ReviewComments[0]
+		if got.Resolved {
+			t.Error("expected Resolved=false after non-resolving reply")
+		}
+		if got.ResolvedRound != 0 {
+			t.Errorf("ResolvedRound = %d, want 0", got.ResolvedRound)
+		}
+	})
+}
+
 // TestAddReplyClearsResolvedRound asserts that adding a reply (which
 // re-opens a resolved comment by setting Resolved=false) also zeroes
 // ResolvedRound, mirroring the documented clearing semantics.

--- a/review_file.go
+++ b/review_file.go
@@ -366,7 +366,18 @@ func findReviewFileByCommentID(commentID string, excludePath string) (string, er
 		if identity == excludePath {
 			return nil
 		}
-		if !reviewFileContainsComment(data, commentID) {
+		// Fast path: skip files that don't contain the ID at all.
+		if !bytes.Contains(data, []byte(commentID)) {
+			return nil
+		}
+		var cj CritJSON
+		if err := json.Unmarshal(data, &cj); err != nil {
+			// Malformed review file; warn and skip so a single corrupt
+			// file doesn't abort the scan or silently hide regressions.
+			fmt.Fprintf(os.Stderr, "crit: warning: malformed review JSON at %s: %v\n", identity, err)
+			return nil //nolint:nilerr // intentional skip on parse failure
+		}
+		if !cjContainsCommentID(&cj, commentID) {
 			return nil
 		}
 		if matchPath != "" {
@@ -409,7 +420,9 @@ func findReviewFileByBranch(branch, excludePath string) (string, error) {
 		}
 		var cj CritJSON
 		if err := json.Unmarshal(data, &cj); err != nil {
-			// Malformed review file; skip rather than aborting.
+			// Malformed review file; skip rather than aborting. Warn once
+			// per malformed file so corruption isn't silently invisible.
+			fmt.Fprintf(os.Stderr, "crit: warning: malformed review JSON at %s: %v\n", identity, err)
 			return nil //nolint:nilerr // intentional skip on parse failure
 		}
 		if cj.Branch != branch {
@@ -433,33 +446,6 @@ func findReviewFileByBranch(branch, excludePath string) (string, error) {
 		return "", fmt.Errorf("%w: %q", errReviewFileNotFoundForBranch, branch)
 	}
 	return matchPath, nil
-}
-
-// reviewFileContainsComment does a quick check if a review JSON file contains
-// a comment with the given ID. Uses string search first as a fast path to
-// avoid parsing files that definitely don't contain the ID.
-func reviewFileContainsComment(data []byte, commentID string) bool {
-	// Fast path: if the ID string doesn't appear at all, skip JSON parsing.
-	if !bytes.Contains(data, []byte(commentID)) {
-		return false
-	}
-	var cj CritJSON
-	if err := json.Unmarshal(data, &cj); err != nil {
-		return false
-	}
-	for _, c := range cj.ReviewComments {
-		if c.ID == commentID {
-			return true
-		}
-	}
-	for _, cf := range cj.Files {
-		for _, c := range cf.Comments {
-			if c.ID == commentID {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // cjContainsCommentID reports whether the given comment ID exists in the

--- a/review_file.go
+++ b/review_file.go
@@ -114,6 +114,63 @@ func resolveReviewPathFromSessions(sessions []sessionEntry) string {
 	return ""
 }
 
+// SnapshotsFile is the per-round-content sidecar inside a review folder. Lives
+// at <folder>/snapshots.json. The crit server reads/writes it; agents do not.
+type SnapshotsFile struct {
+	RoundSnapshots map[string]map[int]RoundSnapshot `json:"round_snapshots"`
+}
+
+// reviewPaths derives the v4 folder layout from a review identity path.
+// The identity may have been a flat .json file in v3; v4 treats it uniformly
+// as a folder. Migration is handled by ensureReviewFolder.
+type reviewPaths struct {
+	Folder    string
+	Review    string
+	Snapshots string
+}
+
+// reviewPathsFor returns the v4 folder-form paths for a review identity.
+// reviewPathsFor does not touch disk; migration is handled separately.
+func reviewPathsFor(identity string) reviewPaths {
+	return reviewPaths{
+		Folder:    identity,
+		Review:    filepath.Join(identity, "review.json"),
+		Snapshots: filepath.Join(identity, "snapshots.json"),
+	}
+}
+
+// loadSnapshotsFile reads <folder>/snapshots.json. Missing file = empty map +
+// nil error (first-boot, legacy review with no snapshots yet, or the folder is
+// in the orphan-snapshots state which is benign on read).
+func loadSnapshotsFile(snapshotsPath string) (SnapshotsFile, error) {
+	sf := SnapshotsFile{RoundSnapshots: map[string]map[int]RoundSnapshot{}}
+	data, err := os.ReadFile(snapshotsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return sf, nil
+		}
+		return sf, fmt.Errorf("reading snapshots file: %w", err)
+	}
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return sf, fmt.Errorf("invalid snapshots file: %w", err)
+	}
+	if sf.RoundSnapshots == nil {
+		sf.RoundSnapshots = map[string]map[int]RoundSnapshot{}
+	}
+	return sf, nil
+}
+
+// saveSnapshotsFile writes the sidecar atomically. Mirrors saveCritJSON.
+func saveSnapshotsFile(snapshotsPath string, sf SnapshotsFile) error {
+	data, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling snapshots file: %w", err)
+	}
+	// atomicWriteFile MkdirAlls the parent, so the review folder is created
+	// implicitly on first sidecar write.
+	return atomicWriteFile(snapshotsPath, append(data, '\n'), 0o644)
+}
+
 // writeCritJSON resolves the review path and writes a CritJSON via saveCritJSON.
 func writeCritJSON(cj CritJSON, outputDir string) error {
 	path, err := resolveReviewPath(outputDir)
@@ -123,10 +180,70 @@ func writeCritJSON(cj CritJSON, outputDir string) error {
 	return saveCritJSON(path, cj)
 }
 
-// loadCritJSON reads the review file from disk, or returns a fresh CritJSON if the file doesn't exist.
+// MIGRATION-REMOVAL: TODO remove this function and its call from loadCritJSON
+// in the release after v4-folder-format ships. Tracked in follow-up issue (see
+// plan v4 §"Follow-up issue draft").
+//
+// ensureReviewFolder migrates a v3-era flat-file review (<identity>) into a
+// v4 folder layout (<identity>/review.json, <identity>/snapshots.json).
+// Idempotent and crash-tolerant. No-op when there's nothing to migrate.
+func ensureReviewFolder(identity string) error {
+	info, err := os.Stat(identity)
+	switch {
+	case err == nil && info.IsDir():
+		return nil
+	case err == nil && !info.IsDir():
+		return migrateFlatToFolder(identity)
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return fmt.Errorf("stat review identity: %w", err)
+	}
+}
+
+// MIGRATION-REMOVAL: TODO delete with ensureReviewFolder.
+func migrateFlatToFolder(identity string) error {
+	tmp := identity + ".crit-migrate.tmp"
+	// A previous crash may have left tmp/ behind. Wipe.
+	_ = os.RemoveAll(tmp)
+
+	if err := os.MkdirAll(tmp, 0o755); err != nil {
+		return fmt.Errorf("creating migration tmp dir: %w", err)
+	}
+
+	if err := os.Rename(identity, filepath.Join(tmp, "review.json")); err != nil {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("moving review file into folder: %w", err)
+	}
+
+	flatSidecar := identity + ".snapshots.json"
+	if _, err := os.Stat(flatSidecar); err == nil {
+		if err := os.Rename(flatSidecar, filepath.Join(tmp, "snapshots.json")); err != nil {
+			fmt.Fprintf(os.Stderr, "crit: warning: could not move snapshot sidecar during migration: %v\n", err)
+		}
+	}
+
+	if err := os.Rename(tmp, identity); err != nil {
+		return fmt.Errorf("finalizing folder migration: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "crit: migrated review storage to folder format: %s\n", identity)
+	return nil
+}
+
+// loadCritJSON reads the review file from disk (folder layout
+// <identity>/review.json), or returns a fresh CritJSON if it doesn't exist.
+// Triggers v3->v4 migration on read for any pre-existing flat-file review.
 func loadCritJSON(critPath string) (CritJSON, error) {
 	var cj CritJSON
-	if data, err := os.ReadFile(critPath); err == nil {
+
+	// MIGRATION-REMOVAL: trigger v3->v4 folder migration on read.
+	if err := ensureReviewFolder(critPath); err != nil {
+		return cj, fmt.Errorf("review folder migration: %w", err)
+	}
+
+	reviewPath := reviewPathsFor(critPath).Review
+	if data, err := os.ReadFile(reviewPath); err == nil {
 		if err := json.Unmarshal(data, &cj); err != nil {
 			return cj, fmt.Errorf("invalid existing review file: %w", err)
 		}
@@ -152,22 +269,29 @@ func loadCritJSON(critPath string) (CritJSON, error) {
 
 // saveCritJSON writes the CritJSON struct to disk with pretty-printed JSON
 // and a trailing newline. Uses atomic writes to prevent corruption.
+// In v4 the review identity is treated as a folder; the review JSON is
+// written to <identity>/review.json and atomicWriteFile MkdirAlls the parent.
 func saveCritJSON(critPath string, cj CritJSON) error {
 	data, err := json.MarshalIndent(cj, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling review file: %w", err)
 	}
-	// atomicWriteFile (atomic_write.go) handles MkdirAll internally.
-	return atomicWriteFile(critPath, append(data, '\n'), 0644)
+	return atomicWriteFile(reviewPathsFor(critPath).Review, append(data, '\n'), 0o644)
 }
 
-// clearCritJSON removes the review file from the resolved path or outputDir.
+// clearCritJSON removes the review folder for the resolved path or outputDir.
 func clearCritJSON(outputDir string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
 		return err
 	}
-	if err := os.Remove(critPath); err != nil && !os.IsNotExist(err) {
+	return clearReviewFolder(critPath)
+}
+
+// clearReviewFolder removes the entire review folder (review.json,
+// snapshots.json, future attachments). Idempotent: a missing folder is fine.
+func clearReviewFolder(identity string) error {
+	if err := os.RemoveAll(identity); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/review_file.go
+++ b/review_file.go
@@ -20,20 +20,21 @@ var errReviewFileNotFoundForBranch = errors.New("no review file found for branch
 // stderr Note so the user knows why the cwd-resolved path was used.
 var errReviewFileAmbiguousForBranch = errors.New("multiple review files match branch")
 
-// resolveReviewPath returns the full path to the review file for the current context.
+// resolveReviewPath returns the review identity path for the current context.
+// In v4 the identity is a folder; review.json and snapshots.json live inside.
 // Resolution order:
-//  1. If outputDir is set, return outputDir/.crit.json (explicit override)
+//  1. If outputDir is set, return outputDir/.crit (explicit override)
 //  2. Check daemon registry for running sessions matching this cwd
 //  3. If one daemon matches, use its ReviewPath
 //  4. If multiple daemons match, use the one matching current branch
-//  5. If no daemon found, compute the centralized path: ~/.crit/reviews/<key>.json
+//  5. If no daemon found, compute the centralized path: ~/.crit/reviews/<key>
 func resolveReviewPath(outputDir string) (string, error) {
 	if outputDir != "" {
 		abs, err := filepath.Abs(outputDir)
 		if err != nil {
 			return "", err
 		}
-		return filepath.Join(abs, ".crit.json"), nil
+		return filepath.Join(abs, ".crit"), nil
 	}
 
 	cwd, err := resolvedCWD()
@@ -184,25 +185,67 @@ func writeCritJSON(cj CritJSON, outputDir string) error {
 // in the release after v4-folder-format ships. Tracked in follow-up issue (see
 // plan v4 §"Follow-up issue draft").
 //
-// ensureReviewFolder migrates a v3-era flat-file review (<identity>) into a
-// v4 folder layout (<identity>/review.json, <identity>/snapshots.json).
-// Idempotent and crash-tolerant. No-op when there's nothing to migrate.
+// ensureReviewFolder migrates legacy review-file shapes into the v4 folder
+// layout at <identity>/. It handles three pre-v4 states, all idempotent and
+// crash-tolerant:
+//
+//  1. <identity> is already a folder: no-op (steady state).
+//  2. <identity>.json/ exists as a folder (early-v4 wrong-shape mid-state with
+//     `.json` accidentally kept on the folder name): rename to <identity>/.
+//  3. <identity>.json exists as a flat file (v3 layout): move into
+//     <identity>/review.json, plus any sibling <identity>.json.snapshots.json
+//     sidecar into <identity>/snapshots.json.
+//
+// No-op when there's nothing to migrate.
 func ensureReviewFolder(identity string) error {
-	info, err := os.Stat(identity)
+	if info, err := os.Stat(identity); err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		// Defense-in-depth: a flat file showed up at the v4 identity path
+		// (e.g. an external tool, or a downgrade). Treat as v3-shaped at
+		// this same path and migrate in place.
+		return migrateFlatToFolder(identity, identity)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat review identity: %w", err)
+	}
+
+	// Legacy <identity>.json path (folder or flat). The v4 identity does not
+	// carry the .json extension; both shapes are pre-v4 and need renaming.
+	legacy := identity + ".json"
+	info, err := os.Stat(legacy)
 	switch {
 	case err == nil && info.IsDir():
-		return nil
+		return renameLegacyJSONFolder(legacy, identity)
 	case err == nil && !info.IsDir():
-		return migrateFlatToFolder(identity)
+		return migrateFlatToFolder(legacy, identity)
 	case os.IsNotExist(err):
 		return nil
 	default:
-		return fmt.Errorf("stat review identity: %w", err)
+		return fmt.Errorf("stat legacy review identity: %w", err)
 	}
 }
 
 // MIGRATION-REMOVAL: TODO delete with ensureReviewFolder.
-func migrateFlatToFolder(identity string) error {
+//
+// renameLegacyJSONFolder fixes the early-v4 mid-state where the review folder
+// was created with a stray `.json` extension (`<identity>.json/`). It renames
+// it to the correct `<identity>/`.
+func renameLegacyJSONFolder(legacyFolder, identity string) error {
+	if err := os.Rename(legacyFolder, identity); err != nil {
+		return fmt.Errorf("renaming legacy .json folder: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "crit: renamed legacy .json review folder to %s\n", identity)
+	return nil
+}
+
+// MIGRATION-REMOVAL: TODO delete with ensureReviewFolder.
+//
+// migrateFlatToFolder converts a v3 flat-file review at flatPath into a v4
+// folder at identity, moving any sibling .snapshots.json sidecar inside.
+// flatPath and identity may be equal (legacy in-place migration) or differ
+// (legacy <identity>.json -> v4 <identity>).
+func migrateFlatToFolder(flatPath, identity string) error {
 	tmp := identity + ".crit-migrate.tmp"
 	// A previous crash may have left tmp/ behind. Wipe.
 	_ = os.RemoveAll(tmp)
@@ -211,12 +254,12 @@ func migrateFlatToFolder(identity string) error {
 		return fmt.Errorf("creating migration tmp dir: %w", err)
 	}
 
-	if err := os.Rename(identity, filepath.Join(tmp, "review.json")); err != nil {
+	if err := os.Rename(flatPath, filepath.Join(tmp, "review.json")); err != nil {
 		_ = os.RemoveAll(tmp)
 		return fmt.Errorf("moving review file into folder: %w", err)
 	}
 
-	flatSidecar := identity + ".snapshots.json"
+	flatSidecar := flatPath + ".snapshots.json"
 	if _, err := os.Stat(flatSidecar); err == nil {
 		if err := os.Rename(flatSidecar, filepath.Join(tmp, "snapshots.json")); err != nil {
 			fmt.Fprintf(os.Stderr, "crit: warning: could not move snapshot sidecar during migration: %v\n", err)

--- a/review_file.go
+++ b/review_file.go
@@ -297,41 +297,76 @@ func clearReviewFolder(identity string) error {
 	return nil
 }
 
-// findReviewFileByCommentID scans all review files in ~/.crit/reviews/ for the given
-// comment ID, skipping excludePath. Returns the path if found in exactly one file,
-// or an error wrapping commentID if it's missing or appears in multiple files.
-func findReviewFileByCommentID(commentID string, excludePath string) (string, error) {
+// walkReviewIdentities iterates over every review identity in
+// ~/.crit/reviews/ — folder-form (v4) and MIGRATION-REMOVAL flat-file (v3) —
+// and invokes visit with the identity path and the bytes of its review.json.
+// Stopping the walk: visit returns a sentinel via the bool/error pair; a
+// non-nil error from visit aborts the walk and is returned.
+func walkReviewIdentities(visit func(identity string, data []byte) error) error {
 	dir, err := reviewsDir()
 	if err != nil {
-		return "", err
+		return err
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("comment %q not found in any review file", commentID)
+			return nil
 		}
-		return "", err
+		return err
 	}
-
-	var matchPath string
 	for _, de := range entries {
-		if !strings.HasSuffix(de.Name(), ".json") {
+		name := de.Name()
+		if de.IsDir() {
+			folder := filepath.Join(dir, name)
+			data, readErr := os.ReadFile(filepath.Join(folder, "review.json"))
+			if readErr != nil {
+				if !os.IsNotExist(readErr) {
+					fmt.Fprintf(os.Stderr, "crit: warning: could not read %s/review.json: %v\n", folder, readErr)
+				}
+				continue
+			}
+			if err := visit(folder, data); err != nil {
+				return err
+			}
 			continue
 		}
-		path := filepath.Join(dir, de.Name())
-		if path == excludePath {
+		// MIGRATION-REMOVAL: legacy v3 flat-file scan.
+		if !strings.HasSuffix(name, ".json") {
 			continue
 		}
+		path := filepath.Join(dir, name)
 		data, readErr := os.ReadFile(path)
 		if readErr != nil {
 			continue
 		}
-		if reviewFileContainsComment(data, commentID) {
-			if matchPath != "" {
-				return "", fmt.Errorf("comment %q found in multiple review files", commentID)
-			}
-			matchPath = path
+		if err := visit(path, data); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+// findReviewFileByCommentID scans all review identities in ~/.crit/reviews/
+// for the given comment ID, skipping excludePath. Returns the identity path
+// (folder for v4, flat .json for unmigrated v3) if found in exactly one
+// place, or an error if missing or ambiguous.
+func findReviewFileByCommentID(commentID string, excludePath string) (string, error) {
+	var matchPath string
+	walkErr := walkReviewIdentities(func(identity string, data []byte) error {
+		if identity == excludePath {
+			return nil
+		}
+		if !reviewFileContainsComment(data, commentID) {
+			return nil
+		}
+		if matchPath != "" {
+			return fmt.Errorf("comment %q found in multiple review files", commentID)
+		}
+		matchPath = identity
+		return nil
+	})
+	if walkErr != nil {
+		return "", walkErr
 	}
 	if matchPath == "" {
 		return "", fmt.Errorf("comment %q not found in any review file", commentID)
@@ -357,42 +392,32 @@ func findReviewFileByBranch(branch, excludePath string) (string, error) {
 	if branch == "" {
 		return "", fmt.Errorf("branch is required")
 	}
-	dir, err := reviewsDir()
-	if err != nil {
-		return "", err
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("%w: %q", errReviewFileNotFoundForBranch, branch)
-		}
-		return "", err
-	}
-
 	var matchPath string
-	for _, de := range entries {
-		if !strings.HasSuffix(de.Name(), ".json") {
-			continue
-		}
-		path := filepath.Join(dir, de.Name())
-		if path == excludePath {
-			continue
-		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			continue
+	walkErr := walkReviewIdentities(func(identity string, data []byte) error {
+		if identity == excludePath {
+			return nil
 		}
 		var cj CritJSON
 		if err := json.Unmarshal(data, &cj); err != nil {
-			continue
+			// Malformed review file; skip rather than aborting.
+			return nil //nolint:nilerr // intentional skip on parse failure
 		}
 		if cj.Branch != branch {
-			continue
+			return nil
 		}
 		if matchPath != "" {
-			return "", fmt.Errorf("%w: %q", errReviewFileAmbiguousForBranch, branch)
+			return fmt.Errorf("%w: %q", errReviewFileAmbiguousForBranch, branch)
 		}
-		matchPath = path
+		matchPath = identity
+		return nil
+	})
+	if walkErr != nil {
+		// Distinguish "not found" (missing reviewsDir) from real errors and
+		// from ambiguity. Ambiguity already wraps errReviewFileAmbiguousForBranch.
+		if errors.Is(walkErr, errReviewFileAmbiguousForBranch) {
+			return "", walkErr
+		}
+		return "", walkErr
 	}
 	if matchPath == "" {
 		return "", fmt.Errorf("%w: %q", errReviewFileNotFoundForBranch, branch)

--- a/review_file.go
+++ b/review_file.go
@@ -272,6 +272,16 @@ func loadCritJSON(critPath string) (CritJSON, error) {
 // In v4 the review identity is treated as a folder; the review JSON is
 // written to <identity>/review.json and atomicWriteFile MkdirAlls the parent.
 func saveCritJSON(critPath string, cj CritJSON) error {
+	// Defense-in-depth: if a future code path stat-tests <identity> and
+	// finds a flat file (e.g. an external tool dropped one in, or a v3
+	// downgrade reintroduced the layout), normalize to the folder form
+	// before writing. ensureReviewFolder is a no-op when <identity> is
+	// already a directory (the steady-state v4 case), so this guard adds
+	// only a single os.Stat per save in production. See plan v4
+	// §Folder-format invariants.
+	if err := ensureReviewFolder(critPath); err != nil {
+		return fmt.Errorf("ensuring review folder: %w", err)
+	}
 	data, err := json.MarshalIndent(cj, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling review file: %w", err)

--- a/review_file.go
+++ b/review_file.go
@@ -245,6 +245,17 @@ func renameLegacyJSONFolder(legacyFolder, identity string) error {
 // folder at identity, moving any sibling .snapshots.json sidecar inside.
 // flatPath and identity may be equal (legacy in-place migration) or differ
 // (legacy <identity>.json -> v4 <identity>).
+//
+// This intentionally does NOT route through atomicWriteFile. atomicWriteFile
+// writes a single byte buffer to a single target file (mkdir + tmpfile +
+// fsync + rename). The migration moves an *existing* file into a freshly
+// created tmp directory and atomically renames the directory into place —
+// no byte writes happen, the original on-disk content is reused via
+// os.Rename. The shapes only superficially overlap (both end in
+// rename-into-place); the migration's atomicity guarantee is "either the
+// flat file or the folder exists", not "the file is fully written or not at
+// all". Reusing atomicWriteFile would require re-reading and re-writing the
+// review JSON for no benefit. (review W6)
 func migrateFlatToFolder(flatPath, identity string) error {
 	tmp := identity + ".crit-migrate.tmp"
 	// A previous crash may have left tmp/ behind. Wipe.
@@ -478,11 +489,9 @@ func findReviewFileByBranch(branch, excludePath string) (string, error) {
 		return nil
 	})
 	if walkErr != nil {
-		// Distinguish "not found" (missing reviewsDir) from real errors and
-		// from ambiguity. Ambiguity already wraps errReviewFileAmbiguousForBranch.
-		if errors.Is(walkErr, errReviewFileAmbiguousForBranch) {
-			return "", walkErr
-		}
+		// walkErr already wraps errReviewFileAmbiguousForBranch when the
+		// scan stopped because two reviews matched the same branch; for any
+		// other error (e.g. unreadable reviewsDir) we surface it verbatim.
 		return "", walkErr
 	}
 	if matchPath == "" {

--- a/review_file_test.go
+++ b/review_file_test.go
@@ -34,6 +34,79 @@ func writeReviewFixture(t *testing.T, name, branch string) string {
 	return path
 }
 
+// writeFolderReviewFixture writes a folder-form review at <reviewsDir>/<name>
+// with the given branch. Returns the folder identity path.
+func writeFolderReviewFixture(t *testing.T, name, branch string) string {
+	t.Helper()
+	dir, err := reviewsDir()
+	if err != nil {
+		t.Fatalf("reviewsDir: %v", err)
+	}
+	folder := filepath.Join(dir, name)
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cj := CritJSON{Branch: branch, Files: map[string]CritJSONFile{}}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, "review.json"), data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return folder
+}
+
+func TestFindReviewFileByBranch_FolderForm(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	want := writeFolderReviewFixture(t, "k1", "feature-x")
+	writeFolderReviewFixture(t, "k2", "other")
+
+	got, err := findReviewFileByBranch("feature-x", "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFindReviewFileByBranch_OrphanFolderSkipped(t *testing.T) {
+	// Folder with no review.json (snapshots-only orphan) must be ignored.
+	t.Setenv("HOME", t.TempDir())
+	dir, _ := reviewsDir()
+	if err := os.MkdirAll(filepath.Join(dir, "orphan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orphan", "snapshots.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := writeFolderReviewFixture(t, "k1", "feature-x")
+
+	got, err := findReviewFileByBranch("feature-x", "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q (orphan should be skipped)", got, want)
+	}
+}
+
+// MIGRATION-REMOVAL: legacy flat-file review files must still be discoverable
+// until the migration shim is deleted.
+func TestFindReviewFileByBranch_MigrationFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	want := writeReviewFixture(t, "k1", "feature-x")
+
+	got, err := findReviewFileByBranch("feature-x", "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFindReviewFileByBranch(t *testing.T) {
 	t.Run("single match returns path", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())

--- a/round_api_test.go
+++ b/round_api_test.go
@@ -158,6 +158,59 @@ func TestHandleRounds_LineStats(t *testing.T) {
 	}
 }
 
+// TestCommentsAtOrBeforeRound_ResolutionStateIsCurrent is a regression test
+// for review W3. Stage 1 deliberately exposes the *current* Resolved /
+// ResolvedRound values on every comment, not the state as of the requested
+// round, so the frontend can compute round-faithful resolution from
+// ResolvedRound itself (Stage 2 work). This test pins that contract: a
+// comment authored at R1 and resolved at R3 must surface from
+// /api/file/comments?round=1 with resolved=true and resolved_round=3.
+//
+// If a future change starts rewriting Resolved server-side based on the
+// requested round, this test will fail and force us to update the docs in
+// commentsAtOrBeforeRound and the corresponding Stage 2 frontend code.
+func TestCommentsAtOrBeforeRound_ResolutionStateIsCurrent(t *testing.T) {
+	srv, sess := newRoundsTestServer(t)
+	// Add a comment at R1 (the seeded session ReviewRound is 2 from the
+	// helper, so set it to 1 first to author).
+	sess.mu.Lock()
+	sess.ReviewRound = 1
+	sess.mu.Unlock()
+	c, ok := sess.AddComment("test.md", 1, 1, "", "fix this", "alice", "", "")
+	if !ok {
+		t.Fatal("AddComment failed")
+	}
+
+	// Advance to R3 and resolve.
+	sess.mu.Lock()
+	sess.ReviewRound = 3
+	sess.mu.Unlock()
+	if _, ok := sess.SetCommentResolved("test.md", c.ID, true); !ok {
+		t.Fatal("SetCommentResolved failed")
+	}
+
+	// Fetch with ?round=1 — Stage 1 contract: current resolution state, not state-at-R1.
+	req := httptest.NewRequest("GET", "/api/file/comments?path=test.md&round=1", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var got []Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 comment at round=1, got %d", len(got))
+	}
+	if !got[0].Resolved {
+		t.Errorf("Resolved at round=1 = false; want true (Stage 1 exposes current state)")
+	}
+	if got[0].ResolvedRound != 3 {
+		t.Errorf("ResolvedRound at round=1 = %d; want 3 (Stage 1 exposes the round of resolution)", got[0].ResolvedRound)
+	}
+}
+
 // TestRoundParam_RejectInvalidConsistently is a regression test for review W2.
 // The four round-aware endpoints must reject malformed ?round values
 // uniformly (400) and accept an empty value (back-compat). Previously

--- a/round_api_test.go
+++ b/round_api_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+// newRoundsTestServer returns a server with a files-mode session preloaded
+// with R1 and R2 snapshots for "test.md" so handlers can be exercised with
+// ?round=N. The current FileEntry.Content matches R2.
+func newRoundsTestServer(t *testing.T) (*Server, *Session) {
+	t.Helper()
+	s, sess := newTestServer(t)
+	// Set R1 (initial content) and R2 (after one edit) snapshots.
+	// File current Content from newTestServer is "line1\nline2\nline3\n".
+	r1 := "line1\nline2\nline3\n"
+	r2 := "line1\nlineTWO\nline3\nline4\n"
+	sess.Files[0].Content = r2
+	sess.RoundSnapshots = map[string]map[int]RoundSnapshot{
+		"test.md": {
+			1: {Content: r1, Status: "modified"},
+			2: {Content: r2, Status: "modified"},
+		},
+	}
+	sess.ReviewRound = 2
+	return s, sess
+}
+
+func TestHandleFileDiff_Round_FilesMode(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file/diff?path=test.md&round=2", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp["hunks"]; !ok {
+		t.Fatalf("hunks missing: %v", resp)
+	}
+	if got, _ := resp["previous_content"].(string); got == "" {
+		t.Fatalf("previous_content empty for R2: %v", resp)
+	}
+	hunks, _ := resp["hunks"].([]any)
+	if len(hunks) == 0 {
+		t.Fatalf("expected diff hunks for R1->R2, got none")
+	}
+}
+
+func TestHandleFileDiff_Round_InvalidParam(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file/diff?path=test.md&round=abc", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("invalid round: status=%d", w.Code)
+	}
+}
+
+func TestHandleFileDiff_Round_OutOfRange(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file/diff?path=test.md&round=99", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Fatalf("out-of-range round: status=%d", w.Code)
+	}
+}
+
+func TestHandleFileDiff_Round_R1NoPrevious(t *testing.T) {
+	// R1 is the baseline — no previous content; diff should be empty hunks.
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file/diff?path=test.md&round=1", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	hunks, _ := resp["hunks"].([]any)
+	if len(hunks) != 0 {
+		t.Fatalf("R1 baseline must have no diff hunks, got %v", hunks)
+	}
+}
+
+func TestHandleSession_Round_FilesMode(t *testing.T) {
+	s, sess := newRoundsTestServer(t)
+	// Add an extra file that exists only in R2 (not in R1).
+	sess.Files = append(sess.Files, &FileEntry{
+		Path:     "new.md",
+		Status:   "added",
+		FileType: "markdown",
+		Content:  "n",
+		Comments: []Comment{},
+	})
+	sess.RoundSnapshots["new.md"] = map[int]RoundSnapshot{
+		2: {Content: "n", Status: "added"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/session?round=1", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d", w.Code)
+	}
+	var info SessionInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range info.Files {
+		if f.Path == "new.md" {
+			t.Fatalf("new.md should be hidden at R1, files=%v", info.Files)
+		}
+	}
+}
+
+func TestHandleRounds_LineStats(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/rounds", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d", w.Code)
+	}
+	var resp struct {
+		CurrentRound int `json:"current_round"`
+		Rounds       []struct {
+			N         int `json:"n"`
+			Additions int `json:"additions"`
+			Deletions int `json:"deletions"`
+		} `json:"rounds"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Rounds) != 2 {
+		t.Fatalf("expected 2 rounds, got %d", len(resp.Rounds))
+	}
+	r1 := resp.Rounds[0]
+	r2 := resp.Rounds[1]
+	if r1.N != 1 || r1.Additions != 0 || r1.Deletions != 0 {
+		t.Errorf("R1 must be baseline (zero stats): %+v", r1)
+	}
+	if r2.N != 2 {
+		t.Errorf("expected R2 second, got %+v", r2)
+	}
+	if r2.Additions == 0 && r2.Deletions == 0 {
+		t.Errorf("R2 must have non-zero line stats: %+v", r2)
+	}
+}

--- a/round_api_test.go
+++ b/round_api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -154,5 +155,71 @@ func TestHandleRounds_LineStats(t *testing.T) {
 	}
 	if r2.Additions == 0 && r2.Deletions == 0 {
 		t.Errorf("R2 must have non-zero line stats: %+v", r2)
+	}
+}
+
+// TestRoundParam_RejectInvalidConsistently is a regression test for review W2.
+// The four round-aware endpoints must reject malformed ?round values
+// uniformly (400) and accept an empty value (back-compat). Previously
+// /api/file and /api/file/diff returned 400 on garbage while
+// /api/file/comments and /api/comments silently ignored it, leaving
+// callers with two contradictory contracts.
+func TestRoundParam_RejectInvalidConsistently(t *testing.T) {
+	endpoints := []string{
+		"/api/session",
+		"/api/file?path=test.md",
+		"/api/file/diff?path=test.md",
+		"/api/file/comments?path=test.md",
+		"/api/comments",
+	}
+	cases := []struct {
+		name       string
+		round      string // raw query value
+		omit       bool   // if true, append no round param at all
+		wantStatus int
+	}{
+		{name: "absent", omit: true, wantStatus: 200},
+		{name: "empty", round: "", wantStatus: 200},
+		{name: "garbage", round: "abc", wantStatus: 400},
+		{name: "negative", round: "-1", wantStatus: 400},
+		{name: "zero", round: "0", wantStatus: 400},
+		// A round number that doesn't have a snapshot is valid syntax
+		// (well-formed integer >= 1); the file-scoped endpoints translate
+		// that to 404 "file_not_in_round", and the list endpoints just
+		// return an empty list. Either way it's NOT a 400.
+		{name: "very_large", round: "99999", wantStatus: 0},
+	}
+	for _, ep := range endpoints {
+		ep := ep
+		for _, tc := range cases {
+			tc := tc
+			t.Run(ep+"/"+tc.name, func(t *testing.T) {
+				srv, _ := newRoundsTestServer(t)
+				url := ep
+				if !tc.omit {
+					sep := "?"
+					if strings.Contains(ep, "?") {
+						sep = "&"
+					}
+					url = ep + sep + "round=" + tc.round
+				}
+				req := httptest.NewRequest("GET", url, nil)
+				w := httptest.NewRecorder()
+				srv.ServeHTTP(w, req)
+				if tc.wantStatus == 400 {
+					if w.Code != 400 {
+						t.Errorf("%s round=%q: status=%d, want 400 (body=%s)", ep, tc.round, w.Code, w.Body.String())
+					}
+					return
+				}
+				if tc.wantStatus == 200 && w.Code != 200 {
+					t.Errorf("%s round=%q: status=%d, want 200 (body=%s)", ep, tc.round, w.Code, w.Body.String())
+				}
+				// wantStatus == 0: accept any non-400.
+				if tc.wantStatus == 0 && w.Code == 400 {
+					t.Errorf("%s round=%q: unexpectedly returned 400 (body=%s)", ep, tc.round, w.Body.String())
+				}
+			})
+		}
 	}
 }

--- a/round_regression_test.go
+++ b/round_regression_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReviewFile_DoesNotContainRoundSnapshots is a regression guard against
+// round snapshots accidentally being persisted into review.json. Snapshots
+// must live exclusively in <folder>/snapshots.json so that AI agents reading
+// review.json never load megabytes of historical file content.
+func TestReviewFile_DoesNotContainRoundSnapshots(t *testing.T) {
+	s := newTestSession(t)
+	s.RoundSnapshots = map[string]map[int]RoundSnapshot{
+		"plan.md": {
+			1: {Content: "v1", Status: "modified", CapturedAt: time.Now()},
+			2: {Content: "v2", Status: "modified", CapturedAt: time.Now()},
+		},
+	}
+	s.AddComment("plan.md", 1, 1, "", "fix", "", "", "")
+
+	flushWrites(s)
+	s.WriteFiles()
+
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
+	if err != nil {
+		t.Fatalf("review.json not written: %v", err)
+	}
+	if strings.Contains(string(data), "round_snapshots") {
+		t.Fatalf("review.json must not contain round_snapshots key:\n%s", data)
+	}
+	// Decoding into a generic map verifies no unexpected top-level keys.
+	var generic map[string]any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := generic["round_snapshots"]; ok {
+		t.Fatal("round_snapshots leaked into review.json")
+	}
+}
+
+// TestSharePayload_DoesNotIncludeRoundSnapshots is a regression guard that
+// inspects the share payload directly. The share API must never carry per-
+// round content bodies — they would balloon payload size and reveal
+// agent-only review history to the share recipient.
+func TestSharePayload_DoesNotIncludeRoundSnapshots(t *testing.T) {
+	files := []shareFile{{Path: "plan.md", Content: "current", Status: "modified"}}
+	comments := []shareComment{{File: "plan.md", Body: "x"}}
+
+	payload := buildSharePayload(files, comments, 2, []string{"plan.md"})
+
+	if _, ok := payload["round_snapshots"]; ok {
+		t.Fatal("share payload contains round_snapshots key")
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "round_snapshots") {
+		t.Fatalf("share payload JSON contains round_snapshots:\n%s", data)
+	}
+}
+
+// TestWriteFiles_EmptyDoesNotDeleteSidecar is the v3-review-flagged B1
+// regression: when WriteFiles finds the CritJSON empty and removes
+// review.json, the snapshots.json sidecar must remain in place. Otherwise
+// a user clearing all comments mid-session would silently lose every
+// captured round.
+func TestWriteFiles_EmptyDoesNotDeleteSidecar(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatalf("NewSessionFromFiles: %v", err)
+	}
+	// Pin the review identity to the test tempdir so this test does not
+	// touch the dev-machine's repo root via the critJSONPath fallback.
+	identity := filepath.Join(dir, ".crit.json")
+	s.ReviewFilePath = identity
+	paths := reviewPathsFor(identity)
+
+	// Seed the sidecar with two rounds of snapshots in memory and on disk.
+	s.RoundSnapshots = map[string]map[int]RoundSnapshot{
+		"plan.md": {
+			1: {Content: "v1", CapturedAt: time.Now()},
+			2: {Content: "v2", CapturedAt: time.Now()},
+		},
+	}
+	if err := saveSnapshotsFile(paths.Snapshots, SnapshotsFile{
+		RoundSnapshots: cloneRoundSnapshots(s.RoundSnapshots),
+	}); err != nil {
+		t.Fatalf("saveSnapshotsFile: %v", err)
+	}
+
+	// Pre-create review.json so WriteFiles' empty-removal branch has
+	// something to delete.
+	if err := saveCritJSON(identity, CritJSON{
+		Branch: s.Branch,
+		Files:  map[string]CritJSONFile{},
+	}); err != nil {
+		t.Fatalf("saveCritJSON: %v", err)
+	}
+
+	// Sanity: both files exist before the call.
+	if _, err := os.Stat(paths.Review); err != nil {
+		t.Fatalf("review.json missing pre-call: %v", err)
+	}
+	if _, err := os.Stat(paths.Snapshots); err != nil {
+		t.Fatalf("snapshots.json missing pre-call: %v", err)
+	}
+
+	// WriteFiles with no comments and no share state -> empty CritJSON ->
+	// removes review.json.
+	flushWrites(s)
+	s.WriteFiles()
+
+	if _, err := os.Stat(paths.Review); !os.IsNotExist(err) {
+		t.Fatalf("review.json should be removed by empty-write branch, err=%v", err)
+	}
+	if _, err := os.Stat(paths.Snapshots); err != nil {
+		t.Fatalf("snapshots.json must be preserved across empty WriteFiles, err=%v", err)
+	}
+	if _, err := os.Stat(paths.Folder); err != nil {
+		t.Fatalf("review folder must remain, err=%v", err)
+	}
+}

--- a/round_regression_test.go
+++ b/round_regression_test.go
@@ -84,7 +84,7 @@ func TestWriteFiles_EmptyDoesNotDeleteSidecar(t *testing.T) {
 	}
 	// Pin the review identity to the test tempdir so this test does not
 	// touch the dev-machine's repo root via the critJSONPath fallback.
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	s.ReviewFilePath = identity
 	paths := reviewPathsFor(identity)
 

--- a/round_snapshot_position_test.go
+++ b/round_snapshot_position_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRoundSnapshotPosition asserts that captureRoundSnapshot records each
+// file's index in s.Files as Position.
+func TestRoundSnapshotPosition(t *testing.T) {
+	s := &Session{
+		Mode:        "files",
+		ReviewRound: 1,
+		Files: []*FileEntry{
+			{Path: "a.md", Status: "modified", Content: "a"},
+			{Path: "b.md", Status: "modified", Content: "b"},
+			{Path: "c.md", Status: "modified", Content: "c"},
+		},
+	}
+	s.captureRoundSnapshot(1)
+
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"a.md", 0},
+		{"b.md", 1},
+		{"c.md", 2},
+	}
+	for _, tc := range cases {
+		got, ok := s.roundSnapshotForFile(tc.path, 1)
+		if !ok {
+			t.Fatalf("snapshot missing for %s", tc.path)
+		}
+		if got.Position != tc.want {
+			t.Errorf("%s: Position = %d, want %d", tc.path, got.Position, tc.want)
+		}
+	}
+}
+
+// TestServeFileAtRound_IncludesPosition confirms the per-round file API
+// surfaces Position in its JSON response.
+func TestServeFileAtRound_IncludesPosition(t *testing.T) {
+	s, sess := newRoundsTestServer(t)
+	// Inject Position into the existing snapshot fixture (the test helper
+	// builds snapshots inline rather than going through captureRoundSnapshot).
+	sess.mu.Lock()
+	rs := sess.RoundSnapshots["test.md"][2]
+	rs.Position = 7
+	sess.RoundSnapshots["test.md"][2] = rs
+	sess.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/file?path=test.md&round=2", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	pos, ok := resp["position"]
+	if !ok {
+		t.Fatalf("position missing from response: %v", resp)
+	}
+	if got, _ := pos.(float64); int(got) != 7 {
+		t.Errorf("position = %v, want 7", pos)
+	}
+}

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -12,8 +12,13 @@ import (
 // file. Agent tooling that reads review.json must remain insulated from the
 // (potentially large) per-round bodies.
 type RoundSnapshot struct {
-	Content    string    `json:"content"`
-	Status     string    `json:"status,omitempty"`
+	Content string `json:"content"`
+	Status  string `json:"status,omitempty"`
+	// Position is the file's index in Session.Files at capture time. It pins
+	// display order at this round so the timeline can render rounds in their
+	// original layout even if the session-level file list reorders later.
+	// Snapshots persisted before this field landed read back as 0.
+	Position   int       `json:"position"`
 	CapturedAt time.Time `json:"captured_at"`
 }
 
@@ -34,7 +39,7 @@ func (s *Session) captureRoundSnapshot(round int) {
 		s.RoundSnapshots = make(map[string]map[int]RoundSnapshot)
 	}
 	now := time.Now().UTC()
-	for _, f := range s.Files {
+	for i, f := range s.Files {
 		if f == nil || f.Lazy || f.Status == "deleted" {
 			continue
 		}
@@ -50,6 +55,7 @@ func (s *Session) captureRoundSnapshot(round int) {
 		byRound[round] = RoundSnapshot{
 			Content:    f.Content,
 			Status:     f.Status,
+			Position:   i,
 			CapturedAt: now,
 		}
 	}

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -69,7 +69,10 @@ func (s *Session) roundSnapshotForFile(path string, round int) (RoundSnapshot, b
 	return rs, ok
 }
 
-// commentsAtOrBeforeRound returns the comments whose ReviewRound <= round.
+// commentsAtOrBeforeRound returns the comments whose ReviewRound <= round,
+// with each surviving comment's Replies filtered to drop entries authored in
+// later rounds. Legacy replies with no ReviewRound set (zero value) inherit
+// their parent's ReviewRound — visible from the parent's round onward.
 // Caller must hold s.mu (RLock is sufficient).
 func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
 	if round <= 0 {
@@ -77,8 +80,29 @@ func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
 	}
 	out := comments[:0:0]
 	for _, c := range comments {
-		if c.ReviewRound <= round {
-			out = append(out, c)
+		if c.ReviewRound > round {
+			continue
+		}
+		if len(c.Replies) > 0 {
+			c.Replies = repliesAtOrBeforeRound(c.Replies, round, c.ReviewRound)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// repliesAtOrBeforeRound returns the replies visible at or before round.
+// A reply with ReviewRound == 0 (legacy / pre-feature data) inherits parentRound,
+// matching the parent comment's existing visibility window.
+func repliesAtOrBeforeRound(replies []Reply, round, parentRound int) []Reply {
+	out := make([]Reply, 0, len(replies))
+	for _, r := range replies {
+		effective := r.ReviewRound
+		if effective == 0 {
+			effective = parentRound
+		}
+		if effective <= round {
+			out = append(out, r)
 		}
 	}
 	return out

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -55,6 +55,60 @@ func (s *Session) captureRoundSnapshot(round int) {
 	}
 }
 
+// roundSnapshotForFile returns the snapshot recorded for (path, round), or
+// false if no snapshot exists. Caller must hold s.mu (RLock is sufficient).
+func (s *Session) roundSnapshotForFile(path string, round int) (RoundSnapshot, bool) {
+	if s.RoundSnapshots == nil {
+		return RoundSnapshot{}, false
+	}
+	byRound := s.RoundSnapshots[path]
+	if byRound == nil {
+		return RoundSnapshot{}, false
+	}
+	rs, ok := byRound[round]
+	return rs, ok
+}
+
+// commentsAtOrBeforeRound returns the comments whose ReviewRound <= round.
+// Caller must hold s.mu (RLock is sufficient).
+func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
+	if round <= 0 {
+		return nil
+	}
+	out := comments[:0:0]
+	for _, c := range comments {
+		if c.ReviewRound <= round {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// availableRounds returns the sorted set of round numbers across all files in
+// s.RoundSnapshots. Caller must hold s.mu (RLock is sufficient).
+func (s *Session) availableRounds() []int {
+	if len(s.RoundSnapshots) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	for _, byRound := range s.RoundSnapshots {
+		for r := range byRound {
+			seen[r] = struct{}{}
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for r := range seen {
+		out = append(out, r)
+	}
+	// Tiny in-place insertion sort; rounds rarely exceed ~10.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
 // cloneRoundSnapshots returns a deep copy of src so the caller can release the
 // session lock before persisting to disk. RoundSnapshot values are treated as
 // immutable post-capture, so the inner struct copy is value-only.

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -1,0 +1,16 @@
+package main
+
+import "time"
+
+// RoundSnapshot captures the content of a single file at a specific review
+// round. Files-mode only. R1 = baseline at session construction;
+// R(N+1) = content the agent produced during round N.
+//
+// Snapshots are persisted in <folder>/snapshots.json — never in the review
+// file. Agent tooling that reads review.json must remain insulated from the
+// (potentially large) per-round bodies.
+type RoundSnapshot struct {
+	Content    string    `json:"content"`
+	Status     string    `json:"status,omitempty"`
+	CapturedAt time.Time `json:"captured_at"`
+}

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -80,6 +80,15 @@ func (s *Session) roundSnapshotForFile(path string, round int) (RoundSnapshot, b
 // later rounds. Legacy replies with no ReviewRound set (zero value) inherit
 // their parent's ReviewRound — visible from the parent's round onward.
 // Caller must hold s.mu (RLock is sufficient).
+//
+// Resolution-state semantics (Stage 1, intentional): the returned Comments
+// carry the *current* Resolved / ResolvedRound values, NOT the state as of
+// `round`. A comment that was open at round 1 and resolved at round 3 will
+// surface here with Resolved=true, ResolvedRound=3 even when the caller asked
+// for round=1. This is by design: Stage 1 exposes ResolvedRound on the wire
+// so the frontend can compute round-faithful resolution state itself; Stage
+// 2 will fold that decision in. Until then, callers MUST inspect both fields
+// rather than trust Resolved alone.
 func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
 	if round <= 0 {
 		return nil

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -1,6 +1,8 @@
 package main
 
-import "time"
+import (
+	"time"
+)
 
 // RoundSnapshot captures the content of a single file at a specific review
 // round. Files-mode only. R1 = baseline at session construction;
@@ -13,4 +15,60 @@ type RoundSnapshot struct {
 	Content    string    `json:"content"`
 	Status     string    `json:"status,omitempty"`
 	CapturedAt time.Time `json:"captured_at"`
+}
+
+// captureRoundSnapshot records the current Content/Status of every loaded,
+// non-deleted file under the given round number. Files-mode only; in git mode
+// the function is a no-op (snapshots are not part of the git-mode contract).
+//
+// Lock contract: caller MUST hold s.mu for writing OR be the only goroutine
+// that could observe s.RoundSnapshots (constructor pre-SetSession).
+func (s *Session) captureRoundSnapshot(round int) {
+	if s.Mode != "files" {
+		return
+	}
+	if round < 1 {
+		return
+	}
+	if s.RoundSnapshots == nil {
+		s.RoundSnapshots = make(map[string]map[int]RoundSnapshot)
+	}
+	now := time.Now().UTC()
+	for _, f := range s.Files {
+		if f == nil || f.Lazy || f.Status == "deleted" {
+			continue
+		}
+		byRound := s.RoundSnapshots[f.Path]
+		if byRound == nil {
+			byRound = make(map[int]RoundSnapshot)
+			s.RoundSnapshots[f.Path] = byRound
+		}
+		if _, ok := byRound[round]; ok {
+			// Idempotent: do not overwrite an existing capture for this round.
+			continue
+		}
+		byRound[round] = RoundSnapshot{
+			Content:    f.Content,
+			Status:     f.Status,
+			CapturedAt: now,
+		}
+	}
+}
+
+// cloneRoundSnapshots returns a deep copy of src so the caller can release the
+// session lock before persisting to disk. RoundSnapshot values are treated as
+// immutable post-capture, so the inner struct copy is value-only.
+func cloneRoundSnapshots(src map[string]map[int]RoundSnapshot) map[string]map[int]RoundSnapshot {
+	if len(src) == 0 {
+		return map[string]map[int]RoundSnapshot{}
+	}
+	dst := make(map[string]map[int]RoundSnapshot, len(src))
+	for path, byRound := range src {
+		inner := make(map[int]RoundSnapshot, len(byRound))
+		for r, rs := range byRound {
+			inner[r] = rs
+		}
+		dst[path] = inner
+	}
+	return dst
 }

--- a/round_snapshots.go
+++ b/round_snapshots.go
@@ -93,6 +93,9 @@ func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
 	if round <= 0 {
 		return nil
 	}
+	// comments[:0:0] forces a fresh backing array on the first append so we
+	// never alias the caller's slice header — the function returns a filtered
+	// view, not an in-place mutation of the input.
 	out := comments[:0:0]
 	for _, c := range comments {
 		if c.ReviewRound > round {

--- a/round_snapshots_integration_test.go
+++ b/round_snapshots_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRoundSnapshots_Integration exercises the full files-mode round
@@ -165,5 +166,76 @@ func TestRoundSnapshots_Integration(t *testing.T) {
 	flat := strings.TrimSuffix(identity, "/") + ".json"
 	if _, err := os.Stat(flat); err == nil {
 		t.Errorf("unexpected legacy flat file at %s", flat)
+	}
+}
+
+// TestLoadCritJSON_ResumedSession_DoesNotRewriteSidecar is a regression test
+// for review W5. Opening an existing review-with-snapshots used to rewrite
+// the sidecar back to disk on every cold boot — an O(N*M) clone+marshal+
+// rename for a no-op that produced bit-identical bytes. The optimization
+// skips the write when (a) the identity was set on entry and (b) the
+// sidecar carried at least one snapshot.
+func TestLoadCritJSON_ResumedSession_DoesNotRewriteSidecar(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte("# Plan\n\nstep one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First session: produce a sidecar with R1+R2 snapshots.
+	s1, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatalf("NewSessionFromFiles: %v", err)
+	}
+	identity := filepath.Join(dir, ".crit")
+	s1.ReviewFilePath = identity
+	s1.captureBaselineAndPersist()
+	s1.mu.Lock()
+	s1.Files[0].Content = "# Plan\n\nstep one\nstep two\n"
+	s1.Files[0].Status = "modified"
+	s1.mu.Unlock()
+	s1.handleRoundCompleteFiles()
+
+	paths := reviewPathsFor(identity)
+	beforeStat, err := os.Stat(paths.Snapshots)
+	if err != nil {
+		t.Fatalf("first sidecar missing: %v", err)
+	}
+
+	// Pin the existing mtime back into the past so a same-second rewrite
+	// would still bump it. Using a 5-second window keeps the test stable
+	// on filesystems that round mtimes (HFS+, FAT).
+	pastMtime := beforeStat.ModTime().Add(-5 * time.Second)
+	if err := os.Chtimes(paths.Snapshots, pastMtime, pastMtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	beforeStat, err = os.Stat(paths.Snapshots)
+	if err != nil {
+		t.Fatalf("re-stat: %v", err)
+	}
+
+	// Second "boot": construct a fresh session, set ReviewFilePath BEFORE
+	// loadCritJSON (matching the cli_serve resumed-session path), then
+	// trigger the load path.
+	s2, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatalf("second NewSessionFromFiles: %v", err)
+	}
+	s2.ReviewFilePath = identity
+	s2.loadCritJSON()
+
+	afterStat, err := os.Stat(paths.Snapshots)
+	if err != nil {
+		t.Fatalf("after-load sidecar missing: %v", err)
+	}
+	if !afterStat.ModTime().Equal(beforeStat.ModTime()) {
+		t.Errorf("sidecar mtime advanced on resumed-session load: before=%v after=%v",
+			beforeStat.ModTime(), afterStat.ModTime())
+	}
+
+	// Snapshots are still in memory.
+	relPath := s2.Files[0].Path
+	if _, ok := s2.RoundSnapshots[relPath][2]; !ok {
+		t.Errorf("R2 snapshot missing in memory after resumed-session load: %+v", s2.RoundSnapshots)
 	}
 }

--- a/round_snapshots_integration_test.go
+++ b/round_snapshots_integration_test.go
@@ -169,6 +169,64 @@ func TestRoundSnapshots_Integration(t *testing.T) {
 	}
 }
 
+// TestHandleRoundCompleteFiles_CapturesBeforeReread is a regression test
+// for review N4 / the existing INVARIANT comment in watch.go: the next
+// round's snapshot must capture the agent's in-memory content BEFORE
+// rereadFileContents pulls the latest bytes from disk. If the order is
+// flipped, R(N+1) would record the same content as R(N) (the on-disk file
+// the agent didn't touch in this scenario) and the timeline silently loses
+// what changed in this round.
+//
+// To exercise the order: keep the on-disk file in its R1 state and bump
+// only the in-memory Content (mimicking an agent that has written its
+// edits to s.Files[i].Content but not yet to disk). After
+// handleRoundCompleteFiles, R2's captured Content must match the
+// in-memory edit, and Files[0].Content must have been re-read back to the
+// on-disk (R1) state.
+func TestHandleRoundCompleteFiles_CapturesBeforeReread(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	r1Body := "# Plan\n\nstep one\n"
+	if err := os.WriteFile(planPath, []byte(r1Body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := filepath.Join(dir, ".crit")
+	s.ReviewFilePath = identity
+	s.captureBaselineAndPersist()
+
+	// Simulate agent edit: change in-memory content only. Disk still holds r1Body.
+	r2InMemory := "# Plan\n\nstep one\nstep two\n"
+	s.mu.Lock()
+	s.Files[0].Content = r2InMemory
+	s.Files[0].Status = "modified"
+	s.mu.Unlock()
+
+	s.handleRoundCompleteFiles()
+
+	relPath := s.Files[0].Path
+	s.mu.RLock()
+	r2, ok := s.RoundSnapshots[relPath][2]
+	currentContent := s.Files[0].Content
+	s.mu.RUnlock()
+	if !ok {
+		t.Fatalf("R2 missing after round-complete: %+v", s.RoundSnapshots)
+	}
+	if r2.Content != r2InMemory {
+		t.Errorf("R2 captured the wrong bytes — order assumption broken.\n  got:  %q\n  want: %q", r2.Content, r2InMemory)
+	}
+	// Sanity: rereadFileContents should have replaced the in-memory content
+	// with the disk content (back to r1Body) — confirms the reread did run
+	// after capture.
+	if currentContent != r1Body {
+		t.Errorf("Files[0].Content after round-complete = %q; want disk content %q (proves reread ran)", currentContent, r1Body)
+	}
+}
+
 // TestLoadCritJSON_ResumedSession_DoesNotRewriteSidecar is a regression test
 // for review W5. Opening an existing review-with-snapshots used to rewrite
 // the sidecar back to disk on every cold boot — an O(N*M) clone+marshal+

--- a/round_snapshots_integration_test.go
+++ b/round_snapshots_integration_test.go
@@ -29,7 +29,7 @@ func TestRoundSnapshots_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSessionFromFiles: %v", err)
 	}
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	s.ReviewFilePath = identity
 
 	// captureBaselineAndPersist already ran in NewSessionFromFiles, but with

--- a/round_snapshots_integration_test.go
+++ b/round_snapshots_integration_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRoundSnapshots_Integration exercises the full files-mode round
+// timeline: R1 baseline at session construction, an agent edit, R2 capture
+// via handleRoundCompleteFiles, and HTTP queries that surface both rounds.
+//
+// This is the only integration-style test for round snapshots. It deliberately
+// avoids the //go:build integration tag so it runs in the default test suite
+// and catches regressions in CI without an opt-in flag.
+func TestRoundSnapshots_Integration(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	r1Body := "# Plan\n\nstep one\n"
+	if err := os.WriteFile(planPath, []byte(r1Body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatalf("NewSessionFromFiles: %v", err)
+	}
+	identity := filepath.Join(dir, ".crit.json")
+	s.ReviewFilePath = identity
+
+	// captureBaselineAndPersist already ran in NewSessionFromFiles, but with
+	// an empty ReviewFilePath. Re-run now that the identity is pinned so the
+	// sidecar lands in the test tempdir instead of the dev repo root.
+	s.captureBaselineAndPersist()
+
+	// File path is whatever NewSessionFromFiles assigned (relative to the
+	// repo root if a VCS was detected, absolute otherwise on a bare tempdir).
+	relPath := s.Files[0].Path
+	if _, ok := s.RoundSnapshots[relPath][1]; !ok {
+		t.Fatalf("R1 baseline missing after constructor: %+v", s.RoundSnapshots)
+	}
+
+	// Simulate an agent edit: bump the in-memory file content.
+	r2Body := "# Plan\n\nstep one\nstep two\nstep three\n"
+	s.mu.Lock()
+	s.Files[0].Content = r2Body
+	// status flag is what captureRoundSnapshot looks at to skip "deleted".
+	s.Files[0].Status = "modified"
+	s.mu.Unlock()
+
+	// Round-complete capture: must take R2 BEFORE rereadFileContents.
+	s.handleRoundCompleteFiles()
+
+	s.mu.RLock()
+	r1, hasR1 := s.RoundSnapshots[relPath][1]
+	r2, hasR2 := s.RoundSnapshots[relPath][2]
+	currentRound := s.ReviewRound
+	s.mu.RUnlock()
+	if !hasR1 || !hasR2 {
+		t.Fatalf("expected R1 and R2 snapshots, got %+v", s.RoundSnapshots)
+	}
+	if r1.Content != r1Body {
+		t.Errorf("R1 content lost: %q", r1.Content)
+	}
+	if r2.Content != r2Body {
+		t.Errorf("R2 content not captured: %q", r2.Content)
+	}
+	if currentRound != 2 {
+		t.Errorf("ReviewRound = %d, want 2", currentRound)
+	}
+
+	// Sidecar should be on disk in the v4 folder layout.
+	paths := reviewPathsFor(identity)
+	sidecar, err := loadSnapshotsFile(paths.Snapshots)
+	if err != nil {
+		t.Fatalf("loadSnapshotsFile: %v", err)
+	}
+	if _, ok := sidecar.RoundSnapshots[relPath][2]; !ok {
+		t.Fatalf("sidecar missing R2 snapshot: %+v", sidecar.RoundSnapshots)
+	}
+
+	// HTTP wiring.
+	srv, err := NewServer(s, frontendFS, "", "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetSession(s)
+	srv.SetShutdownCtx(context.Background())
+
+	// /api/rounds — both rounds present, R2 has non-zero stats.
+	req := httptest.NewRequest("GET", "/api/rounds", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/api/rounds status=%d body=%s", w.Code, w.Body.String())
+	}
+	var roundsResp struct {
+		CurrentRound int `json:"current_round"`
+		Rounds       []struct {
+			N         int `json:"n"`
+			Additions int `json:"additions"`
+			Deletions int `json:"deletions"`
+		} `json:"rounds"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &roundsResp); err != nil {
+		t.Fatal(err)
+	}
+	if roundsResp.CurrentRound != 2 {
+		t.Errorf("current_round = %d, want 2", roundsResp.CurrentRound)
+	}
+	if len(roundsResp.Rounds) != 2 {
+		t.Fatalf("expected 2 rounds, got %d (%+v)", len(roundsResp.Rounds), roundsResp.Rounds)
+	}
+	if roundsResp.Rounds[1].Additions == 0 {
+		t.Errorf("R2 additions should be non-zero: %+v", roundsResp.Rounds[1])
+	}
+
+	// /api/file?round=1 returns R1 content.
+	req = httptest.NewRequest("GET", "/api/file?path="+relPath+"&round=1", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/api/file?round=1 status=%d body=%s", w.Code, w.Body.String())
+	}
+	var fileResp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &fileResp); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := fileResp["content"].(string); got != r1Body {
+		t.Errorf("R1 content via API = %q, want %q", got, r1Body)
+	}
+
+	// /api/file/diff?round=2 reflects R1 -> R2 changes.
+	req = httptest.NewRequest("GET", "/api/file/diff?path="+relPath+"&round=2", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/api/file/diff?round=2 status=%d body=%s", w.Code, w.Body.String())
+	}
+	var diffResp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &diffResp); err != nil {
+		t.Fatal(err)
+	}
+	prev, _ := diffResp["previous_content"].(string)
+	if prev != r1Body {
+		t.Errorf("diff previous_content = %q, want R1 body", prev)
+	}
+	hunks, _ := diffResp["hunks"].([]any)
+	if len(hunks) == 0 {
+		t.Errorf("expected non-empty hunks for R1 -> R2 diff: %v", diffResp)
+	}
+
+	// Folder-layout sanity: review.json + snapshots.json inside the folder,
+	// no flat .json file outside it.
+	if _, err := os.Stat(paths.Folder); err != nil {
+		t.Fatalf("review folder missing: %v", err)
+	}
+	if _, err := os.Stat(paths.Snapshots); err != nil {
+		t.Fatalf("snapshots.json missing inside folder: %v", err)
+	}
+	flat := strings.TrimSuffix(identity, "/") + ".json"
+	if _, err := os.Stat(flat); err == nil {
+		t.Errorf("unexpected legacy flat file at %s", flat)
+	}
+}

--- a/round_snapshots_test.go
+++ b/round_snapshots_test.go
@@ -23,11 +23,11 @@ func TestReviewPathsFor(t *testing.T) {
 			wantSnaps:  "/home/u/.crit/reviews/abc/snapshots.json",
 		},
 		{
-			// In-repo identity ends in .crit.json; the folder name is the same string.
-			identity:   "/tmp/proj/.crit.json",
-			wantFolder: "/tmp/proj/.crit.json",
-			wantReview: "/tmp/proj/.crit.json/review.json",
-			wantSnaps:  "/tmp/proj/.crit.json/snapshots.json",
+			// In-repo identity is the .crit folder (no .json extension).
+			identity:   "/tmp/proj/.crit",
+			wantFolder: "/tmp/proj/.crit",
+			wantReview: "/tmp/proj/.crit/review.json",
+			wantSnaps:  "/tmp/proj/.crit/snapshots.json",
 		},
 	}
 	for _, tc := range cases {
@@ -231,7 +231,7 @@ func TestSaveAndLoadCritJSON_FolderLayout(t *testing.T) {
 
 func TestClearReviewFolder_RemovesFolder(t *testing.T) {
 	dir := t.TempDir()
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	if err := saveCritJSON(identity, CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}); err != nil {
 		t.Fatal(err)
 	}

--- a/round_snapshots_test.go
+++ b/round_snapshots_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReviewPathsFor(t *testing.T) {
+	cases := []struct {
+		identity   string
+		wantFolder string
+		wantReview string
+		wantSnaps  string
+	}{
+		{
+			identity:   "/home/u/.crit/reviews/abc",
+			wantFolder: "/home/u/.crit/reviews/abc",
+			wantReview: "/home/u/.crit/reviews/abc/review.json",
+			wantSnaps:  "/home/u/.crit/reviews/abc/snapshots.json",
+		},
+		{
+			// In-repo identity ends in .crit.json; the folder name is the same string.
+			identity:   "/tmp/proj/.crit.json",
+			wantFolder: "/tmp/proj/.crit.json",
+			wantReview: "/tmp/proj/.crit.json/review.json",
+			wantSnaps:  "/tmp/proj/.crit.json/snapshots.json",
+		},
+	}
+	for _, tc := range cases {
+		got := reviewPathsFor(tc.identity)
+		if got.Folder != tc.wantFolder || got.Review != tc.wantReview || got.Snapshots != tc.wantSnaps {
+			t.Errorf("reviewPathsFor(%q) = %+v", tc.identity, got)
+		}
+	}
+}
+
+func TestSnapshotsFile_RoundTrip(t *testing.T) {
+	ts := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	original := SnapshotsFile{
+		RoundSnapshots: map[string]map[int]RoundSnapshot{
+			"plan.md": {
+				1: {Content: "v1", Status: "modified", CapturedAt: ts},
+				2: {Content: "v2", Status: "modified", CapturedAt: ts},
+			},
+		},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got SnapshotsFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.RoundSnapshots["plan.md"][1].Content != "v1" {
+		t.Fatal("round 1 content lost")
+	}
+	if !got.RoundSnapshots["plan.md"][2].CapturedAt.Equal(ts) {
+		t.Fatal("captured_at lost")
+	}
+}
+
+func TestSnapshotsFile_AbsentReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	folder := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sf, err := loadSnapshotsFile(reviewPathsFor(folder).Snapshots)
+	if err != nil {
+		t.Fatalf("missing sidecar must not error: %v", err)
+	}
+	if len(sf.RoundSnapshots) != 0 {
+		t.Fatalf("want empty, got %+v", sf.RoundSnapshots)
+	}
+}
+
+func TestSaveAndLoadSnapshotsFile(t *testing.T) {
+	dir := t.TempDir()
+	folder := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	paths := reviewPathsFor(folder)
+	sf := SnapshotsFile{RoundSnapshots: map[string]map[int]RoundSnapshot{
+		"a.md": {1: {Content: "x", CapturedAt: time.Now().UTC()}},
+	}}
+	if err := saveSnapshotsFile(paths.Snapshots, sf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(paths.Snapshots); err != nil {
+		t.Fatalf("not written: %v", err)
+	}
+	got, err := loadSnapshotsFile(paths.Snapshots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RoundSnapshots["a.md"][1].Content != "x" {
+		t.Fatalf("round-trip lost content: %+v", got)
+	}
+}
+
+// --- Task 2: ensureReviewFolder migration tests ---
+
+func TestMigrate_FlatFileToFolder(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	flatSidecar := identity + ".snapshots.json"
+	if err := os.WriteFile(identity, []byte(`{"branch":"main","review_round":1,"files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flatSidecar, []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("identity not a folder after migration: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(identity, "review.json")); err != nil {
+		t.Fatalf("review.json missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(identity, "snapshots.json")); err != nil {
+		t.Fatalf("snapshots.json missing: %v", err)
+	}
+	if _, err := os.Stat(flatSidecar); !os.IsNotExist(err) {
+		t.Fatalf("flat sidecar not removed: err=%v", err)
+	}
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(identity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(identity, "review.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatal("folder lost")
+	}
+}
+
+func TestMigrate_NoFlatNoFolder_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("ensureReviewFolder on non-existent identity must not error: %v", err)
+	}
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Fatal("must not create the folder if there's nothing to migrate")
+	}
+}
+
+func TestMigrate_OrphanFlatSidecarOnly(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.WriteFile(identity+".snapshots.json", []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Fatal("must not create folder when only orphan sidecar exists")
+	}
+}
+
+func TestMigrate_BothFolderAndOrphanSidecar_FolderWins(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(identity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(identity, "review.json"), []byte(`{"branch":"new"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identity+".snapshots.json", []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(identity, "review.json"))
+	if !strings.Contains(string(data), "new") {
+		t.Fatal("folder review.json was overwritten")
+	}
+}
+
+// --- Task 3: loadCritJSON / saveCritJSON / clearCritJSON folder layout ---
+
+func TestSaveAndLoadCritJSON_FolderLayout(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+
+	cj := CritJSON{Branch: "main", ReviewRound: 1, Files: map[string]CritJSONFile{}}
+	if err := saveCritJSON(identity, cj); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(identity, "review.json")); err != nil {
+		t.Fatalf("review.json not in folder: %v", err)
+	}
+	got, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Branch != "main" {
+		t.Fatalf("round-trip failed: %+v", got)
+	}
+}
+
+func TestClearReviewFolder_RemovesFolder(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, ".crit.json")
+	if err := saveCritJSON(identity, CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSnapshotsFile(reviewPathsFor(identity).Snapshots, SnapshotsFile{RoundSnapshots: map[string]map[int]RoundSnapshot{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := clearReviewFolder(identity); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Fatalf("folder not removed: err=%v", err)
+	}
+}
+
+func TestLoadCritJSON_TriggersMigration(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.WriteFile(identity, []byte(`{"branch":"main","review_round":1,"files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Branch != "main" {
+		t.Fatalf("round-trip lost: %+v", got)
+	}
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatal("loadCritJSON should have triggered migration")
+	}
+}

--- a/round_snapshots_test.go
+++ b/round_snapshots_test.go
@@ -248,6 +248,84 @@ func TestClearReviewFolder_RemovesFolder(t *testing.T) {
 	}
 }
 
+// --- Tasks 4-7: in-memory snapshots, capture, R1 baseline, sidecar restore ---
+
+func TestSession_CaptureRoundSnapshot_FilesMode(t *testing.T) {
+	s := &Session{
+		Mode: "files",
+		Files: []*FileEntry{
+			{Path: "a.md", Status: "modified", Content: "hello"},
+		},
+	}
+	s.captureRoundSnapshot(1)
+	got, ok := s.RoundSnapshots["a.md"][1]
+	if !ok {
+		t.Fatal("R1 snapshot not captured")
+	}
+	if got.Content != "hello" {
+		t.Errorf("Content = %q", got.Content)
+	}
+}
+
+func TestSession_CaptureRoundSnapshot_GitModeNoOp(t *testing.T) {
+	s := &Session{
+		Mode:  "git",
+		Files: []*FileEntry{{Path: "a.go", Content: "x"}},
+	}
+	s.captureRoundSnapshot(1)
+	if len(s.RoundSnapshots) != 0 {
+		t.Fatalf("git mode must not capture snapshots, got %+v", s.RoundSnapshots)
+	}
+}
+
+func TestSession_CaptureRoundSnapshot_SkipsLazyAndDeleted(t *testing.T) {
+	s := &Session{
+		Mode: "files",
+		Files: []*FileEntry{
+			{Path: "lazy.md", Lazy: true, Content: "x"},
+			{Path: "gone.md", Status: "deleted", Content: "x"},
+			{Path: "ok.md", Status: "modified", Content: "x"},
+		},
+	}
+	s.captureRoundSnapshot(1)
+	if _, ok := s.RoundSnapshots["lazy.md"]; ok {
+		t.Error("lazy file should be skipped")
+	}
+	if _, ok := s.RoundSnapshots["gone.md"]; ok {
+		t.Error("deleted file should be skipped")
+	}
+	if _, ok := s.RoundSnapshots["ok.md"][1]; !ok {
+		t.Error("ok.md R1 missing")
+	}
+}
+
+func TestSession_CaptureRoundSnapshot_Idempotent(t *testing.T) {
+	s := &Session{
+		Mode: "files",
+		Files: []*FileEntry{
+			{Path: "a.md", Status: "modified", Content: "v1"},
+		},
+	}
+	s.captureRoundSnapshot(1)
+	// Mutate file content; second capture for the same round must NOT overwrite.
+	s.Files[0].Content = "v2"
+	s.captureRoundSnapshot(1)
+	if got := s.RoundSnapshots["a.md"][1].Content; got != "v1" {
+		t.Errorf("idempotency violated: round 1 content = %q", got)
+	}
+}
+
+func TestCloneRoundSnapshots_DeepCopy(t *testing.T) {
+	src := map[string]map[int]RoundSnapshot{
+		"a.md": {1: {Content: "x"}},
+	}
+	dst := cloneRoundSnapshots(src)
+	dst["a.md"][1] = RoundSnapshot{Content: "MUT"}
+	if src["a.md"][1].Content != "x" {
+		t.Fatal("clone is shallow")
+	}
+}
+
 func TestLoadCritJSON_TriggersMigration(t *testing.T) {
 	dir := t.TempDir()
 	identity := filepath.Join(dir, "abc")

--- a/round_snapshots_v4_gaps_test.go
+++ b/round_snapshots_v4_gaps_test.go
@@ -75,12 +75,79 @@ func TestMigrate_MalformedFlatFile_StillMigrates(t *testing.T) {
 	}
 }
 
+// TestMigrate_LegacyDotJSONFlatFile covers the v3-on-disk shape where the
+// review file lives at <key>.json (with extension) under ~/.crit/reviews/.
+// The v4 identity drops the extension; ensureReviewFolder must detect the
+// sibling flat file and migrate it into <key>/review.json.
+func TestMigrate_LegacyDotJSONFlatFile(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	legacy := identity + ".json"
+	if err := os.WriteFile(legacy, []byte(`{"branch":"v3","files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// v3 sidecar (unlikely shipped, but the migration handles it).
+	if err := os.WriteFile(legacy+".snapshots.json", []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("v4 identity %s is not a folder: %v", identity, err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy %s not removed: %v", legacy, err)
+	}
+	cj, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatalf("loadCritJSON: %v", err)
+	}
+	if cj.Branch != "v3" {
+		t.Errorf("review payload lost: %+v", cj)
+	}
+	if _, err := os.Stat(filepath.Join(identity, "snapshots.json")); err != nil {
+		t.Errorf("sidecar not moved into folder: %v", err)
+	}
+}
+
+// TestMigrate_LegacyDotJSONFolder covers the early-v4 mid-state where the
+// review folder was created with a stray .json extension on its name. The
+// next ensureReviewFolder call must rename <key>.json/ to <key>/.
+func TestMigrate_LegacyDotJSONFolder(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	legacy := identity + ".json"
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "review.json"), []byte(`{"branch":"midstate","files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy folder %s still present: %v", legacy, err)
+	}
+	cj, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatalf("loadCritJSON: %v", err)
+	}
+	if cj.Branch != "midstate" {
+		t.Errorf("review payload lost across folder rename: %+v", cj)
+	}
+}
+
 // TestMigrate_InRepoCritJSON migrates an in-repo /tmp/.../path/.crit.json
 // (the OutputDir-based identity) to the v4 folder layout. Mirrors the
 // real-world path where a user has --output set to a project subdirectory.
 func TestMigrate_InRepoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	if err := os.WriteFile(identity, []byte(`{"branch":"feat","files":{}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +206,7 @@ func TestWriteFiles_EmptyPreservesAttachments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSessionFromFiles: %v", err)
 	}
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	s.ReviewFilePath = identity
 	paths := reviewPathsFor(identity)
 
@@ -641,7 +708,7 @@ func TestSession_LoadCritJSON_PostSetSessionIsNoOp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	identity := filepath.Join(dir, ".crit.json")
+	identity := filepath.Join(dir, ".crit")
 	s.ReviewFilePath = identity
 
 	// Pre-flag: snapshot some state, then set the flag (simulating

--- a/round_snapshots_v4_gaps_test.go
+++ b/round_snapshots_v4_gaps_test.go
@@ -1,0 +1,773 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- Migration gaps ---
+
+// TestMigrate_LeftoverTmpDir simulates a crash mid-migration that left a
+// previous attempt's <id>.crit-migrate.tmp/ behind. The next migration must
+// wipe it and complete successfully rather than failing because MkdirAll
+// preserves the stale tmp contents.
+func TestMigrate_LeftoverTmpDir(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	tmp := identity + ".crit-migrate.tmp"
+
+	if err := os.MkdirAll(tmp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stale junk inside the tmp dir from a prior crashed run.
+	if err := os.WriteFile(filepath.Join(tmp, "stale.txt"), []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identity, []byte(`{"branch":"main","files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("migration with leftover tmp dir failed: %v", err)
+	}
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("identity not folder after migration: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(identity, "stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("stale tmp content leaked into final folder: %v", err)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("tmp dir not cleaned up: %v", err)
+	}
+}
+
+// TestMigrate_MalformedFlatFile_StillMigrates verifies that the migration
+// shim is structural (rename), not parsing — a flat file with garbage JSON
+// is still moved into the folder layout. Subsequent loadCritJSON will surface
+// the parse error to the user.
+func TestMigrate_MalformedFlatFile_StillMigrates(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.WriteFile(identity, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("migration aborted on malformed JSON: %v", err)
+	}
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("identity not folder: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(identity, "review.json"))
+	if err != nil {
+		t.Fatalf("review.json missing after migration: %v", err)
+	}
+	if string(data) != "{not valid json" {
+		t.Errorf("file content corrupted by migration: %q", data)
+	}
+}
+
+// TestMigrate_InRepoCritJSON migrates an in-repo /tmp/.../path/.crit.json
+// (the OutputDir-based identity) to the v4 folder layout. Mirrors the
+// real-world path where a user has --output set to a project subdirectory.
+func TestMigrate_InRepoCritJSON(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, ".crit.json")
+	if err := os.WriteFile(identity, []byte(`{"branch":"feat","files":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureReviewFolder(identity); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+	info, err := os.Stat(identity)
+	if err != nil || !info.IsDir() {
+		t.Fatalf(".crit.json identity not folder: %v", err)
+	}
+	got, err := loadCritJSON(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Branch != "feat" {
+		t.Errorf("round-trip lost: %+v", got)
+	}
+}
+
+// --- Folder layout: future attachments ---
+
+// TestSaveCritJSON_PreservesUnknownAttachments writes review.json into a
+// folder that already contains a non-crit attachment file. The save must
+// not delete or overwrite siblings — the folder is the per-review namespace
+// for future features (recordings, large diffs, etc).
+func TestSaveCritJSON_PreservesUnknownAttachments(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(identity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	attach := filepath.Join(identity, "attachment.bin")
+	if err := os.WriteFile(attach, []byte("opaque"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := saveCritJSON(identity, CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(attach); err != nil || string(data) != "opaque" {
+		t.Fatalf("attachment lost or corrupted: data=%q err=%v", data, err)
+	}
+}
+
+// TestWriteFiles_EmptyPreservesAttachments is a defense-in-depth follow-up to
+// the existing sidecar regression test: when WriteFiles takes the empty branch
+// and removes review.json, future-attachment siblings must also survive.
+func TestWriteFiles_EmptyPreservesAttachments(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatalf("NewSessionFromFiles: %v", err)
+	}
+	identity := filepath.Join(dir, ".crit.json")
+	s.ReviewFilePath = identity
+	paths := reviewPathsFor(identity)
+
+	if err := os.MkdirAll(paths.Folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	attach := filepath.Join(paths.Folder, "future.bin")
+	if err := os.WriteFile(attach, []byte("future"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveCritJSON(identity, CritJSON{Branch: s.Branch, Files: map[string]CritJSONFile{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	flushWrites(s)
+	s.WriteFiles()
+
+	if _, err := os.Stat(paths.Review); !os.IsNotExist(err) {
+		t.Errorf("review.json should be removed: %v", err)
+	}
+	if data, err := os.ReadFile(attach); err != nil || string(data) != "future" {
+		t.Errorf("attachment lost across empty WriteFiles: data=%q err=%v", data, err)
+	}
+}
+
+// --- Cleanup gaps ---
+
+// TestFindStaleReviews_OrphanFolder_BoundaryNotStale verifies that an orphan
+// snapshots-only folder whose mtime is JUST inside the cutoff (newer than
+// cutoff) is NOT collected. Boundary: orphan with mtime exactly equal to
+// cutoff is also not stale (the code uses Before, not !After).
+func TestFindStaleReviews_OrphanFolder_BoundaryNotStale(t *testing.T) {
+	dir := t.TempDir()
+	orphan := filepath.Join(dir, "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "snapshots.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Folder mtime is 1 day old; cutoff is 7 days. Should NOT be stale.
+	recent := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(orphan, recent, recent); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := findStaleReviews(dir, 7)
+	for _, s := range stale {
+		if s.path == orphan {
+			t.Fatalf("recent orphan folder must not be collected: %+v", s)
+		}
+	}
+}
+
+// TestFindStaleReviews_EmptyFolder_Skipped: a folder inside reviews/ with
+// neither review.json NOR snapshots.json (e.g. a partial mkdir from a crashed
+// constructor) must be ignored. checkStaleReviewFolder returns false.
+func TestFindStaleReviews_EmptyFolder_Skipped(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "emptyfolder")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(empty, old, old); err != nil {
+		t.Fatal(err)
+	}
+	stale := findStaleReviews(dir, 7)
+	for _, s := range stale {
+		if s.path == empty {
+			t.Fatalf("empty folder must not be considered stale: %+v", s)
+		}
+	}
+}
+
+// TestFindStaleReviews_MixedFolderAndFlat verifies the migration-removal
+// branch: a v3 flat .json next to a v4 folder, both stale, are both
+// collected. After the shim is deleted the flat half goes away.
+func TestFindStaleReviews_MixedFolderAndFlat(t *testing.T) {
+	dir := t.TempDir()
+	oldTime := time.Now().Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// v4 folder.
+	folder := filepath.Join(dir, "k1")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cj := CritJSON{Branch: "old1", UpdatedAt: oldTime, Files: map[string]CritJSONFile{}}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(filepath.Join(folder, "review.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// v3 flat.
+	flat := filepath.Join(dir, "k2.json")
+	cj2 := CritJSON{Branch: "old2", UpdatedAt: oldTime, Files: map[string]CritJSONFile{}}
+	data2, _ := json.MarshalIndent(cj2, "", "  ")
+	if err := os.WriteFile(flat, data2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := findStaleReviews(dir, 7)
+	if len(stale) != 2 {
+		t.Fatalf("expected 2 stale (folder + flat), got %d: %+v", len(stale), stale)
+	}
+	branches := map[string]bool{}
+	for _, s := range stale {
+		branches[s.branch] = true
+	}
+	if !branches["old1"] || !branches["old2"] {
+		t.Errorf("missing branch: %+v", branches)
+	}
+}
+
+// TestDeleteStaleReviews_PartialFailureContinues: when one entry's path is
+// missing on disk, the sweep must continue and delete the remaining entries
+// rather than aborting at the first failure. removeStaleReviewPath returns
+// false on missing path; deleteStaleReviews logs and continues.
+func TestDeleteStaleReviews_PartialFailureContinues(t *testing.T) {
+	dir := t.TempDir()
+	// Real folder.
+	good := filepath.Join(dir, "good")
+	if err := os.MkdirAll(good, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(good, "review.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "missing-never-created")
+
+	// Hide stderr to avoid polluting test output.
+	devnull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	defer devnull.Close()
+	prev := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = prev }()
+
+	deleted := deleteStaleReviews([]staleReview{
+		{key: "missing", path: missing},
+		{key: "good", path: good},
+	})
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1 (missing skipped, good removed)", deleted)
+	}
+	if _, err := os.Stat(good); !os.IsNotExist(err) {
+		t.Error("good folder not removed after partial-failure sweep")
+	}
+}
+
+// TestCleanupOnApproval_FlatFileFallback exercises the MIGRATION-REMOVAL
+// branch in removeStaleReviewPath: an unmigrated flat .json review with a
+// sibling .snapshots.json file. Both must be cleaned.
+func TestCleanupOnApproval_FlatFileFallback(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "legacy.json")
+	if err := os.WriteFile(identity, []byte(`{"branch":"main"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := identity + ".snapshots.json"
+	if err := os.WriteFile(sidecar, []byte(`{"round_snapshots":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupOnApproval(true, identity, true)
+
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Errorf("flat review not removed: %v", err)
+	}
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Errorf("flat sidecar not removed: %v", err)
+	}
+}
+
+// --- walkReviewIdentities / find-by-id gaps ---
+
+// TestFindReviewFileByCommentID_AmbiguousAcrossFolderAndFlat: if the same
+// comment ID lives in both a folder and a leftover flat file (test-pollution
+// scenario or an aborted migration in production), the function must return
+// an error rather than silently picking one.
+func TestFindReviewFileByCommentID_AmbiguousAcrossFolderAndFlat(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir, err := reviewsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	commentID := "c_dup_xyz"
+	cj := CritJSON{
+		Branch: "main",
+		Files: map[string]CritJSONFile{
+			"a.go": {Comments: []Comment{{ID: commentID, Body: "x"}}},
+		},
+	}
+	data, _ := json.Marshal(cj)
+
+	// Folder-form review with the comment.
+	folder := filepath.Join(dir, "k1")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, "review.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy flat-file with the same comment.
+	flat := filepath.Join(dir, "k2.json")
+	if err := os.WriteFile(flat, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = findReviewFileByCommentID(commentID, "")
+	if err == nil {
+		t.Fatal("expected ambiguity error when comment exists in both folder and flat review")
+	}
+	if !strings.Contains(err.Error(), "multiple") {
+		t.Errorf("error should mention multiple matches, got: %v", err)
+	}
+}
+
+// TestWalkReviewIdentities_SkipsOrphanFolderSilently: a folder with only
+// snapshots.json (no review.json) is benignly skipped — the visit callback
+// never runs for it. This is the contract the find-by-id/branch helpers rely
+// on after the v4 layout shipped.
+func TestWalkReviewIdentities_SkipsOrphanFolderSilently(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir, _ := reviewsDir()
+	if err := os.MkdirAll(filepath.Join(dir, "orphan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orphan", "snapshots.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "good")
+	if err := os.MkdirAll(good, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(good, "review.json"), []byte(`{"branch":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var visited []string
+	err := walkReviewIdentities(func(identity string, _ []byte) error {
+		visited = append(visited, filepath.Base(identity))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk error: %v", err)
+	}
+	for _, v := range visited {
+		if v == "orphan" {
+			t.Errorf("orphan folder should not be visited: %v", visited)
+		}
+	}
+	found := false
+	for _, v := range visited {
+		if v == "good" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("good folder should be visited, got: %v", visited)
+	}
+}
+
+// TestFindReviewFileByBranch_MalformedJSONSkipped: a corrupt review.json
+// inside the reviews dir must not abort the scan; its identity is silently
+// skipped (via the //nolint:nilerr branch) and a sibling valid review still
+// matches.
+func TestFindReviewFileByBranch_MalformedJSONSkipped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir, _ := reviewsDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(dir, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "review.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := writeFolderReviewFixture(t, "good", "feature-x")
+
+	got, err := findReviewFileByBranch("feature-x", "")
+	if err != nil {
+		t.Fatalf("scan should succeed despite corrupt sibling: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- API edge cases ---
+
+// TestHandleFile_RoundZero rejects ?round=0 with 400 (round is 1-indexed).
+func TestHandleFile_RoundZero(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file?path=test.md&round=0", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("?round=0 should be 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleFile_RoundCurrentMatchesSnapshot: ?round=N where N == current
+// round returns the recorded snapshot, which must match in-memory current
+// content for files present at that round.
+func TestHandleFile_RoundCurrentMatchesSnapshot(t *testing.T) {
+	s, sess := newRoundsTestServer(t)
+	wantContent := sess.RoundSnapshots["test.md"][2].Content
+
+	req := httptest.NewRequest("GET", "/api/file?path=test.md&round=2", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := resp["content"].(string); got != wantContent {
+		t.Errorf("content = %q, want %q", got, wantContent)
+	}
+}
+
+// TestHandleFile_EmptyRoundParamFallsThrough: ?round= (empty value) is
+// treated as "no round param" — the handler falls through to working-tree
+// lookup rather than 400ing. This mirrors how Go's URL parser treats empty
+// values and how the frontend passes "" to mean current.
+func TestHandleFile_EmptyRoundParamFallsThrough(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	req := httptest.NewRequest("GET", "/api/file?path=test.md&round=", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("empty round should fall through to current, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleFile_DuplicateRoundParam_FirstWins: Go's url.Values.Get returns
+// the first value for repeated query keys. Verify the behavior is stable —
+// if a future code change switches to last-wins or errors, this catches it.
+func TestHandleFile_DuplicateRoundParam_FirstWins(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	// round=1 first (valid), round=99 second (out of range).
+	req := httptest.NewRequest("GET", "/api/file?path=test.md&round=1&round=99", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("first round=1 should win, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleRounds_GitMode returns an empty rounds list (200) for non-files
+// sessions. The frontend renders no timeline when rounds is empty.
+func TestHandleRounds_GitMode(t *testing.T) {
+	s, sess := newTestServer(t)
+	sess.Mode = "git"
+	req := httptest.NewRequest("GET", "/api/rounds", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d", w.Code)
+	}
+	var resp struct {
+		Rounds []any `json:"rounds"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Rounds) != 0 {
+		t.Errorf("git mode must return empty rounds, got %d", len(resp.Rounds))
+	}
+}
+
+// TestHandleRounds_MethodNotAllowed verifies non-GET methods are rejected.
+func TestHandleRounds_MethodNotAllowed(t *testing.T) {
+	s, _ := newRoundsTestServer(t)
+	for _, m := range []string{"POST", "PUT", "DELETE"} {
+		req := httptest.NewRequest(m, "/api/rounds", nil)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		if w.Code != 405 {
+			t.Errorf("%s /api/rounds: status=%d, want 405", m, w.Code)
+		}
+	}
+}
+
+// TestHandleFileComments_RoundFiltersByReviewRound: ?round=N on the comments
+// list filters to comments whose ReviewRound <= N.
+func TestHandleFileComments_RoundFiltersByReviewRound(t *testing.T) {
+	s, sess := newRoundsTestServer(t)
+	sess.Files[0].Comments = []Comment{
+		{ID: "c1", ReviewRound: 1, Body: "first round"},
+		{ID: "c2", ReviewRound: 2, Body: "second round"},
+		{ID: "c3", ReviewRound: 3, Body: "future"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/file/comments?path=test.md&round=2", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var got []Comment
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 comments at round<=2, got %d: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if c.ReviewRound > 2 {
+			t.Errorf("comment %q has ReviewRound=%d > 2", c.ID, c.ReviewRound)
+		}
+	}
+}
+
+// --- commentsAtOrBeforeRound edge cases ---
+
+func TestCommentsAtOrBeforeRound_NegativeAndZero(t *testing.T) {
+	cs := []Comment{{ID: "a", ReviewRound: 1}}
+	if got := commentsAtOrBeforeRound(cs, 0); got != nil {
+		t.Errorf("round=0 must return nil, got %v", got)
+	}
+	if got := commentsAtOrBeforeRound(cs, -5); got != nil {
+		t.Errorf("round=-5 must return nil, got %v", got)
+	}
+}
+
+func TestCommentsAtOrBeforeRound_DoesNotMutateInput(t *testing.T) {
+	// commentsAtOrBeforeRound uses comments[:0:0] which forces append to
+	// allocate a new backing array. Verify the input slice is not clobbered.
+	cs := []Comment{
+		{ID: "a", ReviewRound: 1},
+		{ID: "b", ReviewRound: 5},
+	}
+	_ = commentsAtOrBeforeRound(cs, 1)
+	if cs[1].ID != "b" {
+		t.Errorf("input slice mutated: %+v", cs)
+	}
+}
+
+// --- lineStatsForRound edge cases ---
+
+// TestLineStatsForRound_FileAddedAtRoundN: a file with no R(N-1) snapshot
+// but a snapshot at R(N) counts every line as an addition.
+func TestLineStatsForRound_FileAddedAtRoundN(t *testing.T) {
+	sess := &Session{
+		Mode: "files",
+		RoundSnapshots: map[string]map[int]RoundSnapshot{
+			"new.md": {
+				2: {Content: "a\nb\nc\n"},
+			},
+		},
+	}
+	adds, dels := lineStatsForRound(sess, 2)
+	if adds == 0 {
+		t.Errorf("file added at R2 should have non-zero adds, got %d/%d", adds, dels)
+	}
+	if dels != 0 {
+		t.Errorf("file added at R2 should have 0 dels, got %d", dels)
+	}
+}
+
+// TestLineStatsForRound_R1IsBaseline: R1 always returns 0/0 even when
+// snapshots exist.
+func TestLineStatsForRound_R1IsBaseline(t *testing.T) {
+	sess := &Session{
+		Mode: "files",
+		RoundSnapshots: map[string]map[int]RoundSnapshot{
+			"a.md": {1: {Content: "anything\n"}},
+		},
+	}
+	adds, dels := lineStatsForRound(sess, 1)
+	if adds != 0 || dels != 0 {
+		t.Errorf("R1 stats must be 0/0, got %d/%d", adds, dels)
+	}
+}
+
+// --- sessionStarted guard ---
+
+// TestSession_LoadCritJSON_PostSetSessionIsNoOp verifies the lock-discipline
+// guard: once Server.SetSession flips sessionStarted, calling loadCritJSON
+// again is a no-op (logs to stderr, does not mutate session state). This
+// protects against runtime data races on RoundSnapshots / reviewComments.
+func TestSession_LoadCritJSON_PostSetSessionIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewSessionFromFiles([]string{planPath}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := filepath.Join(dir, ".crit.json")
+	s.ReviewFilePath = identity
+
+	// Pre-flag: snapshot some state, then set the flag (simulating
+	// Server.SetSession), and seed disk with DIFFERENT state.
+	s.sessionStarted.Store(0)
+	s.reviewComments = []Comment{{ID: "in-mem", Body: "memory wins"}}
+
+	if err := saveCritJSON(identity, CritJSON{
+		Branch: "fromdisk",
+		ReviewComments: []Comment{
+			{ID: "from-disk", Body: "disk should NOT clobber"},
+		},
+		Files: map[string]CritJSONFile{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s.sessionStarted.Store(1) // post-SetSession
+
+	stderr := captureStderr(t, func() {
+		s.loadCritJSON()
+	})
+	if !strings.Contains(stderr, "BUG: Session.loadCritJSON called post-SetSession") {
+		t.Errorf("expected guard log on stderr, got: %q", stderr)
+	}
+
+	if len(s.reviewComments) != 1 || s.reviewComments[0].ID != "in-mem" {
+		t.Errorf("post-flag loadCritJSON clobbered in-memory state: %+v", s.reviewComments)
+	}
+}
+
+// --- Concurrency: race detector exercise ---
+
+// TestRoundSnapshots_ConcurrentReadWrite hammers captureRoundSnapshot,
+// availableRounds, and roundSnapshotForFile from multiple goroutines. The
+// race detector is the assertion. Capture takes the role of the writer
+// (under s.mu.Lock); availableRounds/roundSnapshotForFile take RLock.
+func TestRoundSnapshots_ConcurrentReadWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping race exercise in short mode")
+	}
+	s := &Session{
+		Mode: "files",
+		Files: []*FileEntry{
+			{Path: "a.md", Status: "modified", Content: "v"},
+			{Path: "b.md", Status: "modified", Content: "v"},
+		},
+	}
+
+	const writers, readers, iters = 2, 4, 100
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				s.mu.Lock()
+				s.captureRoundSnapshot(i + 1)
+				s.mu.Unlock()
+			}
+		}()
+	}
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				s.mu.RLock()
+				_ = s.availableRounds()
+				_, _ = s.roundSnapshotForFile("a.md", 1)
+				s.mu.RUnlock()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- Backward compat: snapshot referencing files no longer in session ---
+
+// TestLoadSnapshotsFromSidecar_OrphanedPathsKept: the sidecar may reference
+// files that have since been removed from the session (file deleted from
+// disk between rounds). The restore must keep the historical entries —
+// they're the only record of past content — even though no live FileEntry
+// references them. lineStatsForRound and /api/rounds gracefully ignore them.
+func TestLoadSnapshotsFromSidecar_OrphanedPathsKept(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(identity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSnapshotsFile(reviewPathsFor(identity).Snapshots, SnapshotsFile{
+		RoundSnapshots: map[string]map[int]RoundSnapshot{
+			"deleted-since.md": {1: {Content: "ghost"}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Session{Mode: "files", Files: []*FileEntry{}}
+	s.loadSnapshotsFromSidecar(identity)
+	if _, ok := s.RoundSnapshots["deleted-since.md"][1]; !ok {
+		t.Error("orphaned snapshot path was discarded; should be preserved for timeline")
+	}
+}
+
+// TestLoadSnapshotsFromSidecar_UnknownFieldsTolerated: forward-compat —
+// future versions may add fields to RoundSnapshot. Unknown fields must be
+// ignored (encoding/json default), never error the load.
+func TestLoadSnapshotsFromSidecar_UnknownFieldsTolerated(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "abc")
+	if err := os.MkdirAll(identity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{
+  "schema_version": 99,
+  "round_snapshots": {
+    "a.md": {"1": {"content": "x", "future_field": "ignored"}}
+  }
+}`
+	if err := os.WriteFile(reviewPathsFor(identity).Snapshots, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Session{Mode: "files"}
+	s.loadSnapshotsFromSidecar(identity)
+	if got := s.RoundSnapshots["a.md"][1].Content; got != "x" {
+		t.Errorf("content = %q, want %q (unknown fields must be ignored)", got, "x")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -196,7 +196,13 @@ func (s *Server) WaitBackground(timeout time.Duration) bool {
 // SetSession attaches a fully initialized session and marks the server as ready.
 // Uses atomic.Pointer to ensure the session pointer is visible to all goroutines
 // immediately after store, which is critical on weakly-ordered architectures (ARM64).
+//
+// Also flips the session's sessionStarted flag so Session.loadCritJSON can
+// enforce its pre-SetSession-only lock contract (see plan v4 §Lock discipline).
 func (s *Server) SetSession(session *Session) {
+	if session != nil {
+		defer session.sessionStarted.Store(1)
+	}
 	s.session.Store(session)
 }
 

--- a/server.go
+++ b/server.go
@@ -566,13 +566,23 @@ func (s *Server) handleRounds(w http.ResponseWriter, r *http.Request) {
 	out := make([]roundEntry, 0, len(rounds))
 	for _, r := range rounds {
 		var capturedAt string
-		// Pick a representative captured_at timestamp from the first file
-		// that has this round. CapturedAt is set per-file in captureRoundSnapshot.
+		// Pick the EARLIEST CapturedAt across every file that snapshotted at
+		// this round — Go map iteration order is randomized, so picking "the
+		// first" produced a non-deterministic captured_at across requests.
+		// The earliest is a meaningful representative (the moment the round
+		// began capturing) and stable for any given snapshot map.
+		var earliest time.Time
 		for _, byRound := range session.RoundSnapshots {
-			if rs, ok := byRound[r]; ok {
-				capturedAt = rs.CapturedAt.Format(time.RFC3339)
-				break
+			rs, ok := byRound[r]
+			if !ok {
+				continue
 			}
+			if earliest.IsZero() || rs.CapturedAt.Before(earliest) {
+				earliest = rs.CapturedAt
+			}
+		}
+		if !earliest.IsZero() {
+			capturedAt = earliest.Format(time.RFC3339)
 		}
 		adds, dels := lineStatsForRound(session, r)
 		out = append(out, roundEntry{

--- a/server.go
+++ b/server.go
@@ -769,6 +769,13 @@ func serveFileDiffAtRound(w http.ResponseWriter, r *http.Request, session *Sessi
 
 // handleFileComments handles GET (list) and POST (create) for file-scoped comments.
 // GET/POST /api/file/comments?path=server.go
+//
+// In files mode, ?round=N filters the GET response via commentsAtOrBeforeRound:
+// only comments authored at or before round N (and replies authored at or
+// before N) are returned. Note that the Resolved / ResolvedRound fields on
+// each returned comment reflect *current* state, not state-at-round-N — the
+// frontend uses ResolvedRound to compute round-faithful resolution itself.
+// See commentsAtOrBeforeRound for the full Stage 1 vs Stage 2 contract.
 func (s *Server) handleFileComments(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 	if path == "" {

--- a/server.go
+++ b/server.go
@@ -349,6 +349,13 @@ func (s *Server) addIntegrationStatus(resp map[string]interface{}) {
 }
 
 // handleSession returns session metadata: mode, branch, file list with stats.
+//
+// GET /api/session[?scope=X&commit=Y&round=N]
+//
+// In files mode, ?round=N filters the file list to files that had a
+// snapshot at that round (so files added in later rounds drop out when
+// viewing an earlier point in the timeline). The round parameter is
+// ignored in git/range mode.
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -356,7 +363,34 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	scope := r.URL.Query().Get("scope")
 	commit := r.URL.Query().Get("commit")
-	writeJSON(w, s.session.Load().GetSessionInfoScoped(scope, commit))
+	session := s.session.Load()
+	info := session.GetSessionInfoScoped(scope, commit)
+
+	if roundStr := r.URL.Query().Get("round"); roundStr != "" && session != nil && session.Mode == "files" {
+		if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
+			info.Files = filterFilesAtRound(session, info.Files, n)
+		}
+	}
+	writeJSON(w, info)
+}
+
+// filterFilesAtRound returns the subset of files that have a snapshot recorded
+// at the given round. Caller must not hold session.mu.
+func filterFilesAtRound(session *Session, files []SessionFileInfo, round int) []SessionFileInfo {
+	session.mu.RLock()
+	defer session.mu.RUnlock()
+	out := make([]SessionFileInfo, 0, len(files))
+	for _, f := range files {
+		byRound := session.RoundSnapshots[f.Path]
+		if byRound == nil {
+			continue
+		}
+		if _, ok := byRound[round]; !ok {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 func (s *Server) handleShareURL(w http.ResponseWriter, r *http.Request) {
@@ -504,14 +538,50 @@ func (s *Server) handleRounds(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
+		adds, dels := lineStatsForRound(session, r)
 		out = append(out, roundEntry{
 			N:            r,
+			Additions:    adds,
+			Deletions:    dels,
 			CommentCount: counts[r],
 			CapturedAt:   capturedAt,
 		})
 	}
 	resp["rounds"] = out
 	writeJSON(w, resp)
+}
+
+// lineStatsForRound aggregates added/removed line counts across every file
+// with a snapshot at round n, comparing against round n-1. R1 (or any round
+// where no n-1 snapshots exist) returns 0/0. Caller must hold session.mu
+// (RLock is sufficient).
+func lineStatsForRound(session *Session, n int) (int, int) {
+	if n <= 1 {
+		return 0, 0
+	}
+	var adds, dels int
+	for _, byRound := range session.RoundSnapshots {
+		curr, ok := byRound[n]
+		if !ok {
+			continue
+		}
+		prev, hasPrev := byRound[n-1]
+		if !hasPrev {
+			// New file at round n: every line counts as an addition.
+			adds += len(splitLines(curr.Content))
+			continue
+		}
+		entries := ComputeLineDiff(prev.Content, curr.Content)
+		for _, e := range entries {
+			switch e.Type {
+			case "added":
+				adds++
+			case "removed":
+				dels++
+			}
+		}
+	}
+	return adds, dels
 }
 
 // handleFile returns file content + metadata for a single file.
@@ -590,7 +660,12 @@ func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, 
 
 // handleFileDiff returns diff hunks for a file.
 // For code files: git diff hunks. For markdown files: inter-round LCS diff.
-// GET /api/file/diff?path=server.go
+// GET /api/file/diff?path=server.go[&round=N]
+//
+// In files mode, ?round=N returns the diff between round N's snapshot and
+// round (N-1)'s snapshot. R1 is the baseline and has no previous content,
+// so the response carries empty hunks. In git/range mode, the round
+// parameter is ignored.
 func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -601,6 +676,11 @@ func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "path query parameter required", http.StatusBadRequest)
 		return
 	}
+
+	if served := serveFileDiffAtRound(w, r, s.session.Load(), path); served {
+		return
+	}
+
 	scope := r.URL.Query().Get("scope")
 	commit := r.URL.Query().Get("commit")
 	snapshot, ok := s.session.Load().GetFileDiffSnapshotScoped(path, scope, commit)
@@ -609,6 +689,49 @@ func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, snapshot)
+}
+
+// serveFileDiffAtRound writes a per-round diff response when the request
+// includes a valid ?round=N for a files-mode session. Returns served=true
+// when it has fully written the response (success or 400/404). Returns
+// served=false when the caller should fall through to the working-tree code
+// path (no round param, or git/range mode).
+func serveFileDiffAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) bool {
+	roundStr := r.URL.Query().Get("round")
+	if roundStr == "" {
+		return false
+	}
+	if session == nil || session.Mode != "files" {
+		return false
+	}
+	round, err := strconv.Atoi(roundStr)
+	if err != nil || round < 1 {
+		http.Error(w, "invalid round", http.StatusBadRequest)
+		return true
+	}
+	session.mu.RLock()
+	rs, ok := session.roundSnapshotForFile(path, round)
+	prev, hasPrev := session.roundSnapshotForFile(path, round-1)
+	session.mu.RUnlock()
+	if !ok {
+		http.Error(w, "file_not_in_round", http.StatusNotFound)
+		return true
+	}
+
+	resp := map[string]any{
+		"hunks":            []DiffHunk{},
+		"previous_content": prev.Content,
+	}
+	if hasPrev && prev.Content != rs.Content {
+		entries := ComputeLineDiff(prev.Content, rs.Content)
+		hunks := DiffEntriesToHunks(entries)
+		if hunks == nil {
+			hunks = []DiffHunk{}
+		}
+		resp["hunks"] = hunks
+	}
+	writeJSON(w, resp)
+	return true
 }
 
 // handleFileComments handles GET (list) and POST (create) for file-scoped comments.

--- a/server.go
+++ b/server.go
@@ -648,10 +648,11 @@ func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, 
 		return true
 	}
 	resp := map[string]any{
-		"path":    path,
-		"round":   round,
-		"content": rs.Content,
-		"status":  rs.Status,
+		"path":     path,
+		"round":    round,
+		"content":  rs.Content,
+		"status":   rs.Status,
+		"position": rs.Position,
 	}
 	if hasPrev {
 		resp["previous_content"] = prev.Content

--- a/server.go
+++ b/server.go
@@ -600,8 +600,7 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if snap, served := serveFileAtRound(w, r, s.session.Load(), path); served {
-		_ = snap
+	if served := serveFileAtRound(w, r, s.session.Load(), path); served {
 		return
 	}
 
@@ -624,18 +623,18 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 // (including 400/404). Returns served=false when the caller should fall
 // through to the working-tree code path (no round param, git/range mode, or
 // no snapshot recorded for this round).
-func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) (any, bool) {
+func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) bool {
 	roundStr := r.URL.Query().Get("round")
 	if roundStr == "" {
-		return nil, false
+		return false
 	}
 	if session == nil || session.Mode != "files" {
-		return nil, false
+		return false
 	}
 	round, err := strconv.Atoi(roundStr)
 	if err != nil || round < 1 {
 		http.Error(w, "invalid round", http.StatusBadRequest)
-		return nil, true
+		return true
 	}
 	session.mu.RLock()
 	rs, ok := session.roundSnapshotForFile(path, round)
@@ -643,7 +642,7 @@ func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, 
 	session.mu.RUnlock()
 	if !ok {
 		http.Error(w, "file_not_in_round", http.StatusNotFound)
-		return nil, true
+		return true
 	}
 	resp := map[string]any{
 		"path":    path,
@@ -655,7 +654,7 @@ func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, 
 		resp["previous_content"] = prev.Content
 	}
 	writeJSON(w, resp)
-	return resp, true
+	return true
 }
 
 // handleFileDiff returns diff hunks for a file.

--- a/server.go
+++ b/server.go
@@ -497,8 +497,14 @@ func (s *Server) handleRounds(w http.ResponseWriter, r *http.Request) {
 		CapturedAt   string `json:"captured_at"`
 	}
 
+	// Span current_round + rounds slice under a single RLock so a
+	// round-complete that lands between the two reads can't yield an
+	// internally inconsistent response (e.g. current=N with rounds ending at N-1).
+	session.mu.RLock()
+	defer session.mu.RUnlock()
+
 	resp := map[string]any{
-		"current_round": session.GetReviewRound(),
+		"current_round": session.ReviewRound,
 		"rounds":        []roundEntry{},
 	}
 
@@ -506,9 +512,6 @@ func (s *Server) handleRounds(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, resp)
 		return
 	}
-
-	session.mu.RLock()
-	defer session.mu.RUnlock()
 
 	rounds := session.availableRounds()
 	if len(rounds) == 0 {

--- a/server.go
+++ b/server.go
@@ -1249,13 +1249,16 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	totalComments := sess.TotalCommentCount()
 	newComments := sess.NewCommentCount()
 	unresolvedComments := sess.UnresolvedCommentCount()
-	critJSON := sess.critJSONPath()
+	// In v4 the session identity is a folder (.../<key>/ or .../.crit/); the
+	// agent-facing review payload lives at <identity>/review.json. Surface the
+	// file path, not the folder, so `cat $review_file` works.
+	reviewFile := reviewPathsFor(sess.critJSONPath()).Review
 	prompt := ""
 	if totalComments > 0 && unresolvedComments > 0 {
 		if sess.Mode == "plan" {
 			// Plan mode: concise feedback for the hook workflow.
 			// Claude revises the plan text directly — no need for crit comment or review file instructions.
-			prompt = s.buildPlanFeedback(critJSON)
+			prompt = s.buildPlanFeedback(reviewFile)
 		} else {
 			prompt = fmt.Sprintf(
 				"Review comments are in %s — comments are grouped per file with start_line/end_line referencing the source. "+
@@ -1265,7 +1268,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 					"Before acting, check each comment's replies array — if you have already replied, the reviewer may be following up conversationally rather than requesting a new code change. "+
 					"For each comment, reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> \"<explanation>\"`. "+
 					"When done run: `%s`",
-				critJSON, sess.ReinvokeCommand())
+				reviewFile, sess.ReinvokeCommand())
 		}
 	} else if totalComments > 0 && unresolvedComments == 0 {
 		prompt = "All comments are resolved — no changes needed, please proceed."
@@ -1278,7 +1281,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, map[string]any{
 		"status":      "finished",
-		"review_file": critJSON,
+		"review_file": reviewFile,
 		"prompt":      prompt,
 		"approved":    approved,
 	})
@@ -1306,7 +1309,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 
 // buildPlanFeedback formats review feedback for plan mode.
 // Points to the review file and hints at crit-cli skill, without inlining every comment.
-func (s *Server) buildPlanFeedback(critJSON string) string {
+func (s *Server) buildPlanFeedback(reviewFile string) string {
 	// Extract slug from PlanDir (last path component)
 	slug := filepath.Base(s.session.Load().PlanDir)
 	return fmt.Sprintf(
@@ -1315,7 +1318,7 @@ func (s *Server) buildPlanFeedback(critJSON string) string {
 			"Each comment has a scope field: \"line\" for inline comments, \"file\" for file-level, or \"review\" for review-level comments. "+
 			"Read the file, revise the plan to address each comment. "+
 			"To reply to comments, use `crit comment --plan %s --reply-to <id> --author <your-name> \"<explanation>\"`.",
-		critJSON, slug)
+		reviewFile, slug)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -1396,7 +1399,7 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 				json.Unmarshal([]byte(event.Content), &finishData)
 				writeJSON(w, map[string]any{
 					"status":       "finished",
-					"review_file":  sess.critJSONPath(),
+					"review_file":  reviewPathsFor(sess.critJSONPath()).Review,
 					"prompt":       finishData.Prompt,
 					"approved":     finishData.Approved,
 					"next_command": buildNextCommand(s.cliArgs),

--- a/server.go
+++ b/server.go
@@ -354,6 +354,31 @@ func (s *Server) addIntegrationStatus(resp map[string]interface{}) {
 	resp["any_integration_installed"] = len(integrations) > 0
 }
 
+// parseRoundParam extracts and validates the ?round=N query parameter.
+//
+// Returns:
+//   - (0, false, true): the parameter is absent or empty — caller should not
+//     apply any round filter (back-compat: pre-feature clients omit it).
+//   - (N, true, true):  parsed round >= 1 — caller may apply the filter.
+//   - (0, false, false): invalid — the function has already written a 400
+//     response and the caller MUST return without writing further.
+//
+// All four round-aware endpoints (/api/session, /api/file, /api/file/diff,
+// /api/file/comments, /api/comments) go through this helper so the contract
+// stays uniform: a malformed value (e.g. "abc", "-1", "0") always yields 400.
+func parseRoundParam(w http.ResponseWriter, r *http.Request) (round int, ok bool, valid bool) {
+	roundStr := r.URL.Query().Get("round")
+	if roundStr == "" {
+		return 0, false, true
+	}
+	n, err := strconv.Atoi(roundStr)
+	if err != nil || n < 1 {
+		http.Error(w, "invalid round", http.StatusBadRequest)
+		return 0, false, false
+	}
+	return n, true, true
+}
+
 // handleSession returns session metadata: mode, branch, file list with stats.
 //
 // GET /api/session[?scope=X&commit=Y&round=N]
@@ -367,15 +392,17 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	round, hasRound, valid := parseRoundParam(w, r)
+	if !valid {
+		return
+	}
 	scope := r.URL.Query().Get("scope")
 	commit := r.URL.Query().Get("commit")
 	session := s.session.Load()
 	info := session.GetSessionInfoScoped(scope, commit)
 
-	if roundStr := r.URL.Query().Get("round"); roundStr != "" && session != nil && session.Mode == "files" {
-		if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
-			info.Files = filterFilesAtRound(session, info.Files, n)
-		}
+	if hasRound && session != nil && session.Mode == "files" {
+		info.Files = filterFilesAtRound(session, info.Files, round)
 	}
 	writeJSON(w, info)
 }
@@ -633,17 +660,16 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 // through to the working-tree code path (no round param, git/range mode, or
 // no snapshot recorded for this round).
 func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) bool {
-	roundStr := r.URL.Query().Get("round")
-	if roundStr == "" {
+	round, hasRound, valid := parseRoundParam(w, r)
+	if !valid {
+		// parseRoundParam wrote 400; signal handled.
+		return true
+	}
+	if !hasRound {
 		return false
 	}
 	if session == nil || session.Mode != "files" {
 		return false
-	}
-	round, err := strconv.Atoi(roundStr)
-	if err != nil || round < 1 {
-		http.Error(w, "invalid round", http.StatusBadRequest)
-		return true
 	}
 	session.mu.RLock()
 	rs, ok := session.roundSnapshotForFile(path, round)
@@ -706,17 +732,15 @@ func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 // served=false when the caller should fall through to the working-tree code
 // path (no round param, or git/range mode).
 func serveFileDiffAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) bool {
-	roundStr := r.URL.Query().Get("round")
-	if roundStr == "" {
+	round, hasRound, valid := parseRoundParam(w, r)
+	if !valid {
+		return true
+	}
+	if !hasRound {
 		return false
 	}
 	if session == nil || session.Mode != "files" {
 		return false
-	}
-	round, err := strconv.Atoi(roundStr)
-	if err != nil || round < 1 {
-		http.Error(w, "invalid round", http.StatusBadRequest)
-		return true
 	}
 	session.mu.RLock()
 	rs, ok := session.roundSnapshotForFile(path, round)
@@ -754,11 +778,13 @@ func (s *Server) handleFileComments(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
+		round, hasRound, valid := parseRoundParam(w, r)
+		if !valid {
+			return
+		}
 		comments := s.session.Load().GetComments(path)
-		if roundStr := r.URL.Query().Get("round"); roundStr != "" && s.session.Load().Mode == "files" {
-			if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
-				comments = commentsAtOrBeforeRound(comments, n)
-			}
+		if hasRound && s.session.Load().Mode == "files" {
+			comments = commentsAtOrBeforeRound(comments, round)
 		}
 		writeJSON(w, comments)
 
@@ -1092,11 +1118,13 @@ func (s *Server) handleReviewCommentReplyRoute(w http.ResponseWriter, r *http.Re
 func (s *Server) handleReviewComments(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
+		round, hasRound, valid := parseRoundParam(w, r)
+		if !valid {
+			return
+		}
 		comments := s.session.Load().GetReviewComments()
-		if roundStr := r.URL.Query().Get("round"); roundStr != "" && s.session.Load().Mode == "files" {
-			if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
-				comments = commentsAtOrBeforeRound(comments, n)
-			}
+		if hasRound && s.session.Load().Mode == "files" {
+			comments = commentsAtOrBeforeRound(comments, round)
 		}
 		writeJSON(w, comments)
 

--- a/server.go
+++ b/server.go
@@ -201,9 +201,15 @@ func (s *Server) WaitBackground(timeout time.Duration) bool {
 //
 // Also flips the session's sessionStarted flag so Session.loadCritJSON can
 // enforce its pre-SetSession-only lock contract (see plan v4 §Lock discipline).
+//
+// Ordering matters: sessionStarted MUST be stored BEFORE the session pointer
+// is published. After s.session.Store, withReady (and any goroutine that
+// observes the session pointer) can call session methods immediately. If
+// sessionStarted were still 0 at that moment, a code path that reaches
+// loadCritJSON would falsely believe it's pre-SetSession and skip the guard.
 func (s *Server) SetSession(session *Session) {
 	if session != nil {
-		defer session.sessionStarted.Store(1)
+		session.sessionStarted.Store(1)
 	}
 	s.session.Store(session)
 }

--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -92,6 +93,7 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, authToken
 	mux.HandleFunc("/api/events", s.withReady(s.handleEvents))
 	mux.HandleFunc("/api/wait-for-event", s.withReady(s.handleWaitForEvent))
 	mux.HandleFunc("/api/round-complete", s.withReady(s.handleRoundComplete))
+	mux.HandleFunc("/api/rounds", s.withReady(s.handleRounds))
 	mux.HandleFunc("/api/focus", s.withReady(s.handleFocus))
 	mux.HandleFunc("/api/picker", s.withReady(s.handlePicker))
 
@@ -437,8 +439,86 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"url": res.URL, "delete_token": res.DeleteToken})
 }
 
+// handleRounds returns the per-round timeline for files-mode sessions. In
+// git/range mode it returns 200 with an empty rounds list (the wire shape
+// stays stable so the frontend doesn't need mode-specific code paths).
+//
+// GET /api/rounds
+func (s *Server) handleRounds(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	session := s.session.Load()
+	if session == nil {
+		writeJSON(w, map[string]any{"current_round": 0, "rounds": []any{}})
+		return
+	}
+
+	type roundEntry struct {
+		N            int    `json:"n"`
+		Additions    int    `json:"additions"`
+		Deletions    int    `json:"deletions"`
+		CommentCount int    `json:"comment_count"`
+		CapturedAt   string `json:"captured_at"`
+	}
+
+	resp := map[string]any{
+		"current_round": session.GetReviewRound(),
+		"rounds":        []roundEntry{},
+	}
+
+	if session.Mode != "files" {
+		writeJSON(w, resp)
+		return
+	}
+
+	session.mu.RLock()
+	defer session.mu.RUnlock()
+
+	rounds := session.availableRounds()
+	if len(rounds) == 0 {
+		writeJSON(w, resp)
+		return
+	}
+
+	// Per-round comment counts (comments where review_round == n).
+	counts := make(map[int]int, len(rounds))
+	for _, f := range session.Files {
+		for _, c := range f.Comments {
+			counts[c.ReviewRound]++
+		}
+	}
+	for _, c := range session.reviewComments {
+		counts[c.ReviewRound]++
+	}
+
+	out := make([]roundEntry, 0, len(rounds))
+	for _, r := range rounds {
+		var capturedAt string
+		// Pick a representative captured_at timestamp from the first file
+		// that has this round. CapturedAt is set per-file in captureRoundSnapshot.
+		for _, byRound := range session.RoundSnapshots {
+			if rs, ok := byRound[r]; ok {
+				capturedAt = rs.CapturedAt.Format(time.RFC3339)
+				break
+			}
+		}
+		out = append(out, roundEntry{
+			N:            r,
+			CommentCount: counts[r],
+			CapturedAt:   capturedAt,
+		})
+	}
+	resp["rounds"] = out
+	writeJSON(w, resp)
+}
+
 // handleFile returns file content + metadata for a single file.
-// GET /api/file?path=server.go
+// GET /api/file?path=server.go[&round=N]
+//
+// In files mode, ?round=N returns the snapshot recorded for that round. In
+// git/range mode, the round parameter is ignored.
 func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -449,6 +529,12 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "path query parameter required", http.StatusBadRequest)
 		return
 	}
+
+	if snap, served := serveFileAtRound(w, r, s.session.Load(), path); served {
+		_ = snap
+		return
+	}
+
 	snapshot, ok := s.session.Load().GetFileSnapshot(path)
 	if !ok {
 		// File not in session (e.g. scoped view showing a file added after startup).
@@ -460,6 +546,46 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, snapshot)
+}
+
+// serveFileAtRound writes a per-round snapshot response if the request
+// includes a valid ?round=N for a files-mode session that has a snapshot for
+// (path, round). Returns served=true when it has fully written the response
+// (including 400/404). Returns served=false when the caller should fall
+// through to the working-tree code path (no round param, git/range mode, or
+// no snapshot recorded for this round).
+func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, path string) (any, bool) {
+	roundStr := r.URL.Query().Get("round")
+	if roundStr == "" {
+		return nil, false
+	}
+	if session == nil || session.Mode != "files" {
+		return nil, false
+	}
+	round, err := strconv.Atoi(roundStr)
+	if err != nil || round < 1 {
+		http.Error(w, "invalid round", http.StatusBadRequest)
+		return nil, true
+	}
+	session.mu.RLock()
+	rs, ok := session.roundSnapshotForFile(path, round)
+	prev, hasPrev := session.roundSnapshotForFile(path, round-1)
+	session.mu.RUnlock()
+	if !ok {
+		http.Error(w, "file_not_in_round", http.StatusNotFound)
+		return nil, true
+	}
+	resp := map[string]any{
+		"path":    path,
+		"round":   round,
+		"content": rs.Content,
+		"status":  rs.Status,
+	}
+	if hasPrev {
+		resp["previous_content"] = prev.Content
+	}
+	writeJSON(w, resp)
+	return resp, true
 }
 
 // handleFileDiff returns diff hunks for a file.
@@ -497,6 +623,11 @@ func (s *Server) handleFileComments(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		comments := s.session.Load().GetComments(path)
+		if roundStr := r.URL.Query().Get("round"); roundStr != "" && s.session.Load().Mode == "files" {
+			if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
+				comments = commentsAtOrBeforeRound(comments, n)
+			}
+		}
 		writeJSON(w, comments)
 
 	case http.MethodPost:
@@ -830,6 +961,11 @@ func (s *Server) handleReviewComments(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		comments := s.session.Load().GetReviewComments()
+		if roundStr := r.URL.Query().Get("round"); roundStr != "" && s.session.Load().Mode == "files" {
+			if n, err := strconv.Atoi(roundStr); err == nil && n >= 1 {
+				comments = commentsAtOrBeforeRound(comments, n)
+			}
+		}
 		writeJSON(w, comments)
 
 	case http.MethodPost:

--- a/session.go
+++ b/session.go
@@ -1685,15 +1685,28 @@ func reportLoadCritJSONLockViolation() {
 //
 // Lock contract: PRE-SETSESSION ONLY. Safe to call only from the constructor
 // path (NewSessionFromFiles, applySessionOverrides, etc.) before any goroutine
-// reads s.RoundSnapshots / s.reviewComments / etc. Callers that need to reload
-// at runtime must extend this to take s.mu.Lock() first. See plan v4
-// §Lock discipline.
+// reads s.RoundSnapshots / s.reviewComments / etc. Runtime callers that hold
+// s.mu.Lock() must use loadCritJSONLocked instead. See plan v4 §Lock discipline.
 func (s *Session) loadCritJSON() {
 	if s.sessionStarted.Load() != 0 {
 		reportLoadCritJSONLockViolation()
 		return
 	}
+	s.loadCritJSONLocked()
+}
 
+// loadCritJSONLocked is the runtime variant of loadCritJSON. It performs the
+// same disk read + in-memory restore but skips the pre-SetSession guard so
+// runtime code paths can reload comments after a state change (e.g. SetFocus
+// rebuilds s.Files and needs to repopulate per-file Comments from disk).
+//
+// Lock contract: caller MUST hold s.mu.Lock() (writer lock). The function
+// mutates s.Files[*].Comments, s.reviewComments, s.ReviewRound,
+// s.sharedURL/deleteToken/shareScope, and s.lastCritJSONMtime, all of which
+// race with concurrent readers under s.mu.RLock(). The pre-SetSession path
+// (loadCritJSON) gets away without the lock because no other goroutine has
+// observed the session yet.
+func (s *Session) loadCritJSONLocked() {
 	identity := s.critJSONPath()
 
 	// MIGRATION-REMOVAL: trigger v3->v4 folder migration on read.

--- a/session.go
+++ b/session.go
@@ -1475,8 +1475,10 @@ func (s *Session) ClearAllComments() {
 	s.waitingForAgent = false
 	critPath := s.critJSONPath()
 	s.mu.Unlock()
-	// Delete the review file from disk (centralized or legacy path).
-	os.Remove(critPath) //nolint:errcheck
+	// Full-folder cleanup; idempotent on missing folder.
+	if err := os.RemoveAll(critPath); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Warning: removing review folder: %v\n", err)
+	}
 }
 
 // ChangeBaseBranch changes the diff base to the given branch, recomputes merge-base,
@@ -1584,8 +1586,21 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 }
 
 // loadCritJSON loads comments and share state from an existing review file.
+//
+// Lock contract: PRE-SETSESSION ONLY. Safe to call only from the constructor
+// path (NewSessionFromFiles, applySessionOverrides, etc.) before any goroutine
+// reads s.RoundSnapshots / s.reviewComments / etc. Callers that need to reload
+// at runtime must extend this to take s.mu.Lock() first. See plan v4
+// §Lock discipline.
 func (s *Session) loadCritJSON() {
-	data, err := os.ReadFile(s.critJSONPath())
+	identity := s.critJSONPath()
+
+	// MIGRATION-REMOVAL: trigger v3->v4 folder migration on read.
+	if err := ensureReviewFolder(identity); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: review folder migration: %v\n", err)
+	}
+
+	data, err := os.ReadFile(reviewPathsFor(identity).Review)
 	if err != nil {
 		return
 	}
@@ -1635,7 +1650,7 @@ func (s *Session) loadCritJSON() {
 	s.reviewComments = cj.ReviewComments
 
 	// Record the mtime so the first ticker tick doesn't re-process our own file.
-	if info, err := os.Stat(s.critJSONPath()); err == nil {
+	if info, err := os.Stat(reviewPathsFor(s.critJSONPath()).Review); err == nil {
 		s.lastCritJSONMtime = info.ModTime()
 	}
 }
@@ -1645,7 +1660,7 @@ func (s *Session) loadCritJSON() {
 // Safe to call multiple times — existing entries (including previous orphans) are skipped.
 // Must be called with s.mu NOT held (acquires the lock internally).
 func (s *Session) restoreOrphanedComments() {
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		return
 	}

--- a/session.go
+++ b/session.go
@@ -1507,7 +1507,9 @@ func (s *Session) ClearAllComments() {
 	// Reset all file state, drop the review file entry and orphaned phantom entries.
 	filtered := make([]*FileEntry, 0, len(s.Files))
 	for _, f := range s.Files {
-		if filepath.Base(f.Path) == ".crit.json" || f.Orphaned {
+		// Drop the v4 review folder (`.crit`) and the legacy v3 flat file
+		// (`.crit.json`) so they never appear in the file list.
+		if base := filepath.Base(f.Path); base == ".crit" || base == ".crit.json" || f.Orphaned {
 			continue
 		}
 		f.Comments = []Comment{}

--- a/session.go
+++ b/session.go
@@ -57,7 +57,12 @@ type Reply struct {
 	Author    string `json:"author,omitempty"`
 	UserID    string `json:"user_id,omitempty"`
 	CreatedAt string `json:"created_at"`
-	GitHubID  int64  `json:"github_id,omitempty"`
+	// ReviewRound is the review round during which this reply was authored.
+	// Used by the per-round timeline to scope reply visibility independently
+	// of the parent comment. Legacy replies (no field set) are treated as
+	// belonging to the parent's ReviewRound — see commentsAtOrBeforeRound.
+	ReviewRound int   `json:"review_round,omitempty"`
+	GitHubID    int64 `json:"github_id,omitempty"`
 
 	// LastPushedBodyHash is a short stable digest of Body at the time of
 	// the most recent successful push (POST or PATCH) to GitHub. Used by
@@ -881,11 +886,12 @@ func (s *Session) AddReviewCommentReply(commentID, body, author, userID string) 
 		if c.ID == commentID {
 			now := time.Now().UTC().Format(time.RFC3339)
 			r := Reply{
-				ID:        randomReplyID(),
-				Body:      body,
-				Author:    author,
-				UserID:    userID,
-				CreatedAt: now,
+				ID:          randomReplyID(),
+				Body:        body,
+				Author:      author,
+				UserID:      userID,
+				CreatedAt:   now,
+				ReviewRound: s.ReviewRound,
 			}
 			s.reviewComments[i].Replies = append(s.reviewComments[i].Replies, r)
 			s.reviewComments[i].Resolved = false
@@ -1056,11 +1062,12 @@ func (s *Session) AddReply(filePath, commentID, body, author, userID string) (Re
 		if c.ID == commentID {
 			now := time.Now().UTC().Format(time.RFC3339)
 			r := Reply{
-				ID:        randomReplyID(),
-				Body:      body,
-				Author:    author,
-				UserID:    userID,
-				CreatedAt: now,
+				ID:          randomReplyID(),
+				Body:        body,
+				Author:      author,
+				UserID:      userID,
+				CreatedAt:   now,
+				ReviewRound: s.ReviewRound,
 			}
 			f.Comments[i].Replies = append(f.Comments[i].Replies, r)
 			f.Comments[i].Resolved = false

--- a/session.go
+++ b/session.go
@@ -1695,6 +1695,48 @@ func (s *Session) loadCritJSON() {
 	s.loadCritJSONLocked()
 }
 
+// restoreShareStateLocked copies share-related fields from cj into the
+// session, gated by share-scope match so we don't carry over a share
+// pointer when the file set has changed since the share was created.
+// Caller must hold s.mu.Lock() (or be the constructor pre-SetSession).
+func (s *Session) restoreShareStateLocked(cj *CritJSON) {
+	if cj.ShareScope != "" {
+		paths := make([]string, 0, len(s.Files))
+		for _, f := range s.Files {
+			paths = append(paths, f.Path)
+		}
+		if shareScope(paths) == cj.ShareScope {
+			s.sharedURL = cj.ShareURL
+			s.deleteToken = cj.DeleteToken
+			s.shareScope = cj.ShareScope
+		}
+		return
+	}
+	if cj.ShareURL != "" {
+		// No scope recorded — load unconditionally.
+		s.sharedURL = cj.ShareURL
+		s.deleteToken = cj.DeleteToken
+	}
+}
+
+// restoreFileCommentsLocked copies per-file comments from cj into matching
+// FileEntry slots, defaulting empty Scope to "line" for legacy comments.
+// Caller must hold s.mu.Lock() (or be the constructor pre-SetSession).
+func (s *Session) restoreFileCommentsLocked(cj *CritJSON) {
+	for _, f := range s.Files {
+		cf, ok := cj.Files[f.Path]
+		if !ok {
+			continue
+		}
+		f.Comments = cf.Comments
+		for i := range f.Comments {
+			if f.Comments[i].Scope == "" {
+				f.Comments[i].Scope = "line"
+			}
+		}
+	}
+}
+
 // loadCritJSONLocked is the runtime variant of loadCritJSON. It performs the
 // same disk read + in-memory restore but skips the pre-SetSession guard so
 // runtime code paths can reload comments after a state change (e.g. SetFocus
@@ -1709,6 +1751,13 @@ func (s *Session) loadCritJSON() {
 func (s *Session) loadCritJSONLocked() {
 	identity := s.critJSONPath()
 
+	// Capture identity-on-entry. If ReviewFilePath / OutputDir were set
+	// BEFORE this call (the canonical resumed-session path in cli_serve),
+	// the on-disk sidecar is already authoritative and we don't need to
+	// rewrite it from in-memory state. Used downstream to skip a
+	// redundant O(N*M) clone+marshal+rename on every cold boot.
+	identityOnEntry := s.ReviewFilePath != "" || s.OutputDir != ""
+
 	// MIGRATION-REMOVAL: trigger v3->v4 folder migration on read.
 	if err := ensureReviewFolder(identity); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: review folder migration: %v\n", err)
@@ -1718,10 +1767,18 @@ func (s *Session) loadCritJSONLocked() {
 	if err != nil {
 		// Fall through to the sidecar load — a folder may exist with only
 		// snapshots.json (orphan-snapshots) and we still want to surface that.
-		s.loadSnapshotsFromSidecar(identity)
+		sidecarHadData := s.loadSnapshotsFromSidecar(identity)
 		// Persist the in-memory R1 baseline that NewSessionFromFiles captured
 		// in case ReviewFilePath / OutputDir was assigned just before this
 		// call (the canonical constructor-time path).
+		//
+		// Resumed-session optimization (review W5): when the sidecar already
+		// carried snapshots and identity was set on entry, the on-disk data
+		// is authoritative — skip the redundant rewrite.
+		if identityOnEntry && sidecarHadData {
+			s.captureRoundSnapshot(s.ReviewRound)
+			return
+		}
 		s.captureBaselineAndPersist()
 		return
 	}
@@ -1730,39 +1787,14 @@ func (s *Session) loadCritJSONLocked() {
 		return
 	}
 
-	// Only restore share state if the file set matches what was shared.
-	if cj.ShareScope != "" {
-		paths := make([]string, 0, len(s.Files))
-		for _, f := range s.Files {
-			paths = append(paths, f.Path)
-		}
-		if shareScope(paths) == cj.ShareScope {
-			s.sharedURL = cj.ShareURL
-			s.deleteToken = cj.DeleteToken
-			s.shareScope = cj.ShareScope
-		}
-	} else if cj.ShareURL != "" {
-		// No scope recorded — load unconditionally.
-		s.sharedURL = cj.ShareURL
-		s.deleteToken = cj.DeleteToken
-	}
+	s.restoreShareStateLocked(&cj)
 
 	// Restore review round so the session continues from where it left off.
 	if cj.ReviewRound > s.ReviewRound {
 		s.ReviewRound = cj.ReviewRound
 	}
 
-	// Restore comments for files that match by path.
-	for _, f := range s.Files {
-		if cf, ok := cj.Files[f.Path]; ok {
-			f.Comments = cf.Comments
-			for i := range f.Comments {
-				if f.Comments[i].Scope == "" {
-					f.Comments[i].Scope = "line"
-				}
-			}
-		}
-	}
+	s.restoreFileCommentsLocked(&cj)
 
 	// Detect orphaned paths: files in the review file with comments but not in the session.
 	s.appendOrphanedFiles(cj.Files)
@@ -1776,32 +1808,44 @@ func (s *Session) loadCritJSONLocked() {
 	}
 
 	// Restore round snapshots from the folder sidecar.
-	s.loadSnapshotsFromSidecar(s.critJSONPath())
+	sidecarHadData := s.loadSnapshotsFromSidecar(s.critJSONPath())
 
 	// If ReviewFilePath / OutputDir was assigned just before this call (the
 	// canonical constructor-time path in cli_serve), the in-memory R1 baseline
 	// captured by NewSessionFromFiles hasn't been persisted yet. Re-run the
 	// best-effort persist now that the identity is known.
+	//
+	// Optimization (review W5): for a resumed session — identity already
+	// known on entry AND the sidecar carried a non-empty snapshot map — the
+	// on-disk sidecar is authoritative and rewriting it is redundant
+	// (O(N*M) clone+marshal+rename on every cold boot). The capture itself
+	// remains idempotent so we still call captureRoundSnapshot to keep R1
+	// well-defined in memory; we just skip the disk write.
+	if identityOnEntry && sidecarHadData {
+		s.captureRoundSnapshot(s.ReviewRound)
+		return
+	}
 	s.captureBaselineAndPersist()
 }
 
 // loadSnapshotsFromSidecar restores Session.RoundSnapshots from
 // <identity>/snapshots.json. Missing file = silent empty map. Malformed = log
-// + fall through (next round-complete rewrites it).
+// + fall through (next round-complete rewrites it). Returns true when the
+// sidecar carried at least one snapshot (i.e. this is a resumed session).
 //
-// Lock contract: pre-SetSession only (mirrors loadCritJSON). The caller is the
-// constructor path and no other goroutine reads s.RoundSnapshots yet.
-func (s *Session) loadSnapshotsFromSidecar(identity string) {
+// Lock contract: pre-SetSession or under s.mu.Lock(). Mutates s.RoundSnapshots.
+func (s *Session) loadSnapshotsFromSidecar(identity string) bool {
 	sidecarPath := reviewPathsFor(identity).Snapshots
 	sf, err := loadSnapshotsFile(sidecarPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: snapshots sidecar unreadable, ignoring: %v\n", err)
-		return
+		return false
 	}
 	if len(sf.RoundSnapshots) == 0 {
-		return
+		return false
 	}
 	s.RoundSnapshots = cloneRoundSnapshots(sf.RoundSnapshots)
+	return true
 }
 
 // restoreOrphanedComments reads the review file and creates phantom FileEntry

--- a/session.go
+++ b/session.go
@@ -1634,6 +1634,18 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 	return nil
 }
 
+// reportLoadCritJSONLockViolation surfaces a post-SetSession loadCritJSON
+// call. In production it logs to stderr and returns so the daemon stays up;
+// in dev/CI (CRIT_DEBUG set) it panics so the regression fails loudly. See
+// plan v4 §Lock discipline.
+func reportLoadCritJSONLockViolation() {
+	const msg = "BUG: Session.loadCritJSON called post-SetSession; ignoring (see plan v4 §Lock discipline)"
+	if os.Getenv("CRIT_DEBUG") != "" {
+		panic(msg)
+	}
+	fmt.Fprintln(os.Stderr, msg)
+}
+
 // loadCritJSON loads comments and share state from an existing review file.
 //
 // Lock contract: PRE-SETSESSION ONLY. Safe to call only from the constructor
@@ -1643,12 +1655,7 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 // §Lock discipline.
 func (s *Session) loadCritJSON() {
 	if s.sessionStarted.Load() != 0 {
-		// Lock-contract violation. Pre-SetSession only. Log + no-op rather
-		// than panic; this preserves liveness in production but loudly
-		// signals the regression in test/dev. Future callers that legitimately
-		// need runtime reloads must promote this method to take s.mu.Lock().
-		fmt.Fprintf(os.Stderr,
-			"BUG: Session.loadCritJSON called post-SetSession; ignoring (see plan v4 §Lock discipline)\n")
+		reportLoadCritJSONLockViolation()
 		return
 	}
 

--- a/session.go
+++ b/session.go
@@ -1664,6 +1664,10 @@ func (s *Session) loadCritJSON() {
 		// Fall through to the sidecar load — a folder may exist with only
 		// snapshots.json (orphan-snapshots) and we still want to surface that.
 		s.loadSnapshotsFromSidecar(identity)
+		// Persist the in-memory R1 baseline that NewSessionFromFiles captured
+		// in case ReviewFilePath / OutputDir was assigned just before this
+		// call (the canonical constructor-time path).
+		s.captureBaselineAndPersist()
 		return
 	}
 	var cj CritJSON
@@ -1718,6 +1722,12 @@ func (s *Session) loadCritJSON() {
 
 	// Restore round snapshots from the folder sidecar.
 	s.loadSnapshotsFromSidecar(s.critJSONPath())
+
+	// If ReviewFilePath / OutputDir was assigned just before this call (the
+	// canonical constructor-time path in cli_serve), the in-memory R1 baseline
+	// captured by NewSessionFromFiles hasn't been persisted yet. Re-run the
+	// best-effort persist now that the identity is known.
+	s.captureBaselineAndPersist()
 }
 
 // loadSnapshotsFromSidecar restores Session.RoundSnapshots from

--- a/session.go
+++ b/session.go
@@ -61,8 +61,12 @@ type Reply struct {
 	// Used by the per-round timeline to scope reply visibility independently
 	// of the parent comment. Legacy replies (no field set) are treated as
 	// belonging to the parent's ReviewRound — see commentsAtOrBeforeRound.
-	ReviewRound int   `json:"review_round,omitempty"`
-	GitHubID    int64 `json:"github_id,omitempty"`
+	ReviewRound int `json:"review_round,omitempty"`
+	// ResolvedRound is the review round during which this reply was resolved
+	// (mirrors Comment.ResolvedRound). Currently set only via the parent
+	// comment's resolve transitions; reserved for future per-reply resolution.
+	ResolvedRound int   `json:"resolved_round,omitempty"`
+	GitHubID      int64 `json:"github_id,omitempty"`
 
 	// LastPushedBodyHash is a short stable digest of Body at the time of
 	// the most recent successful push (POST or PATCH) to GitHub. Used by
@@ -75,21 +79,27 @@ type Reply struct {
 
 // Comment represents a single inline review comment.
 type Comment struct {
-	ID             string  `json:"id"`
-	StartLine      int     `json:"start_line"`
-	EndLine        int     `json:"end_line"`
-	Side           string  `json:"side,omitempty"`
-	Body           string  `json:"body"`
-	Quote          string  `json:"quote,omitempty"`
-	QuoteOffset    *int    `json:"quote_offset,omitempty"`
-	Anchor         string  `json:"anchor,omitempty"`
-	Drifted        bool    `json:"drifted,omitempty"`
-	Author         string  `json:"author,omitempty"`
-	UserID         string  `json:"user_id,omitempty"`
-	Scope          string  `json:"scope,omitempty"`
-	CreatedAt      string  `json:"created_at"`
-	UpdatedAt      string  `json:"updated_at"`
-	Resolved       bool    `json:"resolved,omitempty"`
+	ID          string `json:"id"`
+	StartLine   int    `json:"start_line"`
+	EndLine     int    `json:"end_line"`
+	Side        string `json:"side,omitempty"`
+	Body        string `json:"body"`
+	Quote       string `json:"quote,omitempty"`
+	QuoteOffset *int   `json:"quote_offset,omitempty"`
+	Anchor      string `json:"anchor,omitempty"`
+	Drifted     bool   `json:"drifted,omitempty"`
+	Author      string `json:"author,omitempty"`
+	UserID      string `json:"user_id,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	Resolved    bool   `json:"resolved,omitempty"`
+	// ResolvedRound is the review round during which Resolved transitioned
+	// false -> true. Cleared to 0 when Resolved transitions back to false.
+	// Legacy comments lacking this field are treated as zero on read; the
+	// timeline visibility filter falls back to round 1 for legacy resolved
+	// comments (see commentsAtOrBeforeRound docs).
+	ResolvedRound  int     `json:"resolved_round,omitempty"`
 	Live           bool    `json:"live,omitempty"`
 	CarriedForward bool    `json:"carried_forward,omitempty"`
 	ReviewRound    int     `json:"review_round,omitempty"`
@@ -864,12 +874,19 @@ func (s *Session) DeleteReviewComment(id string) bool {
 }
 
 // ResolveReviewComment sets or clears the resolved flag on a review-level comment.
+// On a false -> true transition, ResolvedRound is stamped from s.ReviewRound.
+// On a true -> false transition, ResolvedRound is cleared to 0.
 func (s *Session) ResolveReviewComment(id string, resolved bool) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, c := range s.reviewComments {
 		if c.ID == id {
 			s.reviewComments[i].Resolved = resolved
+			if resolved {
+				s.reviewComments[i].ResolvedRound = s.ReviewRound
+			} else {
+				s.reviewComments[i].ResolvedRound = 0
+			}
 			s.reviewComments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 			s.scheduleWrite()
 			return s.reviewComments[i], true
@@ -895,6 +912,7 @@ func (s *Session) AddReviewCommentReply(commentID, body, author, userID string) 
 			}
 			s.reviewComments[i].Replies = append(s.reviewComments[i].Replies, r)
 			s.reviewComments[i].Resolved = false
+			s.reviewComments[i].ResolvedRound = 0
 			s.reviewComments[i].UpdatedAt = now
 			s.scheduleWrite()
 			return r, true
@@ -963,6 +981,8 @@ func (s *Session) UpdateComment(filePath, id, body string) (Comment, bool) {
 }
 
 // SetCommentResolved sets or clears the resolved flag on a comment.
+// On a false -> true transition, ResolvedRound is stamped from s.ReviewRound.
+// On a true -> false transition, ResolvedRound is cleared to 0.
 func (s *Session) SetCommentResolved(filePath, id string, resolved bool) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -973,6 +993,11 @@ func (s *Session) SetCommentResolved(filePath, id string, resolved bool) (Commen
 	for i, c := range f.Comments {
 		if c.ID == id {
 			f.Comments[i].Resolved = resolved
+			if resolved {
+				f.Comments[i].ResolvedRound = s.ReviewRound
+			} else {
+				f.Comments[i].ResolvedRound = 0
+			}
 			f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 			s.scheduleWrite()
 			return f.Comments[i], true
@@ -1071,6 +1096,7 @@ func (s *Session) AddReply(filePath, commentID, body, author, userID string) (Re
 			}
 			f.Comments[i].Replies = append(f.Comments[i].Replies, r)
 			f.Comments[i].Resolved = false
+			f.Comments[i].ResolvedRound = 0
 			f.Comments[i].UpdatedAt = now
 			s.scheduleWrite()
 			return r, true

--- a/session.go
+++ b/session.go
@@ -225,6 +225,20 @@ type Session struct {
 
 	reviewComments []Comment
 
+	// RoundSnapshots is in-memory state populated from <folder>/snapshots.json
+	// at boot. Persisted via saveSnapshotsFile; never written into review.json.
+	//
+	// Lock contract: read/write under s.mu, EXCEPT during construction
+	// (NewSessionFromFiles, before SetSession) where the caller is the only
+	// goroutine that could observe it.
+	RoundSnapshots map[string]map[int]RoundSnapshot
+
+	// sessionStarted is set (atomically) by Server.SetSession to mark the
+	// transition from constructor-time (single-goroutine) to runtime
+	// (multi-goroutine). loadCritJSON checks this flag to enforce its
+	// pre-SetSession-only contract. 0 = pre-SetSession, 1 = post-SetSession.
+	sessionStarted atomic.Uint32
+
 	// deletedCommentIDs tracks IDs of file comments deleted in-memory but not
 	// yet written to disk. Keyed by file path -> set of comment IDs. This
 	// prevents mergeFileSnapshotIntoCritJSON from re-adding them from disk.
@@ -571,7 +585,41 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 		s.Files = append(s.Files, fe)
 	}
 
+	s.captureBaselineAndPersist()
+
 	return s, nil
+}
+
+// captureBaselineAndPersist captures the R1 baseline (idempotent so resumed
+// sessions are unaffected) and best-effort writes the sidecar to disk.
+//
+// Skips the sidecar write when the identity would fall back to RepoRoot —
+// this path runs before applySessionOverrides has a chance to assign
+// ReviewFilePath / OutputDir. The first WriteFiles or round-complete will
+// re-emit the sidecar at the canonical centralized path.
+//
+// Pre-SetSession only — caller is the constructor and no concurrent readers
+// exist. See plan v4 §Lock discipline.
+func (s *Session) captureBaselineAndPersist() {
+	s.captureRoundSnapshot(s.ReviewRound)
+	if s.ReviewFilePath == "" && s.OutputDir == "" {
+		return
+	}
+	if len(s.RoundSnapshots) == 0 {
+		return
+	}
+	identity := s.critJSONPath()
+	// MIGRATION-REMOVAL: ensure folder layout up front so a stale flat
+	// review file doesn't fail the sidecar write below.
+	if err := ensureReviewFolder(identity); err != nil {
+		return
+	}
+	sidecar := reviewPathsFor(identity).Snapshots
+	if err := saveSnapshotsFile(sidecar, SnapshotsFile{
+		RoundSnapshots: cloneRoundSnapshots(s.RoundSnapshots),
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: write snapshots sidecar at construction: %v\n", err)
+	}
 }
 
 // walkDirectory recursively walks a directory and returns all file paths,
@@ -1470,6 +1518,7 @@ func (s *Session) ClearAllComments() {
 	s.Files = filtered
 	s.reviewComments = nil
 	s.ReviewRound = 1
+	s.RoundSnapshots = nil // v4 lock-discipline: reset in-lock alongside ReviewRound
 	s.lastCritJSONMtime = time.Time{}
 	s.pendingWrite = false
 	s.waitingForAgent = false
@@ -1593,6 +1642,16 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 // at runtime must extend this to take s.mu.Lock() first. See plan v4
 // §Lock discipline.
 func (s *Session) loadCritJSON() {
+	if s.sessionStarted.Load() != 0 {
+		// Lock-contract violation. Pre-SetSession only. Log + no-op rather
+		// than panic; this preserves liveness in production but loudly
+		// signals the regression in test/dev. Future callers that legitimately
+		// need runtime reloads must promote this method to take s.mu.Lock().
+		fmt.Fprintf(os.Stderr,
+			"BUG: Session.loadCritJSON called post-SetSession; ignoring (see plan v4 §Lock discipline)\n")
+		return
+	}
+
 	identity := s.critJSONPath()
 
 	// MIGRATION-REMOVAL: trigger v3->v4 folder migration on read.
@@ -1602,6 +1661,9 @@ func (s *Session) loadCritJSON() {
 
 	data, err := os.ReadFile(reviewPathsFor(identity).Review)
 	if err != nil {
+		// Fall through to the sidecar load — a folder may exist with only
+		// snapshots.json (orphan-snapshots) and we still want to surface that.
+		s.loadSnapshotsFromSidecar(identity)
 		return
 	}
 	var cj CritJSON
@@ -1653,6 +1715,28 @@ func (s *Session) loadCritJSON() {
 	if info, err := os.Stat(reviewPathsFor(s.critJSONPath()).Review); err == nil {
 		s.lastCritJSONMtime = info.ModTime()
 	}
+
+	// Restore round snapshots from the folder sidecar.
+	s.loadSnapshotsFromSidecar(s.critJSONPath())
+}
+
+// loadSnapshotsFromSidecar restores Session.RoundSnapshots from
+// <identity>/snapshots.json. Missing file = silent empty map. Malformed = log
+// + fall through (next round-complete rewrites it).
+//
+// Lock contract: pre-SetSession only (mirrors loadCritJSON). The caller is the
+// constructor path and no other goroutine reads s.RoundSnapshots yet.
+func (s *Session) loadSnapshotsFromSidecar(identity string) {
+	sidecarPath := reviewPathsFor(identity).Snapshots
+	sf, err := loadSnapshotsFile(sidecarPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: snapshots sidecar unreadable, ignoring: %v\n", err)
+		return
+	}
+	if len(sf.RoundSnapshots) == 0 {
+		return
+	}
+	s.RoundSnapshots = cloneRoundSnapshots(sf.RoundSnapshots)
 }
 
 // restoreOrphanedComments reads the review file and creates phantom FileEntry

--- a/session_focus.go
+++ b/session_focus.go
@@ -226,10 +226,12 @@ func (s *Session) SetFocus(f Focus) error {
 	// buildFilesForFocus / buildFilesForWorkingTree both produce empty
 	// Comments slices, so without this step the next scheduleWrite would
 	// silently overwrite the disk state (including any re-anchor work
-	// done above). loadCritJSON() walks s.Files and restores matching
-	// paths' comments.
+	// done above). loadCritJSONLocked walks s.Files and restores matching
+	// paths' comments. We use the *Locked variant because we hold s.mu —
+	// the public loadCritJSON enforces a pre-SetSession-only guard that
+	// would silently no-op this runtime reload.
 	s.mu.Lock()
-	s.loadCritJSON()
+	s.loadCritJSONLocked()
 	s.mu.Unlock()
 
 	if err := s.persistActiveDiffScope(string(f.DiffScope)); err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -236,7 +236,7 @@ func TestSession_WriteFiles(t *testing.T) {
 	flushWrites(s)
 	s.WriteFiles()
 
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("crit.json not written: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestSession_WriteFiles_SharedURLOnly(t *testing.T) {
 	flushWrites(s)
 	s.WriteFiles()
 
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestSession_LoadCritJSON_NoHash(t *testing.T) {
 			}
 		}
 	}`
-	if err := os.WriteFile(s.critJSONPath(), []byte(cj), 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), []byte(cj), 0644); err != nil {
 		t.Fatalf("write .crit.json: %v", err)
 	}
 
@@ -360,7 +360,7 @@ func TestSession_WriteFiles_PreservesNonSessionFiles(t *testing.T) {
 			}
 		}
 	}`
-	if err := os.WriteFile(s.critJSONPath(), []byte(cj), 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), []byte(cj), 0644); err != nil {
 		t.Fatalf("write .crit.json: %v", err)
 	}
 
@@ -369,7 +369,7 @@ func TestSession_WriteFiles_PreservesNonSessionFiles(t *testing.T) {
 	s.WriteFiles()
 
 	// Reload and verify both files are present
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestSession_LoadCritJSON_MismatchedHash(t *testing.T) {
 			}
 		}
 	}`
-	if err := os.WriteFile(s.critJSONPath(), []byte(cj), 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), []byte(cj), 0644); err != nil {
 		t.Fatalf("write .crit.json: %v", err)
 	}
 
@@ -569,7 +569,7 @@ func TestSession_WriteFiles_OutputDir(t *testing.T) {
 
 	// Should be written to OutputDir, not RepoRoot
 	outPath := filepath.Join(outDir, ".crit.json")
-	data, err := os.ReadFile(outPath)
+	data, err := os.ReadFile(reviewPathsFor(outPath).Review)
 	if err != nil {
 		t.Fatalf(".crit.json not written to output dir: %v", err)
 	}
@@ -1118,7 +1118,7 @@ func TestSession_CarryForward_PreservesAuthor(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	if err := os.WriteFile(s.critJSONPath(), data, 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), data, 0644); err != nil {
 		t.Fatalf("writing .crit.json: %v", err)
 	}
 
@@ -1199,7 +1199,7 @@ func TestCarryForward_FileScopeComments_NoDuplicatesAcrossRounds(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	if err := os.WriteFile(s.critJSONPath(), data, 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), data, 0644); err != nil {
 		t.Fatalf("writing .crit.json: %v", err)
 	}
 
@@ -1229,7 +1229,7 @@ func TestCarryForward_FileScopeComments_NoDuplicatesAcrossRounds(t *testing.T) {
 		},
 	}
 	data, _ = json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(s.critJSONPath(), data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), data, 0644)
 
 	// Set up for round 2
 	for _, f := range s.Files {
@@ -1334,7 +1334,7 @@ func TestCarryForwardPreservesReviewRound(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	if err := os.WriteFile(s.critJSONPath(), data, 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), data, 0644); err != nil {
 		t.Fatalf("writing .crit.json: %v", err)
 	}
 
@@ -1408,13 +1408,13 @@ func TestSession_WriteFiles_MergesExternalComments(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// WriteFiles should merge, not overwrite
 	s.WriteFiles()
 
 	// Read back .crit.json and verify both comments are present
-	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var got CritJSON
 	json.Unmarshal(result, &got)
 
@@ -1463,7 +1463,7 @@ func TestSession_MergeExternalCritJSON_NewComment(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -1548,7 +1548,7 @@ func TestSession_MergeExternalCritJSON_ClearDetected(t *testing.T) {
 	// Write .crit.json with no comments (simulating crit comment --clear)
 	cj := CritJSON{Branch: "main", ReviewRound: 1, Files: map[string]CritJSONFile{}}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -1574,7 +1574,7 @@ func TestLoadCritJSON_IgnoresStaleShareState(t *testing.T) {
 		Files:       map[string]CritJSONFile{},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	// Create session with DIFFERENT files
 	sess := &Session{
@@ -1602,7 +1602,7 @@ func TestLoadCritJSON_RestoresMatchingShareState(t *testing.T) {
 		Files:       map[string]CritJSONFile{},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	// Create session with SAME files
 	sess := &Session{
@@ -2010,7 +2010,7 @@ func TestSession_MergeExternalCritJSON_SkippedDuringPendingWrite(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	// Touch with different mtime to bypass own-write check
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// Merge should be skipped because a write is pending
 	changed := s.mergeExternalCritJSON()
@@ -2055,7 +2055,7 @@ func TestSession_MergeExternalCritJSON_SyncsResolvedState(t *testing.T) {
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -2248,7 +2248,7 @@ func TestSession_MergeExternalCritJSON_SyncsUnresolve(t *testing.T) {
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -2334,7 +2334,7 @@ func TestCritJSONIncludesReviewComments(t *testing.T) {
 	s.AddComment("plan.md", 1, 1, "", "line comment", "", "", "")
 	s.AddFileComment("plan.md", "file comment", "", "")
 	s.WriteFiles()
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2461,7 +2461,7 @@ func TestLoadCritJSONDefaultsScope(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(s.critJSONPath(), data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(s.critJSONPath()).Review), data, 0644)
 
 	s.loadCritJSON()
 	comments := s.GetComments("plan.md")
@@ -2846,7 +2846,7 @@ func TestDeleteComment_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Verify the comment is on disk
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -2866,7 +2866,7 @@ func TestDeleteComment_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Read .crit.json and verify the deleted comment is gone
-	data, err = os.ReadFile(s.critJSONPath())
+	data, err = os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		// If .crit.json was removed (empty), that's also correct
 		return
@@ -2899,7 +2899,7 @@ func TestDeleteReviewComment_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Verify it's on disk
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -2919,7 +2919,7 @@ func TestDeleteReviewComment_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Read .crit.json — should have no review comments
-	data, err = os.ReadFile(s.critJSONPath())
+	data, err = os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		// File removed is also acceptable
 		return
@@ -2968,7 +2968,7 @@ func TestDeleteReply_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Read .crit.json and verify the reply is gone
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -3016,7 +3016,7 @@ func TestDeleteReviewCommentReply_NotReAddedFromDisk(t *testing.T) {
 	s.WriteFiles()
 
 	// Read back .crit.json
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("read .crit.json: %v", err)
 	}
@@ -3066,13 +3066,13 @@ func TestExternalCommentStillMerged(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// WriteFiles should merge the external comment in
 	s.WriteFiles()
 
 	// Read back .crit.json and verify both comments are present
-	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var got CritJSON
 	json.Unmarshal(result, &got)
 
@@ -3247,8 +3247,8 @@ func TestSession_HandleExternalDeletion(t *testing.T) {
 		t.Fatal("expected 1 comment before deletion")
 	}
 
-	// Delete .crit.json externally
-	os.Remove(s.critJSONPath())
+	// Delete the review folder externally (v4: identity is a folder).
+	os.RemoveAll(s.critJSONPath())
 
 	// handleExternalDeletion should detect the deletion and clear in-memory state
 	deleted := s.handleExternalDeletion(s.critJSONPath())
@@ -3280,7 +3280,7 @@ func TestSession_WriteFiles_RoundTrip(t *testing.T) {
 	s.WriteFiles()
 
 	// Read back the .crit.json
-	data1, err := os.ReadFile(s.critJSONPath())
+	data1, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("reading first write: %v", err)
 	}
@@ -3288,7 +3288,7 @@ func TestSession_WriteFiles_RoundTrip(t *testing.T) {
 	// Write again (no changes) and compare
 	flushWrites(s)
 	s.WriteFiles()
-	data2, err := os.ReadFile(s.critJSONPath())
+	data2, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatalf("reading second write: %v", err)
 	}
@@ -3336,7 +3336,7 @@ func TestSession_AddComment_PreservesSideAndQuote(t *testing.T) {
 	flushWrites(s)
 	s.WriteFiles()
 
-	data, _ := os.ReadFile(s.critJSONPath())
+	data, _ := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 
@@ -3359,7 +3359,7 @@ func TestSession_WriteFiles_ReviewCommentsPersisted(t *testing.T) {
 	flushWrites(s)
 	s.WriteFiles()
 
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3446,7 +3446,7 @@ func TestSession_WriteFiles_IncludesResolvedComments(t *testing.T) {
 	flushWrites(s)
 	s.WriteFiles()
 
-	data, err := os.ReadFile(s.critJSONPath())
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3717,7 +3717,7 @@ func TestLoadCritJSON_OrphanedComments(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(critPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(critPath, data, 0o644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3790,7 +3790,7 @@ func TestLoadCritJSON_OrphanedNoComments(t *testing.T) {
 	}
 	data, _ := json.Marshal(cj)
 	os.MkdirAll(filepath.Dir(critPath), 0o755)
-	os.WriteFile(critPath, data, 0o644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644)
 
 	s.loadCritJSON()
 

--- a/session_test.go
+++ b/session_test.go
@@ -541,7 +541,7 @@ func TestDetectFileType(t *testing.T) {
 
 func TestSession_CritJSONPath_Default(t *testing.T) {
 	s := newTestSession(t)
-	want := filepath.Join(s.RepoRoot, ".crit.json")
+	want := filepath.Join(s.RepoRoot, ".crit")
 	if got := s.critJSONPath(); got != want {
 		t.Errorf("critJSONPath() = %q, want %q", got, want)
 	}
@@ -552,7 +552,7 @@ func TestSession_CritJSONPath_OutputDir(t *testing.T) {
 	outDir := t.TempDir()
 	s.OutputDir = outDir
 
-	want := filepath.Join(outDir, ".crit.json")
+	want := filepath.Join(outDir, ".crit")
 	if got := s.critJSONPath(); got != want {
 		t.Errorf("critJSONPath() = %q, want %q", got, want)
 	}
@@ -568,7 +568,7 @@ func TestSession_WriteFiles_OutputDir(t *testing.T) {
 	s.WriteFiles()
 
 	// Should be written to OutputDir, not RepoRoot
-	outPath := filepath.Join(outDir, ".crit.json")
+	outPath := filepath.Join(outDir, ".crit")
 	data, err := os.ReadFile(reviewPathsFor(outPath).Review)
 	if err != nil {
 		t.Fatalf(".crit.json not written to output dir: %v", err)
@@ -582,9 +582,9 @@ func TestSession_WriteFiles_OutputDir(t *testing.T) {
 	}
 
 	// Should NOT exist in RepoRoot
-	repoPath := filepath.Join(s.RepoRoot, ".crit.json")
-	if _, err := os.Stat(repoPath); !os.IsNotExist(err) {
-		t.Error("expected .crit.json to NOT be written to RepoRoot when OutputDir is set")
+	repoPath := filepath.Join(s.RepoRoot, ".crit")
+	if _, err := os.Stat(reviewPathsFor(repoPath).Review); !os.IsNotExist(err) {
+		t.Error("expected review.json to NOT be written to RepoRoot when OutputDir is set")
 	}
 }
 
@@ -1408,13 +1408,13 @@ func TestSession_WriteFiles_MergesExternalComments(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// WriteFiles should merge, not overwrite
 	s.WriteFiles()
 
 	// Read back .crit.json and verify both comments are present
-	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	result, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var got CritJSON
 	json.Unmarshal(result, &got)
 
@@ -1463,7 +1463,7 @@ func TestSession_MergeExternalCritJSON_NewComment(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -1548,7 +1548,7 @@ func TestSession_MergeExternalCritJSON_ClearDetected(t *testing.T) {
 	// Write .crit.json with no comments (simulating crit comment --clear)
 	cj := CritJSON{Branch: "main", ReviewRound: 1, Files: map[string]CritJSONFile{}}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -1563,7 +1563,7 @@ func TestSession_MergeExternalCritJSON_ClearDetected(t *testing.T) {
 
 func TestLoadCritJSON_IgnoresStaleShareState(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	// Write .crit.json with share state for a different file set
 	scope := shareScope([]string{"old-plan.md"})
@@ -1592,7 +1592,7 @@ func TestLoadCritJSON_IgnoresStaleShareState(t *testing.T) {
 
 func TestLoadCritJSON_RestoresMatchingShareState(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	scope := shareScope([]string{"plan.md"})
 	cj := CritJSON{
@@ -2010,7 +2010,7 @@ func TestSession_MergeExternalCritJSON_SkippedDuringPendingWrite(t *testing.T) {
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	// Touch with different mtime to bypass own-write check
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// Merge should be skipped because a write is pending
 	changed := s.mergeExternalCritJSON()
@@ -2055,7 +2055,7 @@ func TestSession_MergeExternalCritJSON_SyncsResolvedState(t *testing.T) {
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -2248,7 +2248,7 @@ func TestSession_MergeExternalCritJSON_SyncsUnresolve(t *testing.T) {
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	time.Sleep(10 * time.Millisecond)
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	changed := s.mergeExternalCritJSON()
 	if !changed {
@@ -3066,13 +3066,13 @@ func TestExternalCommentStillMerged(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// WriteFiles should merge the external comment in
 	s.WriteFiles()
 
 	// Read back .crit.json and verify both comments are present
-	result, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	result, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var got CritJSON
 	json.Unmarshal(result, &got)
 

--- a/session_write.go
+++ b/session_write.go
@@ -33,16 +33,17 @@ func (s *Session) scheduleWrite() {
 	})
 }
 
-// critJSONPath returns the path to the review file.
+// critJSONPath returns the review identity path. In v4 the identity is a
+// folder containing review.json and snapshots.json — see reviewPathsFor.
 func (s *Session) critJSONPath() string {
 	if s.OutputDir != "" {
-		return filepath.Join(s.OutputDir, ".crit.json")
+		return filepath.Join(s.OutputDir, ".crit")
 	}
 	if s.ReviewFilePath != "" {
 		return s.ReviewFilePath
 	}
 	// Fallback for tests and backwards compat
-	return filepath.Join(s.RepoRoot, ".crit.json")
+	return filepath.Join(s.RepoRoot, ".crit")
 }
 
 // writeFilesSnapshot holds all session state needed to write the review file,

--- a/session_write.go
+++ b/session_write.go
@@ -331,6 +331,10 @@ func (s *Session) mergeCommentRepliesAndState(comments []Comment, dc Comment) bo
 			comments[i].Resolved = dc.Resolved
 			changed = true
 		}
+		if dc.ResolvedRound != mc.ResolvedRound {
+			comments[i].ResolvedRound = dc.ResolvedRound
+			changed = true
+		}
 		break
 	}
 	return changed
@@ -384,6 +388,10 @@ func (s *Session) mergeReviewCommentRepliesAndState(dc Comment) bool {
 		}
 		if dc.Resolved != mc.Resolved {
 			s.reviewComments[i].Resolved = dc.Resolved
+			changed = true
+		}
+		if dc.ResolvedRound != mc.ResolvedRound {
+			s.reviewComments[i].ResolvedRound = dc.ResolvedRound
 			changed = true
 		}
 		memRIDs := make(map[string]struct{}, len(mc.Replies))

--- a/session_write.go
+++ b/session_write.go
@@ -81,7 +81,7 @@ func (s *Session) handleExternalDeletion(critPath string) bool {
 	if lastMtime.IsZero() {
 		return false
 	}
-	if _, statErr := os.Stat(critPath); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(reviewPathsFor(critPath).Review); !os.IsNotExist(statErr) {
 		return false
 	}
 
@@ -117,7 +117,7 @@ func (s *Session) clearAllCommentData() {
 // and merges per-file comments.
 func buildCritJSON(snap writeFilesSnapshot) CritJSON {
 	cj := CritJSON{Files: make(map[string]CritJSONFile)}
-	if data, err := os.ReadFile(snap.critPath); err == nil {
+	if data, err := os.ReadFile(reviewPathsFor(snap.critPath).Review); err == nil {
 		if unmarshalErr := json.Unmarshal(data, &cj); unmarshalErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: corrupt review file, starting fresh: %v\n", unmarshalErr)
 		}
@@ -202,8 +202,13 @@ func (s *Session) WriteFiles() {
 	snap := s.snapshotForWrite(critPath)
 	cj := buildCritJSON(snap)
 
+	paths := reviewPathsFor(snap.critPath)
 	if critJSONIsEmpty(cj) {
-		os.Remove(snap.critPath)
+		// B1: remove ONLY review.json. Snapshots are server-only state and
+		// may still be valid for the timeline; full-folder cleanup belongs to
+		// explicit cleanup paths (clearCritJSON, ClearAllComments,
+		// deleteStaleReviews, cleanupOnApproval).
+		os.Remove(paths.Review)
 		s.mu.Lock()
 		s.lastCritJSONMtime = time.Time{}
 		s.pendingWrite = false
@@ -217,11 +222,11 @@ func (s *Session) WriteFiles() {
 		fmt.Fprintf(os.Stderr, "Error marshaling review file: %v\n", err)
 		return
 	}
-	if err := atomicWriteFile(snap.critPath, data, 0644); err != nil {
+	if err := atomicWriteFile(paths.Review, data, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing review file: %v\n", err)
 		return
 	}
-	if info, err := os.Stat(snap.critPath); err == nil {
+	if info, err := os.Stat(paths.Review); err == nil {
 		s.mu.Lock()
 		s.lastCritJSONMtime = info.ModTime()
 		s.pendingWrite = false
@@ -416,7 +421,7 @@ func (s *Session) filterDeletedReviewComments(diskComments []Comment) bool {
 func (s *Session) mergeExternalCritJSON() bool {
 	critPath := s.critJSONPath()
 
-	info, err := os.Stat(critPath)
+	info, err := os.Stat(reviewPathsFor(critPath).Review)
 
 	s.mu.RLock()
 	lastMtime := s.lastCritJSONMtime
@@ -440,7 +445,7 @@ func (s *Session) mergeExternalCritJSON() bool {
 		return false
 	}
 
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return false
 	}

--- a/share.go
+++ b/share.go
@@ -195,7 +195,7 @@ func shareFilesToWeb(files []shareFile, comments []shareComment, shareURL string
 // A missing file is treated as "no args"; other read or unmarshal errors are
 // logged to stderr so they don't silently disappear.
 func loadCliArgsFromReviewFile(critPath string) []string {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "warning: failed to load cli_args from review file: %v\n", err)
@@ -314,7 +314,7 @@ func commentToShareComment(c Comment, filePath, scope, fallbackAuthor string, in
 // from the local comment ID for round-trip tracking. fallbackAuthor fills missing
 // Author fields (typically cfg.Author).
 func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolved, setExternalID bool, fallbackAuthor string) ([]shareComment, int) {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return nil, 1
 	}
@@ -597,7 +597,7 @@ func upsertShareToWeb(cfg CritJSON, files []shareFile, comments []shareComment, 
 // back to creating a new share. Parse errors and other I/O errors are surfaced
 // so callers can refuse to clobber a corrupted file.
 func loadExistingShareCfg(critPath string, paths []string) (CritJSON, bool, error) {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return CritJSON{}, false, nil
@@ -668,7 +668,7 @@ func highestWebIndex(cj CritJSON) int {
 // with HeadSHA + DiffScope=layer so they pass visibleInFocus in range view.
 // See spec §E "Write path — `mergeWebComments`".
 func mergeWebComments(critPath string, newComments []webComment, replyUpdates map[string][]webReply) error {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return err
 	}
@@ -762,7 +762,7 @@ func mergeRepliesIntoComment(c Comment, webReplies []webReply) Comment {
 
 // updateShareState writes LastShareHash and ReviewRound back to the review file.
 func updateShareState(critPath string, hash string, reviewRound int) error {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return err
 	}
@@ -780,7 +780,7 @@ func updateShareState(critPath string, hash string, reviewRound int) error {
 // preserving any existing content.
 func persistShareState(critPath string, shareURL string, deleteToken string, scope string) error {
 	var cj CritJSON
-	if data, err := os.ReadFile(critPath); err == nil {
+	if data, err := os.ReadFile(reviewPathsFor(critPath).Review); err == nil {
 		_ = json.Unmarshal(data, &cj)
 	}
 	if cj.Files == nil {
@@ -798,7 +798,7 @@ func persistShareState(critPath string, shareURL string, deleteToken string, sco
 // hash from the review file. It is the single source of truth for "undo share
 // metadata" — used by both the unpublish CLI path and tests.
 func clearShareState(critPath string) error {
-	data, err := os.ReadFile(critPath)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return nil //nolint:nilerr // no review file means nothing to clear
 	}

--- a/share_attribution_test.go
+++ b/share_attribution_test.go
@@ -253,7 +253,7 @@ func TestShareAttrBackwardsCompatNoUserID(t *testing.T) {
 			}
 		}
 	}`
-	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), []byte(legacy), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".crit"), []byte(legacy), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -65,7 +65,7 @@ func TestShareSyncIntegration(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(initialCJ, "", "  ")
-	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".crit"), data, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -151,8 +151,8 @@ func TestShareSyncIntegration(t *testing.T) {
 
 	// g) Verify the web reviewer comment was pulled into local .crit.json
 	// (post-v4 .crit.json is a folder; the canonical review payload lives at
-	// .crit.json/review.json).
-	localData, err := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	// .crit/review.json).
+	localData, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
 	}
@@ -337,7 +337,7 @@ func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), d, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".crit"), d, 0644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -150,7 +150,9 @@ func TestShareSyncIntegration(t *testing.T) {
 	}
 
 	// g) Verify the web reviewer comment was pulled into local .crit.json
-	localData, err := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	// (post-v4 .crit.json is a folder; the canonical review payload lives at
+	// .crit.json/review.json).
+	localData, err := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	if err != nil {
 		t.Fatalf("reading .crit.json: %v", err)
 	}

--- a/share_test.go
+++ b/share_test.go
@@ -44,7 +44,7 @@ func writeCritJSONForTest(t *testing.T, dir string, cj CritJSON) {
 	if err != nil {
 		t.Fatalf("marshaling CritJSON: %v", err)
 	}
-	if err := os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644); err != nil {
 		t.Fatalf("writing .crit.json: %v", err)
 	}
 }
@@ -64,7 +64,7 @@ func TestLoadCommentsForUpsert_ExcludesResolved(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"plan.md"}, "")
 	if round != 1 {
 		t.Errorf("expected round 1, got %d", round)
 	}
@@ -93,7 +93,7 @@ func TestLoadCommentsForUpsert_SetsExternalID(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"main.go"}, "")
+	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"main.go"}, "")
 	if len(comments) != 1 {
 		t.Fatalf("expected 1 comment, got %d", len(comments))
 	}
@@ -120,7 +120,7 @@ func TestLoadCommentsForUpsert_ReviewLevelComments(t *testing.T) {
 	}
 	writeCritJSONForTest(t, dir, cj)
 
-	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, _ := loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"plan.md"}, "")
 
 	// Should have 2 comments: 1 file-level + 1 unresolved review-level
 	if len(comments) != 2 {
@@ -414,10 +414,10 @@ func TestLoadCommentsForFiles(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(critJSON, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// Only load unresolved comments for plan.md (c1 and c2, not c3)
-	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"plan.md"}, "")
 	if round != 2 {
 		t.Errorf("expected round 2, got %d", round)
 	}
@@ -429,13 +429,13 @@ func TestLoadCommentsForFiles(t *testing.T) {
 	}
 
 	// Load for both files — 3 unresolved (c1, c2, c4), not 5 total
-	comments, _ = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md", "other.go"}, "")
+	comments, _ = loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"plan.md", "other.go"}, "")
 	if len(comments) != 3 {
 		t.Fatalf("expected 3 unresolved comments, got %d", len(comments))
 	}
 
 	// Load for nonexistent file
-	comments, round = loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"nope.md"}, "")
+	comments, round = loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"nope.md"}, "")
 	if len(comments) != 0 {
 		t.Errorf("expected 0 comments, got %d", len(comments))
 	}
@@ -446,7 +446,7 @@ func TestLoadCommentsForFiles(t *testing.T) {
 
 func TestLoadCommentsForFiles_NoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
+	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit"), []string{"plan.md"}, "")
 	if len(comments) != 0 {
 		t.Errorf("expected 0 comments, got %d", len(comments))
 	}
@@ -459,13 +459,13 @@ func TestPersistShareState(t *testing.T) {
 	dir := t.TempDir()
 
 	// Persist to new .crit.json
-	err := persistShareState(filepath.Join(dir, ".crit.json"), "https://crit.md/r/abc", "tok_123", "")
+	err := persistShareState(filepath.Join(dir, ".crit"), "https://crit.md/r/abc", "tok_123", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Read back and verify
-	data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, _ := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	if cj.ShareURL != "https://crit.md/r/abc" {
@@ -488,16 +488,16 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(initial, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// Persist share state
-	err := persistShareState(filepath.Join(dir, ".crit.json"), "https://crit.md/r/def", "tok_456", "")
+	err := persistShareState(filepath.Join(dir, ".crit"), "https://crit.md/r/def", "tok_456", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Read back — comments and branch should be preserved
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	if cj.ShareURL != "https://crit.md/r/def" {
@@ -591,14 +591,14 @@ func TestClearShareState(t *testing.T) {
 		Files:       map[string]CritJSONFile{"plan.md": {Comments: []Comment{{ID: "c1", Body: "test"}}}},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
-	err := clearShareState(filepath.Join(dir, ".crit.json"))
+	err := clearShareState(filepath.Join(dir, ".crit"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	var cleared CritJSON
 	json.Unmarshal(data, &cleared)
 	if cleared.ShareURL != "" {
@@ -630,7 +630,7 @@ func TestHandleShare_Success(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(cj)
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// Mock crit-web server
 	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -703,7 +703,7 @@ func TestHandleShare_OrphanedFileIncluded(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(cj)
-	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit", "review.json")), data, 0644)
 
 	// Mock crit-web server that captures the payload
 	var receivedPayload map[string]any
@@ -876,7 +876,7 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 
 func TestLoadExistingShareCfg(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	// Review file without scope — loads unconditionally
 	cj := CritJSON{
@@ -904,7 +904,7 @@ func TestLoadExistingShareCfg(t *testing.T) {
 
 func TestLoadExistingShareCfg_NoCritJSON(t *testing.T) {
 	dir := t.TempDir()
-	_, ok, err := loadExistingShareCfg(filepath.Join(dir, ".crit.json"), []string{"plan.md"})
+	_, ok, err := loadExistingShareCfg(filepath.Join(dir, ".crit"), []string{"plan.md"})
 	if err != nil {
 		t.Fatalf("missing file should not be an error, got: %v", err)
 	}
@@ -915,7 +915,7 @@ func TestLoadExistingShareCfg_NoCritJSON(t *testing.T) {
 
 func TestLoadExistingShareCfg_NoShareState(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 	cj := CritJSON{Files: map[string]CritJSONFile{}}
 	data, _ := json.MarshalIndent(cj, "", "  ")
 	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
@@ -931,7 +931,7 @@ func TestLoadExistingShareCfg_NoShareState(t *testing.T) {
 
 func TestLoadExistingShareCfg_ScopeMismatch(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	cj := CritJSON{
 		ShareURL:    "https://crit.md/r/old",
@@ -1648,7 +1648,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 func TestMergeWebComments(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	// Setup initial review file
 	cj := CritJSON{
@@ -1805,7 +1805,7 @@ func TestFetchWebComments_FingerprintMatchPreservesReplies(t *testing.T) {
 // persists reply updates onto an existing comment matched by ID.
 func TestMergeWebComments_AppliesReplyUpdates(t *testing.T) {
 	dir := t.TempDir()
-	critPath := filepath.Join(dir, ".crit.json")
+	critPath := filepath.Join(dir, ".crit")
 
 	cj := CritJSON{
 		ReviewRound: 1,

--- a/share_test.go
+++ b/share_test.go
@@ -44,7 +44,7 @@ func writeCritJSONForTest(t *testing.T, dir string, cj CritJSON) {
 	if err != nil {
 		t.Fatalf("marshaling CritJSON: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644); err != nil {
 		t.Fatalf("writing .crit.json: %v", err)
 	}
 }
@@ -414,7 +414,7 @@ func TestLoadCommentsForFiles(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(critJSON, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// Only load unresolved comments for plan.md (c1 and c2, not c3)
 	comments, round := loadCommentsForShare(filepath.Join(dir, ".crit.json"), []string{"plan.md"}, "")
@@ -465,7 +465,7 @@ func TestPersistShareState(t *testing.T) {
 	}
 
 	// Read back and verify
-	data, _ := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, _ := os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	if cj.ShareURL != "https://crit.md/r/abc" {
@@ -488,7 +488,7 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(initial, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// Persist share state
 	err := persistShareState(filepath.Join(dir, ".crit.json"), "https://crit.md/r/def", "tok_456", "")
@@ -497,7 +497,7 @@ func TestPersistShareState_PreservesExisting(t *testing.T) {
 	}
 
 	// Read back — comments and branch should be preserved
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var cj CritJSON
 	json.Unmarshal(data, &cj)
 	if cj.ShareURL != "https://crit.md/r/def" {
@@ -591,14 +591,14 @@ func TestClearShareState(t *testing.T) {
 		Files:       map[string]CritJSONFile{"plan.md": {Comments: []Comment{{ID: "c1", Body: "test"}}}},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	err := clearShareState(filepath.Join(dir, ".crit.json"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json"))
+	data, _ = os.ReadFile(filepath.Join(dir, ".crit.json", "review.json"))
 	var cleared CritJSON
 	json.Unmarshal(data, &cleared)
 	if cleared.ShareURL != "" {
@@ -630,7 +630,7 @@ func TestHandleShare_Success(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(cj)
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// Mock crit-web server
 	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -703,7 +703,7 @@ func TestHandleShare_OrphanedFileIncluded(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(cj)
-	os.WriteFile(filepath.Join(dir, ".crit.json"), data, 0644)
+	os.WriteFile(mustMkdirAll(filepath.Join(dir, ".crit.json", "review.json")), data, 0644)
 
 	// Mock crit-web server that captures the payload
 	var receivedPayload map[string]any
@@ -885,7 +885,7 @@ func TestLoadExistingShareCfg(t *testing.T) {
 		Files:       map[string]CritJSONFile{},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	cfg, ok, err := loadExistingShareCfg(critPath, []string{"anything.md"})
 	if err != nil {
@@ -918,7 +918,7 @@ func TestLoadExistingShareCfg_NoShareState(t *testing.T) {
 	critPath := filepath.Join(dir, ".crit.json")
 	cj := CritJSON{Files: map[string]CritJSONFile{}}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	_, ok, err := loadExistingShareCfg(critPath, []string{"plan.md"})
 	if err != nil {
@@ -940,7 +940,7 @@ func TestLoadExistingShareCfg_ScopeMismatch(t *testing.T) {
 		Files:       map[string]CritJSONFile{},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	// Different file set — should NOT return share state
 	_, ok, err := loadExistingShareCfg(critPath, []string{"new-plan.md"})
@@ -1188,7 +1188,7 @@ func TestLoadCliArgsFromReviewFile(t *testing.T) {
 			Files:   map[string]CritJSONFile{},
 		}
 		data, _ := json.Marshal(cj)
-		os.WriteFile(critPath, data, 0644)
+		os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 		got := loadCliArgsFromReviewFile(critPath)
 		if len(got) != 2 || got[0] != "plan.md" || got[1] != "design.md" {
@@ -1208,7 +1208,7 @@ func TestLoadCliArgsFromReviewFile(t *testing.T) {
 		critPath := filepath.Join(dir, "review.json")
 		cj := CritJSON{Branch: "main", Files: map[string]CritJSONFile{}}
 		data, _ := json.Marshal(cj)
-		os.WriteFile(critPath, data, 0644)
+		os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 		got := loadCliArgsFromReviewFile(critPath)
 		if got != nil {
@@ -1660,7 +1660,7 @@ func TestMergeWebComments(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	os.WriteFile(critPath, data, 0644)
+	os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0644)
 
 	// Merge new comments
 	newComments := []webComment{
@@ -1672,7 +1672,7 @@ func TestMergeWebComments(t *testing.T) {
 	}
 
 	// Read back and verify
-	data, _ = os.ReadFile(critPath)
+	data, _ = os.ReadFile(reviewPathsFor(critPath).Review)
 	var result CritJSON
 	json.Unmarshal(data, &result)
 
@@ -1819,7 +1819,7 @@ func TestMergeWebComments_AppliesReplyUpdates(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(cj, "", "  ")
-	if err := os.WriteFile(critPath, data, 0o644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644); err != nil {
 		t.Fatalf("write crit json: %v", err)
 	}
 
@@ -1830,7 +1830,7 @@ func TestMergeWebComments_AppliesReplyUpdates(t *testing.T) {
 		t.Fatalf("mergeWebComments: %v", err)
 	}
 
-	out, _ := os.ReadFile(critPath)
+	out, _ := os.ReadFile(reviewPathsFor(critPath).Review)
 	var got CritJSON
 	if err := json.Unmarshal(out, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -8,6 +8,16 @@ import (
 	"testing"
 )
 
+// mustMkdirAll ensures the parent directory of path exists, then returns path.
+// Used by tests that seed a file inside the v4 review folder layout without
+// writing the boilerplate at every call site.
+func mustMkdirAll(path string) string {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		panic(err)
+	}
+	return path
+}
+
 // Strip GIT_* from the test process env so production code paths that exec
 // git (e.g. NewSessionFromGit) don't target the parent repo when tests run
 // inside a git hook (pre-commit's `go test ./...` inherits GIT_DIR /

--- a/watch.go
+++ b/watch.go
@@ -468,6 +468,14 @@ func (s *Session) handleRoundCompleteFiles() {
 
 	// File I/O off the hot path. Drift between review.json and snapshots.json
 	// is benign (degrades to "no timeline available").
+	//
+	// ORDERING ASSUMPTION: sidecar writes from concurrent round-completes are
+	// serialized by the debounced round-complete handler upstream — only one
+	// round-complete is in-flight at a time, so the (clone-under-lock,
+	// release-lock, write-off-lock) sequence cannot interleave with a second
+	// captureRoundSnapshot/cloneRoundSnapshots cycle. If that upstream
+	// debounce ever changes (e.g. round-completes become parallel), move the
+	// saveSnapshotsFile call inside the s.mu.Lock() block above.
 	if err := saveSnapshotsFile(sidecarPath, sf); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: write snapshots sidecar: %v\n", err)
 	}

--- a/watch.go
+++ b/watch.go
@@ -458,6 +458,7 @@ func (s *Session) handleRoundCompleteFiles() {
 	// captures R2.
 	s.mu.Lock()
 	nextRound := s.ReviewRound + 1
+	// INVARIANT: captureRoundSnapshot MUST run before rereadFileContents(true); reordering would snapshot the new on-disk content as the previous round and silently corrupt the timeline.
 	s.captureRoundSnapshot(nextRound)
 	sidecarPath := reviewPathsFor(s.critJSONPath()).Snapshots
 	sf := SnapshotsFile{RoundSnapshots: cloneRoundSnapshots(s.RoundSnapshots)}

--- a/watch.go
+++ b/watch.go
@@ -484,8 +484,8 @@ func (s *Session) emitRoundStatus(edits int) {
 // loadResolvedComments reads the review file to pick up resolved fields the agent wrote.
 func (s *Session) loadResolvedComments() {
 	critPath := s.critJSONPath()
-	info, statErr := os.Stat(critPath)
-	data, err := os.ReadFile(critPath)
+	info, statErr := os.Stat(reviewPathsFor(critPath).Review)
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
 	if err != nil {
 		// No review file — clear all PreviousComments
 		s.mu.Lock()

--- a/watch.go
+++ b/watch.go
@@ -449,12 +449,27 @@ func (s *Session) handleRoundCompleteFiles() {
 	// Restore phantom entries for files that disappeared but have comments in the review file.
 	s.restoreOrphanedComments()
 
-	// Re-read all file contents and update hashes
+	// Re-read all file contents and update hashes.
 	// (snapshot markdown PreviousContent in case watcher hasn't polled yet)
+	//
+	// Capture the round we are about to commit BEFORE rereadFileContents and
+	// BEFORE incrementing ReviewRound. On the first round-complete after boot,
+	// ReviewRound == 1 (R1 baseline already captured at construction), so this
+	// captures R2.
 	s.mu.Lock()
+	nextRound := s.ReviewRound + 1
+	s.captureRoundSnapshot(nextRound)
+	sidecarPath := reviewPathsFor(s.critJSONPath()).Snapshots
+	sf := SnapshotsFile{RoundSnapshots: cloneRoundSnapshots(s.RoundSnapshots)}
 	s.rereadFileContents(true)
 	s.ReviewRound++
 	s.mu.Unlock()
+
+	// File I/O off the hot path. Drift between review.json and snapshots.json
+	// is benign (degrades to "no timeline available").
+	if err := saveSnapshotsFile(sidecarPath, sf); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: write snapshots sidecar: %v\n", err)
+	}
 
 	s.finishRoundComplete(edits)
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -497,7 +497,7 @@ func TestRestoreOrphanedComments(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(critPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(critPath, data, 0o644); err != nil {
+	if err := os.WriteFile(mustMkdirAll(reviewPathsFor(critPath).Review), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

Stage 1 is plumbing-only. **No user-perceived behavior change for existing flows** — all current API endpoints, the local UI, and agent-facing JSON behave exactly as before. The new round-aware code paths (`?round=N`, `/api/rounds`) are dormant until Stage 2 calls them.

The one externally-visible change is the on-disk review file layout: `~/.crit/reviews/<key>.json` (file) → `<key>/review.json` (folder + file inside). Auto-migrated on first read so existing reviews keep working. Required for attachments later; transparent to current users.

## What's added

- **`GET /api/rounds`** — new endpoint returning `{current_round, rounds: [{n, additions, deletions, comment_count, captured_at}]}` for the timeline UI.
- **`?round=N` extension** on `/api/file`, `/api/file/diff`, `/api/file/comments`, `/api/comments`, `/api/session`. When set, returns state-at-round-N. Without it: identical to today. Git/range mode ignores the param.
- **Comment + reply scoping** via `review_round` (was already on comments; replies now too). When `?round=N` is set, server returns only comments/replies authored at or before round N. Resolution state is returned as-is (`resolved` reflects current state, not state-at-round-N — round-faithful resolved hiding is a Stage 2 frontend decision).
- **`resolved_round`** field on Comment + Reply. Stamped when `resolved` transitions false → true. Exposed in API; filter is Stage 2's call.
- **`position`** field on `RoundSnapshot` for file display order at capture time — aligns with crit-web's existing schema.
- **Per-round file content snapshots** (files mode), persisted in a sidecar at `<key>/snapshots.json` (kept out of `review.json` so agent context isn't bloated by per-round file dumps).
- **R1 = initial baseline** captured at session construction. First round-complete after construction produces R2.
- **Cleanup wiring** across 6 deletion sites (`findStaleReviews`, `deleteStaleReviews{,Silent}`, `cleanupOnApproval`, `WriteFiles` empty-removal, `ClearAllComments`) — all walk subdirs with MIGRATION-REMOVAL flat-file fallback. Orphan-folder collection.

## Folder format migration (v3 → v4)

`~/.crit/reviews/<key>.json` (flat file) → `~/.crit/reviews/<key>/{review.json,snapshots.json}` (folder).

- One-shot, idempotent, atomic-ish via temp folder + rename.
- Triggered transparently on first `loadCritJSON` after upgrade.
- Logged once per migrated review.
- Crash-tolerant: re-running migration on already-migrated data is a no-op.
- All `MIGRATION-REMOVAL` markers are greppable for the eventual cleanup PR (draft issue body in the v4 plan).

In-repo case: `.crit.json` (flat file) → `.crit/` (folder containing `review.json` + `snapshots.json`).

## Review

- [x] `/crit-review`: passed (0 blockers, 0 warnings, 0 notes after fixes)
- [x] `/crit-intent-check`: CLEAN — all 27 commits map to stated intent, no scope creep
- [x] `go test ./...` — pass
- [x] `go test -race ./...` — pass
- [x] `golangci-lint` — 0 issues

## Test plan

- 100+ new tests covering: folder migration (v3 → v4, idempotent, crash recovery, orphan collection), per-round snapshot capture (capture-before-reread invariant, R1 baseline, files-mode-only no-op), API surface (`?round=` validation across all 5 endpoints, `/api/rounds` shape, line stats, comment + reply scoping), cleanup wiring, sidecar persistence, lock discipline (`loadCritJSON` guard, `SetSession` ordering, `SetFocus` runtime path).
- Manual smoke: roleplay session with 3 rounds, comments + replies, resolve transitions, folder migration from a seeded v3 flat file. Path emitted in finish-prompt verified to point at `<key>/review.json` (cat-able by agents).

## Follow-ups (filed)

- tomasz-tomczyk/crit-web#173 — mirror `resolved_round` in crit-web schema
- tomasz-tomczyk/crit-web#174 — naming alignment (`captured_at` vs `inserted_at`, snapshot `status` enum)
- `MIGRATION-REMOVAL`: post-ship cleanup of v3 flat-file fallback paths once users have rolled forward (greppable marker; draft issue body in plan v4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)