### PR TITLE
Add Jujutsu VCS backend support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ crit/
 ├── share.go             # Share/unpublish to crit-web, share CLI subcommand
 ├── plans.go             # Plan file detection and handling
 ├── integrations.go      # Integration config installation (crit install <agent>)
-├── vcs.go / git_vcs.go / sapling.go / sapling_parse.go  # VCS abstraction (git + sapling)
+├── vcs.go / git_vcs.go / sapling.go / jj.go  # VCS abstraction (git + sapling + jj)
 ├── auth.go              # Hosted crit-web auth flow (login/logout, token storage)
 ├── focus_*.go / picker.go  # Focus mode (range, stacked) + file picker backend
 ├── review_file.go       # Review file (~/.crit/reviews/<key>.json) read/write — saveCritJSON
@@ -58,7 +58,7 @@ crit/
 12. **Headless CLI comment** — `crit comment` writes directly to the review file without starting the server; SSE notifies any running server
 13. **Comment threading** — comments support nested replies and a `resolved` boolean. Review file schema nests replies inside each comment's `replies` array.
 14. **Centralized review storage** — `~/.crit/reviews/<key>.json` keyed by cwd + branch (git mode) or cwd + args (file mode)
-15. **VCS abstraction** — `vcs.go` defines a backend interface; `git_vcs.go` and `sapling.go` are the implementations. Auto-detected, overridable via `--vcs` flag or `vcs` config key. Subcommands not yet threaded through (see TODO at `main.go:1826`).
+15. **VCS abstraction** — `vcs.go` defines a backend interface; `git_vcs.go`, `sapling.go`, and `jj.go` are the implementations. Auto-detected, overridable via `--vcs` flag or `vcs` config key. Subcommands not yet threaded through (see TODO at `main.go:1826`).
 16. **Focus mode** — sub-views over the file list: file focus, range focus (`--range A..B`), stacked focus (range layer in a stacked PR). Lives in `focus_*.go` and `/api/focus`.
 
 <important if="you need to build, test, lint, or run crit">
@@ -117,11 +117,11 @@ Two-level JSON config files, merged (project overrides global):
 Config keys: `port`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `no_update_check`, `no_integration_check`, `vcs`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
-- `author` falls back to `git config user.name` if not set
+- `author` falls back to the configured VCS user name if not set
 - `agent_cmd` is **global config only**; project-level config cannot override (security)
 - `cleanup_on_approve` (default: `true`) — auto-delete review file when reviewer approves with no unresolved comments
 - `ignore_patterns` are unioned (global + project both apply); types: `*.ext`, `dir/`, `exact.file`, `path/*.ext`
-- `vcs` selects backend: `"git"` (default) or `"sl"` (sapling)
+- `vcs` selects backend: `"git"` (default), `"sl"` (sapling), or `"jj"` (Jujutsu)
 - `auth_*` keys hold cached hosted-crit-web credentials (set by `crit auth`); treat as secrets
 - CLI flags override config file values
 </important>

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ All keys are optional — omit any you don't need.
 | `share_url`            | string   | `"https://crit.md"`        | Base URL of the share service. Set to `""` to disable sharing entirely. Self-host with [`crit-web`](https://github.com/tomasz-tomczyk/crit-web).                                        |
 | `quiet`                | bool     | `false`                    | Suppress terminal status output.                                                                                                                                                        |
 | `output`               | string   | repo root or file dir      | Output directory for review files. Reviews are stored in `~/.crit/reviews/` by default.                                                                                                 |
-| `author`               | string   | `git config user.name`     | Author name shown on comments. Falls back to your git user name.                                                                                                                        |
+| `author`               | string   | VCS user name              | Author name shown on comments. Falls back to your configured VCS user name.                                                                                                            |
 | `base_branch`          | string   | auto-detected              | Base branch to diff against (e.g. `"main"`, `"develop"`). Overrides auto-detection.                                                                                                     |
 | `ignore_patterns`      | string[] | `[".crit/"]` | File patterns to exclude from git-mode file lists. Global and project patterns are merged.                                                                                              |
 | `agent_cmd`            | string   | `""`                       | Shell command for "Send to agent" (e.g. `"claude -p"`). **Global config only** — project config cannot set this for security reasons. See [Send to agent](#send-to-agent-experimental). |
@@ -273,7 +273,7 @@ All keys are optional — omit any you don't need.
 | `cleanup_on_approve`   | bool     | `true`                     | Automatically delete the review file when you approve with no unresolved comments. Set to `false` to preserve review history.                                                           |
 | `no_update_check`      | bool     | `false`                    | Don't check for new versions on startup.                                                                                                                                                |
 | `no_integration_check` | bool     | `false`                    | Skip the integration config freshness check on startup.                                                                                                                                 |
-| `vcs`                  | string   | auto-detected              | Preferred VCS backend: `"git"`, `"sl"`. When set, crit uses this VCS instead of auto-detecting. Falls back to git if the configured VCS isn't available. Can also be set via `--vcs` CLI flag (flag takes precedence over config). |
+| `vcs`                  | string   | auto-detected              | Preferred VCS backend: `"git"`, `"sl"`, or `"jj"`. When set, crit uses this VCS instead of auto-detecting. Falls back to git if the configured VCS isn't available. Can also be set via `--vcs` CLI flag (flag takes precedence over config). |
 
 ### CLI flags
 
@@ -285,7 +285,7 @@ All keys are optional — omit any you don't need.
 | `--output`      | `-o`  | `output`              | Output directory for review files      |
 | `--quiet`       | `-q`  | `quiet`               | Suppress status output                 |
 | `--base-branch` |       | `base_branch`         | Base branch to diff against            |
-| `--vcs`         |       | `vcs`                 | VCS backend (`git` or `sl`)            |
+| `--vcs`         |       | `vcs`                 | VCS backend (`git`, `sl`, or `jj`)     |
 | `--no-ignore`   |       |                       | Temporarily bypass all ignore patterns |
 | `--version`     | `-v`  |                       | Print version and exit                 |
 

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -34,7 +34,7 @@ type serverConfig struct {
 	planDir            string // managed storage directory for plan mode
 	planName           string // display name for plan content
 	reviewPath         string // centralized review file path (~/.crit/reviews/<key>.json)
-	vcsOverride        string // "git", "sl"/"sapling", or "" for auto-detect
+	vcsOverride        string // "git", "sl"/"sapling", "jj"/"jujutsu", or "" for auto-detect
 	cfg                Config // full resolved config for the settings panel
 
 	// focus is populated by resolveFocus when --pr or --range is set;
@@ -86,7 +86,7 @@ func parseServerFlags(args []string) serverFlagSet {
 	fs.BoolVar(quiet, "q", false, "Suppress status output (shorthand)")
 	noIgnore := fs.Bool("no-ignore", false, "Disable all ignore patterns from config files")
 	baseBranch := fs.String("base-branch", "", "Base branch to diff against (overrides auto-detection)")
-	vcsFlag := fs.String("vcs", "", "VCS backend to use: git, sl/sapling (default: auto-detect)")
+	vcsFlag := fs.String("vcs", "", "VCS backend to use: git, sl/sapling, jj/jujutsu (default: auto-detect)")
 	planDir := fs.String("plan-dir", "", "")
 	planName := fs.String("name", "", "")
 	prSpec := fs.String("pr", "", "Review a specific PR by number or URL (e.g. 295 or https://github.com/o/r/pull/295)")

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	AuthUserEmail      string   `json:"auth_user_email,omitempty"`
 	AuthUserID         string   `json:"auth_user_id,omitempty"`
 	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
-	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl"
+	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl", "jj"
 }
 
 // CleanupOnApproveEnabled returns whether review files should be cleaned up
@@ -234,6 +234,11 @@ func LoadConfig(projectDir string) Config {
 		switch merged.VCS {
 		case "sl", "sapling":
 			merged.Author = slUserName()
+			if merged.Author == "" {
+				merged.Author = gitUserName()
+			}
+		case "jj", "jujutsu":
+			merged.Author = jjUserName()
 			if merged.Author == "" {
 				merged.Author = gitUserName()
 			}

--- a/git.go
+++ b/git.go
@@ -618,67 +618,65 @@ func walkAncestors(vcs VCS, repoRoot string, maxDepth int) ([]string, error) {
 }
 
 // localBranchTips returns SHAs that have a useful local label, mapped to that
-// label. For git: refs/heads/ entries. For sapling: bookmarks (when present)
-// plus draft commit first-line descriptions for stack labels.
+// label. For git: refs/heads/ entries. For sapling/JJ: bookmarks when present,
+// plus in-progress commit descriptions for stack labels.
 func localBranchTips(vcs VCS, repoRoot string) (map[string]string, error) {
 	if vcs == nil {
 		return nil, nil
 	}
-	if vcs.Name() == "git" {
-		out, err := runGitInDir(repoRoot, "for-each-ref", "--format=%(objectname) %(refname:short)", "refs/heads/")
-		if err != nil {
-			return nil, err
-		}
-		result := make(map[string]string)
-		for _, line := range splitNonEmpty(out) {
-			parts := strings.SplitN(line, " ", 2)
-			if len(parts) == 2 {
-				result[parts[0]] = parts[1]
-			}
-		}
-		return result, nil
+	switch vcs.Name() {
+	case "git":
+		return localBranchTipsGit(repoRoot)
+	case "jj":
+		return localBranchTipsJJ(repoRoot), nil
+	default:
+		return localBranchTipsSapling(repoRoot), nil
+	}
+}
+
+func localBranchTipsGit(repoRoot string) (map[string]string, error) {
+	out, err := runGitInDir(repoRoot, "for-each-ref", "--format=%(objectname) %(refname:short)", "refs/heads/")
+	if err != nil {
+		return nil, err
 	}
 	result := make(map[string]string)
-	if vcs.Name() == "jj" {
-		if bookmarks, err := jjCommandInDir(repoRoot, "bookmark", "list", "-T", "normal_target.commit_id() ++ \" \" ++ name ++ \"\\n\""); err == nil {
-			for _, line := range splitNonEmpty(bookmarks) {
-				parts := strings.SplitN(line, " ", 2)
-				if len(parts) == 2 {
-					result[parts[0]] = parts[1]
-				}
-			}
-		}
-		if drafts, err := jjCommandInDir(repoRoot, "log", "-r", jjTopicChainRevset(repoRoot, 0), "--no-graph", "-T", "commit_id ++ \" \" ++ description.first_line() ++ \"\\n\""); err == nil {
-			for _, line := range splitNonEmpty(drafts) {
-				parts := strings.SplitN(line, " ", 2)
-				if len(parts) == 2 {
-					if _, ok := result[parts[0]]; !ok {
-						result[parts[0]] = parts[1]
-					}
-				}
-			}
-		}
-		return result, nil
+	addLabelLines(result, out, true)
+	return result, nil
+}
+
+func localBranchTipsJJ(repoRoot string) map[string]string {
+	result := make(map[string]string)
+	if bookmarks, err := jjCommandInDir(repoRoot, "bookmark", "list", "-T", "normal_target.commit_id() ++ \" \" ++ name ++ \"\\n\""); err == nil {
+		addLabelLines(result, bookmarks, true)
 	}
+	if drafts, err := jjCommandInDir(repoRoot, "log", "-r", jjTopicChainRevset(repoRoot, 0), "--no-graph", "-T", "commit_id ++ \" \" ++ description.first_line() ++ \"\\n\""); err == nil {
+		addLabelLines(result, drafts, false)
+	}
+	return result
+}
+
+func localBranchTipsSapling(repoRoot string) map[string]string {
+	result := make(map[string]string)
 	if bookmarks, err := slCommandInDir(repoRoot, "bookmarks", "-T", "{node} {bookmark}\n"); err == nil {
-		for _, line := range splitNonEmpty(bookmarks) {
-			parts := strings.SplitN(line, " ", 2)
-			if len(parts) == 2 {
-				result[parts[0]] = parts[1]
-			}
-		}
+		addLabelLines(result, bookmarks, true)
 	}
 	if drafts, err := slCommandInDir(repoRoot, "log", "-r", "draft()", "-T", "{node} {desc|firstline}\n"); err == nil {
-		for _, line := range splitNonEmpty(drafts) {
-			parts := strings.SplitN(line, " ", 2)
-			if len(parts) == 2 {
-				if _, ok := result[parts[0]]; !ok {
-					result[parts[0]] = parts[1]
-				}
-			}
-		}
+		addLabelLines(result, drafts, false)
 	}
-	return result, nil
+	return result
+}
+
+func addLabelLines(result map[string]string, output string, overwrite bool) {
+	for _, line := range splitNonEmpty(output) {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if _, ok := result[parts[0]]; ok && !overwrite {
+			continue
+		}
+		result[parts[0]] = parts[1]
+	}
 }
 
 // remoteBranchTips returns up to 20 remote branches sorted by recency,

--- a/git.go
+++ b/git.go
@@ -554,7 +554,8 @@ func ResolveDefaultBranchSHA(vcs VCS, repoRoot, defaultBranch string) (string, e
 	if vcs == nil || defaultBranch == "" {
 		return "", fmt.Errorf("default branch unknown")
 	}
-	if vcs.Name() == "git" {
+	switch vcs.Name() {
+	case "git":
 		if out, err := runGitInDir(repoRoot, "rev-parse", "--verify", "origin/"+defaultBranch); err == nil {
 			return strings.TrimSpace(out), nil
 		}
@@ -562,15 +563,27 @@ func ResolveDefaultBranchSHA(vcs VCS, repoRoot, defaultBranch string) (string, e
 			return strings.TrimSpace(out), nil
 		}
 		return "", fmt.Errorf("could not resolve %s tip", defaultBranch)
+	case "jj":
+		if defaultBranch == jjTrunkRevset {
+			_, sha := resolveJJDefaultBaseInDir(repoRoot)
+			if sha != "" {
+				return sha, nil
+			}
+		}
+		if sha, err := resolveJJRevisionToCommitID(repoRoot, defaultBranch); err == nil && strings.TrimSpace(sha) != "" {
+			return strings.TrimSpace(sha), nil
+		}
+		return "", fmt.Errorf("could not resolve %s tip", defaultBranch)
+	default:
+		// Sapling: try remote bookmark, then local.
+		if out, err := slCommandInDir(repoRoot, "log", "-r", "remote/"+defaultBranch, "-T", "{node}"); err == nil && strings.TrimSpace(out) != "" {
+			return strings.TrimSpace(out), nil
+		}
+		if out, err := slCommandInDir(repoRoot, "log", "-r", defaultBranch, "-T", "{node}"); err == nil && strings.TrimSpace(out) != "" {
+			return strings.TrimSpace(out), nil
+		}
+		return "", fmt.Errorf("could not resolve %s tip", defaultBranch)
 	}
-	// Sapling: try remote bookmark, then local.
-	if out, err := slCommandInDir(repoRoot, "log", "-r", "remote/"+defaultBranch, "-T", "{node}"); err == nil && strings.TrimSpace(out) != "" {
-		return strings.TrimSpace(out), nil
-	}
-	if out, err := slCommandInDir(repoRoot, "log", "-r", defaultBranch, "-T", "{node}"); err == nil && strings.TrimSpace(out) != "" {
-		return strings.TrimSpace(out), nil
-	}
-	return "", fmt.Errorf("could not resolve %s tip", defaultBranch)
 }
 
 // walkAncestors enumerates HEAD-first the recent ancestor SHAs that are
@@ -579,21 +592,29 @@ func walkAncestors(vcs VCS, repoRoot string, maxDepth int) ([]string, error) {
 	if vcs == nil {
 		return nil, nil
 	}
-	if vcs.Name() == "git" {
+	switch vcs.Name() {
+	case "git":
 		out, err := runGitInDir(repoRoot, "rev-list", "--first-parent", "-n", strconv.Itoa(maxDepth), "HEAD")
 		if err != nil {
 			return nil, err
 		}
 		return splitNonEmpty(out), nil
+	case "jj":
+		out, err := jjCommandInDir(repoRoot, "log", "-r", jjTopicChainRevset(repoRoot, maxDepth), "--no-graph", "-T", "commit_id ++ \"\\n\"")
+		if err != nil {
+			return nil, err
+		}
+		return splitNonEmpty(out), nil
+	default:
+		// Sapling: ancestors of `.` that are still draft.
+		out, err := slCommandInDir(repoRoot, "log", "-r",
+			fmt.Sprintf("ancestors(., %d) & draft()", maxDepth),
+			"-T", "{node}\n")
+		if err != nil {
+			return nil, err
+		}
+		return splitNonEmpty(out), nil
 	}
-	// Sapling: ancestors of `.` that are still draft.
-	out, err := slCommandInDir(repoRoot, "log", "-r",
-		fmt.Sprintf("ancestors(., %d) & draft()", maxDepth),
-		"-T", "{node}\n")
-	if err != nil {
-		return nil, err
-	}
-	return splitNonEmpty(out), nil
 }
 
 // localBranchTips returns SHAs that have a useful local label, mapped to that
@@ -618,6 +639,27 @@ func localBranchTips(vcs VCS, repoRoot string) (map[string]string, error) {
 		return result, nil
 	}
 	result := make(map[string]string)
+	if vcs.Name() == "jj" {
+		if bookmarks, err := jjCommandInDir(repoRoot, "bookmark", "list", "-T", "normal_target.commit_id() ++ \" \" ++ name ++ \"\\n\""); err == nil {
+			for _, line := range splitNonEmpty(bookmarks) {
+				parts := strings.SplitN(line, " ", 2)
+				if len(parts) == 2 {
+					result[parts[0]] = parts[1]
+				}
+			}
+		}
+		if drafts, err := jjCommandInDir(repoRoot, "log", "-r", jjTopicChainRevset(repoRoot, 0), "--no-graph", "-T", "commit_id ++ \" \" ++ description.first_line() ++ \"\\n\""); err == nil {
+			for _, line := range splitNonEmpty(drafts) {
+				parts := strings.SplitN(line, " ", 2)
+				if len(parts) == 2 {
+					if _, ok := result[parts[0]]; !ok {
+						result[parts[0]] = parts[1]
+					}
+				}
+			}
+		}
+		return result, nil
+	}
 	if bookmarks, err := slCommandInDir(repoRoot, "bookmarks", "-T", "{node} {bookmark}\n"); err == nil {
 		for _, line := range splitNonEmpty(bookmarks) {
 			parts := strings.SplitN(line, " ", 2)
@@ -646,10 +688,14 @@ func remoteBranchTips(vcs VCS, repoRoot, defaultBranch string) ([]BranchEntry, e
 	if vcs == nil {
 		return nil, nil
 	}
-	if vcs.Name() == "git" {
+	switch vcs.Name() {
+	case "git":
 		return remoteBranchTipsGit(repoRoot, defaultBranch)
+	case "jj":
+		return remoteBranchTipsJJ(repoRoot, defaultBranch)
+	default:
+		return remoteBranchTipsSapling(repoRoot, defaultBranch)
 	}
-	return remoteBranchTipsSapling(repoRoot, defaultBranch)
 }
 
 func remoteBranchTipsGit(repoRoot, defaultBranch string) ([]BranchEntry, error) {
@@ -673,6 +719,37 @@ func remoteBranchTipsGit(repoRoot, defaultBranch string) ([]BranchEntry, error) 
 		if name == "origin/"+defaultBranch || name == defaultBranch {
 			continue
 		}
+		entries = append(entries, BranchEntry{Name: name, HeadSHA: parts[0]})
+		if len(entries) >= 20 {
+			break
+		}
+	}
+	return entries, nil
+}
+
+func remoteBranchTipsJJ(repoRoot, defaultBranch string) ([]BranchEntry, error) {
+	out, err := jjCommandInDir(repoRoot, "bookmark", "list", "--all-remotes", "-T", "normal_target.commit_id() ++ \" \" ++ name ++ \"@\" ++ remote ++ \"\\n\"")
+	if err != nil {
+		return nil, nil //nolint:nilerr // best-effort; remote bookmarks may not be configured
+	}
+	seen := make(map[string]bool)
+	var entries []BranchEntry
+	for _, line := range splitNonEmpty(out) {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[1])
+		if !strings.Contains(name, "@") || strings.HasSuffix(name, "@") || strings.HasSuffix(name, "@git") || name == "@" {
+			continue
+		}
+		if strings.TrimSuffix(name, "@origin") == defaultBranch || strings.TrimSuffix(name, "@upstream") == defaultBranch {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
 		entries = append(entries, BranchEntry{Name: name, HeadSHA: parts[0]})
 		if len(entries) >= 20 {
 			break
@@ -855,6 +932,7 @@ var skipDirs = map[string]bool{
 	"vendor":       true,
 	"__pycache__":  true,
 	".git":         true,
+	".jj":          true,
 	".sl":          true,
 	"dist":         true,
 	"build":        true,

--- a/github.go
+++ b/github.go
@@ -414,6 +414,9 @@ func ensureSHAFetched(vcs VCS, sha, repoRoot, forkURL string) error {
 	if vcs.Name() == "sl" {
 		return ensureSHAFetchedSapling(vcs, sha, repoRoot, forkURL)
 	}
+	if vcs.Name() == "jj" {
+		return ensureSHAFetchedJJ(vcs, sha, repoRoot, forkURL)
+	}
 	if vcs.Name() != "git" {
 		return fmt.Errorf("commit %s not present locally (auto-fetch not supported for vcs=%q)", sha, vcs.Name())
 	}
@@ -433,6 +436,28 @@ func ensureSHAFetched(vcs VCS, sha, repoRoot, forkURL string) error {
 		return fmt.Errorf("commit %s not present locally; tried origin and fork %s — manual fetch required", sha, forkURL)
 	}
 	return fmt.Errorf("commit %s not present locally; manual fetch required (run `git fetch <remote> %s`)", sha, sha)
+}
+
+// ensureSHAFetchedJJ falls back to git fetch for colocated JJ/Git repos. Pure
+// JJ repos do not expose a stable command for fetching an arbitrary commit id
+// from an arbitrary URL, so range/PR focus reports a clear manual-fetch error.
+func ensureSHAFetchedJJ(vcs VCS, sha, repoRoot, forkURL string) error {
+	if hasGitDirAt(repoRoot) {
+		if err := tryGitFetch(repoRoot, "origin", sha); err == nil && vcs.HasObject(sha, repoRoot) {
+			return nil
+		}
+		if forkURL != "" {
+			if err := tryGitFetch(repoRoot, forkURL, sha); err == nil && vcs.HasObject(sha, repoRoot) {
+				return nil
+			}
+			return fmt.Errorf("commit %s not present locally; tried `git fetch origin %s` and `git fetch %s %s` for colocated JJ repo — manual fetch required", sha, sha, forkURL, sha)
+		}
+		return fmt.Errorf("commit %s not present locally; manual fetch required (run `git fetch <remote> %s` in the colocated JJ repo)", sha, sha)
+	}
+	if forkURL != "" {
+		return fmt.Errorf("commit %s not present locally; PR head is on fork %s. Pure JJ auto-fetch is not supported — fetch it manually and re-run", sha, forkURL)
+	}
+	return fmt.Errorf("commit %s not present locally; pure JJ auto-fetch is not supported — fetch it manually and re-run", sha)
 }
 
 // ensureSHAFetchedSapling tries `sl pull -r <sha>` first, then falls back to

--- a/jj.go
+++ b/jj.go
@@ -1,0 +1,570 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	jjRootCommitID = "0000000000000000000000000000000000000000"
+	jjTrunkRevset  = "trunk()"
+)
+
+// JJVCS implements VCS for Jujutsu repositories. Crit treats JJ's working-copy
+// commit as the review head and uses trunk()/bookmark resolution only to choose
+// the base revision; staged/unstaged scopes are intentionally unavailable.
+type JJVCS struct {
+	defaultOnce   sync.Once
+	defaultBranch string
+	defaultBase   string
+	overrideBase  string
+	mu            sync.RWMutex
+}
+
+func (j *JJVCS) Name() string { return "jj" }
+
+// RepoRoot returns the absolute path to the Jujutsu repository root.
+func (j *JJVCS) RepoRoot() (string, error) {
+	out, err := jjCommandInDir("", "root")
+	if err != nil {
+		return "", fmt.Errorf("jj root: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// CurrentBranch returns a stable session label: a bookmark at @ when present,
+// otherwise JJ's short change id for the working-copy commit.
+func (j *JJVCS) CurrentBranch() string {
+	out, err := jjCommandInDir("", "log", "-r", "@", "--no-graph", "-T", "local_bookmarks ++ \"\\n\" ++ change_id.short() ++ \"\\n\"")
+	if err != nil {
+		return ""
+	}
+	lines := splitNonEmpty(out)
+	if len(lines) == 0 {
+		return ""
+	}
+	bookmarks := strings.Fields(lines[0])
+	if len(bookmarks) > 0 {
+		return bookmarks[0]
+	}
+	if len(lines) > 1 {
+		return strings.TrimSpace(lines[1])
+	}
+	return ""
+}
+
+// DefaultBranch returns the display name for the default base. trunk() is the
+// primary source; when JJ resolves trunk() to root in local-only repos, exact
+// main/master/trunk bookmark lookup is used as a practical fallback.
+func (j *JJVCS) DefaultBranch() string {
+	j.mu.RLock()
+	override := j.overrideBase
+	j.mu.RUnlock()
+	if override != "" {
+		return override
+	}
+	j.defaultOnce.Do(func() {
+		name, sha := resolveJJDefaultBaseInDir("")
+		j.mu.Lock()
+		j.defaultBranch = name
+		j.defaultBase = sha
+		j.mu.Unlock()
+	})
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	if j.overrideBase != "" {
+		return j.overrideBase
+	}
+	return j.defaultBranch
+}
+
+// SetDefaultBranchOverride sets the base ref used for diffs. The value may be a
+// bookmark, remote bookmark, commit id, or JJ revset accepted by jj log -r.
+func (j *JJVCS) SetDefaultBranchOverride(branch string) {
+	j.mu.Lock()
+	j.overrideBase = branch
+	j.mu.Unlock()
+}
+
+func (j *JJVCS) GetDefaultBranchOverride() string {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return j.overrideBase
+}
+
+// DefaultBaseRef returns the commit id behind the default base. Returning a
+// commit id avoids JJ revset alias shadowing for names like `main`.
+func (j *JJVCS) DefaultBaseRef() string {
+	j.mu.RLock()
+	override := j.overrideBase
+	j.mu.RUnlock()
+	if override != "" {
+		if override == jjTrunkRevset {
+			_, sha := resolveJJDefaultBaseInDir("")
+			if sha != "" {
+				return sha
+			}
+		}
+		if sha, err := resolveJJRevisionToCommitID("", override); err == nil {
+			return sha
+		}
+		return override
+	}
+	_ = j.DefaultBranch()
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return j.defaultBase
+}
+
+// MergeBase returns the best common ancestor between @ and ref.
+func (j *JJVCS) MergeBase(ref string) (string, error) {
+	if strings.TrimSpace(ref) == "" {
+		return "", fmt.Errorf("base ref is empty")
+	}
+	base, err := resolveJJRevisionToCommitID("", ref)
+	if err != nil {
+		return "", err
+	}
+	return jjMergeBase("", "@", base)
+}
+
+func (j *JJVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
+	out, err := jjCommandInDir(dir, "diff", "--summary", "-r", "@")
+	if err != nil {
+		return nil, err
+	}
+	return parseJJDiffSummary(out), nil
+}
+
+func (j *JJVCS) ChangedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error) {
+	if strings.TrimSpace(baseRef) == "" {
+		return j.ChangedFilesOnDefaultInDir(dir)
+	}
+	base, err := resolveJJRevisionToCommitID(dir, baseRef)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--summary", "--from", jjCommitRevset(base), "--to", "@")
+	if err != nil {
+		return nil, err
+	}
+	return parseJJDiffSummary(out), nil
+}
+
+// ChangedFilesScoped returns changed files for supported JJ scopes. JJ has no
+// staging area, so staged and unstaged scopes are intentionally empty.
+func (j *JJVCS) ChangedFilesScoped(scope, baseRef string) ([]FileChange, error) {
+	if scope == "branch" {
+		return j.ChangedFilesFromBaseInDir(baseRef, "")
+	}
+	return nil, nil
+}
+
+func (j *JJVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
+	rev, err := resolveJJRevisionToCommitID(dir, sha)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--summary", "-r", jjCommitRevset(rev))
+	if err != nil {
+		return nil, err
+	}
+	return parseJJDiffSummary(out), nil
+}
+
+func (j *JJVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
+	return j.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir)
+}
+
+func (j *JJVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
+	args := []string{"diff", "--git"}
+	if strings.TrimSpace(baseRef) == "" {
+		args = append(args, "-r", "@")
+	} else {
+		base, err := resolveJJRevisionToCommitID(dir, baseRef)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--from", jjCommitRevset(base), "--to", "@")
+	}
+	args = append(args, "--", path)
+	out, err := jjCommandInDirCtx(ctx, dir, args...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnifiedDiff(out), nil
+}
+
+func (j *JJVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+	if scope == "branch" {
+		return j.FileDiffUnified(path, baseRef, dir)
+	}
+	return nil, nil
+}
+
+func (j *JJVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
+	rev, err := resolveJJRevisionToCommitID(dir, sha)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--git", "-r", jjCommitRevset(rev), "--", path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnifiedDiff(out), nil
+}
+
+func (j *JJVCS) FileDiffUnifiedNewFile(path string) ([]DiffHunk, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return FileDiffUnifiedNewFile(string(data)), nil
+}
+
+func (j *JJVCS) CommitLog(baseRef, headRef, dir string) ([]CommitInfo, error) {
+	if strings.TrimSpace(baseRef) == "" {
+		return nil, nil
+	}
+	base, err := resolveJJRevisionToCommitID(dir, baseRef)
+	if err != nil {
+		return nil, err
+	}
+	headRev := "@"
+	if strings.TrimSpace(headRef) != "" {
+		head, err := resolveJJRevisionToCommitID(dir, headRef)
+		if err != nil {
+			return nil, err
+		}
+		headRev = jjCommitRevset(head)
+	}
+	tpl := "commit_id ++ \"\\n\" ++ commit_id.short() ++ \"\\n\" ++ description.first_line() ++ \"\\n\" ++ author.name() ++ \"\\n\" ++ author.timestamp().format(\"%Y-%m-%dT%H:%M:%S%:z\") ++ \"\\n---\\n\""
+	revset := fmt.Sprintf("%s::%s ~ %s", jjCommitRevset(base), headRev, jjCommitRevset(base))
+	out, err := jjCommandInDir(dir, "log", "-r", revset, "--no-graph", "-T", tpl)
+	if err != nil {
+		return nil, err
+	}
+	return parseJJCommitLog(out), nil
+}
+
+func (j *JJVCS) WorkingTreeFingerprint() string {
+	out, err := jjCommandInDir("", "status")
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+func (j *JJVCS) UntrackedFiles(_ string) ([]FileChange, error) {
+	return nil, nil
+}
+
+func (j *JJVCS) AllTrackedFiles(dir string) ([]string, error) {
+	out, err := jjCommandInDir(dir, "file", "list")
+	if err != nil {
+		return nil, err
+	}
+	return splitNonEmpty(out), nil
+}
+
+func (j *JJVCS) RemoteBranches(dir string) ([]string, error) {
+	out, err := jjCommandInDir(dir, "bookmark", "list", "--all-remotes", "-T", "name ++ \"|\" ++ remote ++ \"\\n\"")
+	if err != nil {
+		return nil, nil //nolint:nilerr // remote bookmarks may not be configured
+	}
+	seen := map[string]bool{}
+	var branches []string
+	for _, line := range splitNonEmpty(out) {
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) != 2 || parts[1] == "" || parts[1] == "git" {
+			continue
+		}
+		if !seen[parts[0]] {
+			seen[parts[0]] = true
+			branches = append(branches, parts[0])
+		}
+	}
+	return branches, nil
+}
+
+func (j *JJVCS) DiffNumstat(baseRef, dir string) (map[string]NumstatEntry, error) {
+	if strings.TrimSpace(baseRef) == "" {
+		return nil, nil
+	}
+	base, err := resolveJJRevisionToCommitID(dir, baseRef)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--stat", "--from", jjCommitRevset(base), "--to", "@")
+	if err != nil {
+		return nil, err
+	}
+	return parseJJDiffStat(out), nil
+}
+
+func (j *JJVCS) UserName() string { return jjUserName() }
+
+func (j *JJVCS) FileContentAtRef(path, ref, dir string) (string, error) {
+	data, err := j.ReadFileAtSHA(ref, path, dir)
+	if err != nil || data == nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (j *JJVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileChange, error) {
+	base, err := resolveJJRevisionToCommitID(dir, baseSHA)
+	if err != nil {
+		return nil, err
+	}
+	head, err := resolveJJRevisionToCommitID(dir, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--summary", "--from", jjCommitRevset(base), "--to", jjCommitRevset(head))
+	if err != nil {
+		return nil, err
+	}
+	return parseJJDiffSummary(out), nil
+}
+
+func (j *JJVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error) {
+	base, err := resolveJJRevisionToCommitID(dir, baseSHA)
+	if err != nil {
+		return nil, err
+	}
+	head, err := resolveJJRevisionToCommitID(dir, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandInDir(dir, "diff", "--git", "--from", jjCommitRevset(base), "--to", jjCommitRevset(head), "--", path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnifiedDiff(out), nil
+}
+
+func (j *JJVCS) ReadFileAtSHA(sha, path, dir string) ([]byte, error) {
+	rev, err := resolveJJRevisionToCommitID(dir, sha)
+	if err != nil {
+		return nil, err
+	}
+	out, err := jjCommandBytesInDir(dir, "file", "show", "-r", jjCommitRevset(rev), "--", path)
+	if err != nil {
+		return nil, nil //nolint:nilerr // a missing path at a valid commit is not an error for callers
+	}
+	return out, nil
+}
+
+func (j *JJVCS) HasObject(sha, dir string) bool {
+	_, err := resolveJJRevisionToCommitID(dir, sha)
+	return err == nil
+}
+
+func (j *JJVCS) FileStatusInRepo(path, baseRef, dir string) string {
+	changes, err := j.ChangedFilesFromBaseInDir(baseRef, dir)
+	if err != nil {
+		return ""
+	}
+	for _, fc := range changes {
+		if fc.Path == path {
+			return fc.Status
+		}
+	}
+	return ""
+}
+
+func (j *JJVCS) HasStagingArea() bool { return false }
+
+func (j *JJVCS) SkipDirNames() []string { return []string{".jj", ".git"} }
+
+func jjCommandInDir(dir string, args ...string) (string, error) {
+	out, err := jjCommandBytesInDir(dir, args...)
+	return string(out), err
+}
+
+func jjCommandInDirCtx(ctx context.Context, dir string, args ...string) (string, error) {
+	out, err := jjCommandBytesInDirCtx(ctx, dir, args...)
+	return string(out), err
+}
+
+func jjCommandBytesInDir(dir string, args ...string) ([]byte, error) {
+	return jjCommandBytesInDirCtx(context.Background(), dir, args...)
+}
+
+func jjCommandBytesInDirCtx(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmdArgs := append([]string{"--no-pager", "--color", "never"}, args...)
+	cmd := exec.CommandContext(ctx, "jj", cmdArgs...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return stdout.Bytes(), fmt.Errorf("jj %s: %w: %s", strings.Join(args, " "), err, msg)
+		}
+		return stdout.Bytes(), fmt.Errorf("jj %s: %w", strings.Join(args, " "), err)
+	}
+	return stdout.Bytes(), nil
+}
+
+func resolveJJDefaultBaseInDir(dir string) (name, sha string) {
+	trunk, err := jjCommitIDForRevset(dir, jjTrunkRevset)
+	if err == nil && trunk != "" && !isJJRootCommitID(trunk) {
+		if branch := jjKnownDefaultNameForCommit(dir, trunk); branch != "" {
+			return branch, trunk
+		}
+		return jjTrunkRevset, trunk
+	}
+	for _, candidate := range []string{"main", "master", "trunk"} {
+		if sha, err := resolveJJBookmarkToCommitID(dir, candidate); err == nil && sha != "" && !isJJRootCommitID(sha) {
+			return candidate, sha
+		}
+	}
+	return "", ""
+}
+
+func jjKnownDefaultNameForCommit(dir, sha string) string {
+	for _, candidate := range []string{"main", "master", "trunk"} {
+		if refSHA, err := resolveJJBookmarkToCommitID(dir, candidate); err == nil && refSHA == sha {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func resolveJJBookmarkToCommitID(dir, name string) (string, error) {
+	for _, revset := range []string{
+		fmt.Sprintf("remote_bookmarks(exact:%q, exact:%q)", name, "origin"),
+		fmt.Sprintf("remote_bookmarks(exact:%q, exact:%q)", name, "upstream"),
+		fmt.Sprintf("bookmarks(exact:%q)", name),
+		fmt.Sprintf("remote_bookmarks(exact:%q, exact:%q)", name, "git"),
+		fmt.Sprintf("remote_bookmarks(exact:%q)", name),
+	} {
+		sha, err := jjCommitIDForRevset(dir, revset)
+		if err == nil && sha != "" {
+			return sha, nil
+		}
+	}
+	return "", fmt.Errorf("jj bookmark %q not found", name)
+}
+
+func resolveJJRevisionToCommitID(dir, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("empty JJ revision")
+	}
+	if looksLikeHexPrefix(ref) {
+		if sha, err := jjCommitIDForRevset(dir, jjCommitRevset(ref)); err == nil && sha != "" {
+			return sha, nil
+		}
+	}
+	if isSimpleJJBookmarkName(ref) {
+		if sha, err := resolveJJBookmarkToCommitID(dir, ref); err == nil {
+			return sha, nil
+		}
+	}
+	if sha, err := jjCommitIDForRevset(dir, ref); err == nil && sha != "" {
+		return sha, nil
+	}
+	if sha, err := jjCommitIDForRevset(dir, jjCommitRevset(ref)); err == nil && sha != "" {
+		return sha, nil
+	}
+	return "", fmt.Errorf("could not resolve JJ revision %q", ref)
+}
+
+func jjCommitIDForRevset(dir, revset string) (string, error) {
+	out, err := jjCommandInDir(dir, "log", "-r", revset, "--no-graph", "-T", "commit_id ++ \"\\n\"")
+	if err != nil {
+		return "", err
+	}
+	ids := splitNonEmpty(out)
+	if len(ids) == 0 {
+		return "", fmt.Errorf("JJ revset %q resolved to no commits", revset)
+	}
+	return strings.TrimSpace(ids[0]), nil
+}
+
+func jjMergeBase(dir, headRef, baseSHA string) (string, error) {
+	head, err := resolveJJRevisionToCommitID(dir, headRef)
+	if err != nil {
+		return "", err
+	}
+	revset := fmt.Sprintf("heads(ancestors(%s) & ancestors(%s))", jjCommitRevset(head), jjCommitRevset(baseSHA))
+	return jjCommitIDForRevset(dir, revset)
+}
+
+func jjTopicChainRevset(dir string, maxDepth int) string {
+	limit := ""
+	if maxDepth > 0 {
+		limit = fmt.Sprintf(", %d", maxDepth)
+	}
+	baseName, baseSHA := resolveJJDefaultBaseInDir(dir)
+	if baseName != "" && baseSHA != "" && !isJJRootCommitID(baseSHA) {
+		return fmt.Sprintf("ancestors(@%s) ~ ancestors(%s)", limit, jjCommitRevset(baseSHA))
+	}
+	return fmt.Sprintf("ancestors(@%s) ~ root()", limit)
+}
+
+func jjCommitSubject(dir, sha string) string {
+	rev, err := resolveJJRevisionToCommitID(dir, sha)
+	if err != nil {
+		return ""
+	}
+	out, err := jjCommandInDir(dir, "log", "-r", jjCommitRevset(rev), "--no-graph", "-T", "description.first_line()")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+func jjCommitRevset(sha string) string {
+	return fmt.Sprintf("commit_id(%q)", strings.TrimSpace(sha))
+}
+
+func isJJRootCommitID(sha string) bool {
+	return strings.TrimSpace(sha) == jjRootCommitID
+}
+
+func looksLikeHexPrefix(s string) bool {
+	if len(s) < 4 {
+		return false
+	}
+	for _, r := range s {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isSimpleJJBookmarkName(s string) bool {
+	if s == "" || strings.Contains(s, "@") {
+		return false
+	}
+	return !strings.ContainsAny(s, " ()|&~:")
+}
+
+// jjUserName returns the JJ-configured user name, or empty on error.
+func jjUserName() string {
+	out, err := jjCommandInDir("", "config", "get", "user.name")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+func hasJJDirAt(repoRoot string) bool {
+	info, err := os.Stat(filepath.Join(repoRoot, ".jj"))
+	return err == nil && info.IsDir()
+}

--- a/jj_parse.go
+++ b/jj_parse.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+)
+
+// jjSummaryStatusMap maps `jj diff --summary` status letters to crit status strings.
+var jjSummaryStatusMap = map[byte]string{
+	'M': "modified",
+	'A': "added",
+	'D': "deleted",
+	'R': "renamed",
+}
+
+// parseJJDiffSummary parses `jj diff --summary` output into crit file changes.
+// Renames keep the new path so the review attaches comments to the current file.
+func parseJJDiffSummary(output string) []FileChange {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
+
+	var changes []FileChange
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if len(line) < 3 || line[1] != ' ' {
+			continue
+		}
+		status, ok := jjSummaryStatusMap[line[0]]
+		if !ok {
+			continue
+		}
+		path := line[2:]
+		if status == "renamed" {
+			path = parseJJRenameTarget(path)
+		}
+		if path == "" {
+			continue
+		}
+		changes = append(changes, FileChange{Path: path, Status: status})
+	}
+	return changes
+}
+
+// parseJJRenameTarget extracts the destination from JJ's compact rename syntax.
+// Examples: `{old.txt => new.txt}` -> `new.txt`, `src/{old.go => new.go}` -> `src/new.go`.
+func parseJJRenameTarget(path string) string {
+	path = strings.TrimSpace(path)
+	idx := strings.LastIndex(path, " => ")
+	if idx < 0 {
+		return strings.Trim(path, "{}")
+	}
+
+	leftBrace := strings.LastIndex(path[:idx], "{")
+	rightRel := strings.Index(path[idx+4:], "}")
+	if leftBrace >= 0 && rightRel >= 0 {
+		rightBrace := idx + 4 + rightRel
+		return path[:leftBrace] + path[idx+4:rightBrace] + path[rightBrace+1:]
+	}
+	return strings.Trim(strings.TrimSpace(path[idx+4:]), "{}")
+}
+
+// parseJJDiffStat parses `jj diff --stat` output. JJ uses git-style stat lines,
+// so this reuses the shared stat-line parser used by the Sapling backend.
+func parseJJDiffStat(output string) map[string]NumstatEntry {
+	return parseSaplingDiffStat(output)
+}
+
+// parseJJCommitLog parses templated `jj log` output into CommitInfo values.
+func parseJJCommitLog(output string) []CommitInfo {
+	return parseSaplingCommitLog(output)
+}

--- a/jj_parse_test.go
+++ b/jj_parse_test.go
@@ -1,0 +1,44 @@
+package main
+
+import "testing"
+
+func TestParseJJDiffSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []FileChange
+	}{
+		{name: "empty", input: "", want: nil},
+		{name: "modified", input: "M src/main.go", want: []FileChange{{Path: "src/main.go", Status: "modified"}}},
+		{name: "added", input: "A new file.txt", want: []FileChange{{Path: "new file.txt", Status: "added"}}},
+		{name: "deleted", input: "D old.go", want: []FileChange{{Path: "old.go", Status: "deleted"}}},
+		{name: "rename whole path", input: "R {old.txt => new.txt}", want: []FileChange{{Path: "new.txt", Status: "renamed"}}},
+		{name: "rename shared prefix", input: "R src/{old.go => new.go}", want: []FileChange{{Path: "src/new.go", Status: "renamed"}}},
+		{
+			name:  "mixed",
+			input: "M app.go\r\nA docs/plan.md\nR {a.txt => b.txt}\nD gone.txt",
+			want: []FileChange{
+				{Path: "app.go", Status: "modified"},
+				{Path: "docs/plan.md", Status: "added"},
+				{Path: "b.txt", Status: "renamed"},
+				{Path: "gone.txt", Status: "deleted"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseJJDiffSummary(tt.input)
+			assertFileChangesEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseJJDiffStat(t *testing.T) {
+	got := parseJJDiffStat("app.go  | 2 +-\nnew.txt | 1 +\n2 files changed, 2 insertions(+), 1 deletion(-)")
+	want := map[string]NumstatEntry{
+		"app.go":  {Additions: 1, Deletions: 1},
+		"new.txt": {Additions: 1, Deletions: 0},
+	}
+	assertNumstatEqual(t, got, want)
+}

--- a/jj_test.go
+++ b/jj_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Compile-time interface compliance check.
+var _ VCS = &JJVCS{}
+
+func TestJJVCS_Name(t *testing.T) {
+	j := &JJVCS{}
+	if got := j.Name(); got != "jj" {
+		t.Errorf("Name() = %q, want %q", got, "jj")
+	}
+}
+
+func TestJJVCS_HasStagingArea(t *testing.T) {
+	j := &JJVCS{}
+	if j.HasStagingArea() {
+		t.Error("HasStagingArea() = true, want false")
+	}
+}
+
+func TestJJVCS_SkipDirNames(t *testing.T) {
+	j := &JJVCS{}
+	dirs := j.SkipDirNames()
+	want := map[string]bool{".jj": true, ".git": true}
+	if len(dirs) != len(want) {
+		t.Fatalf("SkipDirNames() = %v, want keys of %v", dirs, want)
+	}
+	for _, d := range dirs {
+		if !want[d] {
+			t.Errorf("unexpected dir name %q in SkipDirNames()", d)
+		}
+	}
+}
+
+func TestJJVCS_DefaultBranchOverride(t *testing.T) {
+	j := &JJVCS{}
+	j.SetDefaultBranchOverride("develop")
+	if got := j.GetDefaultBranchOverride(); got != "develop" {
+		t.Errorf("GetDefaultBranchOverride() = %q, want develop", got)
+	}
+	if got := j.DefaultBranch(); got != "develop" {
+		t.Errorf("DefaultBranch() = %q after override, want develop", got)
+	}
+}
+
+func TestHasJJDirFrom_DetectsDotJJ(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "nested", "repo")
+	if err := os.MkdirAll(filepath.Join(root, ".jj"), 0o755); err != nil {
+		t.Fatalf("mkdir .jj: %v", err)
+	}
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	if !hasJJDirFrom(child) {
+		t.Fatal("expected hasJJDirFrom to detect .jj metadata")
+	}
+}
+
+func TestDetectVCS_JJOverride(t *testing.T) {
+	v := DetectVCS("jj")
+	if _, hasJJ := exec.LookPath("jj"); hasJJ == nil {
+		if _, ok := v.(*JJVCS); !ok {
+			t.Errorf("DetectVCS(jj) returned %T, want *JJVCS", v)
+		}
+		return
+	}
+	// Without jj in PATH, DetectVCS may fall back to git when the test itself
+	// runs inside a git checkout. That fallback is intentional and covered by
+	// the production warning path, so there is nothing stable to assert here.
+}
+
+func TestJJVCS_DefaultBaseRefUsesTrunk(t *testing.T) {
+	work := initTestJJCloneWithOriginMain(t)
+	withCwd(t, work)
+
+	j := &JJVCS{}
+	trunk := runJJ(t, work, "log", "-r", "trunk()", "--no-graph", "-T", "commit_id")
+	if isJJRootCommitID(trunk) {
+		t.Fatal("test setup produced root trunk")
+	}
+	if got := j.DefaultBranch(); got != "main" {
+		t.Errorf("DefaultBranch() = %q, want main", got)
+	}
+	if got := j.DefaultBaseRef(); got != trunk {
+		t.Errorf("DefaultBaseRef() = %q, want trunk %q", got, trunk)
+	}
+}
+
+func TestJJVCS_DefaultBaseRefFallsBackToLocalMainWhenTrunkIsRoot(t *testing.T) {
+	dir := initTestJJRepoWithLocalMain(t)
+	withCwd(t, dir)
+
+	j := &JJVCS{}
+	mainSHA := runJJ(t, dir, "log", "-r", "bookmarks(exact:\"main\")", "--no-graph", "-T", "commit_id")
+	if got := j.DefaultBranch(); got != "main" {
+		t.Errorf("DefaultBranch() = %q, want main", got)
+	}
+	if got := j.DefaultBaseRef(); got != mainSHA {
+		t.Errorf("DefaultBaseRef() = %q, want local main %q", got, mainSHA)
+	}
+}
+
+func TestJJVCS_ChangedFilesAndDiffFromBase(t *testing.T) {
+	dir := initTestJJRepoWithLocalMain(t)
+	j := &JJVCS{}
+	base := runJJ(t, dir, "log", "-r", "bookmarks(exact:\"main\")", "--no-graph", "-T", "commit_id")
+	if err := os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nchange\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := j.ChangedFilesFromBaseInDir(base, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFileChangesEqual(t, changes, []FileChange{
+		{Path: "app.txt", Status: "modified"},
+		{Path: "new.txt", Status: "added"},
+	})
+
+	hunks, err := j.FileDiffUnified("app.txt", base, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hunks) == 0 {
+		t.Fatal("expected diff hunks for app.txt")
+	}
+}
+
+func TestJJVCS_ReadFileAtSHA(t *testing.T) {
+	dir := initTestJJRepoWithLocalMain(t)
+	j := &JJVCS{}
+	sha := runJJ(t, dir, "log", "-r", "bookmarks(exact:\"main\")", "--no-graph", "-T", "commit_id")
+
+	got, err := j.ReadFileAtSHA(sha, "app.txt", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "base\n" {
+		t.Errorf("ReadFileAtSHA = %q, want base", got)
+	}
+	got, err = j.ReadFileAtSHA(sha, "missing.txt", dir)
+	if err != nil || got != nil {
+		t.Errorf("missing path: got (%q, %v), want (nil, nil)", got, err)
+	}
+}
+
+func initTestJJRepoWithLocalMain(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("jj"); err != nil {
+		t.Skip("jj not installed")
+	}
+	dir := t.TempDir()
+	runJJ(t, dir, "git", "init", "--colocate", ".")
+	if err := os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runJJ(t, dir, "file", "track", "app.txt")
+	runJJWithUser(t, dir, "commit", "-m", "base")
+	runJJ(t, dir, "bookmark", "set", "main", "-r", "@-")
+	return dir
+}
+
+func initTestJJCloneWithOriginMain(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("jj"); err != nil {
+		t.Skip("jj not installed")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	base := t.TempDir()
+	seed := filepath.Join(base, "seed")
+	remote := filepath.Join(base, "remote.git")
+	work := filepath.Join(base, "work")
+	if err := os.Mkdir(seed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, seed, "init", "-q", "-b", "main")
+	runGitTest(t, seed, "config", "user.name", "Test")
+	runGitTest(t, seed, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(seed, "app.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, seed, "add", "app.txt")
+	runGitTest(t, seed, "commit", "-q", "-m", "base")
+	runGitTest(t, base, "init", "-q", "--bare", remote)
+	runGitTest(t, seed, "remote", "add", "origin", remote)
+	runGitTest(t, seed, "push", "-q", "origin", "main")
+	runJJ(t, base, "git", "clone", "--colocate", remote, work)
+	return work
+}
+
+func runJJ(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("jj", append([]string{"--no-pager", "--color", "never"}, args...)...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("jj %v failed: %v\n%s", args, err, out)
+	}
+	return stringTrimSpace(string(out))
+}
+
+func runJJWithUser(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := []string{"--no-pager", "--color", "never", "--config", "user.name=Test", "--config", "user.email=test@example.com"}
+	fullArgs = append(fullArgs, args...)
+	cmd := exec.Command("jj", fullArgs...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("jj %v failed: %v\n%s", args, err, out)
+	}
+	return stringTrimSpace(string(out))
+}
+
+func runGitTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return stringTrimSpace(string(out))
+}
+
+func withCwd(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func stringTrimSpace(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r' || s[len(s)-1] == ' ' || s[len(s)-1] == '\t') {
+		s = s[:len(s)-1]
+	}
+	for len(s) > 0 && (s[0] == '\n' || s[0] == '\r' || s[0] == ' ' || s[0] == '\t') {
+		s = s[1:]
+	}
+	return s
+}

--- a/picker.go
+++ b/picker.go
@@ -180,6 +180,16 @@ func topicChainSHAs(vcs VCS, repoRoot string) map[string]bool {
 		}
 		return out
 	}
+	if vcs.Name() == "jj" {
+		revs, err := jjCommandInDir(repoRoot, "log", "-r", jjTopicChainRevset(repoRoot, 0), "--no-graph", "-T", "commit_id ++ \"\\n\"")
+		if err != nil {
+			return out
+		}
+		for _, sha := range splitNonEmpty(revs) {
+			out[sha] = true
+		}
+		return out
+	}
 	// Sapling: draft() exactly captures the topic chain.
 	revs, err := slCommandInDir(repoRoot, "log", "-r", "draft() & ::.", "-T", "{node}\n")
 	if err != nil {
@@ -199,13 +209,16 @@ func commitSubjectFor(vcs VCS, repoRoot, sha string) string {
 		return ""
 	}
 	var subject string
-	if vcs.Name() == "git" {
+	switch vcs.Name() {
+	case "git":
 		out, err := runGitInDir(repoRoot, "log", "-1", "--format=%s", sha)
 		if err != nil {
 			return ""
 		}
 		subject = strings.TrimSpace(out)
-	} else {
+	case "jj":
+		subject = jjCommitSubject(repoRoot, sha)
+	default:
 		out, err := slCommandInDir(repoRoot, "log", "-r", sha, "-T", "{desc|firstline}")
 		if err != nil {
 			return ""
@@ -241,12 +254,25 @@ func assignStackBases(vcs VCS, entries []StackEntry, repoRoot string) []StackEnt
 		}
 		// Deepest: base = merge-base(default, head). Direct shell since the
 		// VCS interface only exposes MergeBase(ref-vs-HEAD).
-		if vcs.Name() == "git" {
+		switch vcs.Name() {
+		case "git":
 			out, err := runGitInDir(repoRoot, "merge-base", defaultBranch, entries[i].HeadSHA)
 			if err == nil {
 				entries[i].BaseSHA = strings.TrimSpace(out)
 			}
-		} else {
+		case "jj":
+			baseForMerge := defaultSHA
+			if baseForMerge == "" {
+				if sha, err := resolveJJRevisionToCommitID(repoRoot, defaultBranch); err == nil {
+					baseForMerge = sha
+				}
+			}
+			if baseForMerge != "" {
+				if mb, err := jjMergeBase(repoRoot, entries[i].HeadSHA, baseForMerge); err == nil {
+					entries[i].BaseSHA = strings.TrimSpace(mb)
+				}
+			}
+		default:
 			out, err := slCommandInDir(repoRoot, "log", "-r",
 				fmt.Sprintf("ancestor(%s, %s)", entries[i].HeadSHA, defaultBranch),
 				"-T", "{node}")

--- a/vcs.go
+++ b/vcs.go
@@ -9,10 +9,10 @@ import (
 )
 
 // VCS abstracts version control operations so crit can support multiple backends
-// (git, Sapling, etc.). Each method corresponds to an existing package-level
-// function in git.go; the interface lets callers work with any VCS uniformly.
+// (git, Sapling, Jujutsu, etc.). Each method corresponds to an existing
+// package-level function in git.go; the interface lets callers work with any VCS uniformly.
 type VCS interface {
-	// Name returns the VCS identifier ("git", "sl", etc.).
+	// Name returns the VCS identifier ("git", "sl", "jj", etc.).
 	Name() string
 
 	// RepoRoot returns the absolute path to the repository root.
@@ -122,10 +122,10 @@ type VCS interface {
 }
 
 // DetectVCS returns the appropriate VCS backend for the current directory.
-// If vcsOverride is set ("git", "sl", or "sapling"), that backend is preferred
-// but falls back to git if the requested backend isn't available.
-// Otherwise, auto-detection checks for .sl/ first (Sapling on git repos has both),
-// then falls back to git. Returns nil if no VCS is detected.
+// If vcsOverride is set ("git", "sl"/"sapling", or "jj"), that backend is
+// preferred but falls back to git if the requested backend isn't available.
+// Otherwise, auto-detection checks for .jj/ first, then .sl/ (Sapling on git
+// repos has both), then falls back to git. Returns nil if no VCS is detected.
 func DetectVCS(vcsOverride string) VCS {
 	switch vcsOverride {
 	case "git":
@@ -139,9 +139,25 @@ func DetectVCS(vcsOverride string) VCS {
 			return &GitVCS{}
 		}
 		return nil
+	case "jj", "jujutsu":
+		if _, err := exec.LookPath("jj"); err == nil {
+			return &JJVCS{}
+		}
+		fmt.Fprintf(os.Stderr, "Warning: vcs=%q requested but jj not in PATH, falling back to git\n", vcsOverride)
+		if IsGitRepo() {
+			return &GitVCS{}
+		}
+		return nil
 	}
 
-	// Auto-detect: check for .sl/ first since Sapling repos on top of git have both.
+	// Auto-detect: check for .jj/ first since colocated JJ repos also have .git/.
+	if hasJJDir() {
+		if _, err := exec.LookPath("jj"); err == nil {
+			return &JJVCS{}
+		}
+	}
+
+	// Check for .sl/ before git since Sapling repos on top of git have both.
 	if hasSLDir() {
 		if _, err := exec.LookPath("sl"); err == nil {
 			return &SaplingVCS{}
@@ -158,6 +174,30 @@ func DetectVCS(vcsOverride string) VCS {
 	}
 
 	return nil
+}
+
+// hasJJDir checks whether a .jj/ directory exists at or above the current directory.
+func hasJJDir() bool {
+	dir, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	return hasJJDirFrom(dir)
+}
+
+// hasJJDirFrom checks whether a .jj/ directory exists at or above the given directory.
+func hasJJDirFrom(dir string) bool {
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".jj")); err == nil && info.IsDir() {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return false
 }
 
 // hasSLDir checks whether a .sl/ directory exists at or above the current directory.


### PR DESCRIPTION
## Summary

Adds first-class Jujutsu (`jj`) support to crit’s VCS abstraction.

- auto-detects `.jj` before `.git` so colocated JJ/Git repos use JJ by default
- supports `--vcs jj` and config `"vcs": "jj"`
- resolves the default review base through `trunk()`, with exact `main` / `master` / `trunk` bookmark fallback for local-only repos
- uses `jj diff --git` so existing diff rendering works unchanged
- disables staged/unstaged scopes for JJ because JJ has no index
- wires JJ into picker/range helpers, author fallback, directory walking, and colocated Git fetch fallback for PR/range SHA validation

 ## Testing

```bash
go test ./...
```