### PR TITLE
fix: remove daemon 1h idle timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ When the agent runs `crit` again (or calls `POST /api/round-complete`):
 3. **`crit plan.md`**: looks up daemon by hash(cwd + "plan.md") — reuses if alive, starts new if dead
 4. **Ctrl+C**: kills the daemon the client started
 5. **`crit stop`**: kills daemon for current cwd; `crit stop --all` kills all daemons for cwd
-6. **Idle timeout**: daemon exits after 1 hour of no HTTP activity
+6. **Lifetime**: daemon runs until killed (Ctrl+C, `crit stop`, or SIGINT/SIGTERM/SIGHUP). No idle timeout — walking away from a review session is fine.
 
 ### Deferred initialization & readiness
 

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -382,26 +381,6 @@ func checkStaleIntegrations(sc *serverConfig, srv *Server, cwd string) {
 	}
 }
 
-func runIdleTimeoutChecker(ctx context.Context, stop context.CancelFunc, idleMu *sync.Mutex, lastActivity *time.Time) {
-	const idleTimeout = 1 * time.Hour
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			idleMu.Lock()
-			idle := time.Since(*lastActivity)
-			idleMu.Unlock()
-			if idle >= idleTimeout {
-				stop()
-				return
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
 func runServe(args []string) {
 	pipe := openReadyPipe()
 
@@ -457,19 +436,8 @@ func runServe(args []string) {
 		daemonFatal(pipe, "Error writing session file: %v", err)
 	}
 
-	var idleMu sync.Mutex
-	lastActivity := time.Now()
-	resetActivity := func() {
-		idleMu.Lock()
-		lastActivity = time.Now()
-		idleMu.Unlock()
-	}
-
 	httpServer := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			resetActivity()
-			srv.ServeHTTP(w, r)
-		}),
+		Handler:     srv,
 		ReadTimeout: 15 * time.Second,
 		IdleTimeout: 60 * time.Second,
 	}
@@ -478,8 +446,8 @@ func runServe(args []string) {
 	defer stop()
 
 	// Wire the shutdown ctx into the server so background goroutines (agent
-	// runner, etc.) can be cancelled on SIGINT/SIGTERM/idle-timeout instead of
-	// orphaning subprocesses and racing with WriteFiles.
+	// runner, etc.) can be cancelled on SIGINT/SIGTERM instead of orphaning
+	// subprocesses and racing with WriteFiles.
 	srv.SetShutdownCtx(ctx)
 
 	go func() {
@@ -507,8 +475,6 @@ func runServe(args []string) {
 		go func() { _, _ = srv.prList.getCtx(ctx) }()
 	}
 
-	go runIdleTimeoutChecker(ctx, stop, &idleMu, &lastActivity)
-
 	type sessionResult struct {
 		session *Session
 		err     error
@@ -534,9 +500,9 @@ func runServe(args []string) {
 	if initErr != nil {
 		log.Printf("Error: %v", initErr)
 		srv.SetInitErr(initErr)
-		// Trigger immediate shutdown instead of waiting for SIGINT or the
-		// idle timeout. Without this the daemon would sit in 503-land for up
-		// to an hour after a failed init, burning a port and a process slot.
+		// Trigger immediate shutdown instead of waiting for SIGINT.
+		// Without this the daemon would sit in 503-land indefinitely
+		// after a failed init, burning a port and a process slot.
 		stop()
 		<-ctx.Done()
 		removeSessionFile(key)

--- a/server.go
+++ b/server.go
@@ -56,7 +56,7 @@ type Server struct {
 
 	// shutdownCtx is the daemon's signal-handled context; child operations
 	// (e.g. runAgentCmd subprocesses) derive their context from this so a
-	// SIGINT/SIGTERM/idle-timeout cancels them instead of leaking. Set via
+	// SIGINT/SIGTERM cancels them instead of leaking. Set via
 	// SetShutdownCtx; nil in tests, in which case a background context is used.
 	shutdownCtx context.Context
 	// bgWG tracks long-running background goroutines (e.g. agent subprocess
@@ -1817,7 +1817,7 @@ func buildAgentPrompt(c Comment, filePath string) string {
 // If agent_cmd contains {prompt}, the placeholder is replaced with the prompt
 // as a single argument. Otherwise, the prompt is piped via stdin.
 func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
-	// Parent on the daemon shutdown ctx so SIGINT/SIGTERM/idle-timeout kills
+	// Parent on the daemon shutdown ctx so SIGINT/SIGTERM kills
 	// the agent subprocess instead of orphaning it (the subprocess has its
 	// own session id via daemonSysProcAttr). Tests that don't wire a shutdown
 	// ctx fall back to context.Background() — same behavior as before.


### PR DESCRIPTION
## Summary
- Drop the 1-hour idle-kill in the daemon's serve loop. Reporter (#476) was losing the review UI mid-session when stepping away for meetings or overnight.
- At this scale (single-user localhost, embedded frontend, <50 files/comments) an idle daemon is tens of MB with self-gating watchers — costs less than the browser tab pointed at it. Process still exits via SIGINT/SIGTERM/SIGHUP and \`crit stop\`.
- Validated by go-expert: no leaks the timeout was masking, watchers (\`watch.go\`) already gate expensive work behind \`isWaitingForAgent()\`.

## Review
- [x] Code review: passed (\`/crit-review\` — intent audit CLEAN, no parity surface, no security surface)
- [x] Parity audit: N/A (Go-only)

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`, \`gofmt -l .\` clean
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run ./...\` passes (pre-commit)

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)