### PR TITLE
ci: fail if integration_hashes_gen.go is out of sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+      - name: Check integration hashes are up to date
+        run: |
+          go run gen_integration_hashes.go
+          if ! git diff --exit-code -- integration_hashes_gen.go; then
+            echo "::error::integration_hashes_gen.go is out of sync with integrations/."
+            echo "::error::Run 'go run gen_integration_hashes.go' and commit the result."
+            exit 1
+          fi
+
       - name: Install and run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
## Summary
- Adds a step to the `lint` job that runs `go run gen_integration_hashes.go` and fails via `git diff --exit-code` if `integration_hashes_gen.go` drifts from the actual files under `integrations/`.
- Catches the silent-drift class of bug surfaced by #500: stale hashes for several integrations and an unregistered `integrations/gemini/*` tree had been sitting on `main` unnoticed.

## Test plan
- [x] Sanity: regen on clean main is a no-op (no diff)
- [x] Forced drift: appended a comment to `integrations/aider/CONVENTIONS.md`, regen produced a diff, `git diff --exit-code` returned 1 (CI would fail). Restored, re-ran, exit 0.
- [x] Step placement: reuses the existing Go toolchain + cache from the `lint` job; no new dependencies, no new workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)