### PR TITLE
fix: backward selection across blank-line boundary

### DIFF
--- a/e2e/tests/select-to-comment.spec.ts
+++ b/e2e/tests/select-to-comment.spec.ts
@@ -207,7 +207,65 @@ test.describe('Select-to-comment (git mode)', () => {
       await expect(formHeader).toContainText('Comment on');
     });
 
-    test('single click (no drag) does not open a form', async ({ page }) => {
+    test('selection endpoint on a gap container still spans full range (regression)', async ({ page, request }) => {
+      const section = mdSection(page);
+      const overviewBlock = section.locator('.line-block', { hasText: 'Overview' }).first();
+      const paraBlock = section.locator('.line-block', { hasText: 'API key authentication' });
+      await expect(overviewBlock).toBeVisible();
+      await expect(paraBlock).toBeVisible();
+
+      // Reproduces the bug class: selection crosses a blank-line boundary and one
+      // endpoint resolves to the parent container (a "gap" between line-blocks)
+      // rather than to a text node. This happens in real browsers with backward
+      // drags across paragraph boundaries — anchor/focus can snap to the parent
+      // element at the child-index between two line-blocks.
+      //
+      // Pre-fix behavior: findLineInfo() walks up via closest('.line-block') from
+      // the parent container and returns null → entire selection-to-comment fails
+      // OR collapses to whichever endpoint did resolve, depending on direction.
+      await page.evaluate(() => {
+        const blocks = Array.from(document.querySelectorAll('.line-block[data-file-path]')) as HTMLElement[];
+        const heading = blocks.find(b => (b.textContent || '').includes('Overview'));
+        const para = blocks.find(b => (b.textContent || '').includes('API key authentication'));
+        if (!heading || !para) throw new Error('blocks not found');
+        const wrapper = heading.parentElement!;
+        const headingText = heading.querySelector('.line-content')!.firstChild as Text;
+        const paraIdx = Array.from(wrapper.childNodes).indexOf(para);
+
+        const range = document.createRange();
+        range.setStart(headingText, 0);
+        // End point lands ON the wrapper container at the index just after the
+        // paragraph block. This is the "gap container" position — exercises the
+        // bug where the endpoint has no .line-block ancestor.
+        range.setEnd(wrapper, paraIdx + 1);
+
+        const sel = window.getSelection()!;
+        sel.removeAllRanges();
+        sel.addRange(range);
+      });
+
+      await page.keyboard.press('c');
+
+      const textarea = section.locator('.comment-form textarea');
+      await expect(textarea).toBeVisible();
+      await textarea.fill('Gap-endpoint comment');
+      await textarea.press('Control+Enter');
+      await expect(section.locator('.comment-card', { hasText: 'Gap-endpoint comment' })).toBeVisible();
+
+      const mdPath = await page.evaluate(() => {
+        const el = document.querySelector('.file-section[id*="plan"] .line-block[data-file-path]');
+        return el ? (el as HTMLElement).dataset.filePath : null;
+      });
+      const res = await request.get(`/api/file/comments?path=${mdPath}`);
+      const comments = await res.json();
+      const c = comments.find((x: { body: string }) => x.body === 'Gap-endpoint comment');
+      expect(c).toBeTruthy();
+      // Range must span from heading (line 3) through paragraph (line 5).
+      expect(c.start_line).toBe(3);
+      expect(c.end_line).toBe(5);
+    });
+
+test('single click (no drag) does not open a form', async ({ page }) => {
       const section = mdSection(page);
       const firstBlock = section.locator('.line-block').first();
       await expect(firstBlock).toBeVisible();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4054,71 +4054,61 @@
 
   function getLineRangeFromSelection(selection) {
     if (!selection || selection.isCollapsed || !selection.toString().trim()) return null;
+    if (selection.rangeCount === 0) return null;
+    const range = selection.getRangeAt(0);
 
-    const anchorNode = selection.anchorNode;
-    const focusNode = selection.focusNode;
-    if (!anchorNode || !focusNode) return null;
+    // Walk every commentable element and keep those the range intersects.
+    // Direction-agnostic: avoids relying on anchorNode/focusNode, which can
+    // snap to non-commentable parent containers when a selection crosses a
+    // blank-line boundary (especially in backward drags).
+    const candidates = [];
 
-    // Walk up from a node to find the nearest commentable element.
-    // Returns { filePath, startLine, endLine, blockIndex, side } or null.
-    function findLineInfo(node) {
-      const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
-      if (!el) return null;
+    document.querySelectorAll('.line-block[data-file-path]').forEach(function(el) {
+      if (el.closest('.comment-form-wrapper') || el.closest('.comment-card')) return;
+      if (!range.intersectsNode(el)) return;
+      candidates.push({
+        filePath: el.dataset.filePath,
+        startLine: parseInt(el.dataset.startLine),
+        endLine: parseInt(el.dataset.endLine),
+        blockIndex: el.dataset.blockIndex !== undefined ? parseInt(el.dataset.blockIndex) : null,
+        side: undefined,
+      });
+    });
 
-      // Check if inside a comment — don't trigger on existing comment text
-      if (el.closest('.comment-form-wrapper') || el.closest('.comment-card')) return null;
+    document.querySelectorAll('[data-diff-line-num]').forEach(function(el) {
+      const ln = parseInt(el.dataset.diffLineNum);
+      if (!(ln > 0)) return;
+      if (el.closest('.comment-form-wrapper') || el.closest('.comment-card')) return;
+      if (!range.intersectsNode(el)) return;
+      candidates.push({
+        filePath: el.dataset.diffFilePath,
+        startLine: ln,
+        endLine: ln,
+        blockIndex: null,
+        side: el.dataset.diffSide || undefined,
+      });
+    });
 
-      // Check if inside non-commentable UI (header, file tree, buttons)
-      if (el.closest('.header') || el.closest('.file-tree') || el.closest('.toc-panel')) return null;
+    if (candidates.length === 0) return null;
 
-      // Try markdown line-block first
-      const lineBlock = el.closest('.line-block[data-file-path]');
-      if (lineBlock) {
-        return {
-          filePath: lineBlock.dataset.filePath,
-          startLine: parseInt(lineBlock.dataset.startLine),
-          endLine: parseInt(lineBlock.dataset.endLine),
-          blockIndex: lineBlock.dataset.blockIndex !== undefined ? parseInt(lineBlock.dataset.blockIndex) : null,
-          side: undefined
-        };
-      }
-
-      // Try diff line
-      const diffLine = el.closest('[data-diff-line-num]');
-      if (diffLine && parseInt(diffLine.dataset.diffLineNum) > 0) {
-        return {
-          filePath: diffLine.dataset.diffFilePath,
-          startLine: parseInt(diffLine.dataset.diffLineNum),
-          endLine: parseInt(diffLine.dataset.diffLineNum),
-          blockIndex: null,
-          side: diffLine.dataset.diffSide || undefined
-        };
-      }
-
-      return null;
+    // All candidates must share filePath and side. If the selection straddles
+    // multiple files or diff sides, bail out rather than guess.
+    const filePath = candidates[0].filePath;
+    const side = candidates[0].side;
+    for (let i = 1; i < candidates.length; i++) {
+      if (candidates[i].filePath !== filePath) return null;
+      if (candidates[i].side !== side) return null;
     }
 
-    const anchorInfo = findLineInfo(anchorNode);
-    const focusInfo = findLineInfo(focusNode);
-
-    if (!anchorInfo || !focusInfo) return null;
-
-    // Both ends must be in the same file
-    if (anchorInfo.filePath !== focusInfo.filePath) return null;
-
-    // For diff selections, both ends must be on the same side
-    if (anchorInfo.side !== focusInfo.side) return null;
-
-    // Compute union range
-    const startLine = Math.min(anchorInfo.startLine, focusInfo.startLine);
-    const endLine = Math.max(anchorInfo.endLine, focusInfo.endLine);
-    const filePath = anchorInfo.filePath;
-    const side = anchorInfo.side;
-
-    // Determine afterBlockIndex: use the larger blockIndex (form appears after last block in range)
+    let startLine = Infinity;
+    let endLine = -Infinity;
     let afterBlockIndex = null;
-    if (anchorInfo.blockIndex !== null && focusInfo.blockIndex !== null) {
-      afterBlockIndex = Math.max(anchorInfo.blockIndex, focusInfo.blockIndex);
+    for (const c of candidates) {
+      if (c.startLine < startLine) startLine = c.startLine;
+      if (c.endLine > endLine) endLine = c.endLine;
+      if (c.blockIndex !== null && (afterBlockIndex === null || c.blockIndex > afterBlockIndex)) {
+        afterBlockIndex = c.blockIndex;
+      }
     }
 
     return { filePath, startLine, endLine, afterBlockIndex, side };


### PR DESCRIPTION
## Summary

- Rewrite `getLineRangeFromSelection` to walk every `.line-block` and `[data-diff-line-num]` element and union the line ranges of those the selection's `Range` intersects, instead of only inspecting `selection.anchorNode` / `focusNode`.
- Fixes user-reported bug: selecting text "backwards" (later → earlier) across a blank-line/paragraph boundary attached the comment only to the first part of the selection (or failed to open the form). One Selection endpoint can snap to the parent container between line-blocks where `closest('.line-block')` returns null; the new approach is direction-agnostic and robust to gap-endpoint positions.
- Adds an e2e regression test that reproduces the gap-endpoint condition programmatically (headless Playwright doesn't reproduce the browser snap behavior with a plain mouse drag).

## Review

- [x] Code review: passed
- [x] Parity audit: mirrors crit-web/ change
- [x] \`go test -race ./...\`: pass
- [x] \`golangci-lint run ./...\`: 0 issues
- [x] \`gofmt\`: clean
- [x] e2e select-to-comment + drag-selection + comments suites: pass

## Test plan

- [x] \`cd e2e && npx playwright test tests/select-to-comment.spec.ts\`
- See also: tomasz-tomczyk/crit-web (paired fix in `assets/js/document-renderer.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)