### PR TITLE
feat: add --file flag and better errors to crit comment --json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ crit pr <num|url>             # Thin shim — forwards to `crit review --pr <n>`
 crit fetch ...                # Fetch remote artefacts (see runFetch)
 crit comment <path>:<line[-end]> <body>         # Add a comment (no server needed)
 crit comment --reply-to <id> [--resolve] <body> # Reply to a comment
-crit comment --json [--author <name>]           # Bulk add comments from stdin JSON
+crit comment --json [--file <path>] [--author <name>]  # Bulk add comments from JSON (stdin or --file; - = stdin)
 crit share <file> [file...]   # Share files to crit-web, print URL
 crit unpublish                # Remove shared review from crit-web
 crit config [--generate]      # Print resolved config (or starter template)

--- a/comment_json_input_test.go
+++ b/comment_json_input_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadCommentJSONInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bulk.json")
+	want := `[{"body":"hello"}]`
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := readCommentJSONInput(path, strings.NewReader("STDIN-IGNORED"))
+	if err != nil {
+		t.Fatalf("readCommentJSONInput: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadCommentJSONInputStdinDash(t *testing.T) {
+	want := `[{"body":"from stdin"}]`
+	got, err := readCommentJSONInput("-", strings.NewReader(want))
+	if err != nil {
+		t.Fatalf("readCommentJSONInput: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadCommentJSONInputStdinDefault(t *testing.T) {
+	want := `[]`
+	got, err := readCommentJSONInput("", strings.NewReader(want))
+	if err != nil {
+		t.Fatalf("readCommentJSONInput: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadCommentJSONInputMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	_, err := readCommentJSONInput(missing, strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error %q does not include path %q", err, missing)
+	}
+}
+
+func TestParseCommentJSONEntriesValid(t *testing.T) {
+	data := []byte(`[{"file":"main.go","line":42,"body":"fix"}]`)
+	entries, err := parseCommentJSONEntries(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) != 1 || entries[0].File != "main.go" || entries[0].Line != 42 {
+		t.Errorf("unexpected entries: %+v", entries)
+	}
+}
+
+func TestParseCommentJSONEntriesRawNewlineInString(t *testing.T) {
+	// A raw LF inside a JSON string is the exact failure mode --file is meant
+	// to give a better error for. We assemble the bytes manually so the test
+	// source itself stays well-formed.
+	data := []byte("[\n  {\"body\": \"line one\nline two\"}\n]")
+	_, err := parseCommentJSONEntries(data)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	msg := err.Error()
+	wants := []string{
+		"Error parsing JSON at byte ",
+		"line ",
+		"column ",
+		">>>HERE<<<",
+		`\n`, // raw newline rendered as visible escape
+	}
+	for _, w := range wants {
+		if !strings.Contains(msg, w) {
+			t.Errorf("error message missing %q\nfull message:\n%s", w, msg)
+		}
+	}
+}
+
+func TestParseCommentFlagsFile(t *testing.T) {
+	got := parseCommentFlags([]string{"--json", "--file", "bulk.json"})
+	if !got.json {
+		t.Error("json flag not set")
+	}
+	if got.file != "bulk.json" {
+		t.Errorf("file = %q, want bulk.json", got.file)
+	}
+
+	got = parseCommentFlags([]string{"--json", "-f", "-"})
+	if got.file != "-" {
+		t.Errorf("file = %q, want -", got.file)
+	}
+}

--- a/comment_json_input_test.go
+++ b/comment_json_input_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -105,4 +108,137 @@ func TestParseCommentFlagsFile(t *testing.T) {
 	if got.file != "-" {
 		t.Errorf("file = %q, want -", got.file)
 	}
+}
+
+func TestJSONErrorOffset(t *testing.T) {
+	var dst struct{ N int }
+	typeErr := json.Unmarshal([]byte(`{"n":"not-a-number"}`), &dst)
+	if typeErr == nil {
+		t.Fatal("setup: expected UnmarshalTypeError")
+	}
+	synErr := json.Unmarshal([]byte(`{`), &dst)
+	if synErr == nil {
+		t.Fatal("setup: expected SyntaxError")
+	}
+
+	tests := []struct {
+		name       string
+		err        error
+		wantOK     bool
+		wantPosOff bool
+	}{
+		{"syntax", synErr, true, true},
+		{"unmarshal-type", typeErr, true, true},
+		{"generic", errors.New("not a json err"), false, false},
+		{"nil", nil, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			off, ok := jsonErrorOffset(tc.err)
+			if ok != tc.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantPosOff && off <= 0 {
+				t.Errorf("expected positive offset, got %d", off)
+			}
+		})
+	}
+}
+
+func TestVisibleControl(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"a\nb", `a\nb`},
+		{"a\rb", `a\rb`},
+		{"a\tb", `a\tb`},
+		{"a\n\r\tb", `a\n\r\tb`},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := visibleControl([]byte(tc.in)); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// runCommentJSONScoped calls os.Exit on error and writes to stdout/stderr, so
+// it's exercised end-to-end via the helper-subprocess pattern (matching
+// TestRunComment_* in main_test.go).
+
+func TestRunCommentJSON_FromFile(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_RunCommentJSONFile", "--")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "Added 1 comment") {
+		t.Errorf("expected success summary, got: %s", out)
+	}
+}
+
+func TestHelperProcess_RunCommentJSONFile(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "test.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	j := filepath.Join(tmp, "comments.json")
+	if err := os.WriteFile(j, []byte(`[{"file":"test.go","line":1,"body":"hello"}]`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	runComment([]string{"--json", "--file", j, "--output", tmp, "--author", "tester"})
+}
+
+func TestRunCommentJSON_ParseErrorExits(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_RunCommentJSONBad", "--")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit; output: %s", out)
+	}
+	if !strings.Contains(string(out), "Error parsing JSON at byte ") {
+		t.Errorf("missing formatted parse error: %s", out)
+	}
+	if !strings.Contains(string(out), `>>>HERE<<<`) {
+		t.Errorf("missing snippet marker: %s", out)
+	}
+}
+
+func TestHelperProcess_RunCommentJSONBad(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	tmp := t.TempDir()
+	bad := filepath.Join(tmp, "bad.json")
+	if err := os.WriteFile(bad, []byte("[\n  {\"body\": \"line one\nline two\"}\n]"), 0o644); err != nil {
+		t.Fatalf("write bad json: %v", err)
+	}
+	runComment([]string{"--json", "--file", bad, "--output", tmp})
+}
+
+func TestRunCommentJSON_MissingFileExits(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_RunCommentJSONMissing", "--")
+	cmd.Env = append(os.Environ(), "GO_TEST_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit; output: %s", out)
+	}
+	if !strings.Contains(string(out), "Error: reading") {
+		t.Errorf("missing reading error in output: %s", out)
+	}
+}
+
+func TestHelperProcess_RunCommentJSONMissing(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	tmp := t.TempDir()
+	runComment([]string{"--json", "--file", filepath.Join(tmp, "does-not-exist.json"), "--output", tmp})
 }

--- a/integrations/aider/CONVENTIONS.md
+++ b/integrations/aider/CONVENTIONS.md
@@ -58,6 +58,19 @@ echo '[
 ]' | crit comment --json --author 'Aider'
 ```
 
+For multi-paragraph reply bodies, prefer `--file <path>`. Raw newlines inside JSON strings are invalid, and shell heredocs make it easy to slip one in:
+
+```bash
+cat > /tmp/replies.json <<'EOF'
+[
+  {"reply_to": "c_a1b2c3", "body": "Fixed.\n\nDetails: split helper, added null guard."}
+]
+EOF
+crit comment --json --file /tmp/replies.json --author 'Aider'
+```
+
+`--file -` reads stdin (same as the default).
+
 ## Next round
 
 When done, run the command crit printed after `Next round:` in its previous output. The daemon is keyed by arguments, so this matters — `crit plan.md` and bare `crit` are different sessions.
@@ -87,7 +100,13 @@ If `crit comment` errors with "comment found in multiple files", disambiguate wi
 
 ### Bulk `--json`
 
-For 3+ comments, prefer `--json` (atomic, single write):
+For 3+ comments, prefer `--json` (atomic, single write). Synopsis:
+
+```
+crit comment --json [--file <path>] [--author <name>]
+```
+
+Stdin form (short single-line bodies):
 
 ```bash
 echo '[
@@ -97,6 +116,17 @@ echo '[
   {"file": "src/auth.go", "line": "50-55", "body": "Extract to helper"},
   {"reply_to": "c_a1b2c3", "body": "Fixed — added null check"}
 ]' | crit comment --json --author 'Aider'
+```
+
+`--file <path>` form — preferred whenever a body has paragraph breaks (raw newlines in a JSON string are invalid):
+
+```bash
+cat > /tmp/crit-bulk.json <<'EOF'
+[
+  {"file": "src/auth.go", "line": 42, "body": "Para 1.\n\nPara 2."}
+]
+EOF
+crit comment --json --file /tmp/crit-bulk.json --author 'Aider'
 ```
 
 Scope inference: `reply_to` → reply; no `file`/`line` → review; `path` only → file; `path` + `line` → line.

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Close the feedback loop on AI coding: review plans and code changes with GitHub-style inline comments, then let the agent address them.",
   "author": {
     "name": "Tomasz Tomczyk"

--- a/integrations/claude-code/skills/crit-cli/SKILL.md
+++ b/integrations/claude-code/skills/crit-cli/SKILL.md
@@ -89,9 +89,10 @@ Hard rules:
 
 <important if="you are leaving 3+ comments in one operation">
 
-Use `--json` for atomicity (single write, no partial state) and speed (one process):
+Use `--json` for atomicity (single write, no partial state) and speed (one process). Two ways to feed the JSON:
 
 ```bash
+# Short, single-line bodies — pipe via stdin:
 echo '[
   {"body": "overall feedback", "scope": "review"},
   {"path": "session.go", "body": "restructure", "scope": "file"},
@@ -101,6 +102,15 @@ echo '[
   {"reply_to": "r_f1e2d3", "body": "Done"}
 ]' | crit comment --json --author 'Claude Code'
 ```
+
+**Prefer `--file <path>` for any multi-paragraph body.** Shell-quoted JSON breaks the moment a `"body"` string contains a raw newline — JSON forbids them, and the shell happily passes them through. Use the Write tool to author the JSON to a temp file, then point crit at it:
+
+```bash
+# After Write-ing /tmp/replies.json:
+crit comment --json --file /tmp/replies.json --author 'Claude Code'
+```
+
+`--file -` reads stdin (same as omitting the flag).
 
 Per-entry schema:
 

--- a/integrations/cline/crit.md
+++ b/integrations/cline/crit.md
@@ -58,6 +58,19 @@ echo '[
 ]' | crit comment --json --author 'Cline'
 ```
 
+For multi-paragraph reply bodies, prefer `--file <path>` — embedding a raw newline inside a JSON `"body"` string breaks parsing, and shell quoting makes that easy to do by accident. Write the JSON to a temp file first:
+
+```bash
+cat > /tmp/replies.json <<'EOF'
+[
+  {"reply_to": "c_a1b2c3", "body": "Fixed.\n\nDetails: split the helper, added null guard."}
+]
+EOF
+crit comment --json --file /tmp/replies.json --author 'Cline'
+```
+
+(`--file -` reads stdin, same as the default.)
+
 ## Next round
 
 When done, run the command crit printed after `Next round:` in its previous output. The daemon is keyed by arguments, so this matters — `crit plan.md` and bare `crit` are different sessions.
@@ -87,7 +100,13 @@ If `crit comment` errors with "comment found in multiple files", disambiguate wi
 
 ### Bulk `--json`
 
-For 3+ comments, prefer `--json` (atomic, single write):
+For 3+ comments, prefer `--json` (atomic, single write). Synopsis:
+
+```
+crit comment --json [--file <path>] [--author <name>]
+```
+
+Stdin form (fine for short, single-line bodies):
 
 ```bash
 echo '[
@@ -97,6 +116,17 @@ echo '[
   {"file": "src/auth.go", "line": "50-55", "body": "Extract to helper"},
   {"reply_to": "c_a1b2c3", "body": "Fixed — added null check"}
 ]' | crit comment --json --author 'Cline'
+```
+
+`--file <path>` form — preferred when any body has paragraph breaks, since a raw newline in a JSON string is a parse error:
+
+```bash
+cat > /tmp/crit-bulk.json <<'EOF'
+[
+  {"file": "src/auth.go", "line": 42, "body": "First paragraph.\n\nSecond paragraph."}
+]
+EOF
+crit comment --json --file /tmp/crit-bulk.json --author 'Cline'
 ```
 
 Scope inference: `reply_to` → reply; no `file`/`line` → review; `path` only → file; `path` + `line` → line.

--- a/integrations/codex/skills/crit-cli/SKILL.md
+++ b/integrations/codex/skills/crit-cli/SKILL.md
@@ -87,9 +87,10 @@ Hard rules:
 
 ## Bulk commenting (3+ comments)
 
-Use `--json` for atomicity (single write, no partial state) and speed (one process):
+Use `--json` for atomicity (single write, no partial state) and speed (one process). The JSON can come from stdin or `--file <path>`:
 
 ```bash
+# stdin — fine for short, single-line bodies:
 echo '[
   {"body": "overall feedback", "scope": "review"},
   {"path": "session.go", "body": "restructure", "scope": "file"},
@@ -99,6 +100,14 @@ echo '[
   {"reply_to": "r_f1e2d3", "body": "Done"}
 ]' | crit comment --json --author 'Codex'
 ```
+
+**For multi-paragraph bodies, prefer `--file`.** A literal newline inside a `"body"` string breaks JSON parsing, and shell-quoted heredocs make this easy to introduce by accident. Write the JSON to a temp file (use your file-edit tool), then:
+
+```bash
+crit comment --json --file /tmp/crit-bulk.json --author 'Codex'
+```
+
+`--file -` is an explicit "read stdin" if you ever need it.
 
 Per-entry schema:
 

--- a/integrations/cursor/skills/crit-cli/SKILL.md
+++ b/integrations/cursor/skills/crit-cli/SKILL.md
@@ -87,9 +87,10 @@ Hard rules:
 
 ## Bulk commenting (3+ comments)
 
-Use `--json` for atomicity (single write, no partial state) and speed (one process):
+Use `--json` for atomicity (single write, no partial state) and speed (one process). Either pipe the JSON or pass `--file <path>`:
 
 ```bash
+# Stdin works for short bodies:
 echo '[
   {"body": "overall feedback", "scope": "review"},
   {"path": "session.go", "body": "restructure", "scope": "file"},
@@ -99,6 +100,14 @@ echo '[
   {"reply_to": "r_f1e2d3", "body": "Done"}
 ]' | crit comment --json --author 'Cursor'
 ```
+
+**Prefer `--file` whenever a body spans more than one line.** Embedding raw newlines in a JSON string is invalid, and shell quoting makes it trivial to slip one in. Write the JSON to a temp file with your edit tool, then:
+
+```bash
+crit comment --json --file /tmp/crit-bulk.json --author 'Cursor'
+```
+
+(`--file -` reads stdin, same as omitting the flag.)
 
 Per-entry schema:
 

--- a/integrations/github-copilot/skills/crit-cli/SKILL.md
+++ b/integrations/github-copilot/skills/crit-cli/SKILL.md
@@ -87,9 +87,10 @@ Hard rules:
 
 ## Bulk commenting with `--json`
 
-When leaving 3+ comments, use `--json` for atomicity (single write, no partial state) and speed (one process):
+When leaving 3+ comments, use `--json` for atomicity (single write, no partial state) and speed (one process). The JSON payload can come from stdin or from `--file <path>`:
 
 ```bash
+# Stdin is fine when bodies are short single lines:
 echo '[
   {"body": "overall feedback", "scope": "review"},
   {"path": "session.go", "body": "restructure", "scope": "file"},
@@ -99,6 +100,14 @@ echo '[
   {"reply_to": "r_f1e2d3", "body": "Done"}
 ]' | crit comment --json --author 'GitHub Copilot'
 ```
+
+**For multi-paragraph bodies, prefer `--file`.** A raw newline inside a `"body"` string is invalid JSON, and it's easy to introduce one when shell-quoting a heredoc. Write the JSON to a temp file via your edit tool, then:
+
+```bash
+crit comment --json --file /tmp/crit-bulk.json --author 'GitHub Copilot'
+```
+
+`--file -` is shorthand for stdin if you need to be explicit.
 
 Per-entry schema:
 

--- a/integrations/opencode/SKILL.md
+++ b/integrations/opencode/SKILL.md
@@ -96,9 +96,10 @@ Hard rules:
 
 ## Bulk commenting with `--json`
 
-When leaving 3+ comments, use `--json` for atomicity (single write, no partial state) and speed (one process):
+When leaving 3+ comments, use `--json` for atomicity (single write, no partial state) and speed (one process). The JSON can come from stdin or `--file <path>`:
 
 ```bash
+# stdin works for short, single-line bodies:
 echo '[
   {"body": "overall feedback", "scope": "review"},
   {"path": "session.go", "body": "restructure", "scope": "file"},
@@ -108,6 +109,19 @@ echo '[
   {"reply_to": "r_f1e2d3", "body": "Done"}
 ]' | crit comment --json --author 'OpenCode'
 ```
+
+**Prefer `--file <path>` when any body spans multiple paragraphs.** A raw newline inside a JSON `"body"` string is invalid, and shell-quoted heredocs make that easy to introduce by accident. Write the JSON to a temp file, then:
+
+```bash
+cat > /tmp/crit-bulk.json <<'EOF'
+[
+  {"file": "src/auth.go", "line": 42, "body": "Para 1.\n\nPara 2."}
+]
+EOF
+crit comment --json --file /tmp/crit-bulk.json --author 'OpenCode'
+```
+
+`--file -` is shorthand for stdin.
 
 Per-entry schema:
 

--- a/integrations/opencode/crit.md
+++ b/integrations/opencode/crit.md
@@ -78,6 +78,19 @@ echo '[
 ]' | crit comment --json --author 'OpenCode'
 ```
 
+For multi-paragraph reply bodies, prefer `crit comment --json --file <path>` — a raw newline inside a JSON `"body"` string is invalid, and shell-quoted heredocs make that easy to slip in. Write the JSON to a temp file first, then point crit at it:
+
+```bash
+cat > /tmp/replies.json <<'EOF'
+[
+  {"reply_to": "c_a1b2c3", "body": "Fixed.\n\nDetails: split helper, added null guard."}
+]
+EOF
+crit comment --json --file /tmp/replies.json --author 'OpenCode'
+```
+
+`--file -` reads stdin (same as the default).
+
 **If there are zero review comments**: inform the user no changes were requested and stop.
 
 ## Step 5: Signal completion and start next round

--- a/integrations/windsurf/crit.md
+++ b/integrations/windsurf/crit.md
@@ -63,6 +63,19 @@ echo '[
 ]' | crit comment --json --author 'Windsurf'
 ```
 
+If any reply body spans multiple paragraphs, write the JSON to a temp file and pass `--file <path>` instead — a raw newline inside a JSON `"body"` string is a parse error, and shell heredocs make it easy to introduce one:
+
+```bash
+cat > /tmp/replies.json <<'EOF'
+[
+  {"reply_to": "c_a1b2c3", "body": "Fixed.\n\nDetails: split helper, added null guard."}
+]
+EOF
+crit comment --json --file /tmp/replies.json --author 'Windsurf'
+```
+
+`--file -` is the explicit "read stdin" form.
+
 ## Next round
 
 When done, run the command crit printed after `Next round:` in its previous output. The daemon is keyed by arguments, so this matters — `crit plan.md` and bare `crit` are different sessions.
@@ -92,7 +105,13 @@ If `crit comment` errors with "comment found in multiple files", disambiguate wi
 
 ### Bulk `--json`
 
-For 3+ comments, prefer `--json` (atomic, single write):
+For 3+ comments, prefer `--json` (atomic, single write). Synopsis:
+
+```
+crit comment --json [--file <path>] [--author <name>]
+```
+
+Stdin form (short single-line bodies):
 
 ```bash
 echo '[
@@ -102,6 +121,17 @@ echo '[
   {"file": "src/auth.go", "line": "50-55", "body": "Extract to helper"},
   {"reply_to": "c_a1b2c3", "body": "Fixed — added null check"}
 ]' | crit comment --json --author 'Windsurf'
+```
+
+`--file <path>` form — use whenever a body has paragraph breaks, since raw newlines in a JSON string are invalid:
+
+```bash
+cat > /tmp/crit-bulk.json <<'EOF'
+[
+  {"file": "src/auth.go", "line": 42, "body": "Para 1.\n\nPara 2."}
+]
+EOF
+crit comment --json --file /tmp/crit-bulk.json --author 'Windsurf'
 ```
 
 Scope inference: `reply_to` → reply; no `file`/`line` → review; `path` only → file; `path` + `line` → line.

--- a/main.go
+++ b/main.go
@@ -1061,6 +1061,7 @@ type commentFlags struct {
 	resolve   bool
 	path      string
 	json      bool
+	file      string
 	plan      string
 	scope     commentFocusOverride
 	args      []string
@@ -1100,6 +1101,9 @@ func parseCommentFlags(args []string) commentFlags {
 			i++
 		case "--json":
 			f.json = true
+		case "--file", "-f":
+			f.file = requireFlagValue(args, i, arg)
+			i++
 		case "--scope":
 			override, err := commentScopeOverrideFromFlag(requireFlagValue(args, i, "--scope"))
 			if err != nil {
@@ -1148,20 +1152,151 @@ func resolveCommentFlags(f *commentFlags) {
 	}
 }
 
+// readCommentJSONInput reads bulk-comment JSON either from the given file path
+// or from stdin. A path of "" or "-" reads stdin (POSIX convention). Errors
+// include the source path so callers can spot file vs. stdin failures quickly.
+func readCommentJSONInput(path string, stdin io.Reader) ([]byte, error) {
+	if path == "" || path == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// parseCommentJSONEntries unmarshals a bulk-comment JSON array, returning a
+// readable, located error message when the input is malformed.
+func parseCommentJSONEntries(data []byte) ([]BulkCommentEntry, error) {
+	var entries []BulkCommentEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, formatJSONParseError(data, err)
+	}
+	return entries, nil
+}
+
+// formatJSONParseError builds a multi-line error describing where in the input
+// JSON parsing failed: byte offset, line/column, a snippet around the offset
+// with control characters made visible, and the original error message.
+func formatJSONParseError(data []byte, err error) error {
+	offset, hasOffset := jsonErrorOffset(err)
+	if !hasOffset {
+		return fmt.Errorf("Error parsing JSON: %w", err)
+	}
+	line, col := lineColForOffset(data, offset)
+	snippet := jsonSnippet(data, offset)
+	return fmt.Errorf("Error parsing JSON at byte %d (line %d, column %d):\n  %s\n  %w",
+		offset, line, col, snippet, err)
+}
+
+// jsonErrorOffset extracts the byte offset from json package errors that carry
+// one. Returns (0, false) if the error has no offset information.
+func jsonErrorOffset(err error) (int64, bool) {
+	var syn *json.SyntaxError
+	if errors.As(err, &syn) {
+		return syn.Offset, true
+	}
+	var typ *json.UnmarshalTypeError
+	if errors.As(err, &typ) {
+		return typ.Offset, true
+	}
+	return 0, false
+}
+
+// lineColForOffset returns 1-based line and column for the given byte offset
+// into data. Tolerates offsets at or past the end of input.
+func lineColForOffset(data []byte, offset int64) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if int(offset) > len(data) {
+		offset = int64(len(data))
+	}
+	line, col := 1, 1
+	for i := int64(0); i < offset; i++ {
+		if data[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
+}
+
+// jsonSnippet returns a single-line excerpt of data around offset with the
+// offending position marked by >>>HERE<<<. Control bytes inside the snippet
+// are rendered as their visible escape forms so e.g. a raw newline appears as
+// the two characters \n rather than wrapping the output.
+func jsonSnippet(data []byte, offset int64) string {
+	const before, after = 40, 40
+	if offset < 0 {
+		offset = 0
+	}
+	if int(offset) > len(data) {
+		offset = int64(len(data))
+	}
+	start := offset - before
+	if start < 0 {
+		start = 0
+	}
+	end := offset + after
+	if int(end) > len(data) {
+		end = int64(len(data))
+	}
+	left := visibleControl(data[start:offset])
+	right := visibleControl(data[offset:end])
+	prefix := ""
+	if start > 0 {
+		prefix = "..."
+	}
+	suffix := ""
+	if int(end) < len(data) {
+		suffix = "..."
+	}
+	return prefix + left + ">>>HERE<<<" + right + suffix
+}
+
+// visibleControl replaces unprintable control bytes (newline, carriage return,
+// tab) with their escape-sequence representation so they survive a single-line
+// terminal print.
+func visibleControl(b []byte) string {
+	var out strings.Builder
+	out.Grow(len(b))
+	for _, c := range b {
+		switch c {
+		case '\n':
+			out.WriteString(`\n`)
+		case '\r':
+			out.WriteString(`\r`)
+		case '\t':
+			out.WriteString(`\t`)
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
+}
+
 func runCommentJSON(f commentFlags) {
 	runCommentJSONScoped(f, inheritedScope{})
 }
 
 func runCommentJSONScoped(f commentFlags, scope inheritedScope) {
-	data, err := io.ReadAll(os.Stdin)
+	data, err := readCommentJSONInput(f.file, os.Stdin)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
-	var entries []BulkCommentEntry
-	if err := json.Unmarshal(data, &entries); err != nil {
-		fmt.Fprintf(os.Stderr, "Error parsing JSON: %v\n", err)
+	entries, err := parseCommentJSONEntries(data)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -1223,7 +1358,8 @@ func printCommentUsage() {
 	fmt.Fprintln(os.Stderr, "       crit comment [--output <dir>] [--author <name>] <path> <body>             File-level comment")
 	fmt.Fprintln(os.Stderr, "       crit comment [--output <dir>] [--author <name>] <path>:<line[-end]> <body> Line-level comment")
 	fmt.Fprintln(os.Stderr, "       crit comment --reply-to <id> [--resolve] [--author <name>] <body>")
-	fmt.Fprintln(os.Stderr, "       crit comment --json [--author <name>] [--output <dir>]    Read comments from stdin as JSON")
+	fmt.Fprintln(os.Stderr, "       crit comment --json [--file <path>] [--author <name>] [--output <dir>]")
+	fmt.Fprintln(os.Stderr, "                                                                  Bulk add comments from JSON (stdin by default; --file <path> or --file - for stdin)")
 	fmt.Fprintln(os.Stderr, "       crit comment [--output <dir>] --clear")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Examples:")
@@ -1234,6 +1370,7 @@ func printCommentUsage() {
 	fmt.Fprintln(os.Stderr, "  crit comment --reply-to c_a3f8b2 --resolve --author 'Claude' 'Split into two functions'")
 	fmt.Fprintln(os.Stderr, "  crit comment --output /tmp/reviews main.go:42 'Fix this bug'")
 	fmt.Fprintln(os.Stderr, "  echo '[{\"file\":\"main.go\",\"line\":42,\"body\":\"Fix this\"}]' | crit comment --json --author 'Claude'")
+	fmt.Fprintln(os.Stderr, "  crit comment --json --file comments.json --author 'Claude'")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Tips:")
 	fmt.Fprintln(os.Stderr, "  Use --author to identify who left the comment (recommended for AI agents)")


### PR DESCRIPTION
## Summary
- New `--file <path>` flag (alias `-f`, with `-` for stdin) on `crit comment --json` so callers can hand JSON over via a file path instead of shell-quoted stdin. Multi-paragraph `"body"` strings are exactly the case where shell quoting silently corrupts JSON; pointing at a file written by the agent's normal write tooling sidesteps the whole class.
- Parse errors now include byte offset, line/column, and a snippet of the input around the offending position with control characters rendered visibly (e.g. `>>>HERE<<<` next to the literal `\n` that broke things). Replaces the opaque `invalid character '\n' in string literal` with a locatable diagnostic.
- Documented the new flag and "prefer `--file` for multi-paragraph bodies" guidance across `AGENTS.md` and all 8 integration prompts (claude-code, codex, cursor, github-copilot, cline, windsurf, opencode, aider). Bumped `plugin.json` to 1.5.1 so claude-code users pick up the updated SKILL.

## Review
- [x] Code review: passed (intent clean, no blockers)
- [x] Parity audit: N/A (no review-page files)

## Test plan
- New tests in `comment_json_input_test.go`: `--file <path>` happy path, `--file -` reads stdin, `--file <missing>` errors with path in message, default stdin still works, malformed JSON parse-error formatting (offset/line/col/snippet/visible-control), flag parsing for `--file` and `-f`.
- `gofmt -l`, `go vet`, `golangci-lint run`, `go test -race ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)