### PR TITLE
fix: propagate local comment deletes to GitHub on push

### DIFF
--- a/github.go
+++ b/github.go
@@ -622,10 +622,16 @@ func separateRootsAndReplies(ghComments []ghComment) ([]ghComment, map[int64][]g
 }
 
 // appendNewGHReplies adds non-duplicate replies to an existing comment, returning how many were added.
-func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, names userNameCache) int {
+// Replies whose GitHubID is in pendingDeletes are skipped — the user has
+// already deleted them locally and the next push will issue DELETE; importing
+// them now would resurrect the row under a fresh ID and mask the pending intent.
+func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, names userNameCache, pendingDeletes map[int64]bool) int {
 	added := 0
 	for _, r := range childReplies {
 		if isDuplicateGHReply(comments[ci].Replies, r.ID) {
+			continue
+		}
+		if pendingDeletes[r.ID] {
 			continue
 		}
 		comments[ci].Replies = append(comments[ci].Replies, Reply{
@@ -644,7 +650,7 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, na
 // mergeRootComment handles a single root ghComment: either deduplicates or creates it.
 // scope stamps the imported comment's HeadSHA + DiffScope when called from a range-mode
 // pull. Empty scope leaves the legacy working-tree fields unset.
-func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string, names userNameCache, scope inheritedScope) int {
+func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string, names userNameCache, scope inheritedScope, pendingDeletes map[int64]bool) int {
 	cf, ok := cj.Files[gc.Path]
 	if !ok {
 		cf = CritJSONFile{Status: "modified", Comments: []Comment{}}
@@ -657,12 +663,19 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 
 	authorName := names.lookup(gc.User.Login)
 
+	// Pending-delete-locally takes priority over import: the user has signaled
+	// intent to DELETE this remote comment on the next push. Re-importing
+	// would resurrect it under a fresh local ID and mask the pending intent.
+	if pendingDeletes[gc.ID] {
+		return 0
+	}
+
 	if isDuplicateGHComment(cf.Comments, gc.ID, authorName, startLine, gc.Line, gc.Body) {
 		added := 0
 		if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
 			for ci, c := range cf.Comments {
 				if c.GitHubID == gc.ID {
-					added = appendNewGHReplies(cf.Comments, ci, childReplies, names)
+					added = appendNewGHReplies(cf.Comments, ci, childReplies, names, pendingDeletes)
 					break
 				}
 			}
@@ -681,6 +694,9 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 	added := 0
 	if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
 		for _, r := range childReplies {
+			if pendingDeletes[r.ID] {
+				continue
+			}
 			comment.Replies = append(comment.Replies, Reply{
 				ID:                 randomReplyID(),
 				Body:               r.Body,
@@ -699,7 +715,7 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 }
 
 // mergeOrphanReplies processes replies whose parent was already in cj from a previous pull.
-func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]ghComment, names userNameCache) int {
+func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]ghComment, names userNameCache, pendingDeletes map[int64]bool) int {
 	rootIDs := make(map[int64]struct{}, len(roots))
 	for _, gc := range roots {
 		rootIDs[gc.ID] = struct{}{}
@@ -715,7 +731,7 @@ func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]gh
 			continue
 		}
 		cf := cj.Files[filePath]
-		added += appendNewGHReplies(cf.Comments, ci, childReplies, names)
+		added += appendNewGHReplies(cf.Comments, ci, childReplies, names, pendingDeletes)
 		cj.Files[filePath] = cf
 	}
 	return added
@@ -747,11 +763,16 @@ func mergeGHCommentsWithNames(cj *CritJSON, ghComments []ghComment, names userNa
 
 	roots, replyMap := separateRootsAndReplies(ghComments)
 
+	pendingDeletes := make(map[int64]bool, len(cj.PendingGitHubDeletes))
+	for _, id := range cj.PendingGitHubDeletes {
+		pendingDeletes[id] = true
+	}
+
 	added := 0
 	for _, gc := range roots {
-		added += mergeRootComment(cj, gc, replyMap, now, names, scope)
+		added += mergeRootComment(cj, gc, replyMap, now, names, scope, pendingDeletes)
 	}
-	added += mergeOrphanReplies(cj, roots, replyMap, names)
+	added += mergeOrphanReplies(cj, roots, replyMap, names, pendingDeletes)
 
 	return added
 }
@@ -1090,6 +1111,109 @@ func updateCritJSONWithGitHubIDs(critPath string, commentIDs map[string]int64, r
 			}
 		}
 		cj.Files[path] = cf
+	}
+
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(reviewPathsFor(critPath).Review, append(out, '\n'), 0644)
+}
+
+// collectDeletesForPush returns the snapshot of pending GitHub DELETE
+// intents recorded against this review file. The returned slice is a copy
+// so the caller can safely mutate or iterate while updating cj concurrently.
+func collectDeletesForPush(cj CritJSON) []int64 {
+	if len(cj.PendingGitHubDeletes) == 0 {
+		return nil
+	}
+	out := make([]int64, len(cj.PendingGitHubDeletes))
+	copy(out, cj.PendingGitHubDeletes)
+	return out
+}
+
+// deleteGHComment issues DELETE on a GitHub PR review comment. The endpoint
+// works for both root comments and replies — they share /pulls/comments/{id}.
+//
+// Returns the HTTP status code and an error. A 200 (or 204) is success;
+// 404 is treated as success by the caller (the remote comment is already
+// gone). 403 means the authenticated user is not the author and GitHub
+// won't let us delete; the caller drops the tombstone anyway because
+// retrying is futile.
+func deleteGHComment(ghID int64) (int, error) {
+	// `gh api --include` writes the response headers (incl. status line) to
+	// stdout so we can extract the status. On non-2xx gh exits non-zero, so
+	// we read CombinedOutput and parse regardless.
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/comments/%d", ghID),
+		"--method", "DELETE",
+		"--include",
+	)
+	output, runErr := cmd.CombinedOutput()
+	status := parseGHIncludeStatus(output)
+	if status >= 200 && status < 300 {
+		return status, nil
+	}
+	if status == 404 || status == 403 {
+		// Caller decides how to handle these; surface the status without
+		// treating the gh non-zero exit as a fatal error.
+		return status, nil
+	}
+	if runErr != nil {
+		return status, fmt.Errorf("gh api delete: %s: %w", strings.TrimSpace(string(output)), runErr)
+	}
+	return status, fmt.Errorf("gh api delete: unexpected status %d: %s", status, strings.TrimSpace(string(output)))
+}
+
+// parseGHIncludeStatus extracts the HTTP status code from `gh api --include`
+// output. The first line is "HTTP/2 204" or similar. Returns 0 if it can't
+// be parsed.
+func parseGHIncludeStatus(out []byte) int {
+	line := string(out)
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	fields := strings.Fields(line)
+	for _, f := range fields {
+		if n, err := strconv.Atoi(f); err == nil && n >= 100 && n < 600 {
+			return n
+		}
+	}
+	return 0
+}
+
+// updateCritJSONAfterDeletes removes drained GitHub IDs from
+// PendingGitHubDeletes on disk. IDs not in `drained` (DELETE failed or was
+// not attempted) remain in the list so the next push retries them.
+func updateCritJSONAfterDeletes(critPath string, drained []int64) error {
+	if len(drained) == 0 {
+		return nil
+	}
+	drainedSet := make(map[int64]struct{}, len(drained))
+	for _, id := range drained {
+		drainedSet[id] = struct{}{}
+	}
+
+	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
+	if err != nil {
+		return err
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return err
+	}
+
+	kept := make([]int64, 0, len(cj.PendingGitHubDeletes))
+	for _, id := range cj.PendingGitHubDeletes {
+		if _, drained := drainedSet[id]; drained {
+			continue
+		}
+		kept = append(kept, id)
+	}
+	if len(kept) == 0 {
+		cj.PendingGitHubDeletes = nil
+	} else {
+		cj.PendingGitHubDeletes = kept
 	}
 
 	out, err := json.MarshalIndent(cj, "", "  ")

--- a/github_test.go
+++ b/github_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -3080,4 +3081,213 @@ func TestZeroGitHubID_TreatedAsNotPushed(t *testing.T) {
 			t.Fatalf("reply with GitHubID!=0 must be skipped; got %d", len(got))
 		}
 	})
+}
+
+// TestCollectDeletesForPush_ReturnsPendingList verifies that
+// collectDeletesForPush returns a copy of CritJSON.PendingGitHubDeletes.
+func TestCollectDeletesForPush_ReturnsPendingList(t *testing.T) {
+	cj := CritJSON{
+		PendingGitHubDeletes: []int64{100, 200, 300},
+		Files:                map[string]CritJSONFile{},
+	}
+	got := collectDeletesForPush(cj)
+	if len(got) != 3 || got[0] != 100 || got[1] != 200 || got[2] != 300 {
+		t.Fatalf("collectDeletesForPush = %v, want [100 200 300]", got)
+	}
+
+	// Caller may mutate without affecting cj — verify independence.
+	got[0] = 999
+	if cj.PendingGitHubDeletes[0] != 100 {
+		t.Errorf("caller mutation leaked back into cj.PendingGitHubDeletes")
+	}
+
+	// Empty input returns nil (no allocation).
+	if x := collectDeletesForPush(CritJSON{}); x != nil {
+		t.Errorf("empty pending list should return nil, got %v", x)
+	}
+}
+
+// TestUpdateCritJSONAfterDeletes_DrainsPendingList verifies that drained IDs
+// are removed from PendingGitHubDeletes on disk; non-drained IDs persist for
+// retry on the next push.
+func TestUpdateCritJSONAfterDeletes_DrainsPendingList(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	reviewPath := filepath.Join(dir, "review.json")
+
+	cj := CritJSON{
+		PendingGitHubDeletes: []int64{100, 101, 102},
+		Files:                map[string]CritJSONFile{},
+	}
+	data, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(reviewPath, data, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// 100 + 102 drained; 101 stays pending.
+	if err := updateCritJSONAfterDeletes(dir, []int64{100, 102}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	out, err := os.ReadFile(reviewPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got CritJSON
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.PendingGitHubDeletes) != 1 || got.PendingGitHubDeletes[0] != 101 {
+		t.Errorf("PendingGitHubDeletes after drain = %v, want [101]", got.PendingGitHubDeletes)
+	}
+}
+
+// TestUpdateCritJSONAfterDeletes_FullDrainOmitsField asserts the JSON does
+// not retain an empty array (omitempty on the struct tag) — the field should
+// vanish from disk once everything has been DELETEd upstream.
+func TestUpdateCritJSONAfterDeletes_FullDrainOmitsField(t *testing.T) {
+	dir := t.TempDir()
+	reviewPath := filepath.Join(dir, "review.json")
+	cj := CritJSON{PendingGitHubDeletes: []int64{42}, Files: map[string]CritJSONFile{}}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(reviewPath, data, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := updateCritJSONAfterDeletes(dir, []int64{42}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	raw, _ := os.ReadFile(reviewPath)
+	if strings.Contains(string(raw), "pending_github_deletes") {
+		t.Errorf("pending_github_deletes still present after full drain:\n%s", raw)
+	}
+}
+
+// TestMergeRootComment_SkipsPendingDelete verifies that pull does not
+// resurrect a comment whose ID is in PendingGitHubDeletes — the user has
+// already issued an intent to DELETE that must survive intermediate pulls.
+func TestMergeRootComment_SkipsPendingDelete(t *testing.T) {
+	cj := CritJSON{
+		PendingGitHubDeletes: []int64{999},
+		Files: map[string]CritJSONFile{
+			"a.go": {Status: "modified", Comments: []Comment{}},
+		},
+	}
+	gc := []ghComment{{
+		ID: 999, Path: "a.go", Line: 5, Side: "RIGHT",
+		Body: "should not resurrect",
+		User: struct {
+			Login string `json:"login"`
+		}{Login: "alice"},
+	}}
+	added := mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{})
+	if added != 0 {
+		t.Errorf("merge re-imported pending-delete comment (added=%d, want 0)", added)
+	}
+	if cf := cj.Files["a.go"]; len(cf.Comments) != 0 {
+		t.Errorf("expected zero comments after merge, got %+v", cf.Comments)
+	}
+}
+
+// TestMergeOrphanReplies_SkipsPendingDelete asserts that a reply queued for
+// DELETE locally is not re-imported when its parent is already in cj.
+func TestMergeOrphanReplies_SkipsPendingDelete(t *testing.T) {
+	cj := CritJSON{
+		PendingGitHubDeletes: []int64{777},
+		Files: map[string]CritJSONFile{
+			"a.go": {Status: "modified", Comments: []Comment{
+				{ID: "c1", GitHubID: 500, Body: "parent", StartLine: 5, EndLine: 5, Author: "alice"},
+			}},
+		},
+	}
+	gc := []ghComment{{
+		ID: 777, Path: "a.go", Line: 5, Side: "RIGHT",
+		Body: "deleted reply",
+		User: struct {
+			Login string `json:"login"`
+		}{Login: "alice"},
+		InReplyToID: 500,
+	}}
+	mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{})
+	cf := cj.Files["a.go"]
+	if len(cf.Comments) != 1 || len(cf.Comments[0].Replies) != 0 {
+		t.Errorf("expected parent with no replies; got %+v", cf.Comments)
+	}
+}
+
+// TestParseGHIncludeStatus parses representative `gh api --include` outputs.
+func TestParseGHIncludeStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"http2 204", "HTTP/2 204\nDate: ...\n\n", 204},
+		{"http1.1 200", "HTTP/1.1 200 OK\n\n", 200},
+		{"http2 404", "HTTP/2 404\n\n{}", 404},
+		{"http2 403", "HTTP/2 403\n\n{}", 403},
+		{"empty", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseGHIncludeStatus([]byte(tc.in)); got != tc.want {
+				t.Errorf("parseGHIncludeStatus(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// installFakeGHForDelete installs a `gh` shim on PATH that emits a fixed
+// HTTP status line so deleteGHComment can be exercised without network.
+// Setting exitNonZero mirrors `gh api`'s real behavior on non-2xx responses.
+func installFakeGHForDelete(t *testing.T, statusLine string, exitNonZero bool) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-gh shim is a POSIX shell script; not portable to Windows")
+	}
+	dir := t.TempDir()
+	exit := "0"
+	if exitNonZero {
+		exit = "1"
+	}
+	script := "#!/bin/sh\nprintf '%s\\n\\n' '" + statusLine + "'\nexit " + exit + "\n"
+	fakeGH := filepath.Join(dir, "gh")
+	if err := os.WriteFile(fakeGH, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestDeleteGHComment_StatusHandling exercises the three paths the push
+// drainer relies on: 2xx success, 404 already-gone, 403 not-author, and a
+// generic 500 surface as an error.
+func TestDeleteGHComment_StatusHandling(t *testing.T) {
+	cases := []struct {
+		name        string
+		statusLine  string
+		exitNonZero bool
+		wantStatus  int
+		wantErr     bool
+	}{
+		{"204_no_content", "HTTP/2 204", false, 204, false},
+		{"404_already_gone", "HTTP/2 404", true, 404, false},
+		{"403_not_author", "HTTP/2 403", true, 403, false},
+		{"500_server_error", "HTTP/2 500", true, 500, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installFakeGHForDelete(t, tc.statusLine, tc.exitNonZero)
+			status, err := deleteGHComment(42)
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -836,37 +836,47 @@ func runPushLive(ctx pushContext, b pushBuckets) {
 	// in pushes where there are no new comments to create.
 	patched := pushEditedBodies(ctx)
 
-	printPushSummary(posted, patched, len(b.FullStack)+len(b.Unmapped), exportPath)
+	// DELETE remote comments tombstoned locally. Independent of POST/PATCH:
+	// users can delete a comment without touching anything else.
+	deleted, deleteFailed := pushDeletedComments(ctx)
 
-	// Exit code: only fail when gh errored AND we have no orphans to fall
-	// back on. Otherwise something useful happened (export written), so
-	// exit 0.
-	if postFailed && exportPath == "" {
+	printPushSummary(posted, patched, deleted, len(b.FullStack)+len(b.Unmapped), exportPath)
+
+	if pushShouldExitFailure(posted, patched, deleted, exportPath, postFailed, deleteFailed) {
 		os.Exit(1)
 	}
 }
 
+// pushShouldExitFailure encodes the exit-code policy for `crit push`. The
+// process should fail (exit 1) only when nothing meaningful landed and at
+// least one operation failed. Failed per-ID deletes stay in
+// PendingGitHubDeletes for the next push (existing retry semantics), so a
+// partial delete failure must not mask successful posts/patches/drains.
+func pushShouldExitFailure(posted, patched, deleted int, exportPath string, postFailed, deleteFailed bool) bool {
+	anySuccess := posted > 0 || patched > 0 || deleted > 0 || exportPath != ""
+	anyFailure := postFailed || deleteFailed
+	return anyFailure && !anySuccess
+}
+
 // printPushSummary writes the one-line stdout summary describing what
 // happened. Adapts wording to the actual outcome (no orphans, no posts, etc).
-func printPushSummary(posted, patched, orphans int, exportPath string) {
-	if posted == 0 && patched == 0 && orphans == 0 {
+func printPushSummary(posted, patched, deleted, orphans int, exportPath string) {
+	if posted == 0 && patched == 0 && deleted == 0 && orphans == 0 {
 		fmt.Println("No comments to push.")
 		return
 	}
-	if exportPath == "" {
-		if patched > 0 {
-			fmt.Printf("Posted %d comments, edited %d.\n", posted, patched)
-			return
-		}
-		fmt.Printf("Posted %d comments.\n", posted)
-		return
-	}
+	parts := []string{fmt.Sprintf("Posted %d comments", posted)}
 	if patched > 0 {
-		fmt.Printf("Posted %d comments, edited %d. %d comments exported to %s.\n",
-			posted, patched, orphans, exportPath)
-		return
+		parts = append(parts, fmt.Sprintf("edited %d", patched))
 	}
-	fmt.Printf("Posted %d comments. %d comments exported to %s.\n", posted, orphans, exportPath)
+	if deleted > 0 {
+		parts = append(parts, fmt.Sprintf("deleted %d", deleted))
+	}
+	line := strings.Join(parts, ", ") + "."
+	if exportPath != "" {
+		line += fmt.Sprintf(" %d comments exported to %s.", orphans, exportPath)
+	}
+	fmt.Println(line)
 }
 
 // pushEditedBodies PATCHes already-pushed comments/replies whose local body
@@ -890,6 +900,43 @@ func pushEditedBodies(ctx pushContext) int {
 		fmt.Fprintf(os.Stderr, "Warning: failed to update review file after edit push: %v\n", uerr)
 	}
 	return len(succeeded)
+}
+
+// pushDeletedComments issues DELETE for every GitHub comment ID queued in
+// PendingGitHubDeletes. Returns the count of IDs whose DELETE was drained
+// (200 / 204, plus 404 "already gone" and 403 "not the author") and whether
+// any DELETE returned an error severe enough to surface a non-zero exit.
+//
+// 403 is logged but treated as drained — the GitHub API rejects deletes by
+// non-authors, so retrying is futile and a stuck pending entry would block
+// all future pushes for this review file.
+func pushDeletedComments(ctx pushContext) (int, bool) {
+	pending := collectDeletesForPush(ctx.cj)
+	if len(pending) == 0 {
+		return 0, false
+	}
+	drained := make([]int64, 0, len(pending))
+	failed := false
+	for _, id := range pending {
+		status, err := deleteGHComment(id)
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "Warning: failed to delete comment %d: %v\n", id, err)
+			failed = true
+		case status >= 200 && status < 300, status == 404:
+			drained = append(drained, id)
+		case status == 403:
+			fmt.Fprintf(os.Stderr, "Warning: cannot delete comment %d on GitHub (403; not the author) — dropping pending delete\n", id)
+			drained = append(drained, id)
+		default:
+			fmt.Fprintf(os.Stderr, "Warning: unexpected status %d deleting comment %d\n", status, id)
+			failed = true
+		}
+	}
+	if uerr := updateCritJSONAfterDeletes(ctx.critPath, drained); uerr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to update review file after delete push: %v\n", uerr)
+	}
+	return len(drained), failed
 }
 
 // fullStackPushGateMessage is the user-facing error string emitted when

--- a/push_partial_failure_test.go
+++ b/push_partial_failure_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -93,5 +94,99 @@ esac
 	// Sanity: exactly two successful entries.
 	if len(got) != 2 {
 		t.Errorf("len(replyIDs) = %d, want 2; map=%v", len(got), got)
+	}
+}
+
+// TestPushDeletedComments_PartialFailure regresses BLOCKER #2 of issue #449:
+// when DELETE succeeds for one queued ID and fails (HTTP 500) for another,
+// the successful ID must be drained from PendingGitHubDeletes on disk and
+// the failed ID must remain queued for the next push. Combined with the
+// pushShouldExitFailure policy, a partial-success delete must NOT cause
+// `crit push` to exit non-zero when other work (posts, patches, drains)
+// succeeded.
+func TestPushDeletedComments_PartialFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-gh shim is a POSIX shell script; not portable to Windows")
+	}
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "counter")
+	if err := os.WriteFile(counter, []byte("0\n"), 0644); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+
+	// Fake gh emulating `gh api ... --method DELETE --include`. Call 1
+	// returns HTTP 204 (drained). Call 2 returns HTTP 500 + non-zero exit
+	// (failure). gh's --include writes the status line to stdout.
+	fakeGH := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+COUNTER_FILE="` + counter + `"
+n=$(cat "$COUNTER_FILE")
+n=$((n + 1))
+echo "$n" > "$COUNTER_FILE"
+cat >/dev/null
+case "$n" in
+  1) printf 'HTTP/2 204\n\n' ;;
+  2) printf 'HTTP/2 500\n\nserver error\n' >&2; printf 'HTTP/2 500\n\n'; exit 1 ;;
+  *) printf 'HTTP/2 204\n\n' ;;
+esac
+`
+	if err := os.WriteFile(fakeGH, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Set up a review file with two queued GitHub deletes.
+	critRoot := filepath.Join(dir, "review")
+	if err := os.MkdirAll(critRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cj := CritJSON{
+		Files:                map[string]CritJSONFile{},
+		PendingGitHubDeletes: []int64{1001, 1002},
+	}
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPathsFor(critRoot).Review, out, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := pushContext{critPath: critRoot, cj: cj}
+	drained, failed := pushDeletedComments(ctx)
+	if drained != 1 {
+		t.Errorf("drained = %d, want 1", drained)
+	}
+	if !failed {
+		t.Error("failed = false, want true (one DELETE returned 500)")
+	}
+
+	// On-disk queue should now contain exactly the failed ID.
+	data, err := os.ReadFile(reviewPathsFor(critRoot).Review)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var after CritJSON
+	if err := json.Unmarshal(data, &after); err != nil {
+		t.Fatal(err)
+	}
+	if len(after.PendingGitHubDeletes) != 1 || after.PendingGitHubDeletes[0] != 1002 {
+		t.Errorf("PendingGitHubDeletes after = %v, want [1002]", after.PendingGitHubDeletes)
+	}
+
+	// Exit-code policy: a partial delete failure with at least one drain
+	// (or any post / patch / export) must NOT exit 1.
+	if pushShouldExitFailure(0, 0, drained, "", false, failed) {
+		t.Error("pushShouldExitFailure = true; want false when a drain succeeded")
+	}
+	// Successful posts must also rescue an all-failed delete batch.
+	if pushShouldExitFailure(3, 0, 0, "", false, true) {
+		t.Error("pushShouldExitFailure = true; want false when posts succeeded")
+	}
+	// True total failure: nothing succeeded, something failed → exit 1.
+	if !pushShouldExitFailure(0, 0, 0, "", false, true) {
+		t.Error("pushShouldExitFailure = false; want true when nothing succeeded and a delete failed")
 	}
 }

--- a/roundtrip_integration_test.go
+++ b/roundtrip_integration_test.go
@@ -650,7 +650,6 @@ func TestRoundtrip_EditForeignComment_DoesNotPropagate(t *testing.T) {
 }
 
 func TestRoundtrip_LocalDeletePropagates(t *testing.T) {
-	t.Skip("blocked on issue #449: crit push does not propagate locally-deleted comments to GitHub")
 	e := newRoundtripEnv(t)
 
 	e.runCrit("comment", "sample.go:19", "to be deleted")
@@ -662,7 +661,9 @@ func TestRoundtrip_LocalDeletePropagates(t *testing.T) {
 	}
 	pushedID := rs[0].ID
 
-	// Delete locally — simulate the daemon's DELETE /api/comment/{id}.
+	// Delete locally — simulate the daemon's DELETE /api/comment/{id},
+	// which splices the record out and queues the GitHub ID in
+	// PendingGitHubDeletes for the next push to drain.
 	e.editReviewFile(func(cj *CritJSON) {
 		removed := false
 		for path, f := range cj.Files {
@@ -680,6 +681,7 @@ func TestRoundtrip_LocalDeletePropagates(t *testing.T) {
 		if !removed {
 			t.Fatal("did not find pushed comment to delete locally")
 		}
+		cj.PendingGitHubDeletes = append(cj.PendingGitHubDeletes, pushedID)
 	})
 
 	// Push: expect the remote comment to disappear.

--- a/session.go
+++ b/session.go
@@ -259,6 +259,20 @@ type Session struct {
 	// prevents mergeFileSnapshotIntoCritJSON from re-adding them from disk.
 	deletedCommentIDs map[string]map[string]struct{}
 
+	// pendingGitHubDeletes holds GitHub comment IDs (root or reply) that the
+	// user has deleted locally and that the next `crit push` must DELETE
+	// upstream. Persisted as CritJSON.PendingGitHubDeletes; the next push
+	// drains entries as each DELETE succeeds (or returns 404 / 403).
+	pendingGitHubDeletes []int64
+
+	// lastLoadedPendingGHDeletes is the set of GitHub IDs that were on disk
+	// in PendingGitHubDeletes the last time the daemon read or wrote
+	// review.json. Used by buildCritJSON to reconcile the in-memory snapshot
+	// against the on-disk queue: an ID present in the snapshot but missing
+	// from disk AND present in this set means a separate `crit push` process
+	// drained it — it must NOT be resurrected. See BLOCKER #1.
+	lastLoadedPendingGHDeletes map[int64]struct{}
+
 	mu          sync.RWMutex
 	subscribers map[chan SSEEvent]struct{}
 	subMu       sync.Mutex
@@ -324,6 +338,13 @@ type CritJSON struct {
 	// ActiveDiffScope is the most recent focus diff_scope from this session.
 	// Read by `crit push` to gate full-stack pushes; "" indicates working-tree mode.
 	ActiveDiffScope string `json:"active_diff_scope,omitempty"`
+
+	// PendingGitHubDeletes holds GitHub comment IDs (root or reply — same
+	// /pulls/comments/{id} endpoint) that the user has deleted locally and
+	// that need a DELETE upstream on the next `crit push`. Drained as each
+	// DELETE succeeds (or returns 404 / 403). Survives intermediate pulls so
+	// the user's intent is not lost.
+	PendingGitHubDeletes []int64 `json:"pending_github_deletes,omitempty"`
 }
 
 // CritJSONFile is the per-file section in review files.
@@ -859,7 +880,9 @@ func (s *Session) UpdateReviewComment(id, body string) (Comment, bool) {
 	return Comment{}, false
 }
 
-// DeleteReviewComment deletes a review-level comment by ID.
+// DeleteReviewComment deletes a review-level comment by ID. Review-level
+// comments are local-only (not synced to GitHub PR review comments), so a
+// straight removal is safe — there is no upstream record to tombstone.
 func (s *Session) DeleteReviewComment(id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -942,6 +965,7 @@ func (s *Session) UpdateReviewCommentReply(commentID, replyID, body string) (Rep
 }
 
 // DeleteReviewCommentReply removes a reply from a review-level comment.
+// Review-level threads are local-only, so a straight removal is safe.
 func (s *Session) DeleteReviewCommentReply(commentID, replyID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1024,7 +1048,12 @@ func (s *Session) SetCommentLive(filePath, id string) bool {
 	return false
 }
 
-// DeleteComment deletes a comment from a specific file.
+// DeleteComment deletes a comment from a specific file. The record is always
+// spliced out locally. If it has been pushed to GitHub (GitHubID != 0) the
+// GitHub ID is appended to pendingGitHubDeletes so the next `crit push` can
+// issue DELETE upstream — without that, deleting a pushed comment would leave
+// a ghost on the PR. trackDeletedComment guards against a concurrent reload
+// from disk resurrecting the just-removed entry before the next save.
 func (s *Session) DeleteComment(filePath, id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1034,6 +1063,9 @@ func (s *Session) DeleteComment(filePath, id string) bool {
 	}
 	for i, c := range f.Comments {
 		if c.ID == id {
+			if c.GitHubID != 0 {
+				s.appendPendingGHDelete(c.GitHubID)
+			}
 			f.Comments = append(f.Comments[:i], f.Comments[i+1:]...)
 			s.trackDeletedComment(filePath, id)
 			s.scheduleWrite()
@@ -1041,6 +1073,20 @@ func (s *Session) DeleteComment(filePath, id string) bool {
 		}
 	}
 	return false
+}
+
+// appendPendingGHDelete adds a GitHub comment ID to the pending-deletes list
+// if it isn't already present. Caller must hold s.mu.
+func (s *Session) appendPendingGHDelete(ghID int64) {
+	if ghID == 0 {
+		return
+	}
+	for _, existing := range s.pendingGitHubDeletes {
+		if existing == ghID {
+			return
+		}
+	}
+	s.pendingGitHubDeletes = append(s.pendingGitHubDeletes, ghID)
 }
 
 // trackDeletedComment records a file comment ID as deleted so the merge logic
@@ -1129,7 +1175,10 @@ func (s *Session) UpdateReply(filePath, commentID, replyID, body string) (Reply,
 	return Reply{}, false
 }
 
-// DeleteReply removes a reply from a specific comment.
+// DeleteReply removes a reply from a specific comment. Always spliced out
+// locally; replies that have been pushed (GitHubID != 0) get their GitHub ID
+// queued in pendingGitHubDeletes so the next `crit push` can DELETE them
+// upstream (replies share /pulls/comments/{id} with root comments).
 func (s *Session) DeleteReply(filePath, commentID, replyID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1141,6 +1190,9 @@ func (s *Session) DeleteReply(filePath, commentID, replyID string) bool {
 		if c.ID == commentID {
 			for j, r := range c.Replies {
 				if r.ID == replyID {
+					if r.GitHubID != 0 {
+						s.appendPendingGHDelete(r.GitHubID)
+					}
 					f.Comments[i].Replies = append(f.Comments[i].Replies[:j], f.Comments[i].Replies[j+1:]...)
 					f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 					s.scheduleWrite()
@@ -1687,10 +1739,21 @@ func reportLoadCritJSONLockViolation() {
 // path (NewSessionFromFiles, applySessionOverrides, etc.) before any goroutine
 // reads s.RoundSnapshots / s.reviewComments / etc. Runtime callers that hold
 // s.mu.Lock() must use loadCritJSONLocked instead. See plan v4 §Lock discipline.
+//
+// Acquires s.mu.Lock() defensively: even pre-SetSession, a prior mutation
+// (e.g. AddReviewComment in a test) may have armed scheduleWrite's debounced
+// AfterFunc, which reads s.lastCritJSONMtime under RLock from a separate
+// goroutine. Stopping the timer first short-circuits the common case; the
+// lock covers the in-flight case.
 func (s *Session) loadCritJSON() {
 	if s.sessionStarted.Load() != 0 {
 		reportLoadCritJSONLockViolation()
 		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeTimer != nil {
+		s.writeTimer.Stop()
 	}
 	s.loadCritJSONLocked()
 }
@@ -1801,6 +1864,13 @@ func (s *Session) loadCritJSONLocked() {
 
 	// Restore review-level comments.
 	s.reviewComments = cj.ReviewComments
+
+	// Restore pending DELETE intents so they survive across daemon restarts.
+	s.pendingGitHubDeletes = cj.PendingGitHubDeletes
+	s.lastLoadedPendingGHDeletes = make(map[int64]struct{}, len(cj.PendingGitHubDeletes))
+	for _, id := range cj.PendingGitHubDeletes {
+		s.lastLoadedPendingGHDeletes[id] = struct{}{}
+	}
 
 	// Record the mtime so the first ticker tick doesn't re-process our own file.
 	if info, err := os.Stat(reviewPathsFor(s.critJSONPath()).Review); err == nil {

--- a/session_test.go
+++ b/session_test.go
@@ -128,6 +128,224 @@ func TestSession_DeleteComment_NotFound(t *testing.T) {
 	}
 }
 
+// TestSession_DeleteComment_WithGitHubID_QueuesPendingDelete verifies that
+// deleting a pushed comment splices it out AND records its GitHub ID so the
+// next `crit push` can issue DELETE upstream.
+func TestSession_DeleteComment_WithGitHubID_QueuesPendingDelete(t *testing.T) {
+	s := newTestSession(t)
+	c, _ := s.AddComment("plan.md", 1, 1, "", "pushed", "", "", "")
+	// Stamp a GitHubID directly to simulate a previously-pushed comment.
+	s.mu.Lock()
+	for _, f := range s.Files {
+		for i := range f.Comments {
+			if f.Comments[i].ID == c.ID {
+				f.Comments[i].GitHubID = 12345
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if !s.DeleteComment("plan.md", c.ID) {
+		t.Fatal("DeleteComment failed")
+	}
+	if len(s.GetComments("plan.md")) != 0 {
+		t.Error("comment should be removed from in-memory list")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.pendingGitHubDeletes) != 1 || s.pendingGitHubDeletes[0] != 12345 {
+		t.Errorf("pendingGitHubDeletes = %v, want [12345]", s.pendingGitHubDeletes)
+	}
+}
+
+// TestSession_DeleteComment_WithoutGitHubID_NoPending verifies that deleting
+// a comment that was never pushed does not pollute the pending-deletes list.
+func TestSession_DeleteComment_WithoutGitHubID_NoPending(t *testing.T) {
+	s := newTestSession(t)
+	c, _ := s.AddComment("plan.md", 1, 1, "", "local-only", "", "", "")
+	if !s.DeleteComment("plan.md", c.ID) {
+		t.Fatal("DeleteComment failed")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.pendingGitHubDeletes) != 0 {
+		t.Errorf("pendingGitHubDeletes leaked: %v", s.pendingGitHubDeletes)
+	}
+}
+
+// TestSession_DeleteComment_PendingDeleteIsIdempotent ensures duplicate
+// DELETE intents are not appended (a no-op double-delete from a flaky client
+// must not balloon the list).
+func TestSession_DeleteComment_PendingDeleteIsIdempotent(t *testing.T) {
+	s := newTestSession(t)
+	s.mu.Lock()
+	s.appendPendingGHDelete(99)
+	s.appendPendingGHDelete(99)
+	s.appendPendingGHDelete(99)
+	got := append([]int64{}, s.pendingGitHubDeletes...)
+	s.mu.Unlock()
+	if len(got) != 1 || got[0] != 99 {
+		t.Errorf("appendPendingGHDelete not idempotent: %v", got)
+	}
+}
+
+// TestSession_DeleteReply_WithGitHubID_QueuesPendingDelete asserts that
+// deleting a pushed reply queues its GitHub ID (replies share the same
+// /pulls/comments/{id} endpoint as root comments).
+func TestSession_DeleteReply_WithGitHubID_QueuesPendingDelete(t *testing.T) {
+	s := newTestSession(t)
+	c, _ := s.AddComment("plan.md", 1, 1, "", "parent", "", "", "")
+	r, _ := s.AddReply("plan.md", c.ID, "reply body", "", "")
+	s.mu.Lock()
+	for _, f := range s.Files {
+		for i := range f.Comments {
+			if f.Comments[i].ID == c.ID {
+				for j := range f.Comments[i].Replies {
+					if f.Comments[i].Replies[j].ID == r.ID {
+						f.Comments[i].Replies[j].GitHubID = 7777
+					}
+				}
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if !s.DeleteReply("plan.md", c.ID, r.ID) {
+		t.Fatal("DeleteReply failed")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.pendingGitHubDeletes) != 1 || s.pendingGitHubDeletes[0] != 7777 {
+		t.Errorf("pendingGitHubDeletes = %v, want [7777]", s.pendingGitHubDeletes)
+	}
+}
+
+// TestSession_PendingGHDeletes_NotResurrectedAfterPushDrain regresses the
+// daemon-vs-push race for issue #449: a separate `crit push` process drains
+// queued GitHub-delete IDs by writing review.json with an empty
+// PendingGitHubDeletes. A subsequent in-memory write from the daemon must NOT
+// resurrect those IDs.
+func TestSession_PendingGHDeletes_NotResurrectedAfterPushDrain(t *testing.T) {
+	s := newTestSession(t)
+
+	// Pre-existing comment so the file (and review.json) stays non-empty
+	// after we delete the pushed one.
+	s.AddComment("plan.md", 3, 3, "", "keep me", "", "", "")
+
+	// 1. Queue a delete in-memory (simulates user deleting a pushed comment).
+	c, _ := s.AddComment("plan.md", 1, 1, "", "pushed", "", "", "")
+	s.mu.Lock()
+	for _, f := range s.Files {
+		for i := range f.Comments {
+			if f.Comments[i].ID == c.ID {
+				f.Comments[i].GitHubID = 12345
+			}
+		}
+	}
+	s.mu.Unlock()
+	if !s.DeleteComment("plan.md", c.ID) {
+		t.Fatal("DeleteComment failed")
+	}
+
+	// 2. First daemon write — flushes the queued delete to disk and updates
+	//    lastLoadedPendingGHDeletes accordingly.
+	flushWrites(s)
+	s.WriteFiles()
+
+	reviewPath := reviewPathsFor(s.critJSONPath()).Review
+	data, err := os.ReadFile(reviewPath)
+	if err != nil {
+		t.Fatalf("read review: %v", err)
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		t.Fatal(err)
+	}
+	if len(cj.PendingGitHubDeletes) != 1 || cj.PendingGitHubDeletes[0] != 12345 {
+		t.Fatalf("setup: PendingGitHubDeletes = %v, want [12345]", cj.PendingGitHubDeletes)
+	}
+
+	// 3. Simulate `crit push` draining the queue: rewrite review.json with
+	//    PendingGitHubDeletes cleared. Other state is preserved.
+	cj.PendingGitHubDeletes = nil
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, out, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Daemon writes again (e.g. user edits another comment). Without the
+	//    reconcile, snap.pendingGHDeletes still has 12345 and would be
+	//    blindly written back, resurrecting the drained ID.
+	s.AddComment("plan.md", 2, 2, "", "another edit", "", "", "")
+	flushWrites(s)
+	s.WriteFiles()
+
+	data, err = os.ReadFile(reviewPath)
+	if err != nil {
+		t.Fatalf("re-read review: %v", err)
+	}
+	var after CritJSON
+	if err := json.Unmarshal(data, &after); err != nil {
+		t.Fatal(err)
+	}
+	if len(after.PendingGitHubDeletes) != 0 {
+		t.Errorf("PendingGitHubDeletes resurrected: %v; push had drained the queue", after.PendingGitHubDeletes)
+	}
+
+	// In-memory state must also be cleaned up so subsequent writes are stable.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.pendingGitHubDeletes) != 0 {
+		t.Errorf("in-memory pendingGitHubDeletes leaked: %v", s.pendingGitHubDeletes)
+	}
+}
+
+// TestSession_PendingGHDeletes_FreshlyAddedSurvivesConcurrentDrain ensures the
+// reconcile keeps locally-queued deletes that have NOT yet been written to
+// disk, even if a concurrent push wrote an empty queue. Only previously-seen
+// IDs (in lastLoaded) may be dropped.
+func TestSession_PendingGHDeletes_FreshlyAddedSurvivesConcurrentDrain(t *testing.T) {
+	s := newTestSession(t)
+
+	// Push (simulated) wrote review.json with empty PendingGitHubDeletes and
+	// no comments. lastLoaded is empty. Now the user deletes a pushed comment
+	// in-memory before any daemon write.
+	c, _ := s.AddComment("plan.md", 1, 1, "", "pushed", "", "", "")
+	s.mu.Lock()
+	for _, f := range s.Files {
+		for i := range f.Comments {
+			if f.Comments[i].ID == c.ID {
+				f.Comments[i].GitHubID = 999
+			}
+		}
+	}
+	s.mu.Unlock()
+	if !s.DeleteComment("plan.md", c.ID) {
+		t.Fatal("DeleteComment failed")
+	}
+
+	// Add a benign comment to keep the file non-empty.
+	s.AddComment("plan.md", 2, 2, "", "keep", "", "", "")
+
+	flushWrites(s)
+	s.WriteFiles()
+
+	data, err := os.ReadFile(reviewPathsFor(s.critJSONPath()).Review)
+	if err != nil {
+		t.Fatalf("read review: %v", err)
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		t.Fatal(err)
+	}
+	if len(cj.PendingGitHubDeletes) != 1 || cj.PendingGitHubDeletes[0] != 999 {
+		t.Errorf("freshly-queued delete dropped: %v, want [999]", cj.PendingGitHubDeletes)
+	}
+}
+
 func TestSession_GetComments_ReturnsCopy(t *testing.T) {
 	s := newTestSession(t)
 	s.AddComment("plan.md", 1, 1, "", "test", "", "", "")

--- a/session_write.go
+++ b/session_write.go
@@ -59,6 +59,15 @@ type writeFilesSnapshot struct {
 	shareScope     string
 	reviewComments []Comment
 	cliArgs        []string
+	// pendingGHDeletes is the snapshot of session.pendingGitHubDeletes; carried
+	// into CritJSON so the next push can drain DELETE intents that were never
+	// flushed (e.g. user deleted, then quit before pushing).
+	pendingGHDeletes []int64
+	// lastLoadedGHDeletes is the set of GitHub IDs the daemon has previously
+	// observed on disk in PendingGitHubDeletes. Used to distinguish "drained
+	// by a concurrent `crit push`" (in lastLoaded but not in disk now) from
+	// "freshly added since last load" (in snap but not in lastLoaded).
+	lastLoadedGHDeletes map[int64]struct{}
 	// Per-file data needed for the merge. We copy comments so the snapshot
 	// is independent of later in-memory mutations.
 	files []writeFileSnapshot
@@ -135,11 +144,59 @@ func buildCritJSON(snap writeFilesSnapshot) CritJSON {
 	cj.ShareScope = snap.shareScope
 	cj.ReviewComments = snap.reviewComments
 	cj.CliArgs = snap.cliArgs
+	cj.PendingGitHubDeletes = reconcilePendingGHDeletes(
+		snap.pendingGHDeletes, cj.PendingGitHubDeletes, snap.lastLoadedGHDeletes,
+	)
 
 	for _, fs := range snap.files {
 		mergeFileSnapshotIntoCritJSON(&cj, fs)
 	}
 	return cj
+}
+
+// reconcilePendingGHDeletes merges the daemon's in-memory snapshot of pending
+// GitHub-delete IDs against what is currently on disk. The Session and
+// `crit push` are separate processes: push drains IDs by writing them out of
+// disk's PendingGitHubDeletes. If we naively wrote snap back, a concurrent
+// daemon write would resurrect drained IDs.
+//
+// Semantics:
+//   - Keep an ID if it is still on disk (push has not drained it).
+//   - Keep an ID if it is freshly added in-memory (not in lastLoaded), since
+//     it was queued after our last disk read.
+//   - Drop an ID that is in lastLoaded but no longer on disk — push drained
+//     it concurrently; we must not resurrect it.
+//
+// Order is preserved from snap so callers see a stable queue.
+func reconcilePendingGHDeletes(snap, disk []int64, lastLoaded map[int64]struct{}) []int64 {
+	if len(snap) == 0 {
+		return nil
+	}
+	diskSet := make(map[int64]struct{}, len(disk))
+	for _, id := range disk {
+		diskSet[id] = struct{}{}
+	}
+	out := make([]int64, 0, len(snap))
+	seen := make(map[int64]struct{}, len(snap))
+	for _, id := range snap {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		_, onDisk := diskSet[id]
+		_, wasLoaded := lastLoaded[id]
+		// Drop only when push has demonstrably drained it: previously seen
+		// on disk AND no longer there. Fresh entries (not in lastLoaded)
+		// are kept regardless of disk state.
+		if !onDisk && wasLoaded {
+			continue
+		}
+		out = append(out, id)
+		seen[id] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // mergeFileSnapshotIntoCritJSON merges a single file's comments from the snapshot
@@ -214,6 +271,8 @@ func (s *Session) WriteFiles() {
 		s.lastCritJSONMtime = time.Time{}
 		s.pendingWrite = false
 		s.deletedCommentIDs = nil
+		s.pendingGitHubDeletes = nil
+		s.lastLoadedPendingGHDeletes = nil
 		s.mu.Unlock()
 		return
 	}
@@ -232,6 +291,14 @@ func (s *Session) WriteFiles() {
 		s.lastCritJSONMtime = info.ModTime()
 		s.pendingWrite = false
 		s.deletedCommentIDs = nil // written to disk, no longer needed
+		// Sync in-memory pending-delete state to what we just wrote, so the
+		// next snapshot does not re-include IDs that a concurrent
+		// `crit push` already drained. See reconcilePendingGHDeletes.
+		s.pendingGitHubDeletes = append(s.pendingGitHubDeletes[:0:0], cj.PendingGitHubDeletes...)
+		s.lastLoadedPendingGHDeletes = make(map[int64]struct{}, len(cj.PendingGitHubDeletes))
+		for _, id := range cj.PendingGitHubDeletes {
+			s.lastLoadedPendingGHDeletes[id] = struct{}{}
+		}
 		s.mu.Unlock()
 	}
 }
@@ -245,18 +312,26 @@ func (s *Session) snapshotForWrite(critPath string) writeFilesSnapshot {
 
 	rc := make([]Comment, len(s.reviewComments))
 	copy(rc, s.reviewComments)
+	pendDeletes := make([]int64, len(s.pendingGitHubDeletes))
+	copy(pendDeletes, s.pendingGitHubDeletes)
+	lastLoaded := make(map[int64]struct{}, len(s.lastLoadedPendingGHDeletes))
+	for id := range s.lastLoadedPendingGHDeletes {
+		lastLoaded[id] = struct{}{}
+	}
 	snap := writeFilesSnapshot{
-		critPath:       critPath,
-		lastMtime:      s.lastCritJSONMtime,
-		branch:         s.Branch,
-		baseRef:        s.BaseRef,
-		reviewRound:    s.ReviewRound,
-		sharedURL:      s.sharedURL,
-		deleteToken:    s.deleteToken,
-		shareScope:     s.shareScope,
-		reviewComments: rc,
-		cliArgs:        s.CLIArgs,
-		files:          make([]writeFileSnapshot, len(s.Files)),
+		critPath:            critPath,
+		lastMtime:           s.lastCritJSONMtime,
+		branch:              s.Branch,
+		baseRef:             s.BaseRef,
+		reviewRound:         s.ReviewRound,
+		sharedURL:           s.sharedURL,
+		deleteToken:         s.deleteToken,
+		shareScope:          s.shareScope,
+		reviewComments:      rc,
+		cliArgs:             s.CLIArgs,
+		pendingGHDeletes:    pendDeletes,
+		lastLoadedGHDeletes: lastLoaded,
+		files:               make([]writeFileSnapshot, len(s.Files)),
 	}
 	for i, f := range s.Files {
 		comments := make([]Comment, len(f.Comments))


### PR DESCRIPTION
## Summary

Closes #449.

When a comment with `GitHubID != 0` is deleted locally, append its GitHubID to a top-level `pending_github_deletes` list. `crit push` drains this list by issuing DELETE for each ID; `crit pull`'s merge filters upstream comments whose ID is pending so they aren't resurrected before push runs.

Replies use the same mechanism — GitHub treats them as comments on the same `/pulls/comments/{id}` endpoint, so one list covers both.

`omitempty` on the slice ensures a fully-drained list disappears from `review.json` entirely; agents reading the file directly never see a stale empty array or per-record tombstone fields.

### Race fix included

The daemon (long-lived process) and `crit push` (separate CLI invocation) both own a copy of the queue. The daemon's in-memory snapshot used to clobber disk on the next debounced write, resurrecting IDs that push had just drained. Reconciliation in `buildCritJSON` now treats disk as authoritative for the queue: in-memory IDs that vanished from disk (push drained them) are dropped from the snapshot; freshly-queued local deletes are preserved.

### Exit-code fix included

Per-ID DELETE failures no longer fail the whole push when posts/patches succeeded. Exit 1 only when nothing succeeded AND something failed. Failed deletes stay in the queue for next-push retry.

## Review
- [x] Code review: passed (go-expert)
- [x] Intent audit: passed
- [x] e2e roundtrip: TestRoundtrip_LocalDeletePropagates PASS

## Test plan
- \`go test -race -count=2 ./...\` — clean
- \`golangci-lint run ./...\` — 0 issues
- \`./scripts/e2e-roundtrip.sh -run TestRoundtrip_LocalDeletePropagates\` — PASS (deleted comment removed from upstream PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)