### PR TITLE
fix: relax comment drift detection for in-place edits

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -603,6 +603,12 @@ func verifyAndCorrectPosition(newLines []string, anchor string, lcsStart, lcsEnd
 		if candidate == anchor {
 			return lcsStart, lcsStart + anchorLen - 1, 0
 		}
+		// Edited-but-recognizable: if LCS predicts the same row and the line
+		// is still close enough to the original, treat as anchored. Avoids
+		// false drift when text was appended/trimmed/tweaked in place.
+		if anchorSimilar(candidate, anchor) {
+			return lcsStart, lcsStart + anchorLen - 1, 0
+		}
 	}
 
 	// LCS position doesn't match — search the entire file.
@@ -613,6 +619,78 @@ func verifyAndCorrectPosition(newLines []string, anchor string, lcsStart, lcsEnd
 
 	// Anchor not found anywhere — mark drifted, keep LCS position.
 	return lcsStart, lcsEnd, 1
+}
+
+// anchorSimilar reports whether candidate and anchor are close enough to
+// treat the comment as still anchored. Catches in-place edits (appended,
+// trimmed, or lightly reworded text) that exact match would flag as drifted.
+func anchorSimilar(candidate, anchor string) bool {
+	a := strings.TrimSpace(candidate)
+	b := strings.TrimSpace(anchor)
+	if a == b {
+		return true
+	}
+	if a == "" || b == "" {
+		return false
+	}
+	// Common case: text was appended to or trimmed from the anchor line.
+	if strings.Contains(a, b) || strings.Contains(b, a) {
+		return true
+	}
+	return levenshteinRatio(a, b) >= 0.7
+}
+
+// levenshteinRatio returns 1 - (distance / maxLen), clamped to [0, 1].
+func levenshteinRatio(a, b string) float64 {
+	ar, br := []rune(a), []rune(b)
+	la, lb := len(ar), len(br)
+	if la == 0 && lb == 0 {
+		return 1
+	}
+	maxLen := la
+	if lb > maxLen {
+		maxLen = lb
+	}
+	d := levenshtein(ar, br)
+	return 1 - float64(d)/float64(maxLen)
+}
+
+// levenshtein computes edit distance between two rune slices using a
+// rolling two-row buffer. O(la*lb) time, O(min(la,lb)) space.
+func levenshtein(a, b []rune) int {
+	if len(a) < len(b) {
+		a, b = b, a
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			m := del
+			if ins < m {
+				m = ins
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
 }
 
 // remapLines translates old start/end line numbers through the LCS line map,

--- a/watch.go
+++ b/watch.go
@@ -634,7 +634,13 @@ func anchorSimilar(candidate, anchor string) bool {
 		return false
 	}
 	// Common case: text was appended to or trimmed from the anchor line.
-	if strings.Contains(a, b) || strings.Contains(b, a) {
+	// Gate on a minimum length so trivial anchors (`}`, `return nil`) don't
+	// match any longer line that happens to contain them.
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	if minLen >= 8 && (strings.Contains(a, b) || strings.Contains(b, a)) {
 		return true
 	}
 	return levenshteinRatio(a, b) >= 0.7

--- a/watch_test.go
+++ b/watch_test.go
@@ -704,13 +704,16 @@ func TestAnchorSimilar(t *testing.T) {
 	}{
 		{"identical", "foo bar", "foo bar", true},
 		{"trim whitespace", "  foo bar  ", "foo bar", true},
-		{"appended text", "foo bar baz qux", "foo bar", true},
-		{"trimmed text", "foo bar", "foo bar baz qux", true},
+		{"appended text", "foo bar baz qux", "foo bar baz", true},
+		{"trimmed text", "foo bar baz", "foo bar baz qux", true},
 		{"minor edit", "the quick brown fox", "the quick brn fox", true},
+		{"short anchor not trivially contained", "} else {", "}", false},
+		{"short anchor too generic", "x = foo()", "x = 1", false},
 		{"empty candidate", "", "foo bar", false},
 		{"empty anchor", "foo bar", "", false},
 		{"unrelated", "the quick brown fox", "lorem ipsum dolor", false},
 		{"heavy rewrite", "foo bar baz", "completely different text here", false},
+		{"multi-line minor edit", "line one\nline two changed", "line one\nline two", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/watch_test.go
+++ b/watch_test.go
@@ -642,6 +642,86 @@ func TestCarryForward_AnchorDrifted(t *testing.T) {
 	}
 }
 
+func TestCarryForward_AnchorEditedInPlaceNotDrifted(t *testing.T) {
+	// Old anchor is a clean prefix of the new line — text appended in place.
+	// LCS maps the line to the same position, but exact match fails.
+	// Should be treated as anchored, not drifted.
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "plan.md")
+	oldContent := "# Plan\n\n- Don't create a group for just 1 commit — merge it into the closest group\n"
+	newContent := "# Plan\n\n- Don't create a group for just 1 commit — merge it into the closest group (unless it's a single significant feature that warrants its own callout)\n"
+	os.WriteFile(mdPath, []byte(newContent), 0644)
+
+	s := &Session{
+		Mode:     "files",
+		RepoRoot: dir,
+		Files: []*FileEntry{
+			{
+				Path:            "plan.md",
+				AbsPath:         mdPath,
+				Status:          "modified",
+				FileType:        "markdown",
+				Content:         newContent,
+				PreviousContent: oldContent,
+				Comments:        []Comment{},
+				PreviousComments: []Comment{
+					{
+						ID:        "c_old",
+						StartLine: 3,
+						EndLine:   3,
+						Body:      "unless that commit is a single significant change/feature!",
+						Anchor:    "- Don't create a group for just 1 commit — merge it into the closest group",
+						Scope:     "line",
+						CreatedAt: "2026-01-01T00:00:00Z",
+						UpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		roundComplete: make(chan struct{}, 1),
+	}
+
+	s.carryForwardComments()
+
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(s.Files[0].Comments))
+	}
+	carried := s.Files[0].Comments[0]
+	if carried.Drifted {
+		t.Error("expected Drifted=false when anchor was edited in place but still recognizable")
+	}
+	if carried.StartLine != 3 || carried.EndLine != 3 {
+		t.Errorf("expected line 3, got %d-%d", carried.StartLine, carried.EndLine)
+	}
+}
+
+func TestAnchorSimilar(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate string
+		anchor    string
+		want      bool
+	}{
+		{"identical", "foo bar", "foo bar", true},
+		{"trim whitespace", "  foo bar  ", "foo bar", true},
+		{"appended text", "foo bar baz qux", "foo bar", true},
+		{"trimmed text", "foo bar", "foo bar baz qux", true},
+		{"minor edit", "the quick brown fox", "the quick brn fox", true},
+		{"empty candidate", "", "foo bar", false},
+		{"empty anchor", "foo bar", "", false},
+		{"unrelated", "the quick brown fox", "lorem ipsum dolor", false},
+		{"heavy rewrite", "foo bar baz", "completely different text here", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anchorSimilar(tt.candidate, tt.anchor); got != tt.want {
+				t.Errorf("anchorSimilar(%q, %q) = %v, want %v",
+					tt.candidate, tt.anchor, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCarryForward_AnchorFindsCorrectPositionWhenLCSWrong(t *testing.T) {
 	dir := t.TempDir()
 	mdPath := filepath.Join(dir, "plan.md")


### PR DESCRIPTION
## Summary
- Carry-forward marked comments as "Drifted" whenever the anchor line text changed at all, even when the original anchor was still a clean prefix of the edited line (e.g. text appended in place).
- Now treats edited-but-recognizable lines as anchored at the LCS-remapped position: substring match (gated to anchors ≥8 chars to avoid spurious hits on `}` / `return`) covers append/trim, Levenshtein ratio ≥ 0.7 covers minor rewordings.
- File-wide search remains exact-match to avoid jumping to look-alike lines elsewhere in the file.

## Review
- [x] Code review: passed (short-anchor gate added in fixup)
- [x] Parity audit: N/A (backend carry-forward; no review-page surface)
- [x] Intent audit: clean

## Test plan
- [x] `go test ./...` — all green
- [x] `gofmt -l .` clean, `golangci-lint run ./...` clean
- [x] New `TestCarryForward_AnchorEditedInPlaceNotDrifted` — reproduces the real-world scenario where text was appended to a list item.
- [x] New `TestAnchorSimilar` table — identical, trim, append, minor edit, short-anchor (gated), unrelated, heavy rewrite, multi-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)