### PR TITLE
fix: preserve CLI argument order for files

### DIFF
--- a/e2e/tests/keyboard.filemode.spec.ts
+++ b/e2e/tests/keyboard.filemode.spec.ts
@@ -4,7 +4,7 @@ import { clearAllComments, loadPage, clearFocus } from './helpers';
 // ============================================================
 // File-Mode-Specific Comment Shortcuts (e, d)
 //
-// These tests use file-mode-specific API seeding (handler.js path)
+// These tests use file-mode-specific API seeding (plan.md path)
 // and verify keyboard shortcuts work in file-mode's document view.
 // Generic keyboard navigation tests live in keyboard.spec.ts.
 // ============================================================
@@ -14,20 +14,20 @@ test.describe('Keyboard Comment Shortcuts — File Mode', () => {
   });
 
   test('e edits comment on focused block', async ({ page, request }) => {
-    // Create a comment on line 1 of handler.js (first file alphabetically, so j lands here)
-    await request.post(`/api/file/comments?path=handler.js`, {
+    // Create a comment on line 1 of plan.md (first file in CLI args, so j lands here)
+    await request.post(`/api/file/comments?path=plan.md`, {
       data: { start_line: 1, end_line: 1, body: 'Filemode edit test' },
     });
 
     await loadPage(page);
-    const section = page.locator('.file-section').filter({ hasText: 'handler.js' });
+    const section = page.locator('.file-section').filter({ hasText: 'plan.md' });
     await expect(section.locator('.document-wrapper')).toBeVisible();
     await clearFocus(page);
 
     // Verify comment exists
     await expect(section.locator('.comment-card')).toBeVisible();
 
-    // Navigate to the first block (handler.js line 1)
+    // Navigate to the first block (plan.md line 1)
     await page.keyboard.press('j');
     const focused = page.locator('.line-block.kb-nav.focused');
     await expect(focused).toHaveCount(1);
@@ -44,20 +44,20 @@ test.describe('Keyboard Comment Shortcuts — File Mode', () => {
   });
 
   test('d deletes comment on focused block', async ({ page, request }) => {
-    // Create a comment on line 1 of handler.js (first file alphabetically)
-    await request.post(`/api/file/comments?path=handler.js`, {
+    // Create a comment on line 1 of plan.md (first file in CLI args)
+    await request.post(`/api/file/comments?path=plan.md`, {
       data: { start_line: 1, end_line: 1, body: 'Filemode delete test' },
     });
 
     await loadPage(page);
-    const section = page.locator('.file-section').filter({ hasText: 'handler.js' });
+    const section = page.locator('.file-section').filter({ hasText: 'plan.md' });
     await expect(section.locator('.document-wrapper')).toBeVisible();
     await clearFocus(page);
 
     // Verify comment exists
     await expect(section.locator('.comment-card')).toBeVisible();
 
-    // Navigate to the first block (handler.js line 1)
+    // Navigate to the first block (plan.md line 1)
     await page.keyboard.press('j');
     await expect(page.locator('.line-block.kb-nav.focused')).toHaveCount(1);
 

--- a/e2e/tests/multifile.multifile.spec.ts
+++ b/e2e/tests/multifile.multifile.spec.ts
@@ -51,6 +51,22 @@ test.describe('Multi-File Mode — Loading', () => {
     const stats = page.locator('#fileTreeStats');
     await expect(stats).toContainText('5');
   });
+
+  test('preserves CLI argument order (does not sort alphabetically)', async ({ page }) => {
+    // Fixture passes: plan.md main.go handler.ex lib/
+    // Expected order: CLI args in given order, then directory contents (walked alphabetically)
+    await expect(page.locator('.file-section')).toHaveCount(5);
+    const sectionIds = await page.locator('.file-section').evaluateAll(els =>
+      els.map(el => (el as HTMLElement).id.replace('file-section-', ''))
+    );
+    expect(sectionIds).toEqual([
+      'plan.md',
+      'main.go',
+      'handler.ex',
+      'lib/config.ex',
+      'lib/utils.ex',
+    ]);
+  });
 });
 
 test.describe('Multi-File Mode — Code File Rendering', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -372,8 +372,11 @@
     return Math.abs(hash) % AUTHOR_COLOR_COUNT;
   }
 
-  // Sort comparator: directories before files at each depth, then alphabetical
+  // Sort comparator: directories before files at each depth, then alphabetical.
+  // In files mode the user's CLI argument order is meaningful, so preserve it
+  // (Array.prototype.sort is stable, so returning 0 keeps original order).
   function fileSortComparator(a, b) {
+    if (session && session.mode === 'files') return 0;
     const pa = a.path.split('/'), pb = b.path.split('/');
     const min = Math.min(pa.length, pb.length);
     for (let i = 0; i < min - 1; i++) {
@@ -1520,8 +1523,10 @@
       container.appendChild(folder);
     }
 
-    // Render files
-    const sortedFiles = node.files.slice().sort(function(a, b) { return a.path.localeCompare(b.path); });
+    // Render files. In files mode preserve user-provided CLI order.
+    const sortedFiles = session.mode === 'files'
+      ? node.files.slice()
+      : node.files.slice().sort(function(a, b) { return a.path.localeCompare(b.path); });
     for (let fi = 0; fi < sortedFiles.length; fi++) {
       const f = sortedFiles[fi];
       const fileName = f.path.split('/').pop();

--- a/session.go
+++ b/session.go
@@ -531,11 +531,7 @@ func expandAndDedupPaths(paths []string, ignorePatterns []string) ([]string, err
 			return nil, fmt.Errorf("file not found: %s", p)
 		}
 		if info.IsDir() {
-			dirFiles, err := walkDirectory(absPath, ignorePatterns)
-			if err != nil {
-				return nil, fmt.Errorf("walking directory %s: %w", p, err)
-			}
-			expandedPaths = append(expandedPaths, dirFiles...)
+			expandedPaths = append(expandedPaths, walkDirectory(absPath, ignorePatterns)...)
 		} else {
 			expandedPaths = append(expandedPaths, absPath)
 		}
@@ -679,52 +675,70 @@ func (s *Session) captureBaselineAndPersist() {
 
 // walkDirectory recursively walks a directory and returns all file paths,
 // skipping hidden directories and common non-text directories.
-func walkDirectory(dir string, ignorePatterns []string) ([]string, error) {
+//
+// Ordering: at each depth, recurse into subdirectories (alphabetical) before
+// listing files (alphabetical). This matches the "directories before files at
+// each depth" grouping users expect when passing a directory like `crit .` —
+// and the frontend now preserves backend order in files mode, so this is the
+// single source of truth for display order.
+func walkDirectory(dir string, ignorePatterns []string) []string {
 	var files []string
-	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil //nolint:nilerr // best-effort walk: skip inaccessible entries
-		}
-		name := d.Name()
+	walkDirSubsFirst(dir, dir, ignorePatterns, &files)
+	return files
+}
 
-		// Skip hidden directories and common non-text directories
-		if d.IsDir() {
-			if strings.HasPrefix(name, ".") || skipDirs[name] {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		// Skip hidden files
+// walkDirSubsFirst is the recursive helper for walkDirectory. It reads dir
+// (os.ReadDir returns entries sorted by name), recurses into subdirectories
+// first, then appends files. ignorePatterns are matched relative to root
+// (the original argument), not the current dir. Best-effort: inaccessible
+// directories are silently skipped.
+func walkDirSubsFirst(dir, root string, ignorePatterns []string, out *[]string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return // best-effort: skip inaccessible dirs
+	}
+	var subdirs, fileEntries []os.DirEntry
+	for _, e := range entries {
+		name := e.Name()
 		if strings.HasPrefix(name, ".") {
-			return nil
+			continue
 		}
-
-		// Skip minified files
+		if e.IsDir() {
+			if skipDirs[name] {
+				continue
+			}
+			subdirs = append(subdirs, e)
+			continue
+		}
 		lowerName := strings.ToLower(name)
 		if strings.HasSuffix(lowerName, ".min.js") || strings.HasSuffix(lowerName, ".min.css") {
-			return nil
+			continue
 		}
-
-		// Skip binary/non-reviewable files by extension
 		ext := strings.ToLower(filepath.Ext(name))
 		if isBinaryExtension(ext) {
-			return nil
+			continue
 		}
-
-		// Apply ignore patterns (use path relative to dir)
-		if relPath, relErr := filepath.Rel(dir, path); relErr == nil {
+		full := filepath.Join(dir, name)
+		if relPath, relErr := filepath.Rel(root, full); relErr == nil {
+			skipped := false
 			for _, pat := range ignorePatterns {
 				if matchPattern(pat, relPath) {
-					return nil
+					skipped = true
+					break
 				}
 			}
+			if skipped {
+				continue
+			}
 		}
-
-		files = append(files, path)
-		return nil
-	})
-	return files, err
+		fileEntries = append(fileEntries, e)
+	}
+	for _, d := range subdirs {
+		walkDirSubsFirst(filepath.Join(dir, d.Name()), root, ignorePatterns, out)
+	}
+	for _, f := range fileEntries {
+		*out = append(*out, filepath.Join(dir, f.Name()))
+	}
 }
 
 // isBinaryExtension returns true for file extensions that are typically binary.


### PR DESCRIPTION
## Summary
- `crit a.md b.md` was always sorting files alphabetically in the frontend, ignoring CLI argument order. Backend already preserved order in `NewSessionFromFiles`; only the frontend's `fileSortComparator` was clobbering it.
- Skip the frontend sort when `session.mode === 'files'` (top-level file list + tree sibling sort), so user-provided order flows through.
- Update `walkDirectory` to yield "directories first at each depth, then alphabetical files" — the order the frontend used to impose for directory args like `crit .` — so backend is now the single source of truth for display order.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-only — crit-web receives shared file lists, not CLI args)

## Test plan
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Playwright `multi-file-mode` suite passes (19 tests, including new regression test asserting CLI order)
- [x] Manual: `crit beta.md alpha.md` displays beta first

🤖 Generated with [Claude Code](https://claude.com/claude-code)