### PR TITLE
fix: detect mid-push auth rotation and abort cleanly

### DIFF
--- a/github.go
+++ b/github.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -45,6 +46,42 @@ type ghComment struct {
 	// see userNameCache.
 	CreatedAt   string `json:"created_at"`
 	InReplyToID int64  `json:"in_reply_to_id"`
+}
+
+// errGHAuthFailed signals that a `gh api` call returned HTTP 401. Callers
+// in the push loop check this with errors.Is to distinguish a token
+// rotation / expiration from generic transport failures: when it appears
+// the rest of the push must abort because every subsequent gh call would
+// fail the same way, and surface a clear "run gh auth refresh" message
+// instead of a vague per-request error spam.
+var errGHAuthFailed = errors.New("gh auth failed (HTTP 401)")
+
+// isGHAuthFailure reports whether `gh api` output (stdout+stderr or the
+// --include status block) indicates an HTTP 401. gh surfaces 401 in two
+// canonical line-anchored shapes: a stderr error line that begins with
+// "gh: HTTP 401" and the HTTP status line in the --include block that
+// begins with "HTTP/1.1 401" / "HTTP/2 401" / "HTTP/2.0 401".
+//
+// We deliberately do NOT match bare "HTTP 401" or "Bad credentials"
+// substrings: they false-trigger when an echoed request body or quoted
+// error text happens to mention either phrase (e.g. a comment body that
+// contains "got HTTP 401 from upstream"). Anchoring to line start keeps
+// detection tied to gh's own framing.
+func isGHAuthFailure(out []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "gh: HTTP 401") {
+			return true
+		}
+		if strings.HasPrefix(line, "HTTP/1.1 401") ||
+			strings.HasPrefix(line, "HTTP/2 401") ||
+			strings.HasPrefix(line, "HTTP/2.0 401") {
+			return true
+		}
+	}
+	return false
 }
 
 // requireGH checks that the gh CLI is installed and authenticated.
@@ -1074,6 +1111,9 @@ func patchGHComment(ghID int64, body string) error {
 	cmd.Stdin = bytes.NewReader(payload)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if isGHAuthFailure(output) {
+			return fmt.Errorf("gh api patch: %s: %w", strings.TrimSpace(string(output)), errGHAuthFailed)
+		}
 		return fmt.Errorf("gh api patch: %s: %w", string(output), err)
 	}
 	return nil
@@ -1142,6 +1182,9 @@ func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
 	cmd.Stdin = bytes.NewReader(payload)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if isGHAuthFailure(output) {
+			return 0, fmt.Errorf("gh api: %s: %w", strings.TrimSpace(string(output)), errGHAuthFailed)
+		}
 		return 0, fmt.Errorf("gh api: %s: %w", string(output), err)
 	}
 	var resp struct {
@@ -1228,6 +1271,10 @@ func createGHReview(prNumber int, comments []map[string]any, message string, eve
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		combined := append(append([]byte{}, stdout.Bytes()...), stderr.Bytes()...)
+		if isGHAuthFailure(combined) {
+			return nil, fmt.Errorf("creating review: %s: %w", strings.TrimSpace(stderr.String()), errGHAuthFailed)
+		}
 		if stderr.Len() > 0 {
 			return nil, fmt.Errorf("creating review: %s", strings.TrimSpace(stderr.String()))
 		}
@@ -1354,6 +1401,9 @@ func deleteGHComment(ghID int64) (int, error) {
 		// Caller decides how to handle these; surface the status without
 		// treating the gh non-zero exit as a fatal error.
 		return status, nil
+	}
+	if status == 401 || isGHAuthFailure(output) {
+		return status, fmt.Errorf("gh api delete: %s: %w", strings.TrimSpace(string(output)), errGHAuthFailed)
 	}
 	if runErr != nil {
 		return status, fmt.Errorf("gh api delete: %s: %w", strings.TrimSpace(string(output)), runErr)

--- a/github_auth_test.go
+++ b/github_auth_test.go
@@ -1,0 +1,85 @@
+package main
+
+import "testing"
+
+// TestIsGHAuthFailure exercises the line-anchored 401 detector. We accept
+// only gh's canonical framings (stderr "gh: HTTP 401:" and the
+// --include status line "HTTP/x 401") and explicitly reject bare
+// "HTTP 401" / "Bad credentials" substrings to avoid false positives
+// from echoed request bodies.
+func TestIsGHAuthFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "gh canonical stderr line",
+			in:   "gh: HTTP 401: Bad credentials",
+			want: true,
+		},
+		{
+			name: "gh canonical stderr line with trailing newline",
+			in:   "gh: HTTP 401: Bad credentials (https://api.github.com/repos/x/y)\n",
+			want: true,
+		},
+		{
+			name: "include block HTTP/1.1 401 at line start",
+			in:   "HTTP/1.1 401 Unauthorized\nDate: Mon\nX-RateLimit-Remaining: 0\n",
+			want: true,
+		},
+		{
+			name: "include block HTTP/2 401 at line start",
+			in:   "HTTP/2 401\nContent-Type: application/json\n",
+			want: true,
+		},
+		{
+			name: "include block HTTP/2.0 401 at line start",
+			in:   "HTTP/2.0 401\n",
+			want: true,
+		},
+		{
+			name: "echoed body containing HTTP 401 mid-line — must not trigger",
+			in:   "creating review: failed: got HTTP 401 from upstream service",
+			want: false,
+		},
+		{
+			name: "Bad credentials mid-line in non-gh context — must not trigger",
+			in:   "comment body: \"the error said Bad credentials but it's a typo\"",
+			want: false,
+		},
+		{
+			name: "200 OK include block",
+			in:   "HTTP/2 200\nContent-Type: application/json\n",
+			want: false,
+		},
+		{
+			name: "404 not-found include block",
+			in:   "HTTP/1.1 404 Not Found\n",
+			want: false,
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: false,
+		},
+		{
+			name: "indented HTTP/1.1 401 (not at line start) — must not trigger",
+			in:   "  HTTP/1.1 401 Unauthorized\n",
+			want: false,
+		},
+		{
+			name: "indented gh: line — must not trigger",
+			in:   "  gh: HTTP 401: Bad credentials\n",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGHAuthFailure([]byte(tt.in))
+			if got != tt.want {
+				t.Errorf("isGHAuthFailure(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -651,24 +651,35 @@ func parsePushFlags(args []string) pushFlags {
 	return f
 }
 
-func postPushReplies(prNumber int, allReplies []ghReplyForPush) map[replyKey]int64 {
+// postPushReplies posts each reply via `gh api`. On the first auth-rotation
+// failure (HTTP 401) it aborts the rest of the batch — every subsequent
+// call would fail identically, and bailing cleanly lets the outer push
+// loop print the K-of-N recovery message. authFailed signals that to the
+// caller. replyCount is the number of replies actually accepted by GitHub
+// before the abort (or in total if no abort happened).
+func postPushReplies(prNumber int, allReplies []ghReplyForPush) (map[replyKey]int64, int, bool) {
 	replyCount := 0
 	replyIDs := make(map[replyKey]int64)
+	authFailed := false
 	for _, reply := range allReplies {
 		replyID, err := postGHReply(prNumber, reply.ParentGHID, reply.Body)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to post reply: %v\n", err)
-		} else {
-			replyCount++
-			if replyID != 0 {
-				replyIDs[replyKey{ParentGHID: reply.ParentGHID, BodyPrefix: truncateStr(reply.Body, 60)}] = replyID
+			if errors.Is(err, errGHAuthFailed) {
+				authFailed = true
+				break
 			}
+			continue
+		}
+		replyCount++
+		if replyID != 0 {
+			replyIDs[replyKey{ParentGHID: reply.ParentGHID, BodyPrefix: truncateStr(reply.Body, 60)}] = replyID
 		}
 	}
 	if replyCount > 0 {
 		fmt.Printf("Posted %d replies\n", replyCount)
 	}
-	return replyIDs
+	return replyIDs, replyCount, authFailed
 }
 
 // resolveCurrentPRHead fetches the PR's current head SHA when in range mode.
@@ -791,48 +802,25 @@ func runPushDryRun(ctx pushContext, b pushBuckets) {
 // runPushLive performs the actual push: writes the orphan export (if any
 // orphans), posts the postable bucket via gh, and prints a summary. Replies
 // to existing GitHub comments are also posted (only for postable parents).
-func runPushLive(ctx pushContext, b pushBuckets) {
-	exportPath := ""
-	if len(b.FullStack)+len(b.Unmapped) > 0 {
-		dir, err := exportsDir()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: could not resolve export dir: %v\n", err)
-		} else {
-			path, werr := writeOrphanExport(ctx.prNumber, b, dir)
-			if werr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to write orphan export: %v\n", werr)
-			} else {
-				exportPath = path
-			}
-		}
-	}
+//
+// Returns the process exit code so callers (and tests) can decide what to
+// do without runPushLive itself terminating the process.
+func runPushLive(ctx pushContext, b pushBuckets) int {
+	exportPath := writePushOrphanExport(ctx, b)
 
-	posted := 0
-	postFailed := false
-	var commentIDs map[string]int64
-	if len(b.Postable) > 0 {
-		ghComments := bucketsToGHComments(b.Postable)
-		ids, err := createGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
-		if err != nil {
-			postFailed = true
-			fmt.Fprintf(os.Stderr, "Error posting review: %v\n", err)
-		} else {
-			posted = len(ghComments)
-			commentIDs = ids
-		}
-	}
+	postable := len(b.Postable)
+	posted, postFailed, postAuthFailed, commentIDs := runPushPostReview(ctx, b)
 
-	// Replies to GitHub-anchored comments are independent of whether there
-	// were new top-level comments to post: the parent already has a
-	// github_id (either imported via pull or pushed by us previously), so
-	// the reply can go out regardless. Skip only if the top-level post
-	// failed — parent IDs assigned in this same push wouldn't be stable.
-	if !postFailed {
+	totalReplies := countNewReplies(ctx.cj)
+	postedReplies := 0
+	replyAuthFailed := false
+	if !postFailed && !postAuthFailed {
 		var allReplies []ghReplyForPush
 		for _, cf := range ctx.cj.Files {
 			allReplies = append(allReplies, collectNewRepliesForPush(cf)...)
 		}
-		replyIDs := postPushReplies(ctx.prNumber, allReplies)
+		var replyIDs map[replyKey]int64
+		replyIDs, postedReplies, replyAuthFailed = postPushReplies(ctx.prNumber, allReplies)
 		if len(commentIDs) > 0 || len(replyIDs) > 0 {
 			if uerr := updateCritJSONWithGitHubIDs(ctx.critPath, commentIDs, replyIDs); uerr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update review file with GitHub IDs: %v\n", uerr)
@@ -840,20 +828,85 @@ func runPushLive(ctx pushContext, b pushBuckets) {
 		}
 	}
 
-	// PATCH already-pushed comments/replies whose local body diverged from
-	// the recorded push-time hash. Independent of the POST path — edits frequently happen
-	// in pushes where there are no new comments to create.
-	patched := pushEditedBodies(ctx)
+	totalEdits := len(collectEditedForPush(ctx.cj))
+	patched := 0
+	editAuthFailed := false
+	if !postAuthFailed && !replyAuthFailed {
+		patched, editAuthFailed = pushEditedBodies(ctx)
+	}
 
-	// DELETE remote comments tombstoned locally. Independent of POST/PATCH:
-	// users can delete a comment without touching anything else.
-	deleted, deleteFailed := pushDeletedComments(ctx)
+	totalDeletes := len(collectDeletesForPush(ctx.cj))
+	deleted := 0
+	deleteFailed := false
+	deleteAuthFailed := false
+	if !postAuthFailed && !replyAuthFailed && !editAuthFailed {
+		deleted, deleteFailed, deleteAuthFailed = pushDeletedComments(ctx)
+	}
+
+	authAborted := postAuthFailed || replyAuthFailed || editAuthFailed || deleteAuthFailed
+	if authAborted {
+		k := posted + postedReplies + patched + deleted
+		n := postable + totalReplies + totalEdits + totalDeletes
+		fmt.Fprintf(os.Stderr,
+			"Pushed %d of %d comments before auth failed. Run 'gh auth refresh' then re-run 'crit push' to post the rest.\n",
+			k, n)
+		return 1
+	}
 
 	printPushSummary(posted, patched, deleted, len(b.FullStack)+len(b.Unmapped), exportPath)
 
 	if pushShouldExitFailure(posted, patched, deleted, exportPath, postFailed, deleteFailed) {
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+// writePushOrphanExport writes the off-PR (full-stack + unmapped) bucket
+// to a side file when needed. Split out of runPushLive purely to keep
+// cyclomatic complexity inside Go Report Card limits.
+func writePushOrphanExport(ctx pushContext, b pushBuckets) string {
+	if len(b.FullStack)+len(b.Unmapped) == 0 {
+		return ""
+	}
+	dir, err := exportsDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not resolve export dir: %v\n", err)
+		return ""
+	}
+	path, werr := writeOrphanExport(ctx.prNumber, b, dir)
+	if werr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to write orphan export: %v\n", werr)
+		return ""
+	}
+	return path
+}
+
+// runPushPostReview posts the Postable bucket as a single GitHub review.
+// Returns the count posted, whether the call failed (any reason), whether
+// the failure was specifically an auth-rotation 401, and the path-to-id
+// mapping for body-hash bookkeeping.
+func runPushPostReview(ctx pushContext, b pushBuckets) (int, bool, bool, map[string]int64) {
+	if len(b.Postable) == 0 {
+		return 0, false, false, nil
+	}
+	ghComments := bucketsToGHComments(b.Postable)
+	ids, err := createGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error posting review: %v\n", err)
+		return 0, true, errors.Is(err, errGHAuthFailed), nil
+	}
+	return len(ghComments), false, false, ids
+}
+
+// countNewReplies counts replies that would be sent in this push (no
+// GitHubID yet, parent already on GitHub). Mirrors collectNewRepliesForPush
+// without allocating the full slice — used purely for the K-of-N total.
+func countNewReplies(cj CritJSON) int {
+	n := 0
+	for _, cf := range cj.Files {
+		n += len(collectNewRepliesForPush(cf))
+	}
+	return n
 }
 
 // pushShouldExitFailure encodes the exit-code policy for `crit push`. The
@@ -889,18 +942,24 @@ func printPushSummary(posted, patched, deleted, orphans int, exportPath string) 
 }
 
 // pushEditedBodies PATCHes already-pushed comments/replies whose local body
-// diverged from the recorded push-time hash. Returns the count of records successfully
-// PATCHed and updated in the review file. Failures log to stderr and are
-// excluded from the count, so the next push will retry them.
-func pushEditedBodies(ctx pushContext) int {
+// diverged from the recorded push-time hash. Returns the count of records
+// successfully PATCHed and updated in the review file, plus an authFailed
+// flag when an HTTP 401 aborted the batch. Non-auth failures log to stderr
+// and are excluded from the count, so the next push will retry them.
+func pushEditedBodies(ctx pushContext) (int, bool) {
 	edits := collectEditedForPush(ctx.cj)
 	if len(edits) == 0 {
-		return 0
+		return 0, false
 	}
 	succeeded := make([]ghEditForPush, 0, len(edits))
+	authFailed := false
 	for _, e := range edits {
 		if err := patchGHComment(e.GitHubID, e.Body); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to edit comment %d: %v\n", e.GitHubID, err)
+			if errors.Is(err, errGHAuthFailed) {
+				authFailed = true
+				break
+			}
 			continue
 		}
 		succeeded = append(succeeded, e)
@@ -908,7 +967,7 @@ func pushEditedBodies(ctx pushContext) int {
 	if uerr := updateCritJSONWithEditedBodies(ctx.critPath, succeeded); uerr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to update review file after edit push: %v\n", uerr)
 	}
-	return len(succeeded)
+	return len(succeeded), authFailed
 }
 
 // pushDeletedComments issues DELETE for every GitHub comment ID queued in
@@ -919,16 +978,20 @@ func pushEditedBodies(ctx pushContext) int {
 // 403 is logged but treated as drained — the GitHub API rejects deletes by
 // non-authors, so retrying is futile and a stuck pending entry would block
 // all future pushes for this review file.
-func pushDeletedComments(ctx pushContext) (int, bool) {
+func pushDeletedComments(ctx pushContext) (int, bool, bool) {
 	pending := collectDeletesForPush(ctx.cj)
 	if len(pending) == 0 {
-		return 0, false
+		return 0, false, false
 	}
 	drained := make([]int64, 0, len(pending))
 	failed := false
+	authFailed := false
 	for _, id := range pending {
 		status, err := deleteGHComment(id)
 		switch {
+		case err != nil && errors.Is(err, errGHAuthFailed):
+			fmt.Fprintf(os.Stderr, "Warning: failed to delete comment %d: %v\n", id, err)
+			authFailed = true
 		case err != nil:
 			fmt.Fprintf(os.Stderr, "Warning: failed to delete comment %d: %v\n", id, err)
 			failed = true
@@ -941,11 +1004,14 @@ func pushDeletedComments(ctx pushContext) (int, bool) {
 			fmt.Fprintf(os.Stderr, "Warning: unexpected status %d deleting comment %d\n", status, id)
 			failed = true
 		}
+		if authFailed {
+			break
+		}
 	}
 	if uerr := updateCritJSONAfterDeletes(ctx.critPath, drained); uerr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to update review file after delete push: %v\n", uerr)
 	}
-	return len(drained), failed
+	return len(drained), failed, authFailed
 }
 
 // fullStackPushGateMessage is the user-facing error string emitted when
@@ -983,7 +1049,9 @@ func runPush(args []string) {
 		runPushDryRun(ctx, b)
 		return
 	}
-	runPushLive(ctx, b)
+	if code := runPushLive(ctx, b); code != 0 {
+		os.Exit(code)
+	}
 }
 
 type commentFlags struct {

--- a/push_auth_rotation_test.go
+++ b/push_auth_rotation_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestRunPushLive_AuthRotationMidPush regresses issue #452: when `gh`'s
+// auth token rotates / expires mid-push, the very next gh-api call returns
+// HTTP 401 and every subsequent one would fail the same way. The push
+// loop must:
+//
+//  1. Detect the 401 specifically (not as a generic 4xx/5xx).
+//  2. Stop iterating immediately — don't keep firing pointless calls.
+//  3. Print a single clear stderr line ("Pushed K of N comments before
+//     auth failed. Run 'gh auth refresh' ...") so the user knows exactly
+//     what landed and how to recover.
+//  4. Exit non-zero so scripts/CI catch the partial push.
+//  5. Persist GitHubIDs only for the K successfully-posted items, so a
+//     rerun (after `gh auth refresh`) only retries the (N-K) leftovers
+//     and never duplicates already-posted replies on GitHub.
+//
+// Property (5) is the key safety guarantee — duplicates would be visible
+// on GitHub and unrecoverable from `crit push` alone.
+func TestRunPushLive_AuthRotationMidPush(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-gh shim is a POSIX shell script; not portable to Windows")
+	}
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "counter")
+	if err := os.WriteFile(counter, []byte("0\n"), 0644); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+
+	// Fake gh: call 1 → 201 with id 9001 (a clean reply post).
+	// Call 2 → exit 4 with `gh: HTTP 401: Bad credentials` on stderr,
+	//          mimicking the real gh CLI's auth-rotation surface.
+	// Call 3+ → also 401 (don't care; the push must abort before reaching
+	//           them — if the abort is broken, we'll see >2 invocations).
+	fakeGH := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+COUNTER_FILE="` + counter + `"
+n=$(cat "$COUNTER_FILE")
+n=$((n + 1))
+echo "$n" > "$COUNTER_FILE"
+cat >/dev/null
+case "$n" in
+  1) echo '{"id": 9001}' ;;
+  *) echo 'gh: HTTP 401: Bad credentials' >&2; exit 4 ;;
+esac
+`
+	if err := os.WriteFile(fakeGH, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Build a review file with three new replies whose parents are already
+	// on GitHub. No new top-level comments (Postable bucket empty), no
+	// edits, no deletes — keeps the K-of-N math unambiguous: N=3 replies.
+	critRoot := filepath.Join(dir, "review")
+	if err := os.MkdirAll(critRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"a.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{
+						ID: "c1", StartLine: 1, EndLine: 1, Body: "parent 1",
+						GitHubID: 100, LastPushedBodyHash: bodyHashAtPush("parent 1"),
+						Replies: []Reply{{ID: "r1", Body: "first reply"}},
+					},
+					{
+						ID: "c2", StartLine: 2, EndLine: 2, Body: "parent 2",
+						GitHubID: 200, LastPushedBodyHash: bodyHashAtPush("parent 2"),
+						Replies: []Reply{{ID: "r2", Body: "second reply"}},
+					},
+					{
+						ID: "c3", StartLine: 3, EndLine: 3, Body: "parent 3",
+						GitHubID: 300, LastPushedBodyHash: bodyHashAtPush("parent 3"),
+						Replies: []Reply{{ID: "r3", Body: "third reply"}},
+					},
+				},
+			},
+		},
+	}
+	writeCritFile(t, critRoot, cj)
+
+	ctx := pushContext{prNumber: 42, critPath: critRoot, cj: cj}
+
+	// Capture stderr while runPushLive runs. The K-of-N recovery message
+	// is part of the contract and is asserted below.
+	stderr := captureStderr(t, func() {
+		code := runPushLive(ctx, pushBuckets{})
+		if code == 0 {
+			t.Errorf("runPushLive exit code = 0; want non-zero on auth failure")
+		}
+	})
+
+	if !strings.Contains(stderr, "Pushed 1 of 3") {
+		t.Errorf("stderr missing 'Pushed 1 of 3'; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "gh auth refresh") {
+		t.Errorf("stderr missing recovery hint 'gh auth refresh'; got:\n%s", stderr)
+	}
+
+	// The fake gh must have stopped after the 401 — i.e. exactly two
+	// invocations. A higher number means the loop didn't abort and is
+	// burning attempts (and stderr) on a token that won't recover.
+	if got := readCounter(t, counter); got != 2 {
+		t.Errorf("fake gh invocation count = %d; want 2 (1 success + 1 401, then abort)", got)
+	}
+
+	// Verify dedup state on disk:
+	//   - reply r1 must have GitHubID 9001 (successfully posted).
+	//   - replies r2 and r3 must still have GitHubID 0 so a retry posts
+	//     only them and not duplicates of r1.
+	after := readCritFile(t, critRoot)
+	got := replyIDsByLocalID(after, "a.go")
+	if got["r1"] != 9001 {
+		t.Errorf("r1.GitHubID = %d, want 9001 (successful post)", got["r1"])
+	}
+	if got["r2"] != 0 {
+		t.Errorf("r2.GitHubID = %d, want 0 (auth-failed, must retry)", got["r2"])
+	}
+	if got["r3"] != 0 {
+		t.Errorf("r3.GitHubID = %d, want 0 (never attempted, must retry)", got["r3"])
+	}
+
+	// --- Second run: the user has refreshed their token. The fake gh now
+	// returns 201 for everything. crit push must only retry r2 and r3 —
+	// re-posting r1 would create a duplicate on GitHub. The dedup
+	// guarantee comes from collectNewRepliesForPush skipping replies
+	// whose GitHubID is non-zero; this leg is a regression test against
+	// that contract weakening.
+	if err := os.WriteFile(counter, []byte("0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	healthy := `#!/bin/sh
+COUNTER_FILE="` + counter + `"
+n=$(cat "$COUNTER_FILE")
+n=$((n + 1))
+echo "$n" > "$COUNTER_FILE"
+cat >/dev/null
+echo '{"id": '"$((9000 + n + 1))"'}'
+`
+	if err := os.WriteFile(fakeGH, []byte(healthy), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx2 := pushContext{prNumber: 42, critPath: critRoot, cj: after}
+	_ = captureStderr(t, func() {
+		if code := runPushLive(ctx2, pushBuckets{}); code != 0 {
+			t.Errorf("second runPushLive exit code = %d; want 0", code)
+		}
+	})
+
+	if got := readCounter(t, counter); got != 2 {
+		t.Errorf("retry posted %d replies; want 2 (only r2 and r3)", got)
+	}
+
+	final := readCritFile(t, critRoot)
+	finalIDs := replyIDsByLocalID(final, "a.go")
+	if finalIDs["r1"] != 9001 {
+		t.Errorf("r1.GitHubID changed to %d on retry; must remain 9001 (no re-post)", finalIDs["r1"])
+	}
+	if finalIDs["r2"] == 0 || finalIDs["r3"] == 0 {
+		t.Errorf("retry left replies unposted: r2=%d r3=%d", finalIDs["r2"], finalIDs["r3"])
+	}
+}
+
+func writeCritFile(t *testing.T, critRoot string, cj CritJSON) {
+	t.Helper()
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := reviewPathsFor(critRoot).Review
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, append(out, '\n'), 0644); err != nil {
+		t.Fatalf("write review file: %v", err)
+	}
+}
+
+func readCritFile(t *testing.T, critRoot string) CritJSON {
+	t.Helper()
+	data, err := os.ReadFile(reviewPathsFor(critRoot).Review)
+	if err != nil {
+		t.Fatalf("read review file: %v", err)
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		t.Fatalf("unmarshal review file: %v", err)
+	}
+	return cj
+}
+
+func replyIDsByLocalID(cj CritJSON, path string) map[string]int64 {
+	out := make(map[string]int64)
+	for _, c := range cj.Files[path].Comments {
+		for _, r := range c.Replies {
+			out[r.ID] = r.GitHubID
+		}
+	}
+	return out
+}
+
+func readCounter(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	s := strings.TrimSpace(string(data))
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/push_partial_failure_test.go
+++ b/push_partial_failure_test.go
@@ -64,7 +64,7 @@ esac
 		{ParentGHID: 300, Body: "third reply"},
 	}
 
-	got := postPushReplies(42, replies)
+	got, _, _ := postPushReplies(42, replies)
 
 	// First reply: parent 100 → id 1001.
 	k1 := replyKey{ParentGHID: 100, BodyPrefix: truncateStr("first reply", 60)}
@@ -155,7 +155,10 @@ esac
 	}
 
 	ctx := pushContext{critPath: critRoot, cj: cj}
-	drained, failed := pushDeletedComments(ctx)
+	drained, failed, authFailed := pushDeletedComments(ctx)
+	if authFailed {
+		t.Fatal("authFailed = true; want false (no 401 in this scenario)")
+	}
 	if drained != 1 {
 		t.Errorf("drained = %d, want 1", drained)
 	}


### PR DESCRIPTION
## Summary
- `crit push` now detects HTTP 401 from `gh api` calls and aborts the rest of the push loop instead of spamming per-item errors. Each per-call failure is wrapped with `errGHAuthFailed` so the loop can short-circuit via `errors.Is`.
- On auth failure, push prints `Pushed K of N comments before auth failed. Run 'gh auth refresh' then re-run 'crit push' to post the rest.` and exits non-zero.
- `runPushLive` was refactored from `os.Exit(1)` to returning an int so the new test can drive it without terminating the process; only call site is `runPush`.
- 401 detection is anchored to `gh`'s canonical error-line shapes (`gh: HTTP 401:` and `HTTP/x 401` at line start) rather than loose substring match — avoids false-positives when comment bodies in the PR happen to contain "HTTP 401" or "Bad credentials".
- Dedup safety verified: re-running push after `gh auth refresh` only retries comments where `github_id == 0` (and items still in the pending-deletes queue) — no double-post of already-pushed work.

## Review
- [x] Code review: passed (Phase 3 surfaced a false-positive risk in the matcher; fixed before pushing)
- [x] Parity audit: N/A (server-side push, no review-page surface)

## Test plan
- New `push_auth_rotation_test.go`: stubs `gh` with a fake binary that returns 201 then `gh: HTTP 401: Bad credentials`. Asserts non-zero exit, K-of-N message in stderr, fake gh invoked exactly twice (loop aborted), only the first reply got `github_id` set. Then re-runs with healthy fake — only the un-pushed replies are retried, already-pushed `github_id` is unchanged.
- New `github_auth_test.go`: table-driven coverage of the matcher — positives (`gh: HTTP 401:`, all `HTTP/x 401` include shapes) and negatives (`HTTP 401` mid-line, `Bad credentials` mid-line, 200/404 status lines, indented variants).
- `go test -race -count=1 ./...` green.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)