### PR TITLE
fix: allow --range/--pr on clean working tree

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -276,7 +276,11 @@ func createSession(sc *serverConfig) (*Session, error) {
 		if sc.baseBranch != "" {
 			vcs.SetDefaultBranchOverride(sc.baseBranch)
 		}
-		session, err = NewSessionFromVCS(vcs, sc.ignorePatterns)
+		// When --pr/--range is set, the working-tree diff is irrelevant —
+		// SetFocus rebuilds the file list from the focus's SHA range. Tolerate
+		// an empty working tree so the daemon doesn't crash with
+		// "no changed files detected" before the focus is applied (#471).
+		session, err = newGitSession(vcs, sc.ignorePatterns, sc.focus == nil)
 	} else {
 		session, err = NewSessionFromFiles(sc.files, sc.ignorePatterns)
 	}

--- a/session.go
+++ b/session.go
@@ -449,12 +449,31 @@ func detectVCSChanges(vcs VCS, root string, ignorePatterns []string) (branch, ba
 // NewSessionFromVCS creates a session by auto-detecting changed files using the given VCS backend.
 // This is the VCS-agnostic equivalent of NewSessionFromGit.
 func NewSessionFromVCS(vcs VCS, ignorePatterns []string) (*Session, error) {
+	return newGitSession(vcs, ignorePatterns, true)
+}
+
+// newGitSession is the implementation behind NewSessionFromVCS. When
+// requireChanges is false, an empty working-tree diff produces a session with
+// no files instead of returning ErrNoChangedFiles — callers that apply a
+// --pr/--range focus rebuild the file list via SetFocus, so the working-tree
+// diff is irrelevant. See issue #471.
+func newGitSession(vcs VCS, ignorePatterns []string, requireChanges bool) (*Session, error) {
 	root, err := vcs.RepoRoot()
 	if err != nil {
 		return nil, fmt.Errorf("not a %s repository: %w", vcs.Name(), err)
 	}
 
 	branch, baseRef, resolvedBase, changes, err := detectVCSChanges(vcs, root, ignorePatterns)
+	if errors.Is(err, ErrNoChangedFiles) && !requireChanges {
+		// detectVCSChanges zeroes its return values on the empty path; recover
+		// the metadata so the session reports the correct branch/base.
+		branch = vcs.CurrentBranch()
+		resolvedBase = vcs.DefaultBranch()
+		if branch != resolvedBase {
+			baseRef, _ = vcs.MergeBase(vcs.DefaultBaseRef())
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -3835,6 +3836,86 @@ func TestCreateSession_LoadsShareFromReviewPath(t *testing.T) {
 	}
 	if session.ReviewRound != 2 {
 		t.Errorf("ReviewRound = %d, want 2", session.ReviewRound)
+	}
+}
+
+// TestCreateSession_RangeFocus_CleanWorkingTree exercises issue #471: when
+// --range is set, the working tree may be clean while the requested commit
+// range still has changes. createSession must not return ErrNoChangedFiles in
+// that case — the focus rebuilds the file list via SetFocus.
+func TestCreateSession_RangeFocus_CleanWorkingTree(t *testing.T) {
+	// Issue #471: --range must succeed on a clean working tree even though the
+	// default working-tree change-detection path returns ErrNoChangedFiles.
+	// SetFocus rebuilds the file list from the SHA range during
+	// applySessionOverrides, so createSession must not bail early.
+	tests := []struct {
+		name           string
+		featureBranch  bool // exercises the merge-base recovery branch
+		wantBranch     string
+		wantBaseBranch string
+	}{
+		{name: "default branch, clean tree", featureBranch: false, wantBranch: "main", wantBaseBranch: "main"},
+		{name: "feature branch, clean tree", featureBranch: true, wantBranch: "feature/clean-tree", wantBaseBranch: "main"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initTestRepo(t)
+			baseSHA := gitT(t, dir, "rev-parse", "HEAD")
+
+			if tc.featureBranch {
+				gitT(t, dir, "checkout", "-b", "feature/clean-tree")
+			}
+			writeFile(t, filepath.Join(dir, "a.md"), "# A\n")
+			gitT(t, dir, "add", "a.md")
+			gitT(t, dir, "commit", "-m", "add a")
+			headSHA := gitT(t, dir, "rev-parse", "HEAD")
+
+			orig, _ := os.Getwd()
+			if err := os.Chdir(dir); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { os.Chdir(orig) })
+
+			sc := &serverConfig{
+				focus: &Focus{Kind: FocusRange, BaseSHA: baseSHA, HeadSHA: headSHA},
+			}
+			session, err := createSession(sc)
+			if err != nil {
+				t.Fatalf("createSession with range focus on clean working tree: %v", err)
+			}
+			if session == nil {
+				t.Fatal("session is nil")
+			}
+			if session.Mode != "git" {
+				t.Errorf("Mode = %q, want %q", session.Mode, "git")
+			}
+			if session.Branch != tc.wantBranch {
+				t.Errorf("Branch = %q, want %q", session.Branch, tc.wantBranch)
+			}
+			if session.BaseBranchName != tc.wantBaseBranch {
+				t.Errorf("BaseBranchName = %q, want %q", session.BaseBranchName, tc.wantBaseBranch)
+			}
+		})
+	}
+}
+
+// TestCreateSession_NoFocus_CleanWorkingTree pins the default behavior: with
+// no focus override (plain `crit` invocation) and a clean working tree, the
+// session must still surface ErrNoChangedFiles. Guards against a future
+// refactor that flips the default and silently allows empty sessions.
+func TestCreateSession_NoFocus_CleanWorkingTree(t *testing.T) {
+	dir := initTestRepo(t)
+	gitT(t, dir, "checkout", "-b", "feature/no-focus-clean")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	sc := &serverConfig{}
+	if _, err := createSession(sc); !errors.Is(err, ErrNoChangedFiles) {
+		t.Fatalf("createSession with clean tree, no focus: err = %v, want ErrNoChangedFiles", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `crit --range A..B` failed with "no changed files detected" when the working tree was clean, even though the requested commit range had changes.
- Root cause: `createSession` calls `NewSessionFromVCS`, which returns `ErrNoChangedFiles` from working-tree change detection — this fires before `SetFocus` has a chance to rebuild the file list from the SHA range.
- Fix: thread a `requireChanges` flag through a new private `newGitSession`. When `sc.focus != nil`, tolerate an empty working-tree diff; `applySessionOverrides` → `SetFocus` will populate `Files` from the focus's SHA range.

## Review
- [x] Code review: passed (go-expert + intent validator)
- [x] Parity audit: N/A (CLI-only Go change)

## Test plan
- New table-driven `TestCreateSession_RangeFocus_CleanWorkingTree` covers both default-branch and feature-branch shapes (the latter exercises the merge-base recovery branch).
- New `TestCreateSession_NoFocus_CleanWorkingTree` pins the default behavior so a future refactor can't silently allow empty sessions.
- Verified the new tests fail without the fix and pass with it.
- Full suite green: `go test -race ./...`, `gofmt -l .`, `golangci-lint run ./...`.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)