### PR TITLE
fix: header context chip colors and hidden unresolved count

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -245,6 +245,7 @@
   let configAuthor = '';
   let uiState = 'reviewing';
   let waitingNotApproved = false;
+  let hiddenUnresolved = 0;
   let pendingUpdates = [];
   let pendingUpdatesVersion = '';
 
@@ -783,6 +784,7 @@
       : 'Crit — ' + (session.files || []).map(f => f.path).join(', '));
 
     files = await loadAllFileData(session.files || [], diffScope);
+    hiddenUnresolved = session.hidden_unresolved || 0;
 
     files.sort(fileSortComparator);
 
@@ -6637,6 +6639,7 @@
           if (files[fi].comments) unresolvedComments += files[fi].comments.filter(function(c) { return !c.resolved; }).length;
         }
         unresolvedComments += reviewComments.filter(function(c) { return !c.resolved; }).length;
+        unresolvedComments += hiddenUnresolved;
         finishBtn.textContent = unresolvedComments === 0 ? 'Approve' : 'Finish Review';
         finishBtn.disabled = false;
         finishBtn.classList.add('btn-primary');
@@ -6841,6 +6844,7 @@
 
         // Reload all files
         files = await loadAllFileData(session.files || [], diffScope);
+        hiddenUnresolved = session.hidden_unresolved || 0;
 
         // Restore per-file user state from previous round
         for (let fi = 0; fi < files.length; fi++) {
@@ -7686,6 +7690,7 @@
         }
 
         files = await loadAllFileData(session.files, diffScope);
+        hiddenUnresolved = session.hidden_unresolved || 0;
         files.sort(fileSortComparator);
         restoreViewedState();
         renderFileTree();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -90,6 +90,8 @@ body {
 /* Brand-tint variant — used by the active branch (head) chip. */
 .header-chip.header-context {
   color: var(--crit-brand);
+  background: var(--crit-brand-subtle);
+  border-color: var(--crit-brand-bg);
 }
 .header-chip.header-context .branch-icon { opacity: 1; }
 .header-chip.header-context #branchName {

--- a/session.go
+++ b/session.go
@@ -2205,18 +2205,19 @@ func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
 
 // SessionInfo returns metadata about the session for the API.
 type SessionInfo struct {
-	Mode            string            `json:"mode"` // "files" or "git"
-	VCSName         string            `json:"vcs_name,omitempty"`
-	Branch          string            `json:"branch"`
-	BaseRef         string            `json:"base_ref"`
-	BaseBranchName  string            `json:"base_branch_name,omitempty"`
-	ReviewRound     int               `json:"review_round"`
-	AvailableScopes []string          `json:"available_scopes"`
-	Files           []SessionFileInfo `json:"files"`
-	ReviewComments  []Comment         `json:"review_comments"`
-	Cwd             string            `json:"cwd,omitempty"`
-	Focus           Focus             `json:"focus"`
-	LastRangeFocus  *Focus            `json:"last_range_focus,omitempty"`
+	Mode             string            `json:"mode"` // "files" or "git"
+	VCSName          string            `json:"vcs_name,omitempty"`
+	Branch           string            `json:"branch"`
+	BaseRef          string            `json:"base_ref"`
+	BaseBranchName   string            `json:"base_branch_name,omitempty"`
+	ReviewRound      int               `json:"review_round"`
+	AvailableScopes  []string          `json:"available_scopes"`
+	Files            []SessionFileInfo `json:"files"`
+	ReviewComments   []Comment         `json:"review_comments"`
+	Cwd              string            `json:"cwd,omitempty"`
+	Focus            Focus             `json:"focus"`
+	LastRangeFocus   *Focus            `json:"last_range_focus,omitempty"`
+	HiddenUnresolved int               `json:"hidden_unresolved"`
 }
 
 // SessionFileInfo is a summary of a file for the session API response.

--- a/session_focus.go
+++ b/session_focus.go
@@ -556,19 +556,21 @@ func (s *Session) GetCommits() []CommitInfo {
 
 // scopedSessionSnapshot holds session state read under lock for scoped queries.
 type scopedSessionSnapshot struct {
-	vcs            VCS
-	baseRef        string
-	baseBranchName string
-	repoRoot       string
-	mode           string
-	branch         string
-	reviewRound    int
-	ignorePatterns []string
-	commentCounts  map[string]int
-	lazyFiles      map[string]*FileEntry
-	reviewComments []Comment
-	focus          Focus
-	lastRangeFocus *Focus
+	vcs              VCS
+	baseRef          string
+	baseBranchName   string
+	repoRoot         string
+	mode             string
+	branch           string
+	reviewRound      int
+	ignorePatterns   []string
+	commentCounts    map[string]int
+	unresolvedCounts map[string]int
+	totalUnresolved  int
+	lazyFiles        map[string]*FileEntry
+	reviewComments   []Comment
+	focus            Focus
+	lastRangeFocus   *Focus
 }
 
 func (s *Session) snapshotForScoped() scopedSessionSnapshot {
@@ -576,15 +578,26 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	defer s.mu.RUnlock()
 
 	commentCounts := make(map[string]int, len(s.Files))
+	unresolvedCounts := make(map[string]int, len(s.Files))
 	lazyFiles := make(map[string]*FileEntry, len(s.Files))
+	totalUnresolved := 0
 	for _, f := range s.Files {
 		commentCounts[f.Path] = countVisibleComments(f.Comments, s.Focus)
+		for _, c := range f.Comments {
+			if !c.Resolved {
+				unresolvedCounts[f.Path]++
+				totalUnresolved++
+			}
+		}
 		if f.Lazy {
 			lazyFiles[f.Path] = f
 		}
 	}
 	rc := make([]Comment, 0, len(s.reviewComments))
 	for _, c := range s.reviewComments {
+		if !c.Resolved {
+			totalUnresolved++
+		}
 		if !visibleInFocus(c, s.Focus) {
 			continue
 		}
@@ -592,19 +605,21 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	}
 
 	return scopedSessionSnapshot{
-		vcs:            s.VCS,
-		baseRef:        s.BaseRef,
-		baseBranchName: s.BaseBranchName,
-		repoRoot:       s.RepoRoot,
-		mode:           s.Mode,
-		branch:         s.Branch,
-		reviewRound:    s.ReviewRound,
-		ignorePatterns: s.IgnorePatterns,
-		commentCounts:  commentCounts,
-		lazyFiles:      lazyFiles,
-		reviewComments: rc,
-		focus:          s.Focus,
-		lastRangeFocus: s.LastRangeFocus,
+		vcs:              s.VCS,
+		baseRef:          s.BaseRef,
+		baseBranchName:   s.BaseBranchName,
+		repoRoot:         s.RepoRoot,
+		mode:             s.Mode,
+		branch:           s.Branch,
+		reviewRound:      s.ReviewRound,
+		ignorePatterns:   s.IgnorePatterns,
+		commentCounts:    commentCounts,
+		unresolvedCounts: unresolvedCounts,
+		totalUnresolved:  totalUnresolved,
+		lazyFiles:        lazyFiles,
+		reviewComments:   rc,
+		focus:            s.Focus,
+		lastRangeFocus:   s.LastRangeFocus,
 	}
 }
 
@@ -708,7 +723,28 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 		info.Files = append(info.Files, fi)
 	}
 
+	info.HiddenUnresolved = snap.hiddenUnresolved(info.Files)
 	return info
+}
+
+// hiddenUnresolved returns the count of unresolved comments that exist outside
+// the given file list (and outside the snapshot's review comments), so the
+// client can correctly label the finish button when out-of-scope comments are
+// not loaded. Computed from data captured under the same lock as the snapshot.
+func (snap *scopedSessionSnapshot) hiddenUnresolved(scopeFiles []SessionFileInfo) int {
+	scopeUnresolved := 0
+	for _, c := range snap.reviewComments {
+		if !c.Resolved {
+			scopeUnresolved++
+		}
+	}
+	for _, fi := range scopeFiles {
+		scopeUnresolved += snap.unresolvedCounts[fi.Path]
+	}
+	if hidden := snap.totalUnresolved - scopeUnresolved; hidden > 0 {
+		return hidden
+	}
+	return 0
 }
 
 // loadScopedFileState reads file state from the session or disk for scoped diff queries.


### PR DESCRIPTION
## Summary
- Add `background` + `border-color` to `.header-chip.header-context` using `--crit-brand-subtle` / `--crit-brand-bg` so the active branch chip has a visible tint in all four themes
- Add `hidden_unresolved` to the session API response: the count of unresolved comments on files outside the current focused/scoped view. The finish-button label (Approve vs Finish Review) now correctly accounts for comments the user can't see in the current scope
- Fixed a TOCTOU in the original approach: total and scope-unresolved counts are now computed under the same `RLock` in `snapshotForScoped`

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (header chip and finish-button CTA are crit-local only)

## Test plan
- Existing test suite passes (`go test -race ./...`)
- Manual: verify header chip shows tint in light/dark/system themes
- Manual: verify finish button shows "Finish Review" when unresolved comments exist on out-of-scope files while in a scoped view

🤖 Generated with [Claude Code](https://claude.com/claude-code)