### PR TITLE
test(e2e): deeper flakiness audit — retrying assertions and CI guards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,7 @@ jobs:
         run: npx playwright install chromium
 
       - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: e2e
         run: npx playwright install-deps chromium
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,7 +13,16 @@ export default defineConfig({
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
-  reporter: [['html', { open: 'never' }], ['list']],
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }], ['list']]
+    : [['html', { open: 'never' }], ['list']],
+
+  // Per-test timeout: 60s on CI (some tests write review files and wait for
+  // SSE events); 30s locally is fine since slow tests won't hit it in practice.
+  timeout: process.env.CI ? 60_000 : 30_000,
+
+  // Hard ceiling so a single hung test can't stall the entire job.
+  globalTimeout: process.env.CI ? 20 * 60 * 1000 : undefined,
 
   use: {
     screenshot: 'only-on-failure',

--- a/e2e/tests/file-tree.spec.ts
+++ b/e2e/tests/file-tree.spec.ts
@@ -22,18 +22,15 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file tree shows correct file names', async ({ page }) => {
-    const fileNames = page.locator('.tree-file-name');
-    const names: string[] = [];
-    const count = await fileNames.count();
-    for (let i = 0; i < count; i++) {
-      names.push(await fileNames.nth(i).textContent() || '');
-    }
-    expect(names).toContain('plan.md');
-    expect(names).toContain('server.go');
-    expect(names).toContain('handler.js');
-    expect(names).toContain('deleted.txt');
-    expect(names).toContain('utils.go');
-    expect(names).toContain('config.yaml');
+    // Wait for the expected files to be visible individually rather than
+    // taking a count() snapshot that races with tree rendering.
+    const tree = page.locator('#fileTreePanel');
+    await expect(tree.locator('.tree-file-name', { hasText: 'plan.md' })).toBeVisible();
+    await expect(tree.locator('.tree-file-name', { hasText: 'server.go' })).toBeVisible();
+    await expect(tree.locator('.tree-file-name', { hasText: 'handler.js' })).toBeVisible();
+    await expect(tree.locator('.tree-file-name', { hasText: 'deleted.txt' })).toBeVisible();
+    await expect(tree.locator('.tree-file-name', { hasText: 'utils.go' })).toBeVisible();
+    await expect(tree.locator('.tree-file-name', { hasText: 'config.yaml' })).toBeVisible();
   });
 
   test('file tree header shows file count', async ({ page }) => {

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { loadPage } from './helpers';
+import { loadPage, clearAllComments } from './helpers';
 
 async function switchScope(page: Page, scope: string) {
   const responsePromise = page.waitForResponse(resp =>
@@ -10,6 +10,10 @@ async function switchScope(page: Page, scope: string) {
   // Wait for the clicked button to become active
   await expect(page.locator(`#scopeToggle .toggle-btn[data-scope="${scope}"]`)).toHaveClass(/active/);
 }
+
+test.beforeEach(async ({ request }) => {
+  await clearAllComments(request);
+});
 
 test.afterEach(async ({ page }) => {
   // Reset scope cookie so other test files aren't affected

--- a/e2e/tests/syntax-highlighting.spec.ts
+++ b/e2e/tests/syntax-highlighting.spec.ts
@@ -15,8 +15,7 @@ test.describe('Syntax Highlighting — Split Mode', () => {
     await expect(rightSide).toBeVisible();
 
     // Check that the content contains <span> elements (hljs highlighting)
-    const spanCount = await rightSide.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(rightSide.locator('span')).not.toHaveCount(0);
   });
 
   test('JavaScript file has syntax-highlighted code in split diff', async ({ page }) => {
@@ -27,8 +26,7 @@ test.describe('Syntax Highlighting — Split Mode', () => {
     const rightSide = section.locator('.diff-split-side.addition .diff-content').first();
     await expect(rightSide).toBeVisible();
 
-    const spanCount = await rightSide.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(rightSide.locator('span')).not.toHaveCount(0);
   });
 
   test('old side (deletion) lines also have syntax highlighting', async ({ page }) => {
@@ -39,31 +37,32 @@ test.describe('Syntax Highlighting — Split Mode', () => {
     const leftSide = section.locator('.diff-split-side.deletion .diff-content').first();
     await expect(leftSide).toBeVisible();
 
-    const spanCount = await leftSide.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(leftSide.locator('span')).not.toHaveCount(0);
   });
 
   test('context lines have syntax highlighting', async ({ page }) => {
     await loadPage(page);
     const section = goSection(page);
 
-    // Context lines (no addition/deletion) should also be highlighted
-    // Find a row where right side has no addition/deletion class
-    const rows = section.locator('.diff-split-row');
-    const count = await rows.count();
-    let foundHighlighted = false;
-    for (let i = 0; i < count && !foundHighlighted; i++) {
-      const right = rows.nth(i).locator('.diff-split-side.right');
-      const isAddition = await right.evaluate(el => el.classList.contains('addition'));
-      const isDeletion = await right.evaluate(el => el.classList.contains('deletion'));
-      const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
-      if (!isAddition && !isDeletion && !isEmpty) {
-        const content = right.locator('.diff-content');
-        const spans = await content.locator('span').count();
-        if (spans > 0) foundHighlighted = true;
+    // Context lines (no addition/deletion) should also be highlighted.
+    // Use toPass() so the DOM is stable before counting rows.
+    await expect(async () => {
+      const rows = section.locator('.diff-split-row');
+      const count = await rows.count();
+      expect(count).toBeGreaterThan(0);
+      let foundHighlighted = false;
+      for (let i = 0; i < count && !foundHighlighted; i++) {
+        const right = rows.nth(i).locator('.diff-split-side.right');
+        const isAddition = await right.evaluate(el => el.classList.contains('addition'));
+        const isDeletion = await right.evaluate(el => el.classList.contains('deletion'));
+        const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
+        if (!isAddition && !isDeletion && !isEmpty) {
+          const spans = await right.locator('.diff-content span').count();
+          if (spans > 0) foundHighlighted = true;
+        }
       }
-    }
-    expect(foundHighlighted).toBe(true);
+      expect(foundHighlighted).toBe(true);
+    }).toPass();
   });
 });
 
@@ -77,12 +76,10 @@ test.describe('Syntax Highlighting — hljs alias resolution', () => {
     await expect(additionLine).toBeVisible();
 
     // Gherkin keywords (Feature, Scenario, Given, When, Then) should be tokenized.
-    const spanCount = await additionLine.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(additionLine.locator('span')).not.toHaveCount(0);
 
     // Confirm hljs class is present somewhere in the section's diff content.
-    const anyHljsClass = await section.locator('.diff-content span[class*="hljs-"]').first();
-    await expect(anyHljsClass).toBeVisible();
+    await expect(section.locator('.diff-content span[class*="hljs-"]').first()).toBeVisible();
   });
 });
 
@@ -96,8 +93,7 @@ test.describe('Syntax Highlighting — Unified Mode', () => {
     const additionLine = section.locator('.diff-container.unified .diff-line.addition .diff-content').first();
     await expect(additionLine).toBeVisible();
 
-    const spanCount = await additionLine.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(additionLine.locator('span')).not.toHaveCount(0);
   });
 
   test('deletion lines in unified mode have syntax highlighting', async ({ page }) => {
@@ -108,8 +104,7 @@ test.describe('Syntax Highlighting — Unified Mode', () => {
     const deletionLine = section.locator('.diff-container.unified .diff-line.deletion .diff-content').first();
     await expect(deletionLine).toBeVisible();
 
-    const spanCount = await deletionLine.locator('span').count();
-    expect(spanCount).toBeGreaterThan(0);
+    await expect(deletionLine.locator('span')).not.toHaveCount(0);
   });
 });
 
@@ -120,19 +115,22 @@ test.describe('Syntax Highlighting — Expanded Context', () => {
 
     // server.go's small gaps are auto-expanded, so context lines are already
     // visible without clicking a spacer. Find a context line and check for spans.
-    const rows = section.locator('.diff-split-row');
-    const count = await rows.count();
-    let foundHighlighted = false;
-    for (let i = 0; i < count && !foundHighlighted; i++) {
-      const right = rows.nth(i).locator('.diff-split-side.right');
-      const isAddition = await right.evaluate(el => el.classList.contains('addition'));
-      const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
-      if (!isAddition && !isEmpty) {
-        const content = right.locator('.diff-content');
-        const spans = await content.locator('span').count();
-        if (spans > 0) foundHighlighted = true;
+    // Wrap in toPass() so the DOM is stable before iterating rows.
+    await expect(async () => {
+      const rows = section.locator('.diff-split-row');
+      const count = await rows.count();
+      expect(count).toBeGreaterThan(0);
+      let foundHighlighted = false;
+      for (let i = 0; i < count && !foundHighlighted; i++) {
+        const right = rows.nth(i).locator('.diff-split-side.right');
+        const isAddition = await right.evaluate(el => el.classList.contains('addition'));
+        const isEmpty = await right.evaluate(el => el.classList.contains('empty'));
+        if (!isAddition && !isEmpty) {
+          const spans = await right.locator('.diff-content span').count();
+          if (spans > 0) foundHighlighted = true;
+        }
       }
-    }
-    expect(foundHighlighted).toBe(true);
+      expect(foundHighlighted).toBe(true);
+    }).toPass();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #489. A deeper pass through every test file and the CI workflow.

**Test suite fixes:**
- `syntax-highlighting.spec.ts`: 6 bare `.count()→expect(count)` → retrying `not.toHaveCount(0)`; 2 count-loop tests wrapped in `toPass()` so DOM is stable before iterating
- `file-tree.spec.ts`: count-loop over file names → 6 individual `toBeVisible()` assertions that auto-retry
- `scope-toggle.spec.ts`: add `clearAllComments` in `beforeEach` — leftover state could silently interfere with hardcoded `toHaveCount` assertions

**Playwright config:**
- Add `['github']` reporter on CI — test failures annotate PR diffs inline instead of requiring artifact downloads
- Raise per-test timeout 30s → 60s on CI (round-complete tests do SSE waits + file I/O)
- Add `globalTimeout: 20min` on CI — prevents a hung test from stalling the entire job indefinitely

**CI workflow:**
- Guard `install-deps` with `cache-hit != 'true'` — `apt-get install` (~30s) was running unconditionally even on a warm Playwright browser cache hit

## Patterns NOT fixed (with reason)
- `.count()` after `.toBeVisible()` gates in drag-selection, incremental-expand, select-to-comment — already stable
- `.count()` inside `toPass()` loops (toc-scrollspy) — self-retrying
- Fixture caching — would require tar/restore with hash-based cache key; complexity not worth it at current run time

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (no frontend/backend behavior changes)

## Test plan
- No Go code changed
- All changes are test infrastructure — makes assertions retrying or adds CI safety guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)