### PR TITLE
fix: atomically rewrite auth_token + identity on login

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -280,9 +280,9 @@ func clearSpinner(dots int) {
 }
 
 // saveAuthSession persists the bearer token and identity fields as one
-// atomic write. Login must use this rather than saveAuthToken +
-// saveAuthIdentity in sequence: a crash between the two writes would leave
-// a token without matching identity (or stale identity from a prior account).
+// atomic write so a crash mid-login cannot leave a token paired with stale
+// identity from a prior account. Empty fields delete the corresponding key
+// rather than leaving stale values behind.
 func saveAuthSession(token tokenResponse) error {
 	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
 		writeOrDelete := func(key, value string) {
@@ -297,48 +297,6 @@ func saveAuthSession(token tokenResponse) error {
 		writeOrDelete("auth_user_id", token.UserID)
 		writeOrDelete("auth_user_name", token.UserName)
 		writeOrDelete("auth_user_email", token.UserEmail)
-		return nil
-	})
-}
-
-// saveAuthIdentity persists the user identity fields from a token response
-// to the global config. All three fields (auth_user_id, auth_user_name,
-// auth_user_email) are rewritten together so a stale value from a previous
-// account cannot survive a re-login: missing fields in the response remove
-// the corresponding key from disk rather than leaving it untouched.
-func saveAuthIdentity(token tokenResponse) error {
-	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
-		writeOrDelete := func(key, value string) {
-			if value == "" {
-				delete(m, key)
-				return
-			}
-			raw, _ := json.Marshal(value)
-			m[key] = raw
-		}
-		writeOrDelete("auth_user_id", token.UserID)
-		writeOrDelete("auth_user_name", token.UserName)
-		writeOrDelete("auth_user_email", token.UserEmail)
-		return nil
-	})
-}
-
-// saveAuthToken writes the auth_token to the global config file.
-func saveAuthToken(token string) error {
-	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
-		raw, err := json.Marshal(token)
-		if err != nil {
-			return err
-		}
-		m["auth_token"] = raw
-		return nil
-	})
-}
-
-// removeAuthToken removes auth_token from the global config file.
-func removeAuthToken() error {
-	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
-		delete(m, "auth_token")
 		return nil
 	})
 }

--- a/auth.go
+++ b/auth.go
@@ -87,13 +87,9 @@ func runAuthLogin(args []string) {
 		os.Exit(1)
 	}
 
-	if err := saveAuthToken(token.AccessToken); err != nil {
-		fmt.Fprintf(os.Stderr, "Error saving token: %v\n", err)
+	if err := saveAuthSession(token); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving credentials: %v\n", err)
 		os.Exit(1)
-	}
-
-	if err := saveAuthIdentity(token); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to persist auth identity: %v\n", err)
 	}
 
 	// If the server didn't return a user_id (older crit-web), fetch it now via
@@ -281,6 +277,28 @@ func clearSpinner(dots int) {
 	if dots > 0 {
 		fmt.Fprint(os.Stderr, "\r"+strings.Repeat(" ", dots+2)+"\r")
 	}
+}
+
+// saveAuthSession persists the bearer token and identity fields as one
+// atomic write. Login must use this rather than saveAuthToken +
+// saveAuthIdentity in sequence: a crash between the two writes would leave
+// a token without matching identity (or stale identity from a prior account).
+func saveAuthSession(token tokenResponse) error {
+	return saveGlobalConfig(func(m map[string]json.RawMessage) error {
+		writeOrDelete := func(key, value string) {
+			if value == "" {
+				delete(m, key)
+				return
+			}
+			raw, _ := json.Marshal(value)
+			m[key] = raw
+		}
+		writeOrDelete("auth_token", token.AccessToken)
+		writeOrDelete("auth_user_id", token.UserID)
+		writeOrDelete("auth_user_name", token.UserName)
+		writeOrDelete("auth_user_email", token.UserEmail)
+		return nil
+	})
 }
 
 // saveAuthIdentity persists the user identity fields from a token response

--- a/auth_test.go
+++ b/auth_test.go
@@ -727,6 +727,106 @@ func TestPollForToken_Integration(t *testing.T) {
 	}
 }
 
+// TestSaveAuthSession_AtomicRewrite verifies that saveAuthSession writes the
+// bearer token and all identity fields in a single atomic config write — this
+// is the fix for the split-write race where a crash between saveAuthToken and
+// saveAuthIdentity could leave a token paired with stale identity from the
+// previous account.
+func TestSaveAuthSession_AtomicRewrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed config with a full session from a previous user.
+	initial := `{
+		"auth_token": "old_token",
+		"auth_user_id": "old-uuid",
+		"auth_user_name": "Old User",
+		"auth_user_email": "old@example.com"
+	}`
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// New login as a different user — every field should change.
+	if err := saveAuthSession(tokenResponse{
+		AccessToken: "new_token",
+		UserID:      "new-uuid",
+		UserName:    "New User",
+		UserEmail:   "new@example.com",
+	}); err != nil {
+		t.Fatalf("saveAuthSession: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+
+	check := func(key, want string) {
+		t.Helper()
+		var got string
+		json.Unmarshal(raw[key], &got)
+		if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	check("auth_token", "new_token")
+	check("auth_user_id", "new-uuid")
+	check("auth_user_name", "New User")
+	check("auth_user_email", "new@example.com")
+}
+
+// TestSaveAuthSession_RemovesFieldsAbsentFromResponse verifies that an older
+// crit-web that returns an empty user_id causes the existing key to be
+// removed from disk in the same write — preventing stale identity from
+// surviving a re-login when the new token response is partial.
+func TestSaveAuthSession_RemovesFieldsAbsentFromResponse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initial := `{
+		"auth_token": "old_token",
+		"auth_user_id": "stale-uuid",
+		"auth_user_name": "Stale User",
+		"auth_user_email": "stale@example.com"
+	}`
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Older server: returns token + name only.
+	if err := saveAuthSession(tokenResponse{
+		AccessToken: "fresh_token",
+		UserName:    "Just Name",
+	}); err != nil {
+		t.Fatalf("saveAuthSession: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+
+	if _, ok := raw["auth_user_id"]; ok {
+		t.Error("auth_user_id should be removed when token response omits it")
+	}
+	if _, ok := raw["auth_user_email"]; ok {
+		t.Error("auth_user_email should be removed when token response omits it")
+	}
+	var token, name string
+	json.Unmarshal(raw["auth_token"], &token)
+	json.Unmarshal(raw["auth_user_name"], &name)
+	if token != "fresh_token" {
+		t.Errorf("auth_token = %q, want fresh_token", token)
+	}
+	if name != "Just Name" {
+		t.Errorf("auth_user_name = %q, want Just Name", name)
+	}
+}
+
 // TestSaveAuthIdentity_OverwritesStaleFields verifies that re-login replaces
 // every identity field, even when the new token response omits some of them.
 // This guards against the prod regression where a previous account's

--- a/auth_test.go
+++ b/auth_test.go
@@ -235,62 +235,18 @@ func TestHandlePollError(t *testing.T) {
 	}
 }
 
-func TestSaveAndRemoveAuthToken(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// Save a token
-	if err := saveAuthToken("crit_test_token"); err != nil {
-		t.Fatalf("saveAuthToken: %v", err)
-	}
-
-	// Verify it was written
-	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
-	if err != nil {
-		t.Fatalf("reading config: %v", err)
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("parsing config: %v", err)
-	}
-	var token string
-	json.Unmarshal(raw["auth_token"], &token)
-	if token != "crit_test_token" {
-		t.Errorf("auth_token = %q, want crit_test_token", token)
-	}
-
-	// Remove the token
-	if err := removeAuthToken(); err != nil {
-		t.Fatalf("removeAuthToken: %v", err)
-	}
-
-	data, err = os.ReadFile(filepath.Join(home, ".crit.config.json"))
-	if err != nil {
-		t.Fatalf("reading config after remove: %v", err)
-	}
-	raw = make(map[string]json.RawMessage)
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("parsing config after remove: %v", err)
-	}
-	if _, ok := raw["auth_token"]; ok {
-		t.Error("auth_token should be removed after removeAuthToken")
-	}
-}
-
 func TestSaveGlobalConfig_PreservesUnknownKeys(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Write a config with an existing key
+	// Write a config with existing keys.
 	initial := `{"share_url": "https://example.com", "port": 3000}` + "\n"
 	os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600)
 
-	// Save auth_token
-	if err := saveAuthToken("crit_tok"); err != nil {
-		t.Fatalf("saveAuthToken: %v", err)
+	if err := saveAuthSession(tokenResponse{AccessToken: "crit_tok"}); err != nil {
+		t.Fatalf("saveAuthSession: %v", err)
 	}
 
-	// Verify both old keys and new key are present
 	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
 	if err != nil {
 		t.Fatalf("reading config: %v", err)
@@ -315,8 +271,8 @@ func TestSaveGlobalConfig_FilePermissions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	if err := saveAuthToken("crit_tok"); err != nil {
-		t.Fatalf("saveAuthToken: %v", err)
+	if err := saveAuthSession(tokenResponse{AccessToken: "crit_tok"}); err != nil {
+		t.Fatalf("saveAuthSession: %v", err)
 	}
 
 	info, err := os.Stat(filepath.Join(home, ".crit.config.json"))
@@ -728,10 +684,10 @@ func TestPollForToken_Integration(t *testing.T) {
 }
 
 // TestSaveAuthSession_AtomicRewrite verifies that saveAuthSession writes the
-// bearer token and all identity fields in a single atomic config write — this
-// is the fix for the split-write race where a crash between saveAuthToken and
-// saveAuthIdentity could leave a token paired with stale identity from the
-// previous account.
+// bearer token and all identity fields in a single atomic config write,
+// guarding against the prod regression (#371) where stale identity from a
+// previous login survived re-login because the bearer and identity were
+// persisted in two separate writes.
 func TestSaveAuthSession_AtomicRewrite(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -822,101 +778,6 @@ func TestSaveAuthSession_RemovesFieldsAbsentFromResponse(t *testing.T) {
 	if token != "fresh_token" {
 		t.Errorf("auth_token = %q, want fresh_token", token)
 	}
-	if name != "Just Name" {
-		t.Errorf("auth_user_name = %q, want Just Name", name)
-	}
-}
-
-// TestSaveAuthIdentity_OverwritesStaleFields verifies that re-login replaces
-// every identity field, even when the new token response omits some of them.
-// This guards against the prod regression where a previous account's
-// auth_user_id survived a login as a different user, causing the daemon to
-// stamp the wrong user_id into shared comments.
-func TestSaveAuthIdentity_OverwritesStaleFields(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// Seed config with stale identity from a previous login (different user).
-	initial := `{
-		"auth_token": "old_token",
-		"auth_user_id": "old-uuid",
-		"auth_user_name": "Old User",
-		"auth_user_email": "old@example.com"
-	}`
-	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// New login as a different user.
-	newToken := tokenResponse{
-		AccessToken: "new_token",
-		UserID:      "new-uuid",
-		UserName:    "New User",
-		UserEmail:   "new@example.com",
-	}
-	if err := saveAuthIdentity(newToken); err != nil {
-		t.Fatalf("saveAuthIdentity: %v", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
-	if err != nil {
-		t.Fatalf("reading config: %v", err)
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("parsing config: %v", err)
-	}
-
-	check := func(key, want string) {
-		t.Helper()
-		var got string
-		json.Unmarshal(raw[key], &got)
-		if got != want {
-			t.Errorf("%s = %q, want %q", key, got, want)
-		}
-	}
-	check("auth_user_id", "new-uuid")
-	check("auth_user_name", "New User")
-	check("auth_user_email", "new@example.com")
-}
-
-// TestSaveAuthIdentity_RemovesFieldsAbsentFromResponse verifies that when the
-// server returns an empty user_id (older crit-web), the existing key is
-// removed from disk rather than silently retained — otherwise the daemon
-// would keep stamping the previous user's id forever.
-func TestSaveAuthIdentity_RemovesFieldsAbsentFromResponse(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	initial := `{
-		"auth_user_id": "stale-uuid",
-		"auth_user_name": "Stale User",
-		"auth_user_email": "stale@example.com"
-	}`
-	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(initial), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Older server: only returns user_name; no user_id, no user_email.
-	if err := saveAuthIdentity(tokenResponse{
-		AccessToken: "tok",
-		UserName:    "Just Name",
-	}); err != nil {
-		t.Fatalf("saveAuthIdentity: %v", err)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(home, ".crit.config.json"))
-	var raw map[string]json.RawMessage
-	json.Unmarshal(data, &raw)
-
-	if _, ok := raw["auth_user_id"]; ok {
-		t.Error("auth_user_id should be removed when token response omits it")
-	}
-	if _, ok := raw["auth_user_email"]; ok {
-		t.Error("auth_user_email should be removed when token response omits it")
-	}
-	var name string
-	json.Unmarshal(raw["auth_user_name"], &name)
 	if name != "Just Name" {
 		t.Errorf("auth_user_name = %q, want Just Name", name)
 	}

--- a/share_attribution_test.go
+++ b/share_attribution_test.go
@@ -150,6 +150,106 @@ func TestShareAuthAttributesUserIdentity(t *testing.T) {
 	}
 }
 
+// TestAuthSessionReLoginEndToEnd verifies that saveAuthSession atomically
+// replaces a previous account's credentials such that a subsequent crit ↔
+// crit-web share authenticates as the new user. Reproduces the prod scenario
+// from #371 where a stale auth_user_id from a prior login leaked into shares
+// of the next user.
+//
+// Unlike the other share-auth tests, this one does NOT inject CRIT_AUTH_TOKEN
+// via env — it persists credentials through saveAuthSession into the global
+// config and lets the crit binary discover them via HOME, exercising the real
+// post-login flow.
+func TestAuthSessionReLoginEndToEnd(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Two distinct authenticated users on crit-web.
+	tokenA, _, nameA := seedUser(t, baseURL, "Login User A")
+	tokenB, userIDB, nameB := seedUser(t, baseURL, "Login User B")
+
+	// Login as A, then re-login as B. The second saveAuthSession must
+	// rewrite every auth_* field; if any of A's identity survives, the
+	// next share will attribute incorrectly.
+	if err := saveAuthSession(tokenResponse{
+		AccessToken: tokenA, UserID: "irrelevant-A", UserName: nameA,
+	}); err != nil {
+		t.Fatalf("saveAuthSession (A): %v", err)
+	}
+	if err := saveAuthSession(tokenResponse{
+		AccessToken: tokenB, UserID: userIDB, UserName: nameB,
+	}); err != nil {
+		t.Fatalf("saveAuthSession (B): %v", err)
+	}
+
+	// Sanity check on disk: every field is B's, none of A's leaked.
+	data, err := os.ReadFile(filepath.Join(home, ".crit.config.json"))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	var diskToken, diskUserID, diskName string
+	json.Unmarshal(raw["auth_token"], &diskToken)
+	json.Unmarshal(raw["auth_user_id"], &diskUserID)
+	json.Unmarshal(raw["auth_user_name"], &diskName)
+	if diskToken != tokenB {
+		t.Fatalf("auth_token = %q, want B's token (re-login leaked A)", diskToken)
+	}
+	if diskUserID != userIDB {
+		t.Fatalf("auth_user_id = %q, want %q (re-login leaked A)", diskUserID, userIDB)
+	}
+	if diskName != nameB {
+		t.Fatalf("auth_user_name = %q, want %q (re-login leaked A)", diskName, nameB)
+	}
+
+	// Run `crit share` with no CRIT_AUTH_TOKEN override — binary reads
+	// the bearer from $HOME/.crit.config.json, which now holds B's session.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n\nStep 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"plan.md": {
+				Comments: []Comment{
+					{ID: "c1", StartLine: 3, EndLine: 3, Body: "post-relogin note", Scope: "line",
+						UserID:    userIDB,
+						CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	})
+	// runCritShareEnv strips CRIT_AUTH_TOKEN and HOME from the env, then re-adds
+	// HOME pointing at the test home so the binary picks up B's persisted session.
+	output, err := runCritShareEnv(t, binary, baseURL, dir, []string{"HOME=" + home}, "plan.md")
+	if err != nil {
+		t.Fatalf("crit share failed: %v\n%s", err, output)
+	}
+	logReview(t, output)
+	reviewToken := extractToken(t, output)
+
+	comments := commentsFromAPI(t, baseURL, reviewToken)
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	c := comments[0]
+	if c.UserID != userIDB {
+		t.Errorf("user_id = %q, want %q (server should attribute to B from re-login bearer)",
+			c.UserID, userIDB)
+	}
+	if c.AuthorDisplayName != nameB {
+		t.Errorf("author_display_name = %q, want %q (verified user record)",
+			c.AuthorDisplayName, nameB)
+	}
+}
+
 // TestShareAuthIgnoresPayloadSpoofedIdentity verifies that when no bearer
 // token is provided, payload-supplied identity fields cannot impersonate
 // a real user. Knowing a user's UUID must not be enough to attribute


### PR DESCRIPTION
## Summary

- Login persisted credentials in two separate `saveGlobalConfig` calls (`saveAuthToken` then `saveAuthIdentity`), leaving a window where a crash between writes could pair a fresh token with stale identity from the previous account — the failure mode that surfaced #371. Collapse them into one `saveAuthSession` closure that rewrites all four `auth_*` fields in a single atomic temp+rename under the existing flock.
- Drop `saveAuthToken`, `saveAuthIdentity`, and `removeAuthToken` — none have production callers anymore. `clearAuthIdentity` already owns logout / 401, and `lazyBackfillAuthUserID` keeps its own narrower closure for the legitimate identity-only backfill path.
- Document the consolidation decision behind closing #392 — the two visible name fields (`author`, `auth_user_name`) stay; `author` is the documented local pen name, `auth_user_name` is opaque session metadata. The atomic-write fix here resolves the underlying #371 class without needing to consolidate config keys.

Closes #392.

## Review

- [x] Code review: passed (go-expert)
- [x] Intent audit: clean
- [x] Parity audit: N/A (no review-page surface)

## Test plan

- Unit: `TestSaveAuthSession_AtomicRewrite`, `TestSaveAuthSession_RemovesFieldsAbsentFromResponse` — cover the bearer + identity rewrite atomically (including partial-server-response field removal).
- Integration (`make e2e-share`): `TestAuthSessionReLoginEndToEnd` seeds two distinct users on crit-web, persists user A's session via `saveAuthSession`, re-persists as user B, runs `crit share` with HOME pointing at the test home (no `CRIT_AUTH_TOKEN` env override) and asserts the server stamps user B on the resulting comment.
- Verified locally: `go test -race -count=1 ./...` and the share integration suite both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)