### PR TITLE
fix: deny rather than silently auto-approve on daemon shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -1888,7 +1888,7 @@ func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 	// Wait for the server to finish initializing before calling review-cycle.
 	if _, _, err := waitForDaemonReady(client, entry.Port); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
-		return true, ""
+		return false, "crit daemon was unreachable; plan was not reviewed."
 	}
 
 	resp, err := client.Post(
@@ -1897,26 +1897,36 @@ func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
 		nil,
 	)
 	if err != nil {
+		// Daemon died (graceful shutdown, crash, or `crit stop`) while we
+		// were waiting. Deny rather than silently auto-approve — an
+		// unreachable daemon means no human signed off on the plan.
 		fmt.Fprintf(os.Stderr, "crit plan-hook: could not reach daemon: %v\n", err)
-		return true, "" // allow through on error
+		return false, "crit daemon became unreachable before review was finished."
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "crit plan-hook: daemon returned %d\n", resp.StatusCode)
-		return true, "" // allow through on infrastructure error
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return true, ""
+		fmt.Fprintf(os.Stderr, "crit plan-hook: could not read daemon response: %v\n", err)
+		return false, "crit daemon response could not be read."
+	}
+
+	// Both 200 (finish) and 503 (server-shutdown) carry a structured
+	// {approved, prompt} body. Other statuses mean infrastructure failure —
+	// deny in that case rather than allowing through.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
+		fmt.Fprintf(os.Stderr, "crit plan-hook: daemon returned %d\n", resp.StatusCode)
+		return false, "crit daemon returned an unexpected status."
 	}
 
 	var result struct {
 		Approved bool   `json:"approved"`
 		Prompt   string `json:"prompt"`
 	}
-	json.Unmarshal(body, &result)
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Fprintf(os.Stderr, "crit plan-hook: malformed daemon response: %v\n", err)
+		return false, "crit daemon returned a malformed response."
+	}
 	return result.Approved, result.Prompt
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1135,6 +1135,90 @@ func TestRunReviewClientRaw_NoReadinessDelay(t *testing.T) {
 	}
 }
 
+// TestRunReviewClientRaw_DaemonShutdownDeniesNotApproves regression-tests the
+// silent auto-approve bug: when the daemon shuts down mid-request the client
+// must return approved=false (with an explanatory prompt), never approved=true.
+// Covers two paths: the daemon answers /api/review-cycle with 503+shutdown
+// payload, and the daemon's HTTP server force-closes the connection.
+func TestRunReviewClientRaw_DaemonShutdownDeniesNotApproves(t *testing.T) {
+	t.Run("503 shutdown response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/session":
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			case "/api/review-cycle":
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(map[string]any{
+					"status":   "shutdown",
+					"approved": false,
+					"prompt":   "crit daemon shut down before review was finished.",
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+
+		port := 0
+		fmt.Sscanf(ts.URL, "http://127.0.0.1:%d", &port)
+		if port == 0 {
+			fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
+		}
+
+		approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+		if approved {
+			t.Fatal("expected approved=false on daemon shutdown, got true (silent auto-approve)")
+		}
+		if prompt == "" {
+			t.Fatal("expected non-empty prompt explaining shutdown, got empty")
+		}
+	})
+
+	t.Run("connection drop mid-request", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/session":
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			case "/api/review-cycle":
+				// Simulate the HTTP server force-closing the connection
+				// (what happens after httpServer.Shutdown's 2s timeout).
+				// Use Errorf (not Fatal) inside the handler goroutine —
+				// t.Fatal must be called from the test goroutine.
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Errorf("ResponseWriter does not support Hijacker")
+					return
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Errorf("hijack failed: %v", err)
+					return
+				}
+				conn.Close()
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+
+		port := 0
+		fmt.Sscanf(ts.URL, "http://127.0.0.1:%d", &port)
+		if port == 0 {
+			fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
+		}
+
+		approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+		if approved {
+			t.Fatal("expected approved=false on connection drop, got true (silent auto-approve)")
+		}
+		if prompt == "" {
+			t.Fatal("expected non-empty prompt explaining the failure, got empty")
+		}
+	})
+}
+
 // TestFetch_PrintsReviewFilePath verifies that crit fetch prints the review
 // file path in both the "no new comments" and "fetched N comments" cases.
 func TestFetch_PrintsReviewFilePath(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -1467,6 +1467,21 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
+			if event.Type == "server-shutdown" {
+				// Daemon is shutting down before the user finished reviewing.
+				// Tell the client explicitly so it can deny rather than fall
+				// through to the connection-error path and silently approve.
+				// Set Content-Type before WriteHeader — writeJSON sets it
+				// internally, but headers set after WriteHeader are dropped.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				writeJSON(w, map[string]any{
+					"status":   "shutdown",
+					"approved": false,
+					"prompt":   "crit daemon shut down before review was finished.",
+				})
+				return
+			}
 		case <-r.Context().Done():
 			w.WriteHeader(http.StatusGatewayTimeout)
 			return


### PR DESCRIPTION
## Summary
- `handleReviewCycle` ignored `server-shutdown` SSE events, so the handler kept blocking through graceful shutdown until the HTTP server force-closed the connection.
- `runReviewClientRaw` then mapped every error path to `(true, "")` — silently approving the plan-hook PermissionRequest whenever the daemon died (graceful shutdown, crash, or `crit stop`).

## Fix
- Server: emits `503` with `{status:"shutdown", approved:false, prompt}` when the shutdown event fires (Content-Type set before WriteHeader so `writeJSON` doesn't drop it).
- Client: never auto-approves on errors. Returns `approved=false` with an explanatory prompt for unreachable / malformed-body / unexpected-status / 503-shutdown cases, so the hook denies (with reason) instead of silently allowing.

## Review
- [x] Code review: passed (go-expert + intent audit, both clean after fixups)
- [x] Parity audit: N/A (backend only)

## Test plan
- New regression tests `TestRunReviewClientRaw_DaemonShutdownDeniesNotApproves`:
  - 503 + structured shutdown payload → asserts `approved=false`, non-empty prompt
  - hijacked connection drop mid-request → asserts `approved=false`, non-empty prompt
- Existing `TestRunReviewClientRaw_*` (readiness / no-delay) still green
- `go test ./...`, `gofmt`, `golangci-lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)