### PR TITLE
fix: reduced-motion spinner gap; rename waitingHasComments; annotate reflow

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -244,7 +244,7 @@
   let deleteToken = '';
   let configAuthor = '';
   let uiState = 'reviewing';
-  let waitingHasComments = false;
+  let waitingNotApproved = false;
   let pendingUpdates = [];
   let pendingUpdatesVersion = '';
 
@@ -6626,7 +6626,7 @@
 
   function setUIState(state) {
     uiState = state;
-    if (state === 'reviewing') waitingHasComments = false;
+    if (state === 'reviewing') waitingNotApproved = false;
     const finishBtn = document.getElementById('finishBtn');
     const waitingOverlay = document.getElementById('waitingOverlay');
 
@@ -6666,7 +6666,7 @@
       }
       const data = await resp.json();
       const approved = !!data.approved;
-      waitingHasComments = !approved;
+      waitingNotApproved = !approved;
       const prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
 
       const dialog = document.getElementById('waitingDialog');
@@ -6681,7 +6681,7 @@
       // Replay the success-mark draw animation each time we enter approved state.
       dialog.classList.remove('approved');
       if (approved) {
-        void dialog.offsetWidth;
+        void dialog.offsetWidth; // force reflow — restarts CSS animations on re-added class
         dialog.classList.add('approved');
         headingEl.textContent = 'Approved';
         messageEl.textContent =
@@ -6896,7 +6896,7 @@
           const clipEl = document.getElementById('waitingClipboard');
           if (promptEl) promptEl.style.display = 'none';
           if (clipEl) clipEl.style.display = 'none';
-          if (waitingHasComments) {
+          if (waitingNotApproved) {
             document.getElementById('waitingMessage').textContent = 'Waiting for your agent to finish...';
           }
         }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1814,6 +1814,7 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   .waiting-dialog.approved .success-mark {
     animation: none;
   }
+  .waiting-spinner .dot { animation: none; opacity: 0.6; }
 }
 
 .waiting-dialog .waiting-edits {


### PR DESCRIPTION
## Summary
- `style.css`: add `.waiting-spinner .dot { animation: none; opacity: 0.6 }` to `prefers-reduced-motion: reduce` block — spinner was exempt despite being visible during the full non-approved waiting period
- `app.js`: rename `waitingHasComments` → `waitingNotApproved` across all 4 sites — variable now means `!approved`, not "has comments"; name was misleading after the approved-state refactor
- `app.js`: add inline comment to `void dialog.offsetWidth` explaining it forces a reflow to restart CSS animations on re-added class

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web has no approved modal)

## Test plan
- Manual: verify spinner stops under `prefers-reduced-motion: reduce` media query
- `grep waitingHasComments` returns nothing — rename complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)