### PR TITLE
fix: post-v0.10.4 release audit cleanup

### DIFF
--- a/cli_install.go
+++ b/cli_install.go
@@ -45,6 +45,7 @@ func runInstall(args []string) {
 		cwd := mustGetwd()
 		home, _ := os.UserHomeDir()
 		global := isGlobalInstall(cwd, home)
+		hadErr := false
 		for _, name := range availableIntegrations() {
 			if name == "windsurf" && global {
 				fmt.Fprintln(os.Stderr, "  Skipped: windsurf (no global install supported — run from a project)")
@@ -52,8 +53,12 @@ func runInstall(args []string) {
 			}
 			if err := installIntegration(name, force); err != nil {
 				fmt.Fprintf(os.Stderr, "  Failed: %s: %v\n", name, err)
+				hadErr = true
 				continue
 			}
+		}
+		if hadErr {
+			os.Exit(1)
 		}
 		return
 	}

--- a/daemon_e2e_test.go
+++ b/daemon_e2e_test.go
@@ -100,7 +100,7 @@ func TestDaemonLifecycle(t *testing.T) {
 	}
 
 	// Verify health endpoint
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/health", entry.Port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/health", entry.Port))
 	if err != nil {
 		t.Fatalf("health check failed: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestDaemonLifecycle(t *testing.T) {
 	readyDeadline := time.Now().Add(10 * time.Second)
 	sessionReady := false
 	for time.Now().Before(readyDeadline) {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/session", entry.Port))
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", entry.Port))
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == 200 {
@@ -132,7 +132,7 @@ func TestDaemonLifecycle(t *testing.T) {
 	go func() {
 		client := &http.Client{Timeout: 10 * time.Second}
 		r, err := client.Post(
-			fmt.Sprintf("http://localhost:%d/api/review-cycle", entry.Port),
+			fmt.Sprintf("http://127.0.0.1:%d/api/review-cycle", entry.Port),
 			"application/json", nil,
 		)
 		if err != nil {
@@ -147,7 +147,7 @@ func TestDaemonLifecycle(t *testing.T) {
 	// Simulate user finishing review
 	time.Sleep(200 * time.Millisecond)
 	finishResp, err := http.Post(
-		fmt.Sprintf("http://localhost:%d/api/finish", entry.Port),
+		fmt.Sprintf("http://127.0.0.1:%d/api/finish", entry.Port),
 		"application/json", nil,
 	)
 	if err != nil {

--- a/focus_cli.go
+++ b/focus_cli.go
@@ -253,7 +253,7 @@ var probeDaemonFocusFn = probeDaemonFocusReal
 
 // probeDaemonFocus contacts the running daemon (if any) and returns its Focus.
 // Returns nil on any failure — best-effort.
-func probeDaemonFocus(_ string) *Focus {
+func probeDaemonFocus() *Focus {
 	return probeDaemonFocusFn()
 }
 
@@ -348,7 +348,7 @@ func loadCritJSONForOutputDir(outputDir string) (CritJSON, bool) {
 // based on the --scope flag, a running daemon's Focus, and the on-disk
 // ActiveDiffScope. Order of precedence per spec §C "crit comment scope inheritance".
 func resolveCommentScope(override commentFocusOverride, outputDir string) (inheritedScope, error) {
-	daemon := probeDaemonFocus(outputDir)
+	daemon := probeDaemonFocus()
 
 	switch override {
 	case scopeOverrideWorkingTree:

--- a/github_test.go
+++ b/github_test.go
@@ -2759,7 +2759,7 @@ func TestResolvePullScope(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			withDaemonFocus(t, tc.daemonFocus)
 			cj := &CritJSON{ActiveDiffScope: tc.diskScope}
-			got := resolvePullScope("", cj)
+			got := resolvePullScope(cj)
 			if got.HeadSHA != tc.wantHead || got.DiffScope != tc.wantScope {
 				t.Errorf("got=%+v want head=%q scope=%q", got, tc.wantHead, tc.wantScope)
 			}

--- a/main.go
+++ b/main.go
@@ -455,8 +455,8 @@ func parsePullFlags(args []string) pullFlags {
 // otherwise the on-disk ActiveDiffScope tells us a range mode is active but
 // HeadSHA is unknown. When neither indicates range mode, scope is empty
 // (legacy working-tree behavior — comments stay visible in working-tree view).
-func resolvePullScope(outputDir string, cj *CritJSON) inheritedScope {
-	if focus := probeDaemonFocus(outputDir); focus != nil && focus.Kind == FocusRange {
+func resolvePullScope(cj *CritJSON) inheritedScope {
+	if focus := probeDaemonFocus(); focus != nil && focus.Kind == FocusRange {
 		return inheritedScope{HeadSHA: focus.HeadSHA, DiffScope: "layer"}
 	}
 	if cj != nil && cj.ActiveDiffScope != "" {
@@ -581,7 +581,7 @@ func runPull(args []string) {
 		cj.ReviewRound = 1
 	}
 
-	scope := resolvePullScope(f.outputDir, &cj)
+	scope := resolvePullScope(&cj)
 	added := mergeGHCommentsScoped(&cj, ghComments, scope, threadResolved)
 
 	if added == 0 {

--- a/share.go
+++ b/share.go
@@ -677,7 +677,7 @@ func mergeWebComments(critPath string, newComments []webComment, replyUpdates ma
 	// even if earlier ones were deleted from the review file.
 	webCount := highestWebIndex(cj)
 
-	scope := resolvePullScope("", &cj)
+	scope := resolvePullScope(&cj)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, wc := range newComments {

--- a/share_integration_test.go
+++ b/share_integration_test.go
@@ -326,7 +326,7 @@ func reviewRoundFromAPI(t *testing.T, baseURL, token string) int {
 	return body.ReviewRound
 }
 
-// writeTestCritJSON writes a CritJSON to .crit.json in dir.
+// writeTestCritJSON writes a CritJSON to .crit/review.json in dir.
 // NOTE: readCritJSON is defined in github_test.go and shared across test files.
 func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 	t.Helper()

--- a/watch.go
+++ b/watch.go
@@ -323,6 +323,7 @@ func carryForwardComment(old Comment, newID string, now string) Comment {
 		CreatedAt:      old.CreatedAt,
 		UpdatedAt:      now,
 		Resolved:       old.Resolved,
+		ResolvedRound:  old.ResolvedRound,
 		CarriedForward: true,
 		Live:           old.Live,
 		ReviewRound:    old.ReviewRound,


### PR DESCRIPTION
## Summary
- `carryForwardComment` now copies `ResolvedRound` — Stage-1 timeline (`round_snapshots.go`) requires both `Resolved` and `ResolvedRound`; resolved comments would otherwise lose their round metadata across markdown rounds.
- `crit install all` now exits non-zero on partial failures (single-target path was already correct).
- Drop dead `outputDir` param from `probeDaemonFocus` (and `resolvePullScope`, which only threaded it to that call).
- `daemon_e2e_test.go`: `localhost` → `127.0.0.1` to match daemon bind (commit 95b8ab7 fixed prod).
- `share_integration_test.go`: fix stale `.crit.json` comment (actual write is `.crit/review.json`).

## Review
- [x] Audit: parallel Go / frontend / parity agents + window clobber check
- [x] Validators: per-finding hostile re-check (3 false positives dropped)
- [x] Post-fix review: SHIP verdict
- [x] Pre-commit: gofmt / golangci-lint / go test / ESLint / Stylelint / CSS-vars green

## Test plan
- [x] go test ./... (33s, all pass)
- [x] go vet clean
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)