### PR TITLE
docs: switch primary brew install to homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Works with Claude Code, Cursor, GitHub Copilot, Aider, Cline, Windsurf and any o
 ## Install
 
 ```bash
-brew install tomasz-tomczyk/tap/crit
+brew install crit
 ```
 
 Also available via [Go, Nix, or binary download](#other-install-methods).


### PR DESCRIPTION
## Summary

- crit was accepted into homebrew-core, so the README now leads with `brew install crit` (no tap prefix)
- Personal tap (`tomasz-tomczyk/tap`) keeps auto-updating from `release.yml` as a fallback for early-access users

## Test plan

- [x] Verified `brew info crit` resolves to homebrew-core formula (stable 0.10.5, bottled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)