### PR TITLE
fix: audit fixes — path safety, shared reads, dir pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ crit/
 ├── review_file.go       # Review file (~/.crit/reviews/<key>.json) read/write — saveCritJSON
 ├── pr_cache.go / pr_fetch.go / push_buckets.go  # GitHub PR fetch/cache, comment bucketing
 ├── remote_files.go      # Fetch files from a remote PR for cross-PR comparisons
-├── browser.go / autodetect.go / lru_bytes.go    # Browser open, base-branch detection, byte cache
+├── browser.go / lru_bytes.go    # Browser open, base-branch detection, byte cache
 ├── comment_cli.go       # `crit comment` headless implementation
 ├── gen_integration_hashes.go / integration_hashes_gen.go  # Build-time integration manifest
 ├── *_test.go            # Tests (testutil_test.go has shared helpers; *_integration_test.go behind build tag)

--- a/comment_cli.go
+++ b/comment_cli.go
@@ -328,7 +328,10 @@ func processBulkFileOrLineEntry(cj *CritJSON, i int, e BulkCommentEntry, author,
 		return fmt.Errorf("entry %d: path %q must be relative and within the repository", i, filePath)
 	}
 	// Normalize for cross-platform storage — see addCommentToCritJSONScoped.
-	cleaned := filepath.ToSlash(filepath.Clean(filePath))
+	// Replace backslashes first so Windows-authored bulk JSON ("subdir\file.go")
+	// normalizes correctly when processed on Unix, where filepath.Clean treats
+	// backslash as a literal filename character.
+	cleaned := filepath.ToSlash(filepath.Clean(strings.ReplaceAll(filePath, `\`, "/")))
 
 	if e.Scope == "file" {
 		appendFileCommentScoped(cj, cleaned, e.Body, author, userID, scope)

--- a/comment_cli.go
+++ b/comment_cli.go
@@ -324,14 +324,15 @@ func processBulkFileOrLineEntry(cj *CritJSON, i int, e BulkCommentEntry, author,
 		return fmt.Errorf("entry %d: file is required for new comments", i)
 	}
 
-	if isAbsoluteOrTraversal(filePath) {
+	// Normalize backslashes before the traversal check — on Unix filepath.Clean
+	// treats backslash as a literal character, so "subdir\..\..\etc\passwd" would
+	// pass isAbsoluteOrTraversal and only reveal the traversal after conversion.
+	normalizedPath := strings.ReplaceAll(filePath, `\`, "/")
+	if isAbsoluteOrTraversal(normalizedPath) {
 		return fmt.Errorf("entry %d: path %q must be relative and within the repository", i, filePath)
 	}
 	// Normalize for cross-platform storage — see addCommentToCritJSONScoped.
-	// Replace backslashes first so Windows-authored bulk JSON ("subdir\file.go")
-	// normalizes correctly when processed on Unix, where filepath.Clean treats
-	// backslash as a literal filename character.
-	cleaned := filepath.ToSlash(filepath.Clean(strings.ReplaceAll(filePath, `\`, "/")))
+	cleaned := filepath.ToSlash(filepath.Clean(normalizedPath))
 
 	if e.Scope == "file" {
 		appendFileCommentScoped(cj, cleaned, e.Body, author, userID, scope)

--- a/comment_json_input_test.go
+++ b/comment_json_input_test.go
@@ -62,7 +62,7 @@ func TestReadCommentJSONInputMissingFile(t *testing.T) {
 
 func TestParseCommentJSONEntriesValid(t *testing.T) {
 	data := []byte(`[{"file":"main.go","line":42,"body":"fix"}]`)
-	entries, err := parseCommentJSONEntries(data)
+	entries, err := parseCommentJSONEntries(data, "-")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -76,13 +76,13 @@ func TestParseCommentJSONEntriesRawNewlineInString(t *testing.T) {
 	// to give a better error for. We assemble the bytes manually so the test
 	// source itself stays well-formed.
 	data := []byte("[\n  {\"body\": \"line one\nline two\"}\n]")
-	_, err := parseCommentJSONEntries(data)
+	_, err := parseCommentJSONEntries(data, "bulk.json")
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
 	}
 	msg := err.Error()
 	wants := []string{
-		"Error parsing JSON at byte ",
+		"Error parsing JSON from bulk.json at byte ",
 		"line ",
 		"column ",
 		">>>HERE<<<",
@@ -203,7 +203,7 @@ func TestRunCommentJSON_ParseErrorExits(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected non-zero exit; output: %s", out)
 	}
-	if !strings.Contains(string(out), "Error parsing JSON at byte ") {
+	if !strings.Contains(string(out), "Error parsing JSON from ") {
 		t.Errorf("missing formatted parse error: %s", out)
 	}
 	if !strings.Contains(string(out), `>>>HERE<<<`) {

--- a/comment_json_input_test.go
+++ b/comment_json_input_test.go
@@ -95,6 +95,34 @@ func TestParseCommentJSONEntriesRawNewlineInString(t *testing.T) {
 	}
 }
 
+func TestJSONSourceLabel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", "stdin"},
+		{"-", "stdin"},
+		{"bulk.json", "bulk.json"},
+		{"path/to/file.json", "path/to/file.json"},
+	}
+	for _, c := range cases {
+		got := jsonSourceLabel(c.in)
+		if got != c.want {
+			t.Errorf("jsonSourceLabel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatJSONParseError_NoOffset(t *testing.T) {
+	// errors.New produces an error with no offset info — exercises the
+	// !hasOffset branch in formatJSONParseError.
+	err := formatJSONParseError([]byte(`[]`), "test.json", errors.New("generic error"))
+	msg := err.Error()
+	if !strings.Contains(msg, "Error parsing JSON from test.json") {
+		t.Errorf("missing source label: %s", msg)
+	}
+	if !strings.Contains(msg, "generic error") {
+		t.Errorf("missing wrapped error: %s", msg)
+	}
+}
+
 func TestParseCommentFlagsFile(t *testing.T) {
 	got := parseCommentFlags([]string{"--json", "--file", "bulk.json"})
 	if !got.json {

--- a/daemon_e2e_test.go
+++ b/daemon_e2e_test.go
@@ -20,15 +20,16 @@ func TestDaemonLifecycle(t *testing.T) {
 		t.Skip("skipping daemon lifecycle test in short mode")
 	}
 	if runtime.GOOS == "windows" {
-		// TODO(windows): the spawned daemon now starts and writes its
-		// session file, but cmd.Wait hangs indefinitely after proc.Kill on
-		// Windows. The detached child + readiness-pipe (ExtraFiles FD 3)
-		// combination produces subprocess-lifecycle behavior that differs
-		// from POSIX in ways we haven't unwound. The runtime daemon code
-		// path is still exercised by daemon_test.go unit tests on Windows;
-		// revisit this E2E once the spawn handshake is reworked (e.g.
-		// port-file polling instead of FD inheritance).
-		t.Skip("daemon E2E spawn/wait/kill semantics differ on Windows; covered by daemon_test.go unit tests; TODO: revisit")
+		// TODO(windows): re-evaluate now that terminateProcess uses
+		// GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT) before falling back to
+		// TerminateProcess — the daemon's signal handler should now run on
+		// shutdown and let cmd.Wait return cleanly. The detached child +
+		// readiness-pipe (ExtraFiles FD 3) combo still produces
+		// subprocess-lifecycle behavior that differs from POSIX, so this
+		// suite remains skipped pending hands-on validation on a Windows
+		// runner. The runtime daemon code path is still exercised by
+		// daemon_test.go unit tests on Windows.
+		t.Skip("daemon E2E spawn/wait/kill semantics differ on Windows; covered by daemon_test.go unit tests; TODO: revisit after CTRL_BREAK shutdown lands")
 	}
 
 	// Build crit binary

--- a/github.go
+++ b/github.go
@@ -1440,7 +1440,7 @@ func updateCritJSONAfterDeletes(critPath string, drained []int64) error {
 		drainedSet[id] = struct{}{}
 	}
 
-	data, err := os.ReadFile(reviewPathsFor(critPath).Review)
+	data, err := readFileShared(reviewPathsFor(critPath).Review)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -1171,27 +1171,40 @@ func readCommentJSONInput(path string, stdin io.Reader) ([]byte, error) {
 }
 
 // parseCommentJSONEntries unmarshals a bulk-comment JSON array, returning a
-// readable, located error message when the input is malformed.
-func parseCommentJSONEntries(data []byte) ([]BulkCommentEntry, error) {
+// readable, located error message when the input is malformed. The source
+// label ("-" for stdin, or the file path) is included in the error so callers
+// can tell file vs. stdin failures apart.
+func parseCommentJSONEntries(data []byte, source string) ([]BulkCommentEntry, error) {
 	var entries []BulkCommentEntry
 	if err := json.Unmarshal(data, &entries); err != nil {
-		return nil, formatJSONParseError(data, err)
+		return nil, formatJSONParseError(data, source, err)
 	}
 	return entries, nil
 }
 
 // formatJSONParseError builds a multi-line error describing where in the input
 // JSON parsing failed: byte offset, line/column, a snippet around the offset
-// with control characters made visible, and the original error message.
-func formatJSONParseError(data []byte, err error) error {
+// with control characters made visible, and the original error message. The
+// source label identifies the input ("-" for stdin, otherwise a file path).
+func formatJSONParseError(data []byte, source string, err error) error {
+	label := jsonSourceLabel(source)
 	offset, hasOffset := jsonErrorOffset(err)
 	if !hasOffset {
-		return fmt.Errorf("Error parsing JSON: %w", err)
+		return fmt.Errorf("Error parsing JSON from %s: %w", label, err)
 	}
 	line, col := lineColForOffset(data, offset)
 	snippet := jsonSnippet(data, offset)
-	return fmt.Errorf("Error parsing JSON at byte %d (line %d, column %d):\n  %s\n  %w",
-		offset, line, col, snippet, err)
+	return fmt.Errorf("Error parsing JSON from %s at byte %d (line %d, column %d):\n  %s\n  %w",
+		label, offset, line, col, snippet, err)
+}
+
+// jsonSourceLabel renders a human-readable label for the JSON input source.
+// Empty or "-" means stdin; anything else is treated as a file path.
+func jsonSourceLabel(source string) string {
+	if source == "" || source == "-" {
+		return "stdin"
+	}
+	return source
 }
 
 // jsonErrorOffset extracts the byte offset from json package errors that carry
@@ -1294,7 +1307,7 @@ func runCommentJSONScoped(f commentFlags, scope inheritedScope) {
 		os.Exit(1)
 	}
 
-	entries, err := parseCommentJSONEntries(data)
+	entries, err := parseCommentJSONEntries(data, f.file)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -27,11 +27,16 @@ func terminationSignals() []os.Signal {
 	return []os.Signal{os.Interrupt}
 }
 
-// terminateProcess asks the given process to exit. On Windows there is no
-// equivalent of SIGTERM for arbitrary processes — os.Process.Signal only
-// accepts os.Kill and os.Interrupt, and os.Interrupt is unimplemented for
-// non-console children. We fall back to TerminateProcess via os.Process.Kill.
+// terminateProcess asks the given process to exit. On Windows we first try
+// GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) so the daemon's
+// signal.NotifyContext handler runs (the daemon child is spawned with
+// CREATE_NEW_PROCESS_GROUP, so the event targets only that group).
+// stopDaemon's polling loop gives the graceful path a moment to shut down
+// before falling back to TerminateProcess via os.Process.Kill.
 func terminateProcess(proc *os.Process) error {
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(proc.Pid)); err == nil {
+		return nil
+	}
 	return proc.Kill()
 }
 

--- a/process_bulk_line_comment_test.go
+++ b/process_bulk_line_comment_test.go
@@ -114,6 +114,28 @@ func TestProcessBulkFileOrLineEntryNormalizesBackslashes(t *testing.T) {
 	}
 }
 
+// TestProcessBulkFileOrLineEntryRejectsBackslashTraversal ensures that
+// Windows-style traversal paths ("subdir\..\..\etc\passwd") are rejected
+// even when the check runs on Unix, where filepath.Clean treats backslash
+// as a literal and would pass the raw input through isAbsoluteOrTraversal.
+func TestProcessBulkFileOrLineEntryRejectsBackslashTraversal(t *testing.T) {
+	cases := []string{
+		`subdir\..\..\etc\passwd`,
+		`..\etc\passwd`,
+		`a\b\..\..\..\secret`,
+	}
+	for _, input := range cases {
+		cj := &CritJSON{Files: map[string]CritJSONFile{}}
+		entry := BulkCommentEntry{File: input, Body: "x", Line: 1}
+		err := processBulkFileOrLineEntry(cj, 0, entry, "alice", "u1", inheritedScope{})
+		if err == nil {
+			t.Errorf("input %q: expected traversal error, got nil", input)
+		} else if !strings.Contains(err.Error(), "must be relative") {
+			t.Errorf("input %q: unexpected error: %v", input, err)
+		}
+	}
+}
+
 func keysOf(m map[string]CritJSONFile) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/process_bulk_line_comment_test.go
+++ b/process_bulk_line_comment_test.go
@@ -83,3 +83,41 @@ func TestProcessBulkLineComment(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessBulkFileOrLineEntryNormalizesBackslashes ensures Windows-style
+// backslash separators in bulk JSON are normalized to forward slashes on all
+// platforms. On Unix, filepath.Clean treats backslash as a literal filename
+// character, so without the explicit replacement a key like "subdir\file.go"
+// would survive into the review file as a single path component.
+func TestProcessBulkFileOrLineEntryNormalizesBackslashes(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantKey string
+	}{
+		{name: "windows separators", input: `subdir\file.go`, wantKey: "subdir/file.go"},
+		{name: "mixed separators", input: `a\b/c.go`, wantKey: "a/b/c.go"},
+		{name: "nested windows", input: `a\b\c\d.go`, wantKey: "a/b/c/d.go"},
+		{name: "already posix", input: "a/b/c.go", wantKey: "a/b/c.go"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cj := &CritJSON{Files: map[string]CritJSONFile{}}
+			entry := BulkCommentEntry{File: c.input, Body: "x", Line: 1}
+			if err := processBulkFileOrLineEntry(cj, 0, entry, "alice", "u1", inheritedScope{}); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if _, ok := cj.Files[c.wantKey]; !ok {
+				t.Fatalf("expected key %q in cj.Files, got %v", c.wantKey, keysOf(cj.Files))
+			}
+		})
+	}
+}
+
+func keysOf(m map[string]CritJSONFile) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/review_file.go
+++ b/review_file.go
@@ -145,7 +145,7 @@ func reviewPathsFor(identity string) reviewPaths {
 // in the orphan-snapshots state which is benign on read).
 func loadSnapshotsFile(snapshotsPath string) (SnapshotsFile, error) {
 	sf := SnapshotsFile{RoundSnapshots: map[string]map[int]RoundSnapshot{}}
-	data, err := os.ReadFile(snapshotsPath)
+	data, err := readFileShared(snapshotsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return sf, nil
@@ -382,7 +382,7 @@ func walkReviewIdentities(visit func(identity string, data []byte) error) error 
 		name := de.Name()
 		if de.IsDir() {
 			folder := filepath.Join(dir, name)
-			data, readErr := os.ReadFile(filepath.Join(folder, "review.json"))
+			data, readErr := readFileShared(filepath.Join(folder, "review.json"))
 			if readErr != nil {
 				if !os.IsNotExist(readErr) {
 					fmt.Fprintf(os.Stderr, "crit: warning: could not read %s/review.json: %v\n", folder, readErr)

--- a/session.go
+++ b/session.go
@@ -718,6 +718,9 @@ func walkDirSubsFirst(dir, root string, ignorePatterns []string, out *[]string) 
 			if skipDirs[name] {
 				continue
 			}
+			if dirIgnored(filepath.Join(dir, name), root, ignorePatterns) {
+				continue
+			}
 			subdirs = append(subdirs, e)
 			continue
 		}
@@ -729,18 +732,8 @@ func walkDirSubsFirst(dir, root string, ignorePatterns []string, out *[]string) 
 		if isBinaryExtension(ext) {
 			continue
 		}
-		full := filepath.Join(dir, name)
-		if relPath, relErr := filepath.Rel(root, full); relErr == nil {
-			skipped := false
-			for _, pat := range ignorePatterns {
-				if matchPattern(pat, relPath) {
-					skipped = true
-					break
-				}
-			}
-			if skipped {
-				continue
-			}
+		if fileIgnored(filepath.Join(dir, name), root, ignorePatterns) {
+			continue
 		}
 		fileEntries = append(fileEntries, e)
 	}
@@ -750,6 +743,43 @@ func walkDirSubsFirst(dir, root string, ignorePatterns []string, out *[]string) 
 	for _, f := range fileEntries {
 		*out = append(*out, filepath.Join(dir, f.Name()))
 	}
+}
+
+// fileIgnored reports whether the file at full (relative to root) matches any
+// ignore pattern. Best-effort: if the relative path can't be computed, the
+// file is not skipped.
+func fileIgnored(full, root string, ignorePatterns []string) bool {
+	relPath, err := filepath.Rel(root, full)
+	if err != nil {
+		return false
+	}
+	for _, pat := range ignorePatterns {
+		if matchPattern(pat, relPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// dirIgnored reports whether the directory at full (relative to root) matches
+// any "dir/" ignore pattern. File-shaped patterns are deliberately ignored
+// here so they only apply per-file in walkDirSubsFirst. Best-effort: if the
+// relative path can't be computed, the directory is not pruned.
+func dirIgnored(full, root string, ignorePatterns []string) bool {
+	relPath, err := filepath.Rel(root, full)
+	if err != nil {
+		return false
+	}
+	dirPath := filepath.ToSlash(relPath) + "/"
+	for _, pat := range ignorePatterns {
+		if !strings.HasSuffix(pat, "/") {
+			continue
+		}
+		if matchPattern(pat, dirPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // isBinaryExtension returns true for file extensions that are typically binary.

--- a/session.go
+++ b/session.go
@@ -762,9 +762,10 @@ func fileIgnored(full, root string, ignorePatterns []string) bool {
 }
 
 // dirIgnored reports whether the directory at full (relative to root) matches
-// any "dir/" ignore pattern. File-shaped patterns are deliberately ignored
-// here so they only apply per-file in walkDirSubsFirst. Best-effort: if the
-// relative path can't be computed, the directory is not pruned.
+// any "dir/" ignore pattern. Non-slash-suffixed patterns (e.g. bare "node_modules")
+// are intentionally skipped — they apply per-file via fileIgnored. Pruning only
+// fires for explicit trailing-slash patterns. Best-effort: if the relative path
+// can't be computed, the directory is not pruned.
 func dirIgnored(full, root string, ignorePatterns []string) bool {
 	relPath, err := filepath.Rel(root, full)
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -5125,3 +5125,48 @@ func TestSession_GetCommits_WorkingTreeMode(t *testing.T) {
 		t.Errorf("messages = [%q, %q], want [B, A]", commits[0].Message, commits[1].Message)
 	}
 }
+
+func TestFileIgnored(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		pat  string
+		rel  string
+		want bool
+	}{
+		{"*.log", "foo.log", true},
+		{"*.log", "foo.go", false},
+		{"vendor/", "vendor/pkg.go", true}, // dir/ prefix also matches files inside
+		{"foo.go", "foo.go", true},
+		{"sub/foo.go", "sub/foo.go", true},
+		{"sub/foo.go", "other/foo.go", false},
+	}
+	for _, c := range cases {
+		full := filepath.Join(root, filepath.FromSlash(c.rel))
+		got := fileIgnored(full, root, []string{c.pat})
+		if got != c.want {
+			t.Errorf("fileIgnored(%q, %q): got %v, want %v", c.rel, c.pat, got, c.want)
+		}
+	}
+}
+
+func TestDirIgnored(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		pat  string
+		rel  string
+		want bool
+	}{
+		{"vendor/", "vendor", true},
+		{"vendor/", "other", false},
+		{"node_modules/", "node_modules", true},
+		{"node_modules", "node_modules", false}, // bare basename: NOT pruned (per contract)
+		{"sub/vendor/", "sub/vendor", true},
+	}
+	for _, c := range cases {
+		full := filepath.Join(root, filepath.FromSlash(c.rel))
+		got := dirIgnored(full, root, []string{c.pat})
+		if got != c.want {
+			t.Errorf("dirIgnored(%q, %q): got %v, want %v", c.rel, c.pat, got, c.want)
+		}
+	}
+}

--- a/session_write.go
+++ b/session_write.go
@@ -127,7 +127,7 @@ func (s *Session) clearAllCommentData() {
 // and merges per-file comments.
 func buildCritJSON(snap writeFilesSnapshot) CritJSON {
 	cj := CritJSON{Files: make(map[string]CritJSONFile)}
-	if data, err := os.ReadFile(reviewPathsFor(snap.critPath).Review); err == nil {
+	if data, err := readFileShared(reviewPathsFor(snap.critPath).Review); err == nil {
 		if unmarshalErr := json.Unmarshal(data, &cj); unmarshalErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: corrupt review file, starting fresh: %v\n", unmarshalErr)
 		}


### PR DESCRIPTION
## Summary
- Normalize backslashes before traversal check in bulk JSON paths — `"subdir\..\..\etc\passwd"` on Unix would previously pass `isAbsoluteOrTraversal` (filepath.Clean treats backslash as literal) then convert to a traversal path
- Add source label to JSON parse errors (file vs stdin in error messages)
- Replace `os.ReadFile` with `readFileShared` for review.json reads in `review_file.go`, `session_write.go`, `github.go` — consistent Windows sharing-violation protection
- Extract `fileIgnored`/`dirIgnored` helpers in `session.go`; prune ignored directories early in `walkDirSubsFirst` rather than per-file
- Use `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT)` in `terminateProcess` on Windows so the daemon's signal handler runs before falling back to TerminateProcess
- Add table tests for `fileIgnored`/`dirIgnored`, backslash traversal rejection
- Remove stale `autodetect.go` reference from `AGENTS.md`

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (no frontend changes)

## Test plan
- `go test -race -count=1 ./...` — pass
- `golangci-lint run ./...` — 0 issues
- New tests: `TestProcessBulkFileOrLineEntryRejectsBackslashTraversal`, `TestFileIgnored`, `TestDirIgnored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)