### PR TITLE
feat: keyboard-accessible sidebar resize handles

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7486,6 +7486,21 @@
       handle.addEventListener('pointerup', onEnd);
       handle.addEventListener('pointercancel', onEnd);
     });
+
+    // Keyboard resize for a11y: ArrowLeft / ArrowRight nudges by 16px.
+    // For left-edge handles (comments panel) the direction flips so
+    // ArrowRight always shrinks the controlled panel — matching pointer
+    // drag semantics.
+    handle.addEventListener('keydown', function(e) {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      e.preventDefault();
+      const dir = cfg.edge === 'left' ? -1 : 1;
+      const sign = e.key === 'ArrowRight' ? 1 : -1;
+      const current = target.getBoundingClientRect().width;
+      const w = Math.max(cfg.min, current + sign * dir * 16);
+      target.style.width = w + 'px';
+      setSetting(cfg.settingKey, Math.round(w));
+    });
   }
 
   // ===== Update Button =====

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -134,14 +134,14 @@
     </div>
     <div class="file-tree-body" id="fileTreeBody"></div>
   </div>
-  <div class="sidebar-resize-handle" id="fileTreeResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize file tree"></div>
+  <div class="sidebar-resize-handle" id="fileTreeResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize file tree" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
   <div class="main-content">
     <div id="reviewConversation" class="review-conversation" hidden></div>
     <div id="filesContainer">
       <div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>
     </div>
   </div>
-  <div class="sidebar-resize-handle" id="commentsPanelResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize comments panel"></div>
+  <div class="sidebar-resize-handle" id="commentsPanelResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize comments panel" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
   <div class="comments-panel comments-panel-hidden" id="commentsPanel">
     <div class="comments-panel-header">
       <div class="comments-panel-header-row1">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -134,14 +134,14 @@
     </div>
     <div class="file-tree-body" id="fileTreeBody"></div>
   </div>
-  <div class="sidebar-resize-handle" id="fileTreeResizer" aria-hidden="true"></div>
+  <div class="sidebar-resize-handle" id="fileTreeResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize file tree"></div>
   <div class="main-content">
     <div id="reviewConversation" class="review-conversation" hidden></div>
     <div id="filesContainer">
       <div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>
     </div>
   </div>
-  <div class="sidebar-resize-handle" id="commentsPanelResizer" aria-hidden="true"></div>
+  <div class="sidebar-resize-handle" id="commentsPanelResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize comments panel"></div>
   <div class="comments-panel comments-panel-hidden" id="commentsPanel">
     <div class="comments-panel-header">
       <div class="comments-panel-header-row1">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2576,8 +2576,10 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
   transition: background 0.15s ease;
 }
 .sidebar-resize-handle:hover,
+.sidebar-resize-handle:focus-visible,
 .sidebar-resize-handle.dragging {
   background: var(--crit-brand);
+  outline: none;
 }
 /* Hide the comments-panel resizer when its panel is hidden. */
 .main-layout:has(#commentsPanel.comments-panel-hidden) #commentsPanelResizer {


### PR DESCRIPTION
## Summary

Sidebar resize handles gain keyboard support and a focus indicator.

- Handles previously used `aria-hidden="true"` and were unreachable by keyboard. Now use `role="separator"`, `tabindex="0"`, `aria-orientation="vertical"`, with ArrowLeft/ArrowRight nudging width by 16px (clamped to min, persists via existing settings cookie).
- Adds `:focus-visible` brand-color style so keyboard users can see the focused handle.

Companion to tomasz-tomczyk/crit-web#177, which ports the resizable-sidebars feature itself plus this same a11y polish to the hosted review surface.

## Review

- [x] Code review: passed
- [x] Parity audit: in sync with crit-web

## Test plan

- [x] go build clean
- [x] gofmt + golangci-lint + go test (race, count=1) all pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)