### PR TITLE
refactor: release audit cleanup — atomic writes, flag parsing, dead code

### DIFF
--- a/aider_install.go
+++ b/aider_install.go
@@ -66,15 +66,12 @@ func installAiderAt(cwd, home string, force bool) error {
 		return fmt.Errorf("reading embedded aider conventions: %w", err)
 	}
 
-	if !force {
-		if _, statErr := os.Stat(paths.conventionsDest); statErr == nil {
-			fmt.Printf("  Skipped:   %s (already exists, use --force to overwrite)\n", paths.conventionsDest)
-		} else {
-			if err := atomicWriteFile(paths.conventionsDest, data, 0o644); err != nil {
-				return fmt.Errorf("writing %s: %w", paths.conventionsDest, err)
-			}
-			fmt.Printf("  Installed: %s\n", paths.conventionsDest)
-		}
+	conventionsExists := false
+	if _, statErr := os.Stat(paths.conventionsDest); statErr == nil {
+		conventionsExists = true
+	}
+	if conventionsExists && !force {
+		fmt.Printf("  Skipped:   %s (already exists, use --force to overwrite)\n", paths.conventionsDest)
 	} else {
 		if err := atomicWriteFile(paths.conventionsDest, data, 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", paths.conventionsDest, err)

--- a/cli_install.go
+++ b/cli_install.go
@@ -12,7 +12,25 @@ import (
 )
 
 func runInstall(args []string) {
-	if len(args) < 1 {
+	target := ""
+	force := false
+	for _, a := range args {
+		switch {
+		case a == "--force" || a == "-f":
+			force = true
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", a)
+			os.Exit(1)
+		default:
+			if target != "" {
+				fmt.Fprintf(os.Stderr, "Error: only one agent name allowed (got %q and %q)\n", target, a)
+				os.Exit(1)
+			}
+			target = a
+		}
+	}
+
+	if target == "" {
 		fmt.Fprintln(os.Stderr, "Usage: crit install <agent>")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Available agents:")
@@ -23,14 +41,6 @@ func runInstall(args []string) {
 		os.Exit(1)
 	}
 
-	force := false
-	for _, arg := range args[1:] {
-		if arg == "--force" || arg == "-f" {
-			force = true
-		}
-	}
-
-	target := args[0]
 	if target == "all" {
 		cwd := mustGetwd()
 		home, _ := os.UserHomeDir()
@@ -266,11 +276,7 @@ func installOneFile(f integration, dest string, force bool) {
 		fmt.Fprintf(os.Stderr, "Error reading embedded file %s: %v\n", f.source, err)
 		os.Exit(1)
 	}
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating directory %s: %v\n", filepath.Dir(dest), err)
-		os.Exit(1)
-	}
-	if err := os.WriteFile(dest, data, 0o644); err != nil {
+	if err := atomicWriteFile(dest, data, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", dest, err)
 		os.Exit(1)
 	}

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -336,6 +336,10 @@ func applySessionOverrides(session *Session, sc *serverConfig) {
 func bindListener(port int) (net.Listener, error) {
 	var listener net.Listener
 	var err error
+	// Retry only makes sense for an explicit port (port != 0): a previous
+	// daemon may still be releasing the socket, so brief backoff lets it
+	// drain. For an ephemeral port (port == 0) the OS picks a free port —
+	// failure means something catastrophic, so break immediately.
 	for attempt := 0; attempt < 3; attempt++ {
 		listener, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err == nil {

--- a/main.go
+++ b/main.go
@@ -2058,12 +2058,11 @@ func runStatus(args []string) {
 		branch = vcs.CurrentBranch()
 	}
 
-	sessions, keys := listSessionsForCWD(cwd)
+	sessions, _ := listSessionsForCWD(cwd)
 	var matchedSession *sessionEntry
 	for i, s := range sessions {
 		if s.Branch == branch || (branch == "" && len(sessions) == 1) {
 			matchedSession = &sessions[i]
-			_ = keys[i]
 			break
 		}
 	}

--- a/share.go
+++ b/share.go
@@ -383,14 +383,6 @@ type webComment struct {
 	Replies           []webReply `json:"replies"`
 }
 
-// buildLocalFingerprints returns a set of body+file+line fingerprints for all
-// local comments. Used to deduplicate web-authored comments (which have no
-// ExternalID) on repeated shares.
-func buildLocalFingerprints(cj CritJSON) map[string]bool {
-	fps, _ := buildLocalFingerprintIndex(cj)
-	return fps
-}
-
 // buildLocalFingerprintIndex returns both the fingerprint set and a map from
 // fingerprint to local comment ID. The ID map lets callers look up the local
 // comment when a web comment matches by fingerprint (so replies can be merged

--- a/share_test.go
+++ b/share_test.go
@@ -1704,7 +1704,7 @@ func TestBuildLocalFingerprints(t *testing.T) {
 				}},
 			},
 		}
-		fps := buildLocalFingerprints(cj)
+		fps, _ := buildLocalFingerprintIndex(cj)
 		key := "fix this|plan.md|5|10"
 		if !fps[key] {
 			t.Errorf("expected fingerprint %q in set", key)
@@ -1719,7 +1719,7 @@ func TestBuildLocalFingerprints(t *testing.T) {
 			Files:          map[string]CritJSONFile{},
 			ReviewComments: []Comment{{ID: "r1", Body: "overall note"}},
 		}
-		fps := buildLocalFingerprints(cj)
+		fps, _ := buildLocalFingerprintIndex(cj)
 		key := "overall note||0|0"
 		if !fps[key] {
 			t.Errorf("expected fingerprint %q in set", key)
@@ -1735,7 +1735,7 @@ func TestBuildLocalFingerprints(t *testing.T) {
 			},
 			ReviewComments: []Comment{{ID: "r1", Body: "looks good"}},
 		}
-		fps := buildLocalFingerprints(cj)
+		fps, _ := buildLocalFingerprintIndex(cj)
 		if len(fps) != 2 {
 			t.Errorf("expected 2 fingerprints, got %d", len(fps))
 		}
@@ -1743,7 +1743,7 @@ func TestBuildLocalFingerprints(t *testing.T) {
 
 	t.Run("empty CritJSON", func(t *testing.T) {
 		cj := CritJSON{Files: map[string]CritJSONFile{}}
-		fps := buildLocalFingerprints(cj)
+		fps, _ := buildLocalFingerprintIndex(cj)
 		if len(fps) != 0 {
 			t.Errorf("expected 0 fingerprints, got %d", len(fps))
 		}


### PR DESCRIPTION
## Summary
- `cli_install.go` `installOneFile`: use `atomicWriteFile` (crash-safe, consistent with all other writes post-#430)
- `aider_install.go`: collapse byte-identical `force`/`!force` write branches into one
- `cli_install.go` `runInstall`: fix order-sensitive flag parsing — `--force` now accepted before or after the agent name
- `main.go`: remove dead `_ = keys[i]` (pre-existing leftover from refactor)
- `share.go`: delete test-only `buildLocalFingerprints` shim; tests now call `buildLocalFingerprintIndex` directly
- `cli_serve.go`: add comment clarifying `bindListener` retry semantics (explicit port retries on transient contention; ephemeral port fails fast)

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (no frontend changes)

## Test plan
- `go test -race -count=1 ./...` — pass
- `golangci-lint run ./...` — 0 issues
- `gofmt -l .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)