### PR TITLE
ci: install sapling so SL backend tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,16 @@ jobs:
           sudo install /tmp/jj-install/jj /usr/local/bin/jj
           jj --version
 
+      - name: Install sapling
+        run: |
+          SL_VERSION="0.2.20260317-201835+0234c21f"
+          SL_VERSION_ENC="${SL_VERSION//+/%2B}"
+          sudo mkdir -p /opt/sapling
+          curl -fsSL "https://github.com/facebook/sapling/releases/download/${SL_VERSION_ENC}/sapling-${SL_VERSION}-linux-x64.tar.xz" \
+            | sudo tar xJ -C /opt/sapling
+          sudo ln -sf /opt/sapling/sl /usr/local/bin/sl
+          sl --version
+
       - name: Cache Go build cache
         uses: actions/cache@v5
         with:
@@ -101,6 +111,16 @@ jobs:
             | tar xz -C /tmp/jj-install
           sudo install /tmp/jj-install/jj /usr/local/bin/jj
           jj --version
+
+      - name: Install sapling
+        run: |
+          SL_VERSION="0.2.20260317-201835+0234c21f"
+          SL_VERSION_ENC="${SL_VERSION//+/%2B}"
+          sudo mkdir -p /opt/sapling
+          curl -fsSL "https://github.com/facebook/sapling/releases/download/${SL_VERSION_ENC}/sapling-${SL_VERSION}-linux-x64.tar.xz" \
+            | sudo tar xJ -C /opt/sapling
+          sudo ln -sf /opt/sapling/sl /usr/local/bin/sl
+          sl --version
 
       - name: Cache Go build cache
         uses: actions/cache@v5

--- a/sapling_test.go
+++ b/sapling_test.go
@@ -230,6 +230,10 @@ func TestHasSLDirFrom_DoesNotDetectDotGitSL(t *testing.T) {
 // missing on PATH.
 func runSL(t *testing.T, dir string, args ...string) string {
 	t.Helper()
+	// HGUSER is honored by older Sapling builds; newer builds require
+	// --config ui.username to be passed explicitly. Set both so the helper
+	// works on whatever sl version the test runner has installed.
+	args = append([]string{"--config", "ui.username=test <test@test.com>"}, args...)
 	cmd := exec.Command("sl", args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "HGUSER=test <test@test.com>")


### PR DESCRIPTION
## Summary

- Add a Sapling install step to the `unit` and `lint` jobs in `test.yml` so the `TestSaplingVCS_*` integration tests in `sapling_test.go` actually execute instead of `t.Skip`-ing when `sl` isn't on PATH.
- Same shape as the recent jj install (#493), but with a different installation mechanism: Sapling's `sl` binary requires its sibling `lib/python3.12/` directory to be co-located, so it must be extracted to a fixed location and symlinked from `/usr/local/bin/sl` (the `sudo install` pattern jj uses doesn't work — `sl` resolves its install dir via `/proc/self/exe`).
- Pin to `0.2.20260317-201835+0234c21f` (the latest release as of today, 2026-03-18). Sapling stopped publishing `.deb`s; current release is a single portable tarball with bundled Python 3.12, designed to work across Ubuntu versions.
- Verified end-to-end in `docker run ubuntu:24.04`: `sl --version` outputs the expected version after the install commands.
- Windows job intentionally left without `sl` (matches jj install scope; tests skip cleanly).

## Test plan

- [x] Verified install in Ubuntu 24.04 container — `sl --version` succeeds
- [x] `mise exec -- go build ./...` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)