### PR TITLE
fix: import GitHub thread resolved state on crit pull

### DIFF
--- a/github.go
+++ b/github.go
@@ -561,6 +561,138 @@ func fetchPRCommentsWithoutSlurp(prNumber int) ([]ghComment, error) {
 	}
 }
 
+// fetchCurrentRepoOwnerName returns (owner, repo) for the current working
+// directory's GitHub repo via `gh repo view`. Used by GraphQL queries which,
+// unlike REST, don't honor the `{owner}/{repo}` placeholder substitution
+// that gh applies to REST endpoints.
+func fetchCurrentRepoOwnerName() (string, string, error) {
+	out, err := exec.Command("gh", "repo", "view", "--json", "owner,name").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("resolving current repo: %w", err)
+	}
+	var resp struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", "", fmt.Errorf("parsing current repo: %w", err)
+	}
+	if resp.Owner.Login == "" || resp.Name == "" {
+		return "", "", fmt.Errorf("gh repo view returned empty owner/name: %s", string(out))
+	}
+	return resp.Owner.Login, resp.Name, nil
+}
+
+// fetchPRThreadResolved returns a map databaseID -> isResolved for every
+// review-thread comment on the PR, gathered from the reviewThreads GraphQL
+// edge. Threads carry the resolved bit only at the thread level, not on the
+// individual REST /pulls/{n}/comments rows — so this is the only path that
+// surfaces "reviewer clicked Resolve on github.com" to `crit pull`. See #453.
+//
+// Pagination: GitHub caps reviewThreads at 100 nodes and comments-per-thread
+// at 100. We page on the outer connection; very large discussions
+// (>100 threads or >100 replies in one thread) are still rare enough at
+// crit's scale that the inner cap is acceptable. If we ever hit it, the
+// merge logic degrades gracefully — only the unseen replies miss the
+// resolved bit, the root still gets it.
+func fetchPRThreadResolved(prNumber int) (map[int64]bool, error) {
+	owner, name, err := fetchCurrentRepoOwnerName()
+	if err != nil {
+		return nil, err
+	}
+	resolved := make(map[int64]bool)
+	cursor := ""
+	for {
+		page, nextCursor, err := fetchPRThreadResolvedPage(owner, name, prNumber, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for id, r := range page {
+			resolved[id] = r
+		}
+		if nextCursor == "" {
+			return resolved, nil
+		}
+		cursor = nextCursor
+	}
+}
+
+// graphqlThreadResp is the typed shape of the reviewThreads GraphQL response.
+type graphqlThreadResp struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []struct {
+						IsResolved bool `json:"isResolved"`
+						Comments   struct {
+							Nodes []struct {
+								DatabaseID int64 `json:"databaseId"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// fetchPRThreadResolvedPage fetches one page of review threads and returns
+// (databaseID -> isResolved, nextCursor, error). nextCursor is "" when no
+// more pages are available.
+func fetchPRThreadResolvedPage(owner, name string, prNumber int, cursor string) (map[int64]bool, string, error) {
+	const query = `query($owner:String!,$name:String!,$pr:Int!,$after:String){
+  repository(owner:$owner, name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100, after:$after){
+        pageInfo{ hasNextPage endCursor }
+        nodes{
+          isResolved
+          comments(first:100){ nodes{ databaseId } }
+        }
+      }
+    }
+  }
+}`
+	args := []string{"api", "graphql",
+		"-f", "owner=" + owner,
+		"-f", "name=" + name,
+		"-F", fmt.Sprintf("pr=%d", prNumber),
+		"-f", "query=" + query,
+	}
+	if cursor != "" {
+		args = append(args, "-f", "after="+cursor)
+	}
+	out, err := exec.Command("gh", args...).Output()
+	if err != nil {
+		return nil, "", fmt.Errorf("fetching PR review threads: %w", err)
+	}
+	var resp graphqlThreadResp
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, "", fmt.Errorf("parsing PR review threads: %w", err)
+	}
+	page := make(map[int64]bool)
+	for _, n := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+		for _, c := range n.Comments.Nodes {
+			if c.DatabaseID == 0 {
+				continue
+			}
+			page[c.DatabaseID] = n.IsResolved
+		}
+	}
+	next := ""
+	if resp.Data.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage {
+		next = resp.Data.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor
+	}
+	return page, next, nil
+}
+
 // isDuplicateGHComment checks if a GitHub comment already exists in the comment list.
 // If ghID is non-zero, matches by GitHubID. Otherwise falls back to author+lines+body.
 func isDuplicateGHComment(comments []Comment, ghID int64, author string, startLine, endLine int, body string) bool {
@@ -647,10 +779,49 @@ func appendNewGHReplies(comments []Comment, ci int, childReplies []ghComment, na
 	return added
 }
 
+// updateDuplicateRoot applies thread-resolved updates and merges new replies
+// onto a root comment that already exists locally (matched by GitHubID).
+// Returns the number of meaningful changes (new replies + at most one for a
+// resolution flip) so runPull's added==0 short-circuit correctly persists.
+func updateDuplicateRoot(
+	cj *CritJSON, cf *CritJSONFile, gc ghComment, replyMap map[int64][]ghComment,
+	names userNameCache, pendingDeletes map[int64]bool,
+	hasRemote, remoteResolved bool, now string,
+) int {
+	added := 0
+	for ci, c := range cf.Comments {
+		if c.GitHubID != gc.ID {
+			continue
+		}
+		if hasRemote && remoteResolved && !c.Resolved {
+			cf.Comments[ci].Resolved = true
+			cf.Comments[ci].ResolvedRound = cj.ReviewRound
+			cf.Comments[ci].UpdatedAt = now
+			added++
+		}
+		if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
+			added += appendNewGHReplies(cf.Comments, ci, childReplies, names, pendingDeletes)
+		}
+		break
+	}
+	return added
+}
+
 // mergeRootComment handles a single root ghComment: either deduplicates or creates it.
 // scope stamps the imported comment's HeadSHA + DiffScope when called from a range-mode
-// pull. Empty scope leaves the legacy working-tree fields unset.
-func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string, names userNameCache, scope inheritedScope, pendingDeletes map[int64]bool) int {
+// pull. Empty scope leaves the legacy working-tree fields unset. threadResolved
+// is the databaseID -> isResolved map from the reviewThreads GraphQL edge;
+// when present, the root's Resolved bit is updated asymmetrically:
+//
+//   - Remote resolved + local unresolved -> set Resolved=true, ResolvedRound=cj.ReviewRound
+//   - Remote unresolved + local resolved -> KEEP local resolved (don't clobber)
+//   - Both same -> no-op
+//
+// The asymmetry mirrors the existing pull semantics for Body (dedup matches
+// existing comments and never overwrites local edits): a local user may have
+// resolved a thread via crit / crit-web independently of github.com, and
+// `crit pull` should not undo that.
+func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment, now string, names userNameCache, scope inheritedScope, pendingDeletes map[int64]bool, threadResolved map[int64]bool) int {
 	cf, ok := cj.Files[gc.Path]
 	if !ok {
 		cf = CritJSONFile{Status: "modified", Comments: []Comment{}}
@@ -670,17 +841,11 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 		return 0
 	}
 
+	remoteResolved, hasRemote := threadResolvedForRoot(gc.ID, replyMap[gc.ID], threadResolved)
+
 	if isDuplicateGHComment(cf.Comments, gc.ID, authorName, startLine, gc.Line, gc.Body) {
-		added := 0
-		if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
-			for ci, c := range cf.Comments {
-				if c.GitHubID == gc.ID {
-					added = appendNewGHReplies(cf.Comments, ci, childReplies, names, pendingDeletes)
-					break
-				}
-			}
-			cj.Files[gc.Path] = cf
-		}
+		added := updateDuplicateRoot(cj, &cf, gc, replyMap, names, pendingDeletes, hasRemote, remoteResolved, now)
+		cj.Files[gc.Path] = cf
 		return added
 	}
 
@@ -690,6 +855,10 @@ func mergeRootComment(cj *CritJSON, gc ghComment, replyMap map[int64][]ghComment
 		Body: gc.Body, Author: authorName, CreatedAt: gc.CreatedAt,
 		UpdatedAt: now, GitHubID: gc.ID, LastPushedBodyHash: bodyHashAtPush(gc.Body),
 	}, scope.asFocus())
+	if hasRemote && remoteResolved {
+		comment.Resolved = true
+		comment.ResolvedRound = cj.ReviewRound
+	}
 
 	added := 0
 	if childReplies, hasReplies := replyMap[gc.ID]; hasReplies {
@@ -742,14 +911,16 @@ func mergeOrphanReplies(cj *CritJSON, roots []ghComment, replyMap map[int64][]gh
 // Handles threading: root comments become top-level Comments, replies become Reply entries.
 // Deduplicates by GitHubID (preferred) or author+lines+body to prevent duplicates from repeated pulls.
 func mergeGHComments(cj *CritJSON, ghComments []ghComment) int {
-	return mergeGHCommentsScoped(cj, ghComments, inheritedScope{})
+	return mergeGHCommentsScoped(cj, ghComments, inheritedScope{}, nil)
 }
 
 // mergeGHCommentsScoped is mergeGHComments with optional HeadSHA + DiffScope
 // stamping for range-mode pulls. scope.DiffScope == "" matches legacy
-// working-tree behavior. See spec §E "Write path — `crit pull` import path".
-func mergeGHCommentsScoped(cj *CritJSON, ghComments []ghComment, scope inheritedScope) int {
-	return mergeGHCommentsWithNames(cj, ghComments, make(userNameCache), scope)
+// working-tree behavior. threadResolved (databaseID -> isResolved) is
+// applied to root comments to mirror github.com thread-resolution state.
+// See spec §E "Write path — `crit pull` import path".
+func mergeGHCommentsScoped(cj *CritJSON, ghComments []ghComment, scope inheritedScope, threadResolved map[int64]bool) int {
+	return mergeGHCommentsWithNames(cj, ghComments, make(userNameCache), scope, threadResolved)
 }
 
 // mergeGHCommentsWithNames is the form of mergeGHComments that lets callers
@@ -757,7 +928,10 @@ func mergeGHCommentsScoped(cj *CritJSON, ghComments []ghComment, scope inherited
 // cache, lazy /users/{login} lookups). Tests can pre-populate to assert on
 // resolved display names without going to the network. scope stamps
 // HeadSHA + DiffScope on newly imported root comments (no-op when empty).
-func mergeGHCommentsWithNames(cj *CritJSON, ghComments []ghComment, names userNameCache, scope inheritedScope) int {
+// threadResolved propagates the thread-level isResolved bit from the
+// GraphQL reviewThreads edge onto the local root comment's Resolved /
+// ResolvedRound — see threadResolvedForRoot for the asymmetric merge.
+func mergeGHCommentsWithNames(cj *CritJSON, ghComments []ghComment, names userNameCache, scope inheritedScope, threadResolved map[int64]bool) int {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cj.UpdatedAt = now
 
@@ -770,11 +944,33 @@ func mergeGHCommentsWithNames(cj *CritJSON, ghComments []ghComment, names userNa
 
 	added := 0
 	for _, gc := range roots {
-		added += mergeRootComment(cj, gc, replyMap, now, names, scope, pendingDeletes)
+		added += mergeRootComment(cj, gc, replyMap, now, names, scope, pendingDeletes, threadResolved)
 	}
 	added += mergeOrphanReplies(cj, roots, replyMap, names, pendingDeletes)
 
 	return added
+}
+
+// threadResolvedForRoot returns the resolved state to apply to a root
+// comment given the thread map. A thread carries one isResolved bit shared
+// across the root and every reply; this looks the bit up via the root's
+// own databaseID first, falling back to any reply's databaseID for the
+// same thread. Returns (resolved, present): present is false when neither
+// the root nor any reply appears in the map (e.g. comment is not part of
+// a tracked review thread, or the GraphQL fetch was skipped).
+func threadResolvedForRoot(rootID int64, replies []ghComment, threadResolved map[int64]bool) (bool, bool) {
+	if threadResolved == nil {
+		return false, false
+	}
+	if r, ok := threadResolved[rootID]; ok {
+		return r, true
+	}
+	for _, rc := range replies {
+		if r, ok := threadResolved[rc.ID]; ok {
+			return r, true
+		}
+	}
+	return false, false
 }
 
 // ghReplyForPush represents a reply that needs to be posted to GitHub.

--- a/github_test.go
+++ b/github_test.go
@@ -2663,7 +2663,7 @@ func TestMergeGHComments_UsesDisplayNameFromCache(t *testing.T) {
 			CreatedAt: "2025-01-01T00:00:00Z"},
 	}
 	names := userNameCache{"alice": "Alice Liddell"}
-	if added := mergeGHCommentsWithNames(&cj, ghComments, names, inheritedScope{}); added != 1 {
+	if added := mergeGHCommentsWithNames(&cj, ghComments, names, inheritedScope{}, nil); added != 1 {
 		t.Fatalf("added = %d, want 1", added)
 	}
 	if got := cj.Files["main.go"].Comments[0].Author; got != "Alice Liddell" {
@@ -2685,7 +2685,7 @@ func TestMergeGHCommentsScoped_StampsHeadAndLayer(t *testing.T) {
 			CreatedAt: "2025-01-01T00:00:00Z"},
 	}
 	scope := inheritedScope{HeadSHA: "headXYZ", DiffScope: "layer"}
-	if added := mergeGHCommentsScoped(&cj, ghComments, scope); added != 1 {
+	if added := mergeGHCommentsScoped(&cj, ghComments, scope, nil); added != 1 {
 		t.Fatalf("added=%d want 1", added)
 	}
 	c := cj.Files["main.go"].Comments[0]
@@ -2710,7 +2710,7 @@ func TestMergeGHCommentsScoped_NoStampWithEmptyScope(t *testing.T) {
 			}{Login: "u"},
 			CreatedAt: "2025-01-01T00:00:00Z"},
 	}
-	mergeGHCommentsScoped(&cj, ghComments, inheritedScope{})
+	mergeGHCommentsScoped(&cj, ghComments, inheritedScope{}, nil)
 	c := cj.Files["main.go"].Comments[0]
 	if c.HeadSHA != "" || c.DiffScope != "" {
 		t.Errorf("comment was stamped despite empty scope: %+v", c)
@@ -3184,7 +3184,7 @@ func TestMergeRootComment_SkipsPendingDelete(t *testing.T) {
 			Login string `json:"login"`
 		}{Login: "alice"},
 	}}
-	added := mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{})
+	added := mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{}, nil)
 	if added != 0 {
 		t.Errorf("merge re-imported pending-delete comment (added=%d, want 0)", added)
 	}
@@ -3212,7 +3212,7 @@ func TestMergeOrphanReplies_SkipsPendingDelete(t *testing.T) {
 		}{Login: "alice"},
 		InReplyToID: 500,
 	}}
-	mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{})
+	mergeGHCommentsWithNames(&cj, gc, userNameCache{"alice": "alice"}, inheritedScope{}, nil)
 	cf := cj.Files["a.go"]
 	if len(cf.Comments) != 1 || len(cf.Comments[0].Replies) != 0 {
 		t.Errorf("expected parent with no replies; got %+v", cf.Comments)
@@ -3289,5 +3289,214 @@ func TestDeleteGHComment_StatusHandling(t *testing.T) {
 				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestThreadResolvedForRoot covers the lookup precedence: root databaseID
+// first, then any reply, then absent.
+func TestThreadResolvedForRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		rootID         int64
+		replies        []ghComment
+		threadResolved map[int64]bool
+		wantResolved   bool
+		wantPresent    bool
+	}{
+		{
+			name:           "nil map returns absent",
+			rootID:         1,
+			threadResolved: nil,
+			wantPresent:    false,
+		},
+		{
+			name:           "root hit takes precedence",
+			rootID:         1,
+			replies:        []ghComment{{ID: 2}},
+			threadResolved: map[int64]bool{1: true, 2: false},
+			wantResolved:   true,
+			wantPresent:    true,
+		},
+		{
+			name:           "reply fallback when root missing",
+			rootID:         1,
+			replies:        []ghComment{{ID: 2}},
+			threadResolved: map[int64]bool{2: true},
+			wantResolved:   true,
+			wantPresent:    true,
+		},
+		{
+			name:           "neither root nor reply -> absent",
+			rootID:         1,
+			replies:        []ghComment{{ID: 2}},
+			threadResolved: map[int64]bool{99: true},
+			wantPresent:    false,
+		},
+		{
+			name:           "explicit unresolved is present=true",
+			rootID:         1,
+			threadResolved: map[int64]bool{1: false},
+			wantResolved:   false,
+			wantPresent:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResolved, gotPresent := threadResolvedForRoot(tc.rootID, tc.replies, tc.threadResolved)
+			if gotResolved != tc.wantResolved || gotPresent != tc.wantPresent {
+				t.Errorf("got (%v,%v), want (%v,%v)",
+					gotResolved, gotPresent, tc.wantResolved, tc.wantPresent)
+			}
+		})
+	}
+}
+
+// TestMergeGHComments_ThreadResolved_NewComment verifies a freshly imported
+// root inherits Resolved=true and ResolvedRound=cj.ReviewRound when its
+// thread is resolved on github.com.
+func TestMergeGHComments_ThreadResolved_NewComment(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}, ReviewRound: 3}
+	ghComments := []ghComment{
+		{ID: 42, Path: "main.go", Line: 5, Side: "RIGHT", Body: "decide", CreatedAt: "2025-01-01T00:00:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+	}
+	threadResolved := map[int64]bool{42: true}
+	added := mergeGHCommentsWithNames(&cj, ghComments, userNameCache{"alice": "alice"}, inheritedScope{}, threadResolved)
+	if added != 1 {
+		t.Fatalf("added = %d, want 1", added)
+	}
+	c := cj.Files["main.go"].Comments[0]
+	if !c.Resolved {
+		t.Errorf("Resolved = false, want true")
+	}
+	if c.ResolvedRound != 3 {
+		t.Errorf("ResolvedRound = %d, want 3", c.ResolvedRound)
+	}
+}
+
+// TestMergeGHComments_ThreadResolved_ExistingDedupedComment exercises the
+// crit pull workflow: an earlier pull imported the comment with
+// Resolved=false; the reviewer later clicked Resolve on github.com; the
+// next pull must update Resolved on the deduplicated local comment.
+func TestMergeGHComments_ThreadResolved_ExistingDedupedComment(t *testing.T) {
+	cj := CritJSON{
+		ReviewRound: 4,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", GitHubID: 42, Author: "alice", Body: "decide",
+						StartLine: 5, EndLine: 5, Resolved: false},
+				},
+			},
+		},
+	}
+	ghComments := []ghComment{
+		{ID: 42, Path: "main.go", Line: 5, Side: "RIGHT", Body: "decide", CreatedAt: "2025-01-01T00:00:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+	}
+	threadResolved := map[int64]bool{42: true}
+	added := mergeGHCommentsWithNames(&cj, ghComments, userNameCache{"alice": "alice"}, inheritedScope{}, threadResolved)
+	// added is 1 because the resolution flip is a meaningful change that
+	// must trigger a save in runPull (added==0 short-circuits persistence).
+	if added != 1 {
+		t.Fatalf("added = %d, want 1 (resolution flip should be counted)", added)
+	}
+	c := cj.Files["main.go"].Comments[0]
+	if !c.Resolved {
+		t.Errorf("Resolved = false, want true")
+	}
+	if c.ResolvedRound != 4 {
+		t.Errorf("ResolvedRound = %d, want 4 (cj.ReviewRound)", c.ResolvedRound)
+	}
+}
+
+// TestMergeGHComments_ThreadUnresolved_DoesNotClobberLocallyResolved
+// pins the asymmetric merge: a thread that is unresolved on github.com
+// must NOT undo a locally-resolved comment. Local users may resolve via
+// crit / crit-web independently of github.com, and crit pull is not
+// authoritative on the unresolved->resolved transition direction.
+func TestMergeGHComments_ThreadUnresolved_DoesNotClobberLocallyResolved(t *testing.T) {
+	cj := CritJSON{
+		ReviewRound: 5,
+		Files: map[string]CritJSONFile{
+			"main.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", GitHubID: 42, Author: "alice", Body: "decide",
+						StartLine: 5, EndLine: 5, Resolved: true, ResolvedRound: 2},
+				},
+			},
+		},
+	}
+	ghComments := []ghComment{
+		{ID: 42, Path: "main.go", Line: 5, Side: "RIGHT", Body: "decide", CreatedAt: "2025-01-01T00:00:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+	}
+	threadResolved := map[int64]bool{42: false}
+	added := mergeGHCommentsWithNames(&cj, ghComments, userNameCache{"alice": "alice"}, inheritedScope{}, threadResolved)
+	if added != 0 {
+		t.Errorf("added = %d, want 0 (no-op when remote is unresolved and local is resolved)", added)
+	}
+	c := cj.Files["main.go"].Comments[0]
+	if !c.Resolved {
+		t.Errorf("Resolved = false, want true (local resolution must not be clobbered)")
+	}
+	if c.ResolvedRound != 2 {
+		t.Errorf("ResolvedRound = %d, want 2 (preserved from prior local resolve)", c.ResolvedRound)
+	}
+}
+
+// TestMergeGHComments_NilThreadMap_NoOp confirms that callers passing nil
+// (e.g., a GraphQL fetch failed best-effort) preserve all existing
+// behavior — no Resolved bits are flipped, no new Resolved bits set.
+func TestMergeGHComments_NilThreadMap_NoOp(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}, ReviewRound: 1}
+	ghComments := []ghComment{
+		{ID: 7, Path: "main.go", Line: 3, Side: "RIGHT", Body: "x", CreatedAt: "2025-01-01T00:00:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "u"}},
+	}
+	mergeGHCommentsWithNames(&cj, ghComments, userNameCache{"u": "u"}, inheritedScope{}, nil)
+	c := cj.Files["main.go"].Comments[0]
+	if c.Resolved {
+		t.Errorf("Resolved = true, want false (nil thread map must not set resolved)")
+	}
+	if c.ResolvedRound != 0 {
+		t.Errorf("ResolvedRound = %d, want 0", c.ResolvedRound)
+	}
+}
+
+// TestMergeGHComments_ThreadResolvedViaReplyID covers the case where the
+// resolved bit lookup for the root falls back to a reply's databaseID.
+// (e.g., the GraphQL response indexed only the reply's databaseID — both
+// are valid keys since the bit is shared across the thread.)
+func TestMergeGHComments_ThreadResolvedViaReplyID(t *testing.T) {
+	cj := CritJSON{Files: map[string]CritJSONFile{}, ReviewRound: 2}
+	ghComments := []ghComment{
+		{ID: 42, Path: "main.go", Line: 5, Side: "RIGHT", Body: "root", CreatedAt: "2025-01-01T00:00:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+		{ID: 43, Path: "main.go", Line: 5, Side: "RIGHT", Body: "reply", CreatedAt: "2025-01-01T00:01:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "bob"}, InReplyToID: 42},
+	}
+	// Only the reply's databaseID is in the map — root must still be flagged.
+	threadResolved := map[int64]bool{43: true}
+	mergeGHCommentsWithNames(&cj, ghComments, userNameCache{"alice": "alice", "bob": "bob"}, inheritedScope{}, threadResolved)
+	c := cj.Files["main.go"].Comments[0]
+	if !c.Resolved {
+		t.Errorf("Resolved = false, want true (lookup must fall back to reply databaseID)")
+	}
+	if c.ResolvedRound != 2 {
+		t.Errorf("ResolvedRound = %d, want 2", c.ResolvedRound)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -535,6 +535,15 @@ func runPull(args []string) {
 		os.Exit(1)
 	}
 
+	// Thread-resolved state lives on the GraphQL reviewThreads edge, not on
+	// REST /pulls/{n}/comments. We fetch it best-effort: a GraphQL failure
+	// (token scope, transient outage) shouldn't block a comment pull. See #453.
+	threadResolved, threadErr := fetchPRThreadResolved(prNumber)
+	if threadErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch review-thread resolution state: %v\n", threadErr)
+		threadResolved = nil
+	}
+
 	critPath, err := resolveReviewPath(f.outputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -573,7 +582,7 @@ func runPull(args []string) {
 	}
 
 	scope := resolvePullScope(f.outputDir, &cj)
-	added := mergeGHCommentsScoped(&cj, ghComments, scope)
+	added := mergeGHCommentsScoped(&cj, ghComments, scope, threadResolved)
 
 	if added == 0 {
 		fmt.Printf("No new inline comments found on PR #%d\n", prNumber)

--- a/roundtrip_integration_test.go
+++ b/roundtrip_integration_test.go
@@ -864,7 +864,6 @@ func TestRoundtrip_AnchorLineDeleted_Outdated(t *testing.T) {
 // GraphQL resolveReviewThread; subsequent pull must mirror that state to
 // the local resolved flag.
 func TestRoundtrip_GitHubThreadResolvedOnWeb(t *testing.T) {
-	t.Skip("blocked on issue #453: crit pull does not import GitHub review-thread resolved state")
 	e := newRoundtripEnv(t)
 
 	e.runCrit("comment", "sample.go:19", "needs decision")


### PR DESCRIPTION
## Summary
- `crit pull` now reads thread-level `isResolved` via GraphQL (`reviewThreads`) and joins it onto imported comments by databaseID. Previously, resolves done on github.com (or via the `resolveReviewThread` mutation) silently leaked past the local `Comment.Resolved` flag.
- Asymmetric merge: GitHub-resolved → local resolved (always); GitHub-unresolved + local resolved → keep local. Mirrors the existing Body-on-pull precedent and avoids clobbering resolutions made via crit / crit-web.
- GraphQL fetch is best-effort: a failure logs a warning and proceeds with the existing REST-only merge.
- Unskips `TestRoundtrip_GitHubThreadResolvedOnWeb` in the e2e harness.

## Review
- [x] Code review: passed (1 inherited pre-existing dedup-by-body limitation noted, not introduced by this PR)
- [x] Parity audit: N/A (server-side GH sync, no review-page surface)

## Test plan
- New unit tests cover thread-resolved propagation on new + deduped comments, asymmetric clobber-protection, nil-map no-op, and reply-ID fallback.
- `go test -race -count=1 ./...` green.
- Roundtrip e2e against `crit-md/crit-roundtrip-sandbox` passes.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)