### PR TITLE
feat: configurable listen host (--host / CRIT_HOST)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ crit/
 7. **Comments reference source line numbers** — stored in `~/.crit/reviews/<key>.json` with per-file sections
 8. **Real-time output** — review file written on every comment change (200ms debounce)
 9. **File watching** — git mode polls `git status --porcelain`; files mode polls mtimes; reloads via SSE
-10. **Localhost only** — server binds to `127.0.0.1`, no CORS headers needed
+10. **Localhost by default** — server binds to `127.0.0.1` (no CORS headers needed). Configurable via `--host` / `CRIT_HOST` / `host` config key (e.g. `0.0.0.0` for LAN). No auth, so non-loopback binds are explicit opt-in.
 11. **Two-level config** — `~/.crit.config.json` (global) merged with `.crit.config.json` (project), CLI flags override both. `agent_cmd` is global-only (prevents malicious repos from hijacking the agent command)
 12. **Headless CLI comment** — `crit comment` writes directly to the review file without starting the server; SSE notifies any running server
 13. **Comment threading** — comments support nested replies and a `resolved` boolean. Review file schema nests replies inside each comment's `replies` array.
@@ -114,7 +114,7 @@ Two-level JSON config files, merged (project overrides global):
 - **Global**: `~/.crit.config.json` — user-wide defaults
 - **Project**: `.crit.config.json` in repo root — per-project overrides
 
-Config keys: `port`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `no_update_check`, `no_integration_check`, `vcs`.
+Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `no_update_check`, `no_integration_check`, `vcs`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to `git config user.name` if not set
@@ -242,7 +242,7 @@ Static: `GET /files/<path>` — serve files from repo root (path traversal prote
 
 <important if="you are modifying server security, request handling, or path-validation logic">
 
-- Server binds to `127.0.0.1` only
+- Server binds to `127.0.0.1` by default; user can opt into a different host via `--host` / `CRIT_HOST` / `host` config key. There is no auth, so any non-loopback bind exposes file content + comment-write API to anyone who can reach the port — that's why it's an explicit opt-in (CLI flag / env var / config key).
 - `/files/` validates paths, blocks `..` traversal, verifies resolved path stays within repo root
 - Body size: 10MB for comments, 1MB for share-url via `http.MaxBytesReader`
 - HTTP server: `ReadTimeout: 15s`, `IdleTimeout: 60s` (no `WriteTimeout` — SSE needs open connections)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ After the first agent interaction, the comment becomes a **live thread**:
 - **Syntax highlighting.** Code blocks are highlighted and split per-line, so you can comment on individual lines inside a fence.
 - **Live file watching.** The browser reloads automatically when the source file changes.
 - **Dark/light/system theme.** Three-button pill in the header, persisted to localStorage.
-- **Local by default.** Server binds to `127.0.0.1`. Your files stay on your machine unless you explicitly share.
+- **Local by default.** Server binds to `127.0.0.1`. Your files stay on your machine unless you explicitly share. (Override with `--host` / `CRIT_HOST` / `host` config key — e.g. `0.0.0.0` to expose on your LAN. No auth, so it's an explicit opt-in.)
 - **No analytics or tracking.** Crit collects zero telemetry. No usage stats, no crash reports, no phone-home. If we ever add anonymous usage statistics in the future, they will be explicitly opt-in.
 - **Update check.** On startup, Crit makes one network request to check for a newer version and prints a notice if one is available. Set `CRIT_NO_UPDATE_CHECK=1` to disable it.
 
@@ -261,6 +261,7 @@ All keys are optional — omit any you don't need.
 | Key                    | Type     | Default                    | Description                                                                                                                                                                             |
 | ---------------------- | -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `port`                 | int      | `0` (random)               | Port for the local server. `0` picks a random available port.                                                                                                                           |
+| `host`                 | string   | `"127.0.0.1"`              | Listen host. Set to `"0.0.0.0"` to expose the server on your LAN. There is no auth, so any non-loopback bind is an explicit opt-in.                                                     |
 | `no_open`              | bool     | `false`                    | Don't auto-open the browser when starting a review.                                                                                                                                     |
 | `share_url`            | string   | `"https://crit.md"`        | Base URL of the share service. Set to `""` to disable sharing entirely. Self-host with [`crit-web`](https://github.com/tomasz-tomczyk/crit-web).                                        |
 | `quiet`                | bool     | `false`                    | Suppress terminal status output.                                                                                                                                                        |
@@ -280,6 +281,7 @@ All keys are optional — omit any you don't need.
 | Flag            | Short | Equivalent config key | Description                            |
 | --------------- | ----- | --------------------- | -------------------------------------- |
 | `--port`        | `-p`  | `port`                | Port to listen on                      |
+| `--host`        |       | `host`                | Listen host (default `127.0.0.1`)      |
 | `--no-open`     |       | `no_open`             | Don't auto-open browser                |
 | `--share-url`   |       | `share_url`           | Share service URL                      |
 | `--output`      | `-o`  | `output`              | Output directory for review files      |
@@ -311,6 +313,7 @@ crit --no-ignore
 | Variable                    | Description                                       |
 | --------------------------- | ------------------------------------------------- |
 | `CRIT_PORT`                 | Default port for the local server                 |
+| `CRIT_HOST`                 | Listen host (default `127.0.0.1`)                 |
 | `CRIT_SHARE_URL`            | Override the share service URL                    |
 | `CRIT_AUTH_TOKEN`           | Override the auth token (skips `crit auth login`) |
 | `CRIT_NO_UPDATE_CHECK`      | Disable the update check on startup               |

--- a/cli_dispatch.go
+++ b/cli_dispatch.go
@@ -70,6 +70,7 @@ Usage:
 
 Options:
   -p, --port <port>           Port to listen on (default: random)
+      --host <host>           Host to listen on (default: 127.0.0.1; e.g. 0.0.0.0 to expose on LAN)
   -o, --output <dir>          Output directory for review file
       --no-open               Don't auto-open browser
       --no-ignore             Disable all file ignore patterns
@@ -84,6 +85,7 @@ Options:
 Environment:
   CRIT_SHARE_URL              Override the share service URL
   CRIT_PORT                   Override the default port
+  CRIT_HOST                   Override the listen host (default 127.0.0.1)
   CRIT_NO_UPDATE_CHECK        Disable update check on startup
   CRIT_AUTH_TOKEN              Override the auth token (skip login)
   CRIT_NO_INTEGRATION_CHECK   Disable integration staleness check

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -19,6 +19,7 @@ import (
 // It combines CLI flags, environment variables, and config file settings.
 type serverConfig struct {
 	port               int
+	host               string // listen host; default 127.0.0.1, may be 0.0.0.0 to expose on LAN
 	noOpen             bool
 	quiet              bool
 	shareURL           string
@@ -50,6 +51,7 @@ type serverConfig struct {
 // serverFlagSet holds the parsed flag values before config resolution.
 type serverFlagSet struct {
 	port        int
+	host        string
 	noOpen      bool
 	showVersion bool
 	shareURL    string
@@ -76,6 +78,7 @@ func parseServerFlags(args []string) serverFlagSet {
 	fs := flag.NewFlagSet("crit", flag.ExitOnError)
 	port := fs.Int("port", 0, "Port to listen on (default: random available port)")
 	fs.IntVar(port, "p", 0, "Port to listen on (shorthand)")
+	host := fs.String("host", "", "Host to listen on (default: 127.0.0.1; e.g. 0.0.0.0 to expose on LAN — no auth, opt in deliberately)")
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 	fs.BoolVar(showVersion, "v", false, "Print version and exit (shorthand)")
@@ -100,6 +103,7 @@ func parseServerFlags(args []string) serverFlagSet {
 
 	return serverFlagSet{
 		port:        *port,
+		host:        *host,
 		noOpen:      *noOpen,
 		showVersion: *showVersion,
 		shareURL:    *shareURL,
@@ -130,8 +134,26 @@ func resolvePort(flagPort, cfgPort int) int {
 	return cfgPort
 }
 
+// resolveHost returns the effective listen host. Precedence: --host flag,
+// CRIT_HOST env var, config file value, then "127.0.0.1" as a final fallback
+// (LoadConfig should already have applied that default; the fallback here
+// guards direct callers that bypass LoadConfig).
+func resolveHost(flagHost, cfgHost string) string {
+	if flagHost != "" {
+		return flagHost
+	}
+	if envHost := os.Getenv("CRIT_HOST"); envHost != "" {
+		return envHost
+	}
+	if cfgHost != "" {
+		return cfgHost
+	}
+	return "127.0.0.1"
+}
+
 func applyConfigDefaults(sf *serverFlagSet, cfg Config) {
 	sf.port = resolvePort(sf.port, cfg.Port)
+	sf.host = resolveHost(sf.host, cfg.Host)
 	if !sf.noOpen && cfg.NoOpen {
 		sf.noOpen = true
 	}
@@ -195,6 +217,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 
 	return &serverConfig{
 		port:               sf.port,
+		host:               sf.host,
 		noOpen:             sf.noOpen,
 		quiet:              sf.quiet,
 		shareURL:           sf.shareURL,
@@ -316,7 +339,11 @@ func applySessionOverrides(session *Session, sc *serverConfig) {
 	}
 }
 
-func bindListener(port int) (net.Listener, error) {
+func bindListener(host string, port int) (net.Listener, error) {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	var listener net.Listener
 	var err error
 	// Retry only makes sense for an explicit port (port != 0): a previous
@@ -324,7 +351,7 @@ func bindListener(port int) (net.Listener, error) {
 	// drain. For an ephemeral port (port == 0) the OS picks a free port —
 	// failure means something catastrophic, so break immediately.
 	for attempt := 0; attempt < 3; attempt++ {
-		listener, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		listener, err = net.Listen("tcp", addr)
 		if err == nil {
 			return listener, nil
 		}
@@ -373,7 +400,7 @@ func runServe(args []string) {
 	}
 	sc.quiet = true
 
-	listener, err := bindListener(sc.port)
+	listener, err := bindListener(sc.host, sc.port)
 	if err != nil {
 		daemonFatal(pipe, "Error starting server: %v", err)
 	}

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -135,9 +135,8 @@ func resolvePort(flagPort, cfgPort int) int {
 }
 
 // resolveHost returns the effective listen host. Precedence: --host flag,
-// CRIT_HOST env var, config file value, then "127.0.0.1" as a final fallback
-// (LoadConfig should already have applied that default; the fallback here
-// guards direct callers that bypass LoadConfig).
+// CRIT_HOST env var, config file value (LoadConfig defaults Host to
+// "127.0.0.1" when no config sets it, so cfgHost is always populated).
 func resolveHost(flagHost, cfgHost string) string {
 	if flagHost != "" {
 		return flagHost
@@ -145,10 +144,7 @@ func resolveHost(flagHost, cfgHost string) string {
 	if envHost := os.Getenv("CRIT_HOST"); envHost != "" {
 		return envHost
 	}
-	if cfgHost != "" {
-		return cfgHost
-	}
-	return "127.0.0.1"
+	return cfgHost
 }
 
 func applyConfigDefaults(sf *serverFlagSet, cfg Config) {
@@ -340,9 +336,6 @@ func applySessionOverrides(session *Session, sc *serverConfig) {
 }
 
 func bindListener(host string, port int) (net.Listener, error) {
-	if host == "" {
-		host = "127.0.0.1"
-	}
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	var listener net.Listener
 	var err error

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 // Config holds all configuration values from config files.
 type Config struct {
 	Port               int      `json:"port,omitempty"`
+	Host               string   `json:"host,omitempty"` // listen host (default 127.0.0.1)
 	NoOpen             bool     `json:"no_open,omitempty"`
 	ShareURL           string   `json:"share_url,omitempty"`
 	Quiet              bool     `json:"quiet,omitempty"`
@@ -55,6 +56,7 @@ func (c Config) String() string {
 func defaultConfig() generatedConfig {
 	return generatedConfig{
 		Port:       0,
+		Host:       "127.0.0.1",
 		NoOpen:     false,
 		ShareURL:   "https://crit.md",
 		Quiet:      false,
@@ -78,6 +80,7 @@ func defaultConfig() generatedConfig {
 // in project config files where it could be accidentally committed.
 type generatedConfig struct {
 	Port               int      `json:"port"`
+	Host               string   `json:"host"`
 	NoOpen             bool     `json:"no_open"`
 	ShareURL           string   `json:"share_url"`
 	Quiet              bool     `json:"quiet"`
@@ -153,6 +156,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if project.Port != 0 {
 		merged.Port = project.Port
 	}
+	if project.Host != "" {
+		merged.Host = project.Host
+	}
 	if projectPresence.NoOpen {
 		merged.NoOpen = project.NoOpen
 	}
@@ -226,6 +232,9 @@ func LoadConfig(projectDir string) Config {
 	}
 	if !globalPresence.IgnorePatterns && !projectPresence.IgnorePatterns {
 		merged.IgnorePatterns = []string{".crit/"}
+	}
+	if merged.Host == "" {
+		merged.Host = "127.0.0.1"
 	}
 
 	// 5. Fall back to VCS user name if no author configured.

--- a/main_test.go
+++ b/main_test.go
@@ -540,6 +540,105 @@ func TestResolveServerConfig_PortPrecedence(t *testing.T) {
 	})
 }
 
+func TestResolveServerConfig_HostPrecedence(t *testing.T) {
+	orig := defaultBranchOverride
+	defer func() {
+		defaultBranchOverride = orig
+		defaultBranchOnce = sync.Once{}
+	}()
+
+	t.Run("CLI flag wins over env and config", func(t *testing.T) {
+		defaultBranchOverride = ""
+		defaultBranchOnce = sync.Once{}
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"host": "10.0.0.1"}`), 0644)
+		homeDir := t.TempDir()
+		setHome(t, homeDir)
+		t.Setenv("CRIT_HOST", "10.0.0.2")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := resolveServerConfig([]string{"--host", "0.0.0.0"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.host != "0.0.0.0" {
+			t.Errorf("host = %q, want 0.0.0.0 (CLI flag)", sc.host)
+		}
+	})
+
+	t.Run("env var wins over config when no CLI flag", func(t *testing.T) {
+		defaultBranchOverride = ""
+		defaultBranchOnce = sync.Once{}
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"host": "10.0.0.1"}`), 0644)
+		homeDir := t.TempDir()
+		setHome(t, homeDir)
+		t.Setenv("CRIT_HOST", "10.0.0.2")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := resolveServerConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.host != "10.0.0.2" {
+			t.Errorf("host = %q, want 10.0.0.2 (env var)", sc.host)
+		}
+	})
+
+	t.Run("config wins when no CLI flag or env var", func(t *testing.T) {
+		defaultBranchOverride = ""
+		defaultBranchOnce = sync.Once{}
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"host": "10.0.0.1"}`), 0644)
+		homeDir := t.TempDir()
+		setHome(t, homeDir)
+		t.Setenv("CRIT_HOST", "")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := resolveServerConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.host != "10.0.0.1" {
+			t.Errorf("host = %q, want 10.0.0.1 (config file)", sc.host)
+		}
+	})
+
+	t.Run("default 127.0.0.1 when nothing set", func(t *testing.T) {
+		defaultBranchOverride = ""
+		defaultBranchOnce = sync.Once{}
+
+		dir := t.TempDir()
+		homeDir := t.TempDir()
+		setHome(t, homeDir)
+		t.Setenv("CRIT_HOST", "")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := resolveServerConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.host != "127.0.0.1" {
+			t.Errorf("host = %q, want 127.0.0.1 (default)", sc.host)
+		}
+	})
+}
+
 func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 	orig := defaultBranchOverride
 	defer func() {


### PR DESCRIPTION
## Summary
- Adds `--host` CLI flag, `CRIT_HOST` env var, and `host` config key for the crit server's listen address. Default stays `127.0.0.1`.
- `bindListener` now takes (host, port) via `net.JoinHostPort` (IPv6-safe).
- Resolution precedence mirrors port: CLI flag > env > config > default.

## Why
Originated from a user request: people running crit on a remote dev box or VM want to expose the review UI to other machines on their LAN (`crit --host 0.0.0.0` or via `CRIT_HOST=0.0.0.0`). There's no auth, so non-loopback binds are an explicit opt-in (CLI/env/config — never silent).

## Review
- [x] /crit-review static pass: SHIP IT, 0 blockers, 0 warnings
- [x] go-expert review: no blockers; addressed simplification note (collapsed triple-layered default to a single source of truth in LoadConfig)
- [x] Red-team brainstorm: known limitation — passing --host <specific-LAN-IP> (rather than 0.0.0.0) breaks same-machine client probes (crit stop, plan-hook) because they hardcode 127.0.0.1. The 0.0.0.0 case (which is the user's actual ask) works fine. Will revisit if anyone needs interface-specific binds.

## Test plan
- [x] `go test -race ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l .` — clean
- [x] New TestResolveServerConfig_HostPrecedence covers all 4 precedence rungs (flag/env/config/default), mirroring the existing port test

🤖 Generated with [Claude Code](https://claude.com/claude-code)