### PR TITLE
fix: scope unified diff comment highlight to commented side

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -62,6 +62,37 @@ func main() {
 }
 GOFILE
 
+# legacy.go — initial version with a long block that will be replaced.
+# The replacement creates a hunk where the old-side line number of a deletion
+# coincides with the new-side line number of a context line further down,
+# exposing the unified comment-highlight overshoot bug.
+cat > legacy.go << 'GOFILE'
+package legacy
+
+// Header comment 1
+// Header comment 2
+// Header comment 3
+// Header comment 4
+
+func Old1() {}
+func Old2() {}
+func Old3() {}
+func Old4() {}
+func Old5() {}
+func Old6() {}
+func Old7() {}
+func Old8() {}
+func Old9() {}
+func Old10() {}
+func Old11() {}
+func Old12() {}
+
+func Keep1() {}
+func Keep2() {}
+func Keep3() {}
+func Keep4() {}
+GOFILE
+
 cat > deleted.txt << 'EOF'
 This file will be deleted.
 It has some content that used to matter.
@@ -255,6 +286,30 @@ GOFILE
 
 # Delete deleted.txt
 rm deleted.txt
+
+# Replace legacy.go's Old1..Old12 block with a small New1..New4 block.
+# This produces: del run (old 8-19), add run (new 8-11), then context line
+# `func Keep1() {}` at new line 13 — which has the same number as old 13
+# (`func Old6() {}`) inside the deletion. Used to test that comment
+# highlight on new-side line 13 stays on Keep1 only.
+cat > legacy.go << 'GOFILE'
+package legacy
+
+// Header comment 1
+// Header comment 2
+// Header comment 3
+// Header comment 4
+
+func New1() {}
+func New2() {}
+func New3() {}
+func New4() {}
+
+func Keep1() {}
+func Keep2() {}
+func Keep3() {}
+func Keep4() {}
+GOFILE
 
 # Modify routes.go to produce a multi-hunk diff with a large gap (>20 unchanged lines)
 # between hunks. This ensures spacers remain visible for testing after auto-expansion

--- a/e2e/tests/commit-selection.spec.ts
+++ b/e2e/tests/commit-selection.spec.ts
@@ -65,12 +65,12 @@ test.describe('Commit Selection', () => {
     // Label should update to show the selected commit
     await expect(page.locator('#commitDropdownLabel')).not.toHaveText('All commits');
 
-    // The commit only has 4 files (server.go, deleted.txt, plan.md, handler.js)
+    // The commit has at most 5 files (server.go, deleted.txt, plan.md, handler.js, legacy.go)
     // whereas "All" has more (includes staged utils.go and unstaged config.yaml)
     const fileSections = page.locator('.file-section');
     await expect(async () => {
       const count = await fileSections.count();
-      expect(count).toBeLessThanOrEqual(4);
+      expect(count).toBeLessThanOrEqual(5);
       expect(count).toBeGreaterThan(0);
     }).toPass();
   });

--- a/e2e/tests/file-tree.spec.ts
+++ b/e2e/tests/file-tree.spec.ts
@@ -15,10 +15,10 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file tree lists all files from the session', async ({ page }) => {
-    // Git fixture has: plan.md, server.go, handler.js, deleted.txt, routes.go (committed)
-    // + utils.go, login.feature (staged), config.yaml (untracked) = 8 total
+    // Git fixture has: plan.md, server.go, handler.js, deleted.txt, routes.go, legacy.go (committed)
+    // + utils.go, login.feature (staged), config.yaml (untracked) = 9 total
     const treeFiles = page.locator('.tree-file');
-    await expect(treeFiles).toHaveCount(8);
+    await expect(treeFiles).toHaveCount(9);
   });
 
   test('file tree shows correct file names', async ({ page }) => {
@@ -39,7 +39,7 @@ test.describe('File Tree — Git Mode', () => {
   test('file tree header shows file count', async ({ page }) => {
     const stats = page.locator('#fileTreeStats');
     await expect(stats).toBeVisible();
-    await expect(stats).toContainText('7');
+    await expect(stats).toContainText('9');
   });
 
   test('file tree header shows addition stats', async ({ page }) => {
@@ -117,9 +117,9 @@ test.describe('File Tree — Git Mode', () => {
     const addedIcons = page.locator('.tree-file-status-icon.added');
     await expect(addedIcons).toHaveCount(4);
 
-    // server.go, routes.go, and utils.go (staged modification) are modified
+    // server.go, routes.go, legacy.go, and utils.go (staged modification) are modified
     const modifiedIcons = page.locator('.tree-file-status-icon.modified');
-    await expect(modifiedIcons).toHaveCount(3);
+    await expect(modifiedIcons).toHaveCount(4);
 
     // deleted.txt is deleted
     const deletedIcons = page.locator('.tree-file-status-icon.deleted');

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -39,8 +39,8 @@ test.describe('Scope Toggle', () => {
   test('switching to branch scope shows only committed files', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'branch');
-    // Branch: server.go, deleted.txt, plan.md, handler.js, routes.go (5 committed)
-    await expect(page.locator('.file-section')).toHaveCount(5);
+    // Branch: server.go, deleted.txt, plan.md, handler.js, routes.go, legacy.go (6 committed)
+    await expect(page.locator('.file-section')).toHaveCount(6);
     await expect(page.locator('.file-section', { hasText: 'server.go' })).toBeVisible();
     await expect(page.locator('.file-section', { hasText: 'plan.md' })).toBeVisible();
   });

--- a/e2e/tests/unified-comment-visual-range.spec.ts
+++ b/e2e/tests/unified-comment-visual-range.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+// Regression: in unified diff, a single-line comment on a new-side context line
+// below a deletion block must NOT highlight deletion lines further up just
+// because their old-side line numbers happen to share a value with the
+// commented context line's new-side number.
+//
+// Fixture (legacy.go):
+//   - Initial: package + 4 header comments + blank + func Old1..Old12 (lines 8-19) + blank + func Keep1..Keep4 (lines 21-24)
+//   - Modified: func Old1..Old12 replaced with func New1..New4 (new lines 8-11)
+//   - Resulting hunk: del lines (oldNum 8-19) + add lines (newNum 8-11) + context blank (newNum 12) + context func Keep1 (newNum 13)
+//   - oldNum 13 is `func Old6() {}` deep in the deletion; newNum 13 is `func Keep1() {}` below the additions.
+test.describe('Unified diff — comment range scoping', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('single-line comment on new-side context line below a deletion block does not highlight the deletion', async ({ page, request }) => {
+    // Sanity-check the diff shape produced by the fixture.
+    const diffRes = await request.get('/api/file/diff?path=legacy.go');
+    const diffData = await diffRes.json();
+    const hunks = diffData.hunks || [];
+    expect(hunks.length).toBeGreaterThan(0);
+
+    const allLines = hunks.flatMap((h: { Lines: { Type: string; OldNum: number; NewNum: number }[] }) => h.Lines);
+    // Confirm the collision exists: a del line with OldNum===13 AND a context line with NewNum===13.
+    const delAt13 = allLines.find((l: { Type: string; OldNum: number }) => l.Type === 'del' && l.OldNum === 13);
+    const contextAt13 = allLines.find((l: { Type: string; NewNum: number }) => l.Type === 'context' && l.NewNum === 13);
+    expect(delAt13).toBeTruthy();
+    expect(contextAt13).toBeTruthy();
+
+    // Comment on new-side line 13 (the context line `func Keep1() {}`).
+    const res = await request.post('/api/file/comments?path=legacy.go', {
+      data: { start_line: 13, end_line: 13, body: 'comment on Keep1' },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await loadPage(page);
+
+    const section = page.locator('#file-section-legacy\\.go');
+    await expect(section).toBeVisible();
+
+    // Switch to unified mode (toggle is in the page header, not per-file).
+    const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
+    await expect(unifiedBtn).toBeVisible();
+    await unifiedBtn.click();
+
+    // Exactly one line should carry has-comment, and it must be a context line (not a deletion).
+    const highlighted = section.locator('.diff-line.has-comment');
+    await expect(highlighted).toHaveCount(1);
+
+    // The deletion block must not be highlighted.
+    await expect(section.locator('.diff-line.deletion.has-comment')).toHaveCount(0);
+    // The addition block must not be highlighted either.
+    await expect(section.locator('.diff-line.addition.has-comment')).toHaveCount(0);
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3816,14 +3816,16 @@
   }
 
   // For unified diff: build a Set of visual indices that should have has-comment.
-  // This handles interleaved add/del lines correctly by using sequential position.
+  // Anchor strictly to the comment's side so unrelated lines elsewhere in the
+  // hunk that happen to share a number on the opposite side are not included.
+  // Lines between the anchored start/end are highlighted regardless of type
+  // (so deletions within a multi-line range still get highlighted).
   function buildUnifiedCommentVisualSet(hunks, comments) {
     if (!comments.length) return new Set();
-    // Flatten all hunk lines with their line numbers
     const lines = [];
     for (const hunk of hunks) {
       for (const line of hunk.Lines) {
-        lines.push({ oldNum: line.OldNum, newNum: line.NewNum });
+        lines.push({ type: line.Type, oldNum: line.OldNum, newNum: line.NewNum });
       }
     }
     const set = new Set();
@@ -3832,16 +3834,19 @@
       if (c.scope === 'file') continue;
       if (hideResolved && c.resolved) continue;
       const side = c.side || '';
+      // Only lines that *belong* to the comment's side can anchor. For new-side
+      // comments that means add/context lines (with a real NewNum); for old-side
+      // it means del/context lines (with a real OldNum).
       let startIdx = -1, endIdx = -1;
       for (let i = 0; i < lines.length; i++) {
-        // startIdx: match either OldNum or NewNum so deletions adjacent to
-        // the comment boundary are included in the visual range
-        if (startIdx === -1 && (lines[i].oldNum === c.start_line || lines[i].newNum === c.start_line)) {
-          startIdx = i;
-        }
-        // endIdx: match only the comment's side to avoid overshooting
-        const endNum = side === 'old' ? lines[i].oldNum : lines[i].newNum;
-        if (endNum === c.end_line) endIdx = i;
+        const ln = lines[i];
+        const num = side === 'old' ? ln.oldNum : ln.newNum;
+        const onSide = side === 'old'
+          ? (ln.type === 'del' || ln.type === 'context')
+          : (ln.type === 'add' || ln.type === 'context');
+        if (!onSide || !num) continue;
+        if (startIdx === -1 && num === c.start_line) startIdx = i;
+        if (num === c.end_line) endIdx = i;
       }
       if (startIdx !== -1 && endIdx !== -1) {
         for (let i = startIdx; i <= endIdx; i++) set.add(i);


### PR DESCRIPTION
## Summary
- Comments anchored to a single line in the unified-diff view were highlighting every line up through the comment, including unrelated deletions earlier in the same hunk, when an unrelated line on the opposite side happened to share the commented line number.
- `buildUnifiedCommentVisualSet` now anchors strictly to the comment's side: new-side comments only match `add`/`context` lines by `NewNum`; old-side only match `del`/`context` by `OldNum`. Lines between the anchored start/end stay highlighted regardless of type, so genuine multi-line ranges spanning deletions still work.

## Review
- [x] Code review: passed (frontend-expert fresh pass, 0 blockers)
- [x] Parity audit: N/A — `crit-web/assets/js/document-renderer.js` has no equivalent unified code-diff renderer

## Test plan
- New `e2e/tests/unified-comment-visual-range.spec.ts` regression test reproduces the bug (old-vs-new line-number collision in a long deletion hunk); fails on old code (13 highlighted lines), passes on new (1).
- `mise exec -- go test -race ./...` passes
- `mise exec -- golangci-lint run ./...` clean
- Existing `comment-range-highlight.spec.ts` (7 tests) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)