### PR TITLE
ci: install jj so JJ backend tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install jj
+        run: |
+          JJ_VERSION=0.40.0
+          mkdir -p /tmp/jj-install
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz -C /tmp/jj-install
+          sudo install /tmp/jj-install/jj /usr/local/bin/jj
+          jj --version
+
       - name: Cache Go build cache
         uses: actions/cache@v5
         with:
@@ -84,6 +93,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install jj
+        run: |
+          JJ_VERSION=0.40.0
+          mkdir -p /tmp/jj-install
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz -C /tmp/jj-install
+          sudo install /tmp/jj-install/jj /usr/local/bin/jj
+          jj --version
+
       - name: Cache Go build cache
         uses: actions/cache@v5
         with:
@@ -111,6 +129,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
+      # jj is intentionally not installed on Windows; JJ backend tests skip
+      # when `jj` is not on PATH. Linux coverage is provided by the unit job.
 
       - name: Cache Go build cache
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

- Add a `jj` install step to the `unit` and `lint` jobs in `test.yml` so the JJ backend tests in `jj_test.go` actually execute instead of `t.Skip`-ing when `jj` isn't on PATH.
- Without this, JJ backend coverage on PRs touching `jj.go` is effectively zero (the integration tests bail at `exec.LookPath("jj")`), which trips `codecov/patch`.
- Install method: prebuilt linux-musl binary from the `jj-vcs/jj` GitHub release, pinned to `v0.40.0` (one month old, conservative choice over the day-old v0.41.0). `jj` isn't packaged in apt and there's no official `setup-jj` action — direct binary download is the convention used by other Go projects that depend on jj (see e.g. [`gh-repo-tools`](https://github.com/osteele/gh-repo-tools/blob/main/.github/workflows/go.yml)).
- Windows job intentionally left without `jj` — tests skip cleanly when the binary is absent and the Linux `unit` job provides coverage.

Motivated by #491 (Jujutsu VCS backend) — landing this on main first so #491's codecov reads true after rebase.

## Test plan

- [x] `mise exec -- go build ./...` passes
- [ ] CI green on this PR (no JJ tests on `main` yet, so the install step is a no-op until #491 lands; verifies the install step itself doesn't break anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)