### PR TITLE
feat: image copy/paste support in review

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// maxAttachmentBytes is the upper bound on a single pasted image after decode.
+// 5 MiB comfortably covers full-screen screenshots while keeping the share
+// payload (base64-inlined attachments + JSON) within crit-web's request limits.
+const maxAttachmentBytes = 5 << 20
+
+// attachmentExtByMIME maps the MIME types we accept to the file extension
+// used on disk and in the URL. Anything outside this map is rejected at
+// upload time.
+var attachmentExtByMIME = map[string]string{
+	"image/png":  "png",
+	"image/jpeg": "jpg",
+	"image/gif":  "gif",
+	"image/webp": "webp",
+}
+
+// attachmentMIMEByExt is the reverse lookup used when serving and when
+// inlining data URIs. Built from attachmentExtByMIME so the two stay in sync.
+var attachmentMIMEByExt = func() map[string]string {
+	m := make(map[string]string, len(attachmentExtByMIME))
+	for mime, ext := range attachmentExtByMIME {
+		m[ext] = mime
+	}
+	// Both jpg and jpeg are accepted on the URL side; map jpeg explicitly.
+	m["jpeg"] = "image/jpeg"
+	return m
+}()
+
+// attachmentFilenameRE matches our on-disk filenames: a UUIDv4 plus an
+// allowed extension. UUIDs guarantee no collisions across the lifetime of
+// a review folder; the strict pattern doubles as path-traversal protection
+// (no "..", no "/" can pass).
+var attachmentFilenameRE = regexp.MustCompile(
+	`^([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.(png|jpe?g|gif|webp)$`,
+)
+
+// attachmentMarkdownRE finds markdown image references that point at our
+// attachments dir using the canonical relative path stored in review.json.
+// The filename group is validated separately via attachmentFilenameRE so
+// the regex itself can stay permissive on the suffix.
+//
+// Matches: ![alt text](attachments/<file>)
+//
+//	![alt text](attachments/<file> "title")
+//
+// Not matched: ![](https://...), ![](/api/...), ![](./...) — anything that
+// isn't a bare relative path under attachments/ is left alone so external
+// images and historical absolute URLs survive the rewriters intact.
+var attachmentMarkdownRE = regexp.MustCompile(
+	`!\[([^\]]*)\]\(attachments/([A-Za-z0-9._-]+)(?:\s+"[^"]*")?\)`,
+)
+
+// randomUUID returns a UUIDv4 in canonical 8-4-4-4-12 hex form. crypto/rand
+// is the only randomness source — no fallback to time-based IDs even on
+// rand failure (which only happens if the kernel can't seed, in which case
+// we want to refuse to write anything).
+func randomUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("read random bytes for uuid: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// saveAttachment writes data into the review's attachments dir under a
+// fresh UUIDv4 name. It detects MIME via http.DetectContentType and rejects
+// anything outside attachmentExtByMIME. Returns the bare filename (no path)
+// that the frontend should use in the markdown image URL.
+//
+// Each successful call writes a new file even for byte-identical pastes —
+// the reviewer's feedback explicitly chose UUIDs over content-addressing
+// to avoid worrying about hash collisions and to keep the original-name
+// alt text decoupled from on-disk identity.
+func saveAttachment(reviewPath string, data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", errors.New("empty attachment payload")
+	}
+	if len(data) > maxAttachmentBytes {
+		return "", fmt.Errorf("attachment too large: %d bytes (max %d)", len(data), maxAttachmentBytes)
+	}
+
+	mime := http.DetectContentType(data)
+	// DetectContentType may return "image/jpeg; charset=utf-8" — strip params.
+	if idx := strings.Index(mime, ";"); idx >= 0 {
+		mime = strings.TrimSpace(mime[:idx])
+	}
+	ext, ok := attachmentExtByMIME[mime]
+	if !ok {
+		return "", fmt.Errorf("unsupported image type: %s", mime)
+	}
+
+	if reviewPath == "" {
+		return "", errors.New("no review path; cannot store attachment")
+	}
+	dir := reviewPathsFor(reviewPath).Attachments
+
+	uuid, err := randomUUID()
+	if err != nil {
+		return "", err
+	}
+	filename := uuid + "." + ext
+	target := filepath.Join(dir, filename)
+
+	if err := atomicWriteFile(target, data, 0o600); err != nil {
+		return "", fmt.Errorf("write attachment: %w", err)
+	}
+	return filename, nil
+}
+
+// attachmentPathFor resolves a filename to an absolute path inside the
+// attachments dir, returning the path and detected MIME on success.
+// Filename is validated against attachmentFilenameRE so traversal ("..",
+// "/") is impossible.
+func attachmentPathFor(reviewPath, filename string) (path, mime string, err error) {
+	m := attachmentFilenameRE.FindStringSubmatch(filename)
+	if m == nil {
+		return "", "", errors.New("invalid attachment filename")
+	}
+	if reviewPath == "" {
+		return "", "", errors.New("no review path")
+	}
+	mime, ok := attachmentMIMEByExt[strings.ToLower(m[2])]
+	if !ok {
+		return "", "", errors.New("unknown attachment extension")
+	}
+	return filepath.Join(reviewPathsFor(reviewPath).Attachments, filename), mime, nil
+}
+
+// inlineAttachmentsAsDataURIs rewrites local attachments/<file> markdown
+// references in body to data: URIs by reading and base64-encoding each
+// referenced file. External and absolute URLs are untouched. Missing or
+// oversized files are left as-is (and will simply 404 on the shared viewer
+// rather than blowing up the share request).
+//
+// Called from the share path so that shared reviews carry the actual image
+// bytes — crit-web has no asset endpoint of its own.
+func inlineAttachmentsAsDataURIs(reviewPath, body string) string {
+	if reviewPath == "" || !strings.Contains(body, "attachments/") {
+		return body
+	}
+	return attachmentMarkdownRE.ReplaceAllStringFunc(body, func(match string) string {
+		sub := attachmentMarkdownRE.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		alt, filename := sub[1], sub[2]
+		path, mime, err := attachmentPathFor(reviewPath, filename)
+		if err != nil {
+			return match
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return match
+		}
+		// Cap inlined size defensively — a misbehaving caller couldn't
+		// have got past saveAttachment's check, but belt + braces.
+		if len(data) > maxAttachmentBytes {
+			return match
+		}
+		encoded := base64.StdEncoding.EncodeToString(data)
+		return fmt.Sprintf("![%s](data:%s;base64,%s)", alt, mime, encoded)
+	})
+}
+
+// stripAttachmentReferences removes local attachments/<file> markdown
+// image refs from body and returns the rewritten body plus the number
+// stripped. External and absolute URLs are left intact. Used on the GitHub
+// push path: pasted images live only inside the local crit review folder,
+// so the GitHub-rendered comment substitutes a "view in Crit" notice.
+func stripAttachmentReferences(body string) (string, int) {
+	if !strings.Contains(body, "attachments/") {
+		return body, 0
+	}
+	count := 0
+	out := attachmentMarkdownRE.ReplaceAllStringFunc(body, func(match string) string {
+		count++
+		return ""
+	})
+	if count == 0 {
+		return body, 0
+	}
+	// Collapse the blank line(s) the deletion may have left behind so the
+	// remaining text reads naturally on GitHub.
+	out = strings.TrimRight(out, " \n")
+	noun := "image"
+	if count != 1 {
+		noun = "images"
+	}
+	out += fmt.Sprintf("\n\n_[%d %s removed — view in Crit]_", count, noun)
+	return out, count
+}
+
+// bodyRewriter processes a comment body before it leaves crit en route to
+// GitHub. nil is interpreted as "leave the body alone"; this is convenient
+// for unit tests that don't care about attachment handling.
+type bodyRewriter func(body string) string
+
+// stripBodyRewriter removes local attachment refs from a body and appends
+// a "view in Crit" notice. Pasted images live only inside the local review
+// folder; the push path is the only outbound boundary that doesn't carry
+// the bytes (share-to-crit-web inlines as data URI; the GitHub comment
+// gets a notice instead).
+func stripBodyRewriter(body string) string {
+	out, _ := stripAttachmentReferences(body)
+	return out
+}
+
+// sanitizeAttachmentAltText turns an arbitrary upload filename into safe
+// markdown alt text. Strips control characters, collapses whitespace, drops
+// brackets and parentheses (which would terminate the markdown image
+// syntax), and caps length. Empty result is allowed — callers fall back to
+// a default when this returns "".
+func sanitizeAttachmentAltText(name string) string {
+	const maxLen = 120
+	var b strings.Builder
+	b.Grow(len(name))
+	prevSpace := false
+	for _, r := range name {
+		switch {
+		case r < 0x20, r == 0x7f:
+			continue
+		case r == '[', r == ']', r == '(', r == ')':
+			continue
+		case r == ' ', r == '\t':
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		default:
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if len(out) > maxLen {
+		out = strings.TrimSpace(out[:maxLen])
+	}
+	return out
+}

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeTestPNG returns a tiny valid PNG (1×1 of the given color) so the MIME
+// sniff in saveAttachment takes the success path. We don't pin a fixed byte
+// string because http.DetectContentType only needs the first 512 bytes — a
+// real PNG is the only safe way to keep this test stable across stdlib
+// changes.
+func makeTestPNG(t *testing.T, c color.RGBA) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, c)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// newReviewIdentity returns a review-folder path under t.TempDir() — the v4
+// "identity" form. Mirrors the production layout where the JSON lives at
+// <identity>/review.json and attachments at <identity>/attachments/.
+func newReviewIdentity(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "abcd1234")
+}
+
+// uuidV4Pattern is reused across tests to validate the bare UUID portion
+// of a saved attachment filename without committing to a specific UUID.
+const uuidV4Pattern = `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
+
+func TestRandomUUID_Format(t *testing.T) {
+	got, err := randomUUID()
+	if err != nil {
+		t.Fatalf("randomUUID: %v", err)
+	}
+	if !attachmentFilenameRE.MatchString(got + ".png") {
+		t.Errorf("randomUUID produced %q which does not parse with .png suffix", got)
+	}
+	// Verify a second call produces a different UUID — ensures we're not
+	// returning a constant or stale buffer.
+	other, _ := randomUUID()
+	if got == other {
+		t.Errorf("randomUUID returned the same UUID twice: %q", got)
+	}
+}
+
+func TestReviewPathsFor_Attachments(t *testing.T) {
+	identity := "/home/u/.crit/reviews/deadbeef"
+	got := reviewPathsFor(identity).Attachments
+	want := "/home/u/.crit/reviews/deadbeef/attachments"
+	if got != want {
+		t.Errorf("Attachments = %q, want %q", got, want)
+	}
+}
+
+func TestSaveAttachment(t *testing.T) {
+	t.Run("rejects empty payload", func(t *testing.T) {
+		_, err := saveAttachment(newReviewIdentity(t), nil)
+		if err == nil {
+			t.Fatal("expected error for empty payload")
+		}
+	})
+
+	t.Run("rejects oversized payload", func(t *testing.T) {
+		_, err := saveAttachment(newReviewIdentity(t), bytes.Repeat([]byte{0xff}, maxAttachmentBytes+1))
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("expected too-large error, got %v", err)
+		}
+	})
+
+	t.Run("rejects non-image MIME", func(t *testing.T) {
+		_, err := saveAttachment(newReviewIdentity(t), []byte("just plain text not an image"))
+		if err == nil || !strings.Contains(err.Error(), "unsupported image type") {
+			t.Fatalf("expected unsupported-type error, got %v", err)
+		}
+	})
+
+	t.Run("rejects empty review path", func(t *testing.T) {
+		_, err := saveAttachment("", makeTestPNG(t, color.RGBA{255, 0, 0, 255}))
+		if err == nil {
+			t.Fatal("expected error when reviewPath is empty")
+		}
+	})
+
+	t.Run("writes png and returns uuid-shaped name", func(t *testing.T) {
+		review := newReviewIdentity(t)
+		data := makeTestPNG(t, color.RGBA{0, 200, 0, 255})
+		filename, err := saveAttachment(review, data)
+		if err != nil {
+			t.Fatalf("saveAttachment: %v", err)
+		}
+		if !attachmentFilenameRE.MatchString(filename) {
+			t.Errorf("filename %q does not match UUID pattern", filename)
+		}
+		// File should exist with the bytes we sent.
+		path := filepath.Join(reviewPathsFor(review).Attachments, filename)
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read back: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Errorf("written bytes don't round-trip")
+		}
+	})
+
+	t.Run("two pastes of identical bytes get distinct UUID names", func(t *testing.T) {
+		review := newReviewIdentity(t)
+		data := makeTestPNG(t, color.RGBA{1, 2, 3, 255})
+		first, err := saveAttachment(review, data)
+		if err != nil {
+			t.Fatalf("first: %v", err)
+		}
+		second, err := saveAttachment(review, data)
+		if err != nil {
+			t.Fatalf("second: %v", err)
+		}
+		if first == second {
+			t.Errorf("expected distinct UUIDs for separate saves; got same %q twice", first)
+		}
+	})
+}
+
+func TestAttachmentPathFor(t *testing.T) {
+	review := newReviewIdentity(t)
+
+	t.Run("rejects path-traversal filenames", func(t *testing.T) {
+		traversal := []string{
+			"../etc/passwd",
+			"abc/../../../etc/passwd",
+			"./hidden.png",
+			"name with space.png",
+		}
+		for _, name := range traversal {
+			if _, _, err := attachmentPathFor(review, name); err == nil {
+				t.Errorf("expected error for %q, got nil", name)
+			}
+		}
+	})
+
+	t.Run("rejects non-uuid filename", func(t *testing.T) {
+		// A 64-hex sha-style name (the v3 shape) must be rejected now.
+		legacy := strings.Repeat("a", 64) + ".png"
+		if _, _, err := attachmentPathFor(review, legacy); err == nil {
+			t.Errorf("legacy sha256 filename should be rejected")
+		}
+	})
+
+	t.Run("accepts uuid-shaped filename", func(t *testing.T) {
+		uuid, _ := randomUUID()
+		path, mime, err := attachmentPathFor(review, uuid+".png")
+		if err != nil {
+			t.Fatalf("attachmentPathFor: %v", err)
+		}
+		if mime != "image/png" {
+			t.Errorf("mime = %q, want image/png", mime)
+		}
+		want := filepath.Join(reviewPathsFor(review).Attachments, uuid+".png")
+		if path != want {
+			t.Errorf("path = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestInlineAttachmentsAsDataURIs(t *testing.T) {
+	review := newReviewIdentity(t)
+	data := makeTestPNG(t, color.RGBA{50, 60, 70, 255})
+	filename, err := saveAttachment(review, data)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Run("rewrites local relative ref to data URI", func(t *testing.T) {
+		body := "see ![screenshot.png](attachments/" + filename + ")"
+		got := inlineAttachmentsAsDataURIs(review, body)
+		if !strings.Contains(got, "data:image/png;base64,") {
+			t.Errorf("expected data URI, got %q", got)
+		}
+		if !strings.Contains(got, "![screenshot.png](") {
+			t.Errorf("alt text not preserved: %q", got)
+		}
+	})
+
+	t.Run("leaves external URLs alone", func(t *testing.T) {
+		body := "![](https://example.com/img.png)"
+		got := inlineAttachmentsAsDataURIs(review, body)
+		if got != body {
+			t.Errorf("external URL was rewritten: %q", got)
+		}
+	})
+
+	t.Run("leaves absolute /api/ URLs alone (legacy/external)", func(t *testing.T) {
+		body := "![](/api/anything/elsewhere.png)"
+		got := inlineAttachmentsAsDataURIs(review, body)
+		if got != body {
+			t.Errorf("absolute URL was rewritten: %q", got)
+		}
+	})
+
+	t.Run("missing file leaves ref intact (renders 404 on shared viewer)", func(t *testing.T) {
+		ghost, _ := randomUUID()
+		body := "![](attachments/" + ghost + ".png)"
+		got := inlineAttachmentsAsDataURIs(review, body)
+		if got != body {
+			t.Errorf("missing file should leave ref intact, got %q", got)
+		}
+	})
+}
+
+func TestStripAttachmentReferences(t *testing.T) {
+	uuid, _ := randomUUID()
+	t.Run("strips multiple refs and appends placeholder", func(t *testing.T) {
+		body := "first ![a](attachments/" + uuid + ".png) and ![b](attachments/" + uuid + ".jpg)"
+		out, n := stripAttachmentReferences(body)
+		if n != 2 {
+			t.Errorf("strip count = %d, want 2", n)
+		}
+		if strings.Contains(out, "attachments/") {
+			t.Errorf("attachment refs survived: %q", out)
+		}
+		if !strings.Contains(out, "view in Crit") {
+			t.Errorf("placeholder not appended: %q", out)
+		}
+	})
+
+	t.Run("no-op when no attachment refs", func(t *testing.T) {
+		body := "![](https://example.com/x.png)"
+		out, n := stripAttachmentReferences(body)
+		if n != 0 || out != body {
+			t.Errorf("expected no-op, got n=%d out=%q", n, out)
+		}
+	})
+}
+
+func TestSanitizeAttachmentAltText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "screenshot.png", "screenshot.png"},
+		{"strip control chars", "screen\x01shot.png", "screenshot.png"},
+		{"strip markdown delimiters", "[bug](report).png", "bugreport.png"},
+		{"collapse whitespace", "two  spaces  here.png", "two spaces here.png"},
+		{"truncate beyond 120", strings.Repeat("a", 200), strings.Repeat("a", 120)},
+		{"empty stays empty", "", ""},
+		{"only delimiters → empty", "[]()", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeAttachmentAltText(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleAttachments_UploadAndGet exercises the full HTTP roundtrip:
+// POST a multipart form, parse the response, then GET the relative URL
+// (rewritten by the frontend hook into /api/attachments/<filename>) and
+// verify the bytes match.
+func TestHandleAttachments_UploadAndGet(t *testing.T) {
+	review := newReviewIdentity(t)
+	srv := &Server{reviewPath: review}
+
+	// Build a multipart POST with the original filename header.
+	data := makeTestPNG(t, color.RGBA{200, 100, 50, 255})
+	body, contentType := buildMultipartFile(t, "screen-shot.png", data)
+	req := httptest.NewRequest(http.MethodPost, "/api/attachments", body)
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	srv.handleAttachments(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["original_filename"] != "screen-shot.png" {
+		t.Errorf("original_filename = %q, want screen-shot.png", resp["original_filename"])
+	}
+	wantURL := "attachments/" + resp["filename"]
+	if resp["url"] != wantURL {
+		t.Errorf("url = %q, want %q (relative form)", resp["url"], wantURL)
+	}
+	if !attachmentFilenameRE.MatchString(resp["filename"]) {
+		t.Errorf("filename %q does not match UUID pattern", resp["filename"])
+	}
+
+	// GET it back via the absolute URL form.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/attachments/"+resp["filename"], nil)
+	getRec := httptest.NewRecorder()
+	srv.handleAttachments(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200; body=%s", getRec.Code, getRec.Body.String())
+	}
+	if !bytes.Equal(getRec.Body.Bytes(), data) {
+		t.Errorf("GET body did not round-trip the upload bytes")
+	}
+	if ct := getRec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+	if cc := getRec.Header().Get("Cache-Control"); !strings.Contains(cc, "immutable") {
+		t.Errorf("Cache-Control = %q, want immutable directive", cc)
+	}
+}
+
+func TestHandleAttachments_RejectsBadInput(t *testing.T) {
+	review := newReviewIdentity(t)
+	srv := &Server{reviewPath: review}
+
+	t.Run("POST with path suffix is 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments/anything", nil)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("GET without filename is 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/attachments", nil)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("DELETE is 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/attachments/x", nil)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want 405", rec.Code)
+		}
+	})
+
+	t.Run("GET unknown UUID is 404", func(t *testing.T) {
+		ghost, _ := randomUUID()
+		req := httptest.NewRequest(http.MethodGet, "/api/attachments/"+ghost+".png", nil)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("GET malformed filename is 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/attachments/not-a-uuid.png", nil)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("any verb without review path is 503", func(t *testing.T) {
+		bare := &Server{reviewPath: ""}
+		req := httptest.NewRequest(http.MethodGet, "/api/attachments/x", nil)
+		rec := httptest.NewRecorder()
+		bare.handleAttachments(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", rec.Code)
+		}
+	})
+
+	t.Run("POST with non-image bytes is 415", func(t *testing.T) {
+		body, contentType := buildMultipartFile(t, "notes.txt", []byte("plain text"))
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments", body)
+		req.Header.Set("Content-Type", contentType)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusUnsupportedMediaType {
+			t.Errorf("status = %d, want 415; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// buildMultipartFile constructs a multipart/form-data body with one "file"
+// part. Returns the body reader and the Content-Type header to set.
+func buildMultipartFile(t *testing.T, filename string, data []byte) (io.Reader, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(data); err != nil {
+		t.Fatalf("write multipart body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -134,6 +135,32 @@ func TestSaveAttachment(t *testing.T) {
 			t.Errorf("expected distinct UUIDs for separate saves; got same %q twice", first)
 		}
 	})
+
+	t.Run("write failure surfaces as 'write attachment' error", func(t *testing.T) {
+		// POSIX-only: chmod doesn't reliably block writes on Windows.
+		if runtime.GOOS == "windows" {
+			t.Skip("chmod-based write block doesn't apply on Windows")
+		}
+		// Skip when running as root — root bypasses POSIX permission checks
+		// and would make this test pass spuriously.
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses POSIX perms; chmod 0o500 won't block writes")
+		}
+		review := newReviewIdentity(t)
+		dir := reviewPathsFor(review).Attachments
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir attachments: %v", err)
+		}
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Fatalf("chmod attachments dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+		_, err := saveAttachment(review, makeTestPNG(t, color.RGBA{4, 5, 6, 255}))
+		if err == nil || !strings.Contains(err.Error(), "write attachment") {
+			t.Fatalf("expected write-attachment error, got %v", err)
+		}
+	})
 }
 
 func TestAttachmentPathFor(t *testing.T) {
@@ -173,6 +200,13 @@ func TestAttachmentPathFor(t *testing.T) {
 		want := filepath.Join(reviewPathsFor(review).Attachments, uuid+".png")
 		if path != want {
 			t.Errorf("path = %q, want %q", path, want)
+		}
+	})
+
+	t.Run("rejects empty review path with valid uuid filename", func(t *testing.T) {
+		uuid, _ := randomUUID()
+		if _, _, err := attachmentPathFor("", uuid+".png"); err == nil {
+			t.Errorf("expected error when reviewPath is empty")
 		}
 	})
 }
@@ -220,6 +254,42 @@ func TestInlineAttachmentsAsDataURIs(t *testing.T) {
 			t.Errorf("missing file should leave ref intact, got %q", got)
 		}
 	})
+
+	t.Run("filename passes markdown regex but not UUID regex leaves ref intact", func(t *testing.T) {
+		// The markdown regex accepts [A-Za-z0-9._-]+ as the filename, but
+		// attachmentPathFor enforces the strict UUID pattern. "foo.png"
+		// passes the outer markdown regex but is rejected by the inner
+		// path validator → defensive return-as-is branch.
+		body := "![alt](attachments/foo.png)"
+		got := inlineAttachmentsAsDataURIs(review, body)
+		if got != body {
+			t.Errorf("non-uuid filename should leave ref intact, got %q", got)
+		}
+	})
+
+	t.Run("oversized file on disk leaves ref intact (defensive cap)", func(t *testing.T) {
+		// Bypass saveAttachment's size check by writing directly. The defensive
+		// cap inside inlineAttachmentsAsDataURIs guards against data that got
+		// past the upload boundary by some other path.
+		bigReview := newReviewIdentity(t)
+		bigDir := reviewPathsFor(bigReview).Attachments
+		if err := os.MkdirAll(bigDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		uuid, _ := randomUUID()
+		bigFile := filepath.Join(bigDir, uuid+".png")
+		// 6 MiB — past maxAttachmentBytes. Prefix with PNG header so a future
+		// reader that runs DetectContentType also classifies it correctly.
+		oversized := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0xff}, maxAttachmentBytes+1024)...)
+		if err := os.WriteFile(bigFile, oversized, 0o600); err != nil {
+			t.Fatalf("write oversized file: %v", err)
+		}
+		body := "![](attachments/" + uuid + ".png)"
+		got := inlineAttachmentsAsDataURIs(bigReview, body)
+		if got != body {
+			t.Errorf("oversized file should leave ref intact, got %q", got)
+		}
+	})
 }
 
 func TestStripAttachmentReferences(t *testing.T) {
@@ -243,6 +313,19 @@ func TestStripAttachmentReferences(t *testing.T) {
 		out, n := stripAttachmentReferences(body)
 		if n != 0 || out != body {
 			t.Errorf("expected no-op, got n=%d out=%q", n, out)
+		}
+	})
+
+	t.Run("contains 'attachments/' substring but no valid ref", func(t *testing.T) {
+		// Hits the defensive count==0 branch: substring check passes but the
+		// markdown ref regex matches nothing.
+		body := "this mentions attachments/foo but is not a markdown image ref"
+		out, n := stripAttachmentReferences(body)
+		if n != 0 {
+			t.Errorf("count = %d, want 0", n)
+		}
+		if out != body {
+			t.Errorf("body changed unexpectedly: got %q", out)
 		}
 	})
 }
@@ -391,6 +474,86 @@ func TestHandleAttachments_RejectsBadInput(t *testing.T) {
 		srv.handleAttachments(rec, req)
 		if rec.Code != http.StatusUnsupportedMediaType {
 			t.Errorf("status = %d, want 415; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("POST with malformed multipart body is 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments",
+			strings.NewReader("this is not a multipart body"))
+		// Declare a boundary that doesn't appear in the body so ParseMultipartForm fails.
+		req.Header.Set("Content-Type", "multipart/form-data; boundary=xxxnotpresent")
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("POST with wrong form-file field name is 400", func(t *testing.T) {
+		// Properly formed multipart, but the file is in field "upload" rather
+		// than the expected "file" — surfaces as a FormFile lookup error.
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		fw, err := mw.CreateFormFile("upload", "screenshot.png")
+		if err != nil {
+			t.Fatalf("CreateFormFile: %v", err)
+		}
+		if _, err := fw.Write(makeTestPNG(t, color.RGBA{1, 2, 3, 255})); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := mw.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments", &buf)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "Missing 'file'") {
+			t.Errorf("expected 'Missing file' in body, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("POST empty file part is 400 (not 415)", func(t *testing.T) {
+		// An empty multipart file part passes ParseMultipartForm + FormFile,
+		// then ReadFull returns n=0, then saveAttachment rejects with
+		// "empty attachment payload" — covers the non-MIME saveAttachment
+		// error branch (status 400, not 415).
+		body, contentType := buildMultipartFile(t, "empty.png", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments", body)
+		req.Header.Set("Content-Type", contentType)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "empty") {
+			t.Errorf("expected 'empty' in body, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("POST oversized payload is 413", func(t *testing.T) {
+		// Generate a body whose "file" part exceeds maxAttachmentBytes. The
+		// handler's MaxBytesReader fires once the request body exceeds the
+		// cap; the response status is 413 only when ParseMultipartForm gets
+		// past parsing and ReadFull observes n > maxAttachmentBytes. To make
+		// that branch reachable we keep the multipart envelope under the
+		// MaxBytesReader cap (maxAttachmentBytes + 1 MiB) while ensuring the
+		// inner file is large enough that the post-read n > max check fires.
+		oversized := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0xff}, maxAttachmentBytes+1024)...)
+		body, contentType := buildMultipartFile(t, "huge.png", oversized)
+		req := httptest.NewRequest(http.MethodPost, "/api/attachments", body)
+		req.Header.Set("Content-Type", contentType)
+		rec := httptest.NewRecorder()
+		srv.handleAttachments(rec, req)
+		// Two acceptable outcomes depending on whether MaxBytesReader trips
+		// before ReadFull or after: both end up as a client-side error class
+		// (4xx). Assert specifically on the in-handler check so it's the
+		// expected branch covered.
+		if rec.Code != http.StatusRequestEntityTooLarge && rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 413 or 400; body=%s", rec.Code, rec.Body.String())
 		}
 	})
 }

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -61,9 +61,9 @@ func TestRandomUUID_Format(t *testing.T) {
 }
 
 func TestReviewPathsFor_Attachments(t *testing.T) {
-	identity := "/home/u/.crit/reviews/deadbeef"
+	identity := filepath.Join("home", "u", ".crit", "reviews", "deadbeef")
 	got := reviewPathsFor(identity).Attachments
-	want := "/home/u/.crit/reviews/deadbeef/attachments"
+	want := filepath.Join(identity, "attachments")
 	if got != want {
 		t.Errorf("Attachments = %q, want %q", got, want)
 	}

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -356,6 +356,31 @@ func bindListener(host string, port int) (net.Listener, error) {
 	return nil, err
 }
 
+// resolveServeReviewPath computes the daemon's review folder so that
+// srv.reviewPath, the session-registry entry, session.ReviewFilePath, and
+// session.critJSONPath() (post applyPlanOverrides, which sets OutputDir = planDir)
+// all agree on one folder. Precedence: --output > --plan-dir > centralized
+// ~/.crit/reviews/<key>.
+//
+// Bug history: before the planDir branch was added, plan-mode daemons wrote
+// attachments to ~/.crit/reviews/<key>/attachments/ while review.json and the
+// share-payload inliner targeted <planDir>/.crit/ — pasted images turned into
+// [image: <alt>] placeholders on crit-web because the inliner couldn't find
+// the file on disk and silently left the raw attachments/<uuid> ref in place.
+func resolveServeReviewPath(outputDir, planDir, sessionKey string) string {
+	switch {
+	case outputDir != "":
+		abs, _ := filepath.Abs(outputDir)
+		return filepath.Join(abs, ".crit")
+	case planDir != "":
+		abs, _ := filepath.Abs(planDir)
+		return filepath.Join(abs, ".crit")
+	default:
+		path, _ := reviewFilePath(sessionKey)
+		return path
+	}
+}
+
 func serveSessionKey(sc *serverConfig) string {
 	cwd, _ := resolvedCWD()
 	if sc.planDir != "" {
@@ -418,12 +443,7 @@ func runServe(args []string) {
 	if vcs := DetectVCS(sc.vcsOverride); vcs != nil {
 		branch = vcs.CurrentBranch()
 	}
-	if sc.outputDir != "" {
-		abs, _ := filepath.Abs(sc.outputDir)
-		sc.reviewPath = filepath.Join(abs, ".crit")
-	} else {
-		sc.reviewPath, _ = reviewFilePath(key)
-	}
+	sc.reviewPath = resolveServeReviewPath(sc.outputDir, sc.planDir, key)
 	srv.reviewPath = sc.reviewPath
 	srv.cliArgs = sc.files
 	if err := writeSessionFile(key, sessionEntry{

--- a/cli_serve_test.go
+++ b/cli_serve_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -81,4 +82,37 @@ func TestPreflightNoChangedFiles_NotARepo(t *testing.T) {
 	if msg := preflightNoChangedFiles(sc); msg != "" {
 		t.Errorf("expected empty message outside a repo, got:\n%s", msg)
 	}
+}
+
+// TestResolveServeReviewPath_PlanModeColocatesWithReviewFile verifies that
+// plan-mode daemons compute a review path under the plan dir, so attachment
+// upload and share-payload inlining target the same folder. Pre-fix, plan
+// mode fell through to the centralized ~/.crit/reviews/<key> path while
+// session.critJSONPath() returned <planDir>/.crit — the split caused pasted
+// images to render as [image: <alt>] placeholders on crit-web.
+func TestResolveServeReviewPath(t *testing.T) {
+	t.Run("outputDir wins", func(t *testing.T) {
+		dir := t.TempDir()
+		got := resolveServeReviewPath(dir, "/some/plan/dir", "deadbeef")
+		want := filepath.Join(dir, ".crit")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("planDir used when outputDir empty", func(t *testing.T) {
+		planDir := t.TempDir()
+		got := resolveServeReviewPath("", planDir, "deadbeef")
+		want := filepath.Join(planDir, ".crit")
+		if got != want {
+			t.Errorf("plan-mode review path: got %q, want %q (must co-locate with review.json so attachments/ inlining can find them)", got, want)
+		}
+	})
+
+	t.Run("centralized path when neither outputDir nor planDir set", func(t *testing.T) {
+		got := resolveServeReviewPath("", "", "deadbeef123")
+		if !strings.Contains(got, "deadbeef123") {
+			t.Errorf("centralized path should embed session key; got %q", got)
+		}
+	})
 }

--- a/e2e/tests/image-paste.spec.ts
+++ b/e2e/tests/image-paste.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+import { clearAllComments, loadPage, mdSection, switchToDocumentView, addComment, getMdPath } from './helpers';
+
+// Tiny 1x1 transparent PNG, base64-encoded. Decoded client-side and fed into
+// the synthetic ClipboardEvent / DragEvent so the upload endpoint sees real
+// image bytes that pass http.DetectContentType.
+const PNG_1x1_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAQH/k6sV0AAAAABJRU5ErkJggg==';
+
+// Dispatch a synthetic ClipboardEvent('paste') on the focused element with a
+// File built from base64 PNG bytes. Runs in the page context.
+async function pasteImage(page: Page, target: Locator) {
+  await target.focus();
+  await target.evaluate((el, b64) => {
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const file = new File([bytes], 'pasted-shot.png', { type: 'image/png' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    const event = new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: dt,
+    });
+    el.dispatchEvent(event);
+  }, PNG_1x1_BASE64);
+}
+
+// Dispatch synthetic dragover + drop events on the target with a File
+// payload. Simulates the user dragging an image file in from the OS.
+async function dropImage(page: Page, target: Locator) {
+  await target.evaluate((el, b64) => {
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const file = new File([bytes], 'dropped-shot.png', { type: 'image/png' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    const dragover = new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt });
+    el.dispatchEvent(dragover);
+    const drop = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt });
+    el.dispatchEvent(drop);
+  }, PNG_1x1_BASE64);
+}
+
+// Match the markdown ref produced by uploadAndInsertImage on success.
+const ATTACHMENT_REF_RE = /!\[[^\]]*\]\(attachments\/[0-9a-f-]+\.png\)/;
+
+test.describe('Image paste & drag-drop', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('pasting image into new top-level comment form inserts markdown ref', async ({ page }) => {
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    await section.locator('.line-block').first().hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeVisible();
+
+    await pasteImage(page, textarea);
+
+    // The upload is async — wait for the placeholder to be swapped for the
+    // real markdown ref. toHaveValue auto-retries up to the expect timeout.
+    await expect(textarea).toHaveValue(ATTACHMENT_REF_RE);
+  });
+
+  test('pasting image into reply form inserts markdown ref (regression for top-level-only bug)', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Existing comment');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Click reply input to expand into the textarea.
+    await card.locator('.reply-input').click();
+    const replyTextarea = card.locator('.reply-textarea');
+    await expect(replyTextarea).toBeFocused();
+
+    await pasteImage(page, replyTextarea);
+
+    await expect(replyTextarea).toHaveValue(ATTACHMENT_REF_RE);
+  });
+
+  test('dropping image file onto new comment textarea inserts markdown ref', async ({ page }) => {
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    await section.locator('.line-block').first().hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeVisible();
+
+    await dropImage(page, textarea);
+
+    await expect(textarea).toHaveValue(ATTACHMENT_REF_RE);
+  });
+
+  test('dropping image file onto reply textarea inserts markdown ref', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Existing comment');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    await card.locator('.reply-input').click();
+    const replyTextarea = card.locator('.reply-textarea');
+    await expect(replyTextarea).toBeFocused();
+
+    await dropImage(page, replyTextarea);
+
+    await expect(replyTextarea).toHaveValue(ATTACHMENT_REF_RE);
+  });
+
+  test('pasting image into reply EDIT textarea inserts markdown ref', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    const comment = await addComment(request, mdPath, 1, 'Top comment');
+    await request.post(`/api/comment/${comment.id}/replies?path=${encodeURIComponent(mdPath)}`, {
+      data: { body: 'Original reply', author: 'reviewer' },
+    });
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const reply = section.locator('.comment-reply').first();
+    await expect(reply).toBeVisible();
+
+    // Open the reply edit form.
+    await reply.hover();
+    await reply.locator('.reply-actions button[title="Edit"]').click();
+    const editTextarea = reply.locator('textarea');
+    await expect(editTextarea).toBeVisible();
+
+    await pasteImage(page, editTextarea);
+
+    await expect(editTextarea).toHaveValue(/Original reply.*!\[[^\]]*\]\(attachments\/[0-9a-f-]+\.png\)/s);
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4964,6 +4964,75 @@
     });
   }
 
+  // attachImageDragDrop wires drag-and-drop image uploads onto a textarea.
+  // Mirrors attachImagePaste's contract: filter for image/* files, route to
+  // uploadAndInsertImage, leave non-image drags to the browser's native
+  // text-drop behavior. dragover MUST preventDefault when we want to accept
+  // the drop — without it, the drop event never fires.
+  function attachImageDragDrop(textarea) {
+    function hasFiles(event) {
+      const dt = event.dataTransfer;
+      // dataTransfer.types is a DOMStringList; "Files" indicates an OS file
+      // drag. Text-only drags (selection drags, link drags) won't include it.
+      return !!(dt && dt.types && Array.prototype.indexOf.call(dt.types, 'Files') !== -1);
+    }
+
+    textarea.addEventListener('dragenter', function(event) {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      textarea.classList.add('drag-active');
+    });
+
+    textarea.addEventListener('dragover', function(event) {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+      textarea.classList.add('drag-active');
+    });
+
+    textarea.addEventListener('dragleave', function(event) {
+      // Only clear when the drag truly leaves the textarea (not when crossing
+      // an internal selection boundary — textareas have no children, so we
+      // can rely on a simple class toggle without ref-counting).
+      if (event.target === textarea) {
+        textarea.classList.remove('drag-active');
+      }
+    });
+
+    textarea.addEventListener('drop', function(event) {
+      const dt = event.dataTransfer;
+      if (!dt || !dt.files || dt.files.length === 0) {
+        textarea.classList.remove('drag-active');
+        return;
+      }
+      const images = [];
+      for (let i = 0; i < dt.files.length; i++) {
+        const file = dt.files[i];
+        if (file && file.type && file.type.indexOf('image/') === 0) {
+          images.push(file);
+        }
+      }
+      if (images.length === 0) {
+        textarea.classList.remove('drag-active');
+        return;
+      }
+      // We're handling at least one image — claim the drop so the browser
+      // doesn't try to navigate to the dropped file URL.
+      event.preventDefault();
+      textarea.classList.remove('drag-active');
+      textarea.focus();
+      images.forEach(function(file) { uploadAndInsertImage(textarea, file); });
+    });
+  }
+
+  // Wires both paste and drag-drop image uploads onto a textarea. Single
+  // entry point so every comment textarea (top-level, edit, reply, reply edit)
+  // gets the same upload behavior.
+  function attachImageUploads(textarea) {
+    attachImagePaste(textarea);
+    attachImageDragDrop(textarea);
+  }
+
   function uploadAndInsertImage(textarea, file) {
     const seq = ++pendingImagePasteSeq;
     const placeholder = '![uploading…](crit-pending-' + seq + ')';
@@ -5046,7 +5115,7 @@
     if (opts.initialBody) textarea.value = opts.initialBody;
 
     attachFilePicker(textarea);
-    attachImagePaste(textarea);
+    attachImageUploads(textarea);
 
     const doSubmit = opts.onSubmit
       ? function() { opts.onSubmit(textarea.value); }
@@ -6433,6 +6502,7 @@
     textarea.value = currentText;
     textarea.rows = 3;
     bodyEl.replaceWith(textarea);
+    attachImageUploads(textarea);
     textarea.focus();
 
     const saveBtn = document.createElement('button');
@@ -6520,6 +6590,7 @@
     buttons.appendChild(submitBtn);
 
     attachFilePicker(textarea);
+    attachImageUploads(textarea);
 
     function expand() {
       if (form.classList.contains('expanded')) return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -36,6 +36,25 @@
     return '<span class="file-ref">' + escapeHtml(path) + '</span>';
   };
 
+  // ===== Attachment Image Src Rewrite =====
+  // Markdown stored in review.json uses canonical relative paths
+  // (`attachments/<uuid>.<ext>`) — never absolute URLs. Each render target
+  // rewrites at its own publish boundary; in the local UI that means
+  // pointing the browser at /api/attachments/<uuid>.<ext>. External URLs
+  // (https/http/data/absolute paths) pass through untouched so historical
+  // GitHub raw URLs or external image hosts still render after `crit pull`.
+  commentMd.renderer.rules.image = function(tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    const srcIdx = token.attrIndex('src');
+    if (srcIdx >= 0) {
+      const src = token.attrs[srcIdx][1];
+      if (!/^https?:\/\/|^data:|^\//.test(src) && /^attachments\//.test(src)) {
+        token.attrs[srcIdx][1] = '/api/' + src;
+      }
+    }
+    return self.renderToken(tokens, idx, options);
+  };
+
   // ===== Suggestion Diff Renderer =====
   function renderSuggestionDiff(suggestionContent, originalLines) {
     const sugLines = suggestionContent.replace(/\n$/, '').split('\n');
@@ -4544,6 +4563,107 @@
     }
   }
 
+  // ===== Image Paste =====
+  // Attach a paste handler to a comment textarea so screenshots and other
+  // images on the clipboard upload via POST /api/attachments and get
+  // inserted as markdown image references at the cursor.
+  //
+  // The inserted markdown carries the *relative* path returned by the
+  // server (`attachments/<uuid>.<ext>`) — that's the canonical form stored
+  // in review.json. The local UI's render-time hook (commentMd image rule
+  // above) rewrites it to /api/attachments/... at display time.
+  //
+  // While an upload is in flight a `![uploading…](crit-pending-N)`
+  // placeholder sits at the cursor; on success it's swapped for the real
+  // markdown reference, on failure for an italic _[image upload failed]_
+  // note. The placeholder tag is suffixed with a per-textarea counter so
+  // simultaneous pastes don't collide.
+  let pendingImagePasteSeq = 0;
+  function attachImagePaste(textarea) {
+    textarea.addEventListener('paste', function(event) {
+      const clipboard = event.clipboardData;
+      if (!clipboard) return;
+      const items = clipboard.items;
+      if (!items || items.length === 0) return;
+
+      const images = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind === 'file' && item.type && item.type.indexOf('image/') === 0) {
+          const file = item.getAsFile();
+          if (file) images.push(file);
+        }
+      }
+      if (images.length === 0) return;
+
+      // We're handling images — block the default paste so the raw bytes
+      // don't get dumped as garbage text into the textarea.
+      event.preventDefault();
+      images.forEach(function(file) { uploadAndInsertImage(textarea, file); });
+    });
+  }
+
+  function uploadAndInsertImage(textarea, file) {
+    const seq = ++pendingImagePasteSeq;
+    const placeholder = '![uploading…](crit-pending-' + seq + ')';
+    insertAtCursor(textarea, placeholder);
+
+    const formData = new FormData();
+    // Pass the original filename explicitly so it survives any clipboard
+    // that strips it from the File object. Server sanitizes server-side.
+    formData.append('file', file, file.name || '');
+
+    fetch('/api/attachments', { method: 'POST', body: formData })
+      .then(function(res) {
+        if (!res.ok) {
+          return res.text().then(function(msg) {
+            throw new Error(msg || ('Upload failed: ' + res.status));
+          });
+        }
+        return res.json();
+      })
+      .then(function(data) {
+        if (!data || !data.url) throw new Error('Malformed upload response');
+        const alt = (data.original_filename || '').trim();
+        replaceInTextarea(textarea, placeholder, '![' + alt + '](' + data.url + ')');
+      })
+      .catch(function(err) {
+        console.error('Image paste upload failed:', err);
+        replaceInTextarea(textarea, placeholder, '_[image upload failed]_');
+      });
+  }
+
+  function insertAtCursor(textarea, text) {
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const before = textarea.value.substring(0, start);
+    const after = textarea.value.substring(end);
+    textarea.value = before + text + after;
+    const cursor = start + text.length;
+    textarea.selectionStart = textarea.selectionEnd = cursor;
+    textarea.focus();
+    // Trigger input listeners (draft autosave, etc.)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function replaceInTextarea(textarea, needle, replacement) {
+    const idx = textarea.value.indexOf(needle);
+    if (idx === -1) return;
+    // Preserve cursor when the placeholder is not where the user is typing.
+    const selStart = textarea.selectionStart;
+    const selEnd = textarea.selectionEnd;
+    textarea.value = textarea.value.substring(0, idx) + replacement + textarea.value.substring(idx + needle.length);
+    const delta = replacement.length - needle.length;
+    if (selStart > idx + needle.length) {
+      textarea.selectionStart = selStart + delta;
+      textarea.selectionEnd = selEnd + delta;
+    } else if (selStart >= idx) {
+      // Cursor was inside the placeholder — drop it just after the replacement.
+      textarea.selectionStart = textarea.selectionEnd = idx + replacement.length;
+    }
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
   // ===== Comment Form =====
   function createCommentFormUI(opts) {
     const formObj = opts.formObj;
@@ -4565,6 +4685,7 @@
     if (opts.initialBody) textarea.value = opts.initialBody;
 
     attachFilePicker(textarea);
+    attachImagePaste(textarea);
 
     const doSubmit = opts.onSubmit
       ? function() { opts.onSubmit(textarea.value); }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -43,7 +43,7 @@
   // pointing the browser at /api/attachments/<uuid>.<ext>. External URLs
   // (https/http/data/absolute paths) pass through untouched so historical
   // GitHub raw URLs or external image hosts still render after `crit pull`.
-  commentMd.renderer.rules.image = function(tokens, idx, options, env, self) {
+  commentMd.renderer.rules.image = function(tokens, idx, options, _env, self) {
     const token = tokens[idx];
     const srcIdx = token.attrIndex('src');
     if (srcIdx >= 0) {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1175,6 +1175,14 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   margin: 0.5em 0;
 }
 .comment-body pre code { background: none; padding: 0; }
+.comment-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  border: 1px solid var(--crit-border);
+  margin: 4px 0;
+  display: block;
+}
 
 /* Suggestion diff inside comments */
 .suggestion-diff {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1552,6 +1552,14 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   color: var(--crit-editor-fg-muted);
 }
 
+/* Highlight a textarea when an image file is being dragged over it.
+   Applied/removed by attachImageDragDrop in app.js. */
+textarea.drag-active {
+  outline: 2px dashed var(--crit-brand);
+  outline-offset: -2px;
+  background: var(--crit-brand-subtle);
+}
+
 .comment-form-actions {
   display: flex;
   justify-content: flex-end;

--- a/github.go
+++ b/github.go
@@ -1043,7 +1043,13 @@ type ghReplyForPush struct {
 
 // collectNewRepliesForPush finds replies that haven't been pushed to GitHub yet.
 // A reply needs pushing if its GitHubID is 0 (local-only) and its parent Comment has a GitHubID (on GitHub).
-func collectNewRepliesForPush(cf CritJSONFile) []ghReplyForPush {
+//
+// rewrite handles image markdown in reply bodies — see bucketsToGHComments.
+// nil falls back to the strip rewriter.
+func collectNewRepliesForPush(cf CritJSONFile, rewrite bodyRewriter) []ghReplyForPush {
+	if rewrite == nil {
+		rewrite = stripBodyRewriter
+	}
 	var replies []ghReplyForPush
 	for _, c := range cf.Comments {
 		if c.GitHubID == 0 {
@@ -1053,7 +1059,7 @@ func collectNewRepliesForPush(cf CritJSONFile) []ghReplyForPush {
 			if r.GitHubID == 0 {
 				replies = append(replies, ghReplyForPush{
 					ParentGHID: c.GitHubID,
-					Body:       r.Body,
+					Body:       rewrite(r.Body),
 				})
 			}
 		}
@@ -1237,7 +1243,7 @@ func critJSONToGHComments(cj CritJSON) []map[string]any {
 				"path": path,
 				"line": c.EndLine,
 				"side": "RIGHT",
-				"body": c.Body,
+				"body": stripBodyRewriter(c.Body),
 			}
 			if c.StartLine != c.EndLine {
 				comment["start_line"] = c.StartLine

--- a/github_test.go
+++ b/github_test.go
@@ -602,7 +602,7 @@ func TestCollectNewRepliesForPush(t *testing.T) {
 		},
 	}
 
-	replies := collectNewRepliesForPush(cf)
+	replies := collectNewRepliesForPush(cf, nil)
 	if len(replies) != 1 {
 		t.Fatalf("expected 1 new reply, got %d", len(replies))
 	}
@@ -625,7 +625,7 @@ func TestCollectNewRepliesForPush_NoGitHubRoot(t *testing.T) {
 		},
 	}
 
-	replies := collectNewRepliesForPush(cf)
+	replies := collectNewRepliesForPush(cf, nil)
 	if len(replies) != 0 {
 		t.Fatalf("expected 0 replies for local-only comment, got %d", len(replies))
 	}
@@ -674,7 +674,7 @@ func TestCollectNewRepliesForPush_ParentSources(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := collectNewRepliesForPush(tc.cf)
+			got := collectNewRepliesForPush(tc.cf, nil)
 			if len(got) != tc.wantReplies {
 				t.Fatalf("got %d replies, want %d: %+v", len(got), tc.wantReplies, got)
 			}
@@ -3046,7 +3046,7 @@ func TestZeroGitHubID_TreatedAsNotPushed(t *testing.T) {
 				{ID: "rp1", GitHubID: 0, Body: "local reply"},
 			}},
 		}}
-		got := collectNewRepliesForPush(cf)
+		got := collectNewRepliesForPush(cf, nil)
 		if len(got) != 0 {
 			t.Fatalf("reply with GitHubID==0 parent must be skipped; got %d", len(got))
 		}
@@ -3060,7 +3060,7 @@ func TestZeroGitHubID_TreatedAsNotPushed(t *testing.T) {
 				{ID: "rp1", GitHubID: 0, Body: "new local reply"},
 			}},
 		}}
-		got := collectNewRepliesForPush(cf)
+		got := collectNewRepliesForPush(cf, nil)
 		if len(got) != 1 {
 			t.Fatalf("reply (GitHubID==0, parent!=0) must be queued; got %d", len(got))
 		}
@@ -3076,7 +3076,7 @@ func TestZeroGitHubID_TreatedAsNotPushed(t *testing.T) {
 				{ID: "rp1", GitHubID: 200, Body: "remote reply"},
 			}},
 		}}
-		got := collectNewRepliesForPush(cf)
+		got := collectNewRepliesForPush(cf, nil)
 		if len(got) != 0 {
 			t.Fatalf("reply with GitHubID!=0 must be skipped; got %d", len(got))
 		}

--- a/main.go
+++ b/main.go
@@ -807,8 +807,10 @@ func runPushDryRun(ctx pushContext, b pushBuckets) {
 func runPushLive(ctx pushContext, b pushBuckets) int {
 	exportPath := writePushOrphanExport(ctx, b)
 
+	rewrite := stripBodyRewriter
+
 	postable := len(b.Postable)
-	posted, postFailed, postAuthFailed, commentIDs := runPushPostReview(ctx, b)
+	posted, postFailed, postAuthFailed, commentIDs := runPushPostReview(ctx, b, rewrite)
 
 	totalReplies := countNewReplies(ctx.cj)
 	postedReplies := 0
@@ -816,7 +818,7 @@ func runPushLive(ctx pushContext, b pushBuckets) int {
 	if !postFailed && !postAuthFailed {
 		var allReplies []ghReplyForPush
 		for _, cf := range ctx.cj.Files {
-			allReplies = append(allReplies, collectNewRepliesForPush(cf)...)
+			allReplies = append(allReplies, collectNewRepliesForPush(cf, rewrite)...)
 		}
 		var replyIDs map[replyKey]int64
 		replyIDs, postedReplies, replyAuthFailed = postPushReplies(ctx.prNumber, allReplies)
@@ -881,14 +883,16 @@ func writePushOrphanExport(ctx pushContext, b pushBuckets) string {
 }
 
 // runPushPostReview posts the Postable bucket as a single GitHub review.
+// rewrite preprocesses each comment body before it ships (image upload+swap
+// in production; nil falls back to strip-with-placeholder).
 // Returns the count posted, whether the call failed (any reason), whether
 // the failure was specifically an auth-rotation 401, and the path-to-id
 // mapping for body-hash bookkeeping.
-func runPushPostReview(ctx pushContext, b pushBuckets) (int, bool, bool, map[string]int64) {
+func runPushPostReview(ctx pushContext, b pushBuckets, rewrite bodyRewriter) (int, bool, bool, map[string]int64) {
 	if len(b.Postable) == 0 {
 		return 0, false, false, nil
 	}
-	ghComments := bucketsToGHComments(b.Postable)
+	ghComments := bucketsToGHComments(b.Postable, rewrite)
 	ids, err := createGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error posting review: %v\n", err)
@@ -900,10 +904,11 @@ func runPushPostReview(ctx pushContext, b pushBuckets) (int, bool, bool, map[str
 // countNewReplies counts replies that would be sent in this push (no
 // GitHubID yet, parent already on GitHub). Mirrors collectNewRepliesForPush
 // without allocating the full slice — used purely for the K-of-N total.
+// nil rewriter is fine: the body content does not affect the count.
 func countNewReplies(cj CritJSON) int {
 	n := 0
 	for _, cf := range cj.Files {
-		n += len(collectNewRepliesForPush(cf))
+		n += len(collectNewRepliesForPush(cf, nil))
 	}
 	return n
 }
@@ -1710,8 +1715,8 @@ func removeStaleReviewPath(path string) bool {
 	return true
 }
 
-// cleanupOnApproval deletes the review file when the review is approved
-// and cleanup is enabled.
+// cleanupOnApproval deletes the review folder (review.json, snapshots.json,
+// and any attachments) when the review is approved and cleanup is enabled.
 func cleanupOnApproval(approved bool, reviewPath string, cleanupEnabled bool) {
 	if !(approved && cleanupEnabled && reviewPath != "") {
 		return

--- a/push_buckets.go
+++ b/push_buckets.go
@@ -267,7 +267,11 @@ func detailedDryRun(b pushBuckets) string {
 // writeDryRunLine appends one comment line to the dry-run output. Body is
 // truncated to 60 runes and newlines are squashed so the line stays compact.
 func writeDryRunLine(sb *strings.Builder, sc scopedComment) {
-	body := strings.ReplaceAll(sc.Comment.Body, "\n", " ")
+	// Dry-run preview shows the strip view (attachment refs gone, placeholder
+	// note appended). The live push may upload-and-swap instead — we don't
+	// run that side-effect here because dry-run is read-only.
+	stripped, _ := stripAttachmentReferences(sc.Comment.Body)
+	body := strings.ReplaceAll(stripped, "\n", " ")
 	fmt.Fprintf(sb, "  %s: %s\n", commentLocator(sc), truncateStr(body, 60))
 }
 
@@ -276,9 +280,15 @@ func writeDryRunLine(sb *strings.Builder, sc scopedComment) {
 // acts on already-filtered postable comments — the resolved/GitHubID checks
 // are redundant here (bucketCommentsForPush enforces them) but cheap and
 // defensive.
-func bucketsToGHComments(postable []scopedComment) []map[string]any {
+//
+// rewrite is applied to each comment body before it ships. Production push
+// passes stripBodyRewriter; tests may pass nil for strip behavior.
+func bucketsToGHComments(postable []scopedComment, rewrite bodyRewriter) []map[string]any {
 	if len(postable) == 0 {
 		return nil
+	}
+	if rewrite == nil {
+		rewrite = stripBodyRewriter
 	}
 	out := make([]map[string]any, 0, len(postable))
 	for _, sc := range postable {
@@ -290,7 +300,7 @@ func bucketsToGHComments(postable []scopedComment) []map[string]any {
 			"path": sc.Path,
 			"line": c.EndLine,
 			"side": "RIGHT",
-			"body": c.Body,
+			"body": rewrite(c.Body),
 		}
 		if c.StartLine != c.EndLine && c.StartLine > 0 {
 			comment["start_line"] = c.StartLine

--- a/push_buckets_test.go
+++ b/push_buckets_test.go
@@ -288,7 +288,7 @@ func TestBucketsToGHComments_ShapesCorrectly(t *testing.T) {
 		{Path: "a.go", Comment: Comment{StartLine: 3, EndLine: 3, Body: "single"}},
 		{Path: "b.go", Comment: Comment{StartLine: 5, EndLine: 8, Body: "range"}},
 	}
-	got := bucketsToGHComments(postable)
+	got := bucketsToGHComments(postable, nil)
 	if len(got) != 2 {
 		t.Fatalf("len=%d want 2", len(got))
 	}
@@ -306,11 +306,67 @@ func TestBucketsToGHComments_ShapesCorrectly(t *testing.T) {
 }
 
 func TestBucketsToGHComments_EmptyInput(t *testing.T) {
-	if got := bucketsToGHComments(nil); got != nil {
+	if got := bucketsToGHComments(nil, nil); got != nil {
 		t.Errorf("nil input should return nil, got %+v", got)
 	}
-	if got := bucketsToGHComments([]scopedComment{}); got != nil {
+	if got := bucketsToGHComments([]scopedComment{}, nil); got != nil {
 		t.Errorf("empty input should return nil, got %+v", got)
+	}
+}
+
+// Default (nil) rewriter strips local attachment refs and appends a
+// "view in Crit" placeholder. Verifies the body sent to GitHub doesn't
+// leak relative attachments/<uuid> paths.
+func TestBucketsToGHComments_StripsLocalAttachmentRefsByDefault(t *testing.T) {
+	uuid, _ := randomUUID()
+	body := "look at this:\n\n![](attachments/" + uuid + ".png)\n\nthoughts?"
+	postable := []scopedComment{{
+		Path: "ui.tsx", Comment: Comment{StartLine: 1, EndLine: 1, Body: body},
+	}}
+	got := bucketsToGHComments(postable, nil)
+	if len(got) != 1 {
+		t.Fatalf("len=%d want 1", len(got))
+	}
+	out, _ := got[0]["body"].(string)
+	if strings.Contains(out, "](attachments/") {
+		t.Errorf("body still contains local attachment ref: %q", out)
+	}
+	if !strings.Contains(out, "view in Crit") {
+		t.Errorf("expected placeholder note in body: %q", out)
+	}
+}
+
+// Generic delegation check: when the caller passes a rewriter that swaps
+// attachments/<uuid> for some other URL, bucketsToGHComments forwards the
+// body unchanged through that rewriter (no placeholder appended). Not a
+// production scenario — production passes stripBodyRewriter — but the
+// rewriter parameter is part of the function's contract.
+func TestBucketsToGHComments_SwapsLocalAttachmentRefsWhenUpload(t *testing.T) {
+	uuid, _ := randomUUID()
+	body := "look at this:\n\n![bug.png](attachments/" + uuid + ".png)\n\nthoughts?"
+	swap := func(b string) string {
+		return strings.ReplaceAll(
+			b,
+			"attachments/"+uuid+".png",
+			"https://raw.githubusercontent.com/o/r/feature/.crit/images/"+uuid+".png",
+		)
+	}
+	postable := []scopedComment{{
+		Path: "ui.tsx", Comment: Comment{StartLine: 1, EndLine: 1, Body: body},
+	}}
+	got := bucketsToGHComments(postable, swap)
+	if len(got) != 1 {
+		t.Fatalf("len=%d want 1", len(got))
+	}
+	out, _ := got[0]["body"].(string)
+	if !strings.Contains(out, "raw.githubusercontent.com/o/r/feature/.crit/images/"+uuid+".png") {
+		t.Errorf("body missing GitHub raw URL: %q", out)
+	}
+	if strings.Contains(out, "](attachments/") {
+		t.Errorf("body still references local attachments/: %q", out)
+	}
+	if strings.Contains(out, "view in Crit") {
+		t.Errorf("body should not carry strip placeholder when upload swaps URL: %q", out)
 	}
 }
 

--- a/review_file.go
+++ b/review_file.go
@@ -125,18 +125,20 @@ type SnapshotsFile struct {
 // The identity may have been a flat .json file in v3; v4 treats it uniformly
 // as a folder. Migration is handled by ensureReviewFolder.
 type reviewPaths struct {
-	Folder    string
-	Review    string
-	Snapshots string
+	Folder      string
+	Review      string
+	Snapshots   string
+	Attachments string
 }
 
 // reviewPathsFor returns the v4 folder-form paths for a review identity.
 // reviewPathsFor does not touch disk; migration is handled separately.
 func reviewPathsFor(identity string) reviewPaths {
 	return reviewPaths{
-		Folder:    identity,
-		Review:    filepath.Join(identity, "review.json"),
-		Snapshots: filepath.Join(identity, "snapshots.json"),
+		Folder:      identity,
+		Review:      filepath.Join(identity, "review.json"),
+		Snapshots:   filepath.Join(identity, "snapshots.json"),
+		Attachments: filepath.Join(identity, "attachments"),
 	}
 }
 
@@ -343,7 +345,8 @@ func saveCritJSON(critPath string, cj CritJSON) error {
 	return atomicWriteFile(reviewPathsFor(critPath).Review, append(data, '\n'), 0o644)
 }
 
-// clearCritJSON removes the review folder for the resolved path or outputDir.
+// clearCritJSON removes the review folder (review.json, snapshots.json, and
+// any attachments) for the resolved path or outputDir.
 func clearCritJSON(outputDir string) error {
 	critPath, err := resolveReviewPath(outputDir)
 	if err != nil {
@@ -353,7 +356,7 @@ func clearCritJSON(outputDir string) error {
 }
 
 // clearReviewFolder removes the entire review folder (review.json,
-// snapshots.json, future attachments). Idempotent: a missing folder is fine.
+// snapshots.json, attachments). Idempotent: a missing folder is fine.
 func clearReviewFolder(identity string) error {
 	if err := os.RemoveAll(identity); err != nil && !os.IsNotExist(err) {
 		return err

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -110,6 +111,16 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, authToken
 	mux.HandleFunc("/api/file/diff", s.withReady(s.handleFileDiff))
 	mux.HandleFunc("/api/file/comments", s.withReady(s.handleFileComments))
 	mux.HandleFunc("/api/comment/", s.withReady(s.handleCommentByID))
+
+	// Attachment upload (POST) and serving (GET /api/attachments/{filename}).
+	// The trailing slash form ServeMux uses means the bare /api/attachments
+	// path is matched by the same handler; we route on method + presence of
+	// a suffix so both upload and fetch live in one place. Markdown stores
+	// the relative form `attachments/<uuid>.<ext>`; the frontend rewrites
+	// to /api/attachments/<uuid>.<ext> at render time so this URL space is
+	// only ever hit through the rewrite hook (or direct curl).
+	mux.HandleFunc("/api/attachments", s.withReady(s.handleAttachments))
+	mux.HandleFunc("/api/attachments/", s.withReady(s.handleAttachments))
 
 	// Static file serving (repo files need session; embedded assets do not)
 	mux.HandleFunc("/files/", s.withReady(s.handleFiles))
@@ -1560,6 +1571,128 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// handleAttachments dispatches both attachment upload (POST /api/attachments)
+// and fetch (GET /api/attachments/{filename}). Storage lives at
+// reviewPathsFor(s.reviewPath).Attachments so the v4 clearReviewFolder pass
+// removes attachments alongside review.json on cleanup.
+func (s *Server) handleAttachments(w http.ResponseWriter, r *http.Request) {
+	if s.reviewPath == "" {
+		http.Error(w, "Attachment storage unavailable (no review path)", http.StatusServiceUnavailable)
+		return
+	}
+
+	suffix := strings.TrimPrefix(r.URL.Path, "/api/attachments")
+	suffix = strings.TrimPrefix(suffix, "/")
+
+	switch r.Method {
+	case http.MethodPost:
+		if suffix != "" {
+			http.Error(w, "POST takes no path suffix", http.StatusBadRequest)
+			return
+		}
+		s.handleAttachmentUpload(w, r)
+	case http.MethodGet:
+		if suffix == "" {
+			http.Error(w, "Filename required", http.StatusBadRequest)
+			return
+		}
+		s.handleAttachmentGet(w, r, suffix)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleAttachmentUpload accepts a single multipart form field named "file"
+// containing image bytes. Validates MIME, persists via saveAttachment, and
+// returns the *relative* URL (`attachments/<uuid>.<ext>`) the frontend
+// should embed verbatim in the comment markdown — the source of truth in
+// review.json is the relative form, with each render target rewriting at
+// its own publish boundary.
+//
+// The original_filename is sanitized server-side and returned so the
+// frontend can use it as alt text without trusting raw upload metadata.
+func (s *Server) handleAttachmentUpload(w http.ResponseWriter, r *http.Request) {
+	// Cap the entire request body. Multipart adds a small overhead beyond
+	// the raw image bytes; a generous +1MB ceiling keeps the math simple.
+	r.Body = http.MaxBytesReader(w, r.Body, maxAttachmentBytes+(1<<20))
+
+	if err := r.ParseMultipartForm(maxAttachmentBytes + (1 << 20)); err != nil {
+		http.Error(w, "Invalid multipart form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "Missing 'file' field", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// Read up to maxAttachmentBytes+1 so we can detect overflow distinctly
+	// from a successful read at exactly the cap.
+	buf := make([]byte, maxAttachmentBytes+1)
+	n, err := io.ReadFull(file, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		http.Error(w, "Read upload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if n > maxAttachmentBytes {
+		http.Error(w, fmt.Sprintf("Image too large (max %d bytes)", maxAttachmentBytes), http.StatusRequestEntityTooLarge)
+		return
+	}
+	data := buf[:n]
+
+	filename, err := saveAttachment(s.reviewPath, data)
+	if err != nil {
+		// MIME rejections deserve 415; everything else is 400.
+		if strings.HasPrefix(err.Error(), "unsupported image type") {
+			http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// header may be nil if FormFile is called creatively in tests; guard.
+	originalFilename := ""
+	if header != nil {
+		originalFilename = sanitizeAttachmentAltText(header.Filename)
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, map[string]string{
+		"filename":          filename,
+		"original_filename": originalFilename,
+		"url":               "attachments/" + filename,
+	})
+}
+
+// handleAttachmentGet serves a previously uploaded attachment by its UUID
+// filename. The filename regex makes path traversal impossible without the
+// caller having to look at r.URL.Path themselves.
+func (s *Server) handleAttachmentGet(w http.ResponseWriter, r *http.Request, filename string) {
+	path, mime, err := attachmentPathFor(s.reviewPath, filename)
+	if err != nil {
+		http.Error(w, "Invalid attachment filename", http.StatusBadRequest)
+		return
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		http.Error(w, "Attachment not found", http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		http.Error(w, "Stat failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", mime)
+	// UUIDs are never reused; the bytes behind a URL never change.
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	http.ServeContent(w, r, filename, info.ModTime(), f)
 }
 
 func (s *Server) handleFiles(w http.ResponseWriter, r *http.Request) {

--- a/share.go
+++ b/share.go
@@ -282,7 +282,15 @@ func loadCommentsForShare(critPath string, filePaths []string, fallbackAuthor st
 // includeResolved and setExternalID flags. The filePath and scope fields are
 // set by the caller based on context. fallbackAuthor is used when c.Author is
 // empty (typically cfg.Author).
-func commentToShareComment(c Comment, filePath, scope, fallbackAuthor string, includeResolved, setExternalID bool) shareComment {
+//
+// critPath is the v4 review identity (folder); it's used to locate the
+// attachments dir so any attachments/<uuid>.<ext> markdown references in
+// the body (or its replies) get rewritten to data: URIs before the share
+// payload leaves the host. crit-web has no asset endpoint, so this
+// inlining is the only way pasted screenshots survive a share. Passing
+// "" disables inlining (used in unit tests that don't write attachments
+// to disk).
+func commentToShareComment(c Comment, filePath, scope, fallbackAuthor, critPath string, includeResolved, setExternalID bool) shareComment {
 	author := c.Author
 	if author == "" {
 		author = fallbackAuthor
@@ -291,7 +299,7 @@ func commentToShareComment(c Comment, filePath, scope, fallbackAuthor string, in
 		File:      filePath,
 		StartLine: c.StartLine,
 		EndLine:   c.EndLine,
-		Body:      c.Body,
+		Body:      inlineAttachmentsAsDataURIs(critPath, c.Body),
 		Quote:     c.Quote,
 		Author:    author,
 		UserID:    c.UserID,
@@ -311,7 +319,7 @@ func commentToShareComment(c Comment, filePath, scope, fallbackAuthor string, in
 		if ra == "" {
 			ra = fallbackAuthor
 		}
-		sr := shareReply{Body: r.Body, Author: ra, UserID: r.UserID}
+		sr := shareReply{Body: inlineAttachmentsAsDataURIs(critPath, r.Body), Author: ra, UserID: r.UserID}
 		if setExternalID {
 			sr.ExternalID = r.ID
 		}
@@ -355,14 +363,14 @@ func loadCommentsFromCritJSON(critPath string, filePaths []string, includeResolv
 				continue
 			}
 			scope := c.Scope
-			comments = append(comments, commentToShareComment(c, filePath, scope, fallbackAuthor, includeResolved, setExternalID))
+			comments = append(comments, commentToShareComment(c, filePath, scope, fallbackAuthor, critPath, includeResolved, setExternalID))
 		}
 	}
 	for _, c := range cj.ReviewComments {
 		if !includeResolved && c.Resolved {
 			continue
 		}
-		comments = append(comments, commentToShareComment(c, "", "review", fallbackAuthor, includeResolved, setExternalID))
+		comments = append(comments, commentToShareComment(c, "", "review", fallbackAuthor, critPath, includeResolved, setExternalID))
 	}
 	return comments, round
 }

--- a/share_test.go
+++ b/share_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"image/color"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1884,5 +1885,215 @@ func TestMergeWebComments_AppliesReplyUpdates(t *testing.T) {
 	}
 	if len(comments[0].Replies) != 1 || comments[0].Replies[0].Body != "thanks" {
 		t.Errorf("expected merged reply, got %+v", comments[0].Replies)
+	}
+}
+
+// TestShareReviewFiles_InlinesAttachmentsEndToEnd is a full-stack regression
+// test for the share path: starting from a real review folder on disk (v4
+// layout with review.json and attachments/<uuid>.<ext>), invoke
+// shareReviewFiles end-to-end, capture the JSON payload sent to the
+// crit-web stub, and assert that comment + reply bodies have their local
+// attachment refs rewritten to data:image/png;base64,... — and do NOT carry
+// raw `attachments/...` refs that crit-web has no way to resolve.
+//
+// This guards against future refactors that bypass commentToShareComment's
+// inlineAttachmentsAsDataURIs call (the only place rewriting happens). The
+// existing TestCommentToShareComment/inlines_local_attachments_for_share_when_critPath_set
+// covers the unit, this covers the wiring above it.
+func TestShareReviewFiles_InlinesAttachmentsEndToEnd(t *testing.T) {
+	// Build a real v4 review folder on disk.
+	review := newReviewIdentity(t)
+	png := makeTestPNG(t, color.RGBA{12, 34, 56, 255})
+	filename, err := saveAttachment(review, png)
+	if err != nil {
+		t.Fatalf("saveAttachment: %v", err)
+	}
+
+	cj := CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"README.md": {
+				Comments: []Comment{
+					{
+						ID:        "c_topimg",
+						StartLine: 5,
+						EndLine:   5,
+						Body:      "look at this:\n\n![img.png](attachments/" + filename + ")",
+						Author:    "Alice",
+						Scope:     "line",
+					},
+					{
+						ID:        "c_replyimg",
+						StartLine: 7,
+						EndLine:   7,
+						Body:      "this one too",
+						Author:    "Alice",
+						Scope:     "line",
+						Replies: []Reply{
+							{ID: "rp_1", Body: "in reply:\n\n![img.png](attachments/" + filename + ")", Author: "Bob"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := saveCritJSON(review, cj); err != nil {
+		t.Fatalf("saveCritJSON: %v", err)
+	}
+
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"url":"http://stub/r/x","delete_token":"tok"}`))
+	}))
+	defer srv.Close()
+
+	files := []shareFile{{Path: "README.md", Content: "stub content\n"}}
+	if _, err := shareReviewFiles(review, files, []string{"README.md"}, srv.URL, "", "Alice"); err != nil {
+		t.Fatalf("shareReviewFiles: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(captured, &payload); err != nil {
+		t.Fatalf("decode payload: %v\nbody=%q", err, string(captured))
+	}
+	commentsAny, _ := payload["comments"].([]any)
+	if len(commentsAny) != 2 {
+		t.Fatalf("expected 2 comments in payload, got %d", len(commentsAny))
+	}
+
+	for i, c := range commentsAny {
+		m := c.(map[string]any)
+		body, _ := m["body"].(string)
+		// Top-level comment body — either it had an attachment ref or it didn't.
+		if strings.Contains(body, "attachments/") {
+			t.Errorf("comment[%d] body still contains raw attachments/ ref: %q", i, truncate(body, 200))
+		}
+		hasImg := strings.Contains(body, "![")
+		if hasImg && !strings.Contains(body, "data:image/png;base64,") {
+			t.Errorf("comment[%d] has image syntax but no data URI: %q", i, truncate(body, 200))
+		}
+		replies, _ := m["replies"].([]any)
+		for j, r := range replies {
+			rm := r.(map[string]any)
+			rb, _ := rm["body"].(string)
+			if strings.Contains(rb, "attachments/") {
+				t.Errorf("comment[%d].reply[%d] body still contains raw attachments/ ref: %q", i, j, truncate(rb, 200))
+			}
+			if strings.Contains(rb, "![") && !strings.Contains(rb, "data:image/png;base64,") {
+				t.Errorf("comment[%d].reply[%d] has image syntax but no data URI: %q", i, j, truncate(rb, 200))
+			}
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// TestShareReviewFiles_PlanMode_InlinesAttachments guards the plan-mode share
+// path. In plan mode the daemon stores review.json under <planDir>/.crit/
+// (because applyPlanOverrides sets session.OutputDir = planDir, and
+// critJSONPath() returns OutputDir/.crit), and the server's attachment
+// upload writes to <srv.reviewPath>/attachments/. Both MUST resolve to the
+// same folder; if a regression reintroduces a split (e.g. by missing a
+// planDir branch when computing srv.reviewPath), the upload handler writes
+// to ~/.crit/reviews/<key>/attachments/ while share inlining looks in
+// <planDir>/.crit/attachments/ — the file isn't found, the regex match
+// returns the body unchanged, and crit-web renders [image: <alt>]
+// placeholders for what should be inlined data: URIs.
+//
+// This test pins the invariant by laying out a plan-style folder
+// (review.json + attachments/<uuid>.<ext> co-located) and asserting that
+// shareReviewFiles produces a payload with data: URIs.
+func TestShareReviewFiles_PlanMode_InlinesAttachments(t *testing.T) {
+	// Plan-style layout: review folder is <planDir>/.crit/ — review.json
+	// and attachments live there together.
+	planDir := t.TempDir()
+	critPath := filepath.Join(planDir, ".crit")
+	if err := os.MkdirAll(critPath, 0o755); err != nil {
+		t.Fatalf("mkdir critPath: %v", err)
+	}
+
+	png := makeTestPNG(t, color.RGBA{200, 50, 100, 255})
+	filename, err := saveAttachment(critPath, png)
+	if err != nil {
+		t.Fatalf("saveAttachment: %v", err)
+	}
+	// Confirm the attachment is where the inliner will look for it.
+	if _, err := os.Stat(filepath.Join(critPath, "attachments", filename)); err != nil {
+		t.Fatalf("attachment not co-located with review.json: %v", err)
+	}
+
+	planFile := "remove-readme-md-2026-05-11.md"
+	cj := CritJSON{
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			planFile: {
+				Comments: []Comment{
+					{
+						ID:        "c_top",
+						StartLine: 1,
+						EndLine:   1,
+						Body:      "test image\n\n![image.png](attachments/" + filename + ")",
+						Author:    "Samuel Tissot",
+						Scope:     "line",
+						Replies: []Reply{
+							{ID: "rp_1", Body: "sub\n\n![image.png](attachments/" + filename + ")", Author: "Samuel Tissot"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := saveCritJSON(critPath, cj); err != nil {
+		t.Fatalf("saveCritJSON: %v", err)
+	}
+
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"url":"http://stub/r/plan","delete_token":"tok"}`))
+	}))
+	defer srv.Close()
+
+	files := []shareFile{{Path: planFile, Content: "stub plan content\n"}}
+	if _, err := shareReviewFiles(critPath, files, []string{planFile}, srv.URL, "", "Samuel Tissot"); err != nil {
+		t.Fatalf("shareReviewFiles: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(captured, &payload); err != nil {
+		t.Fatalf("decode payload: %v\nbody=%q", err, string(captured))
+	}
+	commentsAny, _ := payload["comments"].([]any)
+	if len(commentsAny) != 1 {
+		t.Fatalf("expected 1 comment in payload, got %d", len(commentsAny))
+	}
+	m := commentsAny[0].(map[string]any)
+	body, _ := m["body"].(string)
+	if strings.Contains(body, "attachments/") {
+		t.Errorf("plan-mode comment body still contains raw attachments/ ref (inlining failed): %q", truncate(body, 200))
+	}
+	if !strings.Contains(body, "data:image/png;base64,") {
+		t.Errorf("plan-mode comment body missing data URI: %q", truncate(body, 200))
+	}
+	replies, _ := m["replies"].([]any)
+	if len(replies) != 1 {
+		t.Fatalf("expected 1 reply, got %d", len(replies))
+	}
+	rb, _ := replies[0].(map[string]any)["body"].(string)
+	if strings.Contains(rb, "attachments/") {
+		t.Errorf("plan-mode reply body still contains raw attachments/ ref (inlining failed): %q", truncate(rb, 200))
+	}
+	if !strings.Contains(rb, "data:image/png;base64,") {
+		t.Errorf("plan-mode reply body missing data URI: %q", truncate(rb, 200))
 	}
 }

--- a/share_test.go
+++ b/share_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"image/color"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1564,7 +1566,7 @@ func TestCommentToShareComment(t *testing.T) {
 			Author:      "Alice",
 			ReviewRound: 2,
 		}
-		sc := commentToShareComment(c, "main.go", "line", "", false, false)
+		sc := commentToShareComment(c, "main.go", "line", "", "", false, false)
 		if sc.File != "main.go" {
 			t.Errorf("File = %q, want main.go", sc.File)
 		}
@@ -1590,7 +1592,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("includes resolved when flag set", func(t *testing.T) {
 		c := Comment{Resolved: true}
-		sc := commentToShareComment(c, "", "", "", true, false)
+		sc := commentToShareComment(c, "", "", "", "", true, false)
 		if !sc.Resolved {
 			t.Error("expected Resolved=true when includeResolved=true")
 		}
@@ -1598,7 +1600,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("excludes resolved when flag not set", func(t *testing.T) {
 		c := Comment{Resolved: true}
-		sc := commentToShareComment(c, "", "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", "", false, false)
 		if sc.Resolved {
 			t.Error("expected Resolved=false when includeResolved=false")
 		}
@@ -1606,7 +1608,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("sets external ID when flag set", func(t *testing.T) {
 		c := Comment{ID: "c123"}
-		sc := commentToShareComment(c, "", "", "", false, true)
+		sc := commentToShareComment(c, "", "", "", "", false, true)
 		if sc.ExternalID != "c123" {
 			t.Errorf("ExternalID = %q, want c123", sc.ExternalID)
 		}
@@ -1614,7 +1616,7 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("omits external ID when flag not set", func(t *testing.T) {
 		c := Comment{ID: "c123"}
-		sc := commentToShareComment(c, "", "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", "", false, false)
 		if sc.ExternalID != "" {
 			t.Errorf("ExternalID = %q, want empty", sc.ExternalID)
 		}
@@ -1628,7 +1630,7 @@ func TestCommentToShareComment(t *testing.T) {
 				{Body: "verified", Author: "Alice"},
 			},
 		}
-		sc := commentToShareComment(c, "f.md", "", "", false, false)
+		sc := commentToShareComment(c, "f.md", "", "", "", false, false)
 		if len(sc.Replies) != 2 {
 			t.Fatalf("expected 2 replies, got %d", len(sc.Replies))
 		}
@@ -1639,9 +1641,50 @@ func TestCommentToShareComment(t *testing.T) {
 
 	t.Run("review round zero omitted", func(t *testing.T) {
 		c := Comment{ReviewRound: 0}
-		sc := commentToShareComment(c, "", "", "", false, false)
+		sc := commentToShareComment(c, "", "", "", "", false, false)
 		if sc.ReviewRound != 0 {
 			t.Errorf("ReviewRound = %d, want 0 (omitted for round 0)", sc.ReviewRound)
+		}
+	})
+
+	t.Run("inlines local attachments for share when critPath set", func(t *testing.T) {
+		review := newReviewIdentity(t)
+		data := makeTestPNG(t, color.RGBA{50, 100, 150, 255})
+		filename, err := saveAttachment(review, data)
+		if err != nil {
+			t.Fatalf("seed attachment: %v", err)
+		}
+		c := Comment{
+			Body: "look: ![bug.png](attachments/" + filename + ")",
+			Replies: []Reply{
+				{Body: "yes ![](attachments/" + filename + ")"},
+			},
+		}
+		sc := commentToShareComment(c, "main.go", "line", "", review, false, false)
+		if !strings.Contains(sc.Body, "data:image/png;base64,") {
+			t.Errorf("expected inlined data URI in body, got: %q", sc.Body)
+		}
+		if strings.Contains(sc.Body, "](attachments/") {
+			t.Errorf("body still references attachments/: %q", sc.Body)
+		}
+		if !strings.Contains(sc.Body, "![bug.png](") {
+			t.Errorf("alt text dropped during inline: %q", sc.Body)
+		}
+		if len(sc.Replies) != 1 {
+			t.Fatalf("expected 1 reply, got %d", len(sc.Replies))
+		}
+		if !strings.Contains(sc.Replies[0].Body, "data:image/png;base64,") {
+			t.Errorf("reply body not inlined: %q", sc.Replies[0].Body)
+		}
+	})
+
+	t.Run("leaves attachments alone when critPath empty", func(t *testing.T) {
+		uuid, _ := randomUUID()
+		body := "![](attachments/" + uuid + ".png)"
+		c := Comment{Body: body}
+		sc := commentToShareComment(c, "f.md", "line", "", "", false, false)
+		if sc.Body != body {
+			t.Errorf("body should be untouched without critPath, got: %q", sc.Body)
 		}
 	})
 }

--- a/test/test-plan-copy.md
+++ b/test/test-plan-copy.md
@@ -137,7 +137,11 @@ signed with the user's webhook secret. Receivers should verify this before proce
 - [ ] GET /notifications feed with cursor pagination
 - [ ] POST /notifications/:id/read and POST /notifications/read-all
 - [ ] Email delivery via SES
-- [ ] Webhook delivery with HMAC signature verification
+- [ ] Webhook delivery with HMAC signature verification, supporting:
+  - `POST /webhooks/:id` → 2xx success, persist `delivered_at`.
+  - `POST /webhooks/:id` → 4xx client error, mark `dead` and stop retrying.
+  - `POST /webhooks/:id` → 5xx / timeout, schedule retry with backoff.
+  - `DELETE /webhooks/:id` → owner-only, requires `X-Internal-Token`.
 - [ ] Retry worker with exponential backoff
 - [ ] Integration tests for the delivery pipeline
 - [ ] Runbook: how to inspect and manually retry stuck deliveries


### PR DESCRIPTION
## Image support in review
enables the ability to paste images in the comment section of the review.
issue: #458 

### Supported
#### Local 
- adds the image in `.crit/reviews/<review_id>/attachments/*`
- survive restart
<img width="2100" height="1170" alt="image" src="https://github.com/user-attachments/assets/75fdfc76-1cca-4c0b-a8f4-770a2c32b64f" />

#### Sharing 
- adds the b64 images content inline in the markdown
<img width="3544" height="1608" alt="crit_image_shared" src="https://github.com/user-attachments/assets/f92baa47-ac98-4325-aa1f-55b0369e8ba0" />

### Not supported
- **Github PR**: I removed what I originally add because the quick solution was to add the image to the repo under `.crit/attachments/*` but I find that just pollutes the repo. Also this can be properly handle once the upload attachment feature is done.
#### Current Github Solution
I just strip the image and show the omission via text.
<img width="1456" height="999" alt="crit_pr_review" src="https://github.com/user-attachments/assets/9870b63b-bb8c-409c-ae83-ebeb885c94ec" />

## AI
disclaimer this work was done with Claude Code Opus 4.7. _I refrained from drinking to much water during development_ :) 

## Testing
- User tested for a few days.
- `go test ./...` clean
- `make e2e`  clean
- `make test-diff` didn't report any error as far as I can tell.
- linting tool have been ran.

