### PR TITLE
fix: close finish-review modal on backdrop click

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6787,6 +6787,10 @@
     setUIState('reviewing');
   });
 
+  document.getElementById('waitingOverlay').addEventListener('click', function(e) {
+    if (e.target === this) setUIState('reviewing');
+  });
+
   document.getElementById('waitingClipboard').addEventListener('click', async function() {
     const prompt = document.getElementById('waitingPrompt').textContent;
     try {


### PR DESCRIPTION
## Summary
- Click outside the Finish Review / Review Complete overlay (on the backdrop) now closes it, mirroring existing patterns used by the settings, share, and confirm overlays (`e.target === overlay` check on `#waitingOverlay`).

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- [ ] Open Finish Review modal, click on the dimmed backdrop → modal closes, returns to reviewing state
- [ ] Click inside the dialog body → modal stays open

See also: tomasz-tomczyk/crit-web#179 (companion fix for the Get prompt modal in crit-web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)