### PR TITLE
fix: keyboard-nav line highlight visible in light mode

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -605,6 +605,7 @@ body {
 
 .line-block.focused {
   background: var(--crit-line-focus-bg);
+  box-shadow: inset 2px 0 0 var(--crit-brand);
 }
 
 .line-block.line-block-added {
@@ -643,11 +644,6 @@ body {
 }
 .deletion-marker.change-flash {
   animation: change-flash 1s ease-out;
-}
-
-.diff-line.focused,
-.diff-split-row.focused {
-  background: var(--crit-line-focus-bg);
 }
 
 /* ===== Gutter ===== */
@@ -3715,7 +3711,10 @@ body.sidebar-resizing * {
 .diff-container.unified .diff-line.addition { background: var(--crit-diff-add-bg); }
 .diff-container.unified .diff-line.deletion { background: var(--crit-diff-del-bg); }
 .diff-container.unified .diff-line.has-comment { background: var(--crit-comment-range-bg); }
-.diff-container.unified .diff-line.focused { background: var(--crit-line-focus-bg); }
+.diff-container.unified .diff-line.focused {
+  background: var(--crit-line-focus-bg);
+  border-left-color: var(--crit-brand);
+}
 .diff-container.unified .diff-line.selected,
 .diff-container.unified .diff-line.form-selected { background: var(--crit-brand-subtle); }
 .diff-container.unified .diff-gutter {
@@ -3757,7 +3756,10 @@ body.sidebar-resizing * {
 .diff-split-side.empty { background: var(--crit-editor-bg-card); }
 .diff-split-side.selected,
 .diff-split-side.form-selected { background: var(--crit-brand-subtle); }
-.diff-split-row.focused .diff-split-side { background: var(--crit-line-focus-bg); }
+.diff-split-row.focused .diff-split-side {
+  background: var(--crit-line-focus-bg);
+  border-left-color: var(--crit-brand);
+}
 .diff-split-side .diff-gutter-num { min-width: 44px; }
 .diff-split-side.deletion .diff-gutter-num { background: var(--crit-diff-del-gutter); }
 .diff-split-side.addition .diff-gutter-num { background: var(--crit-diff-add-gutter); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3715,7 +3715,10 @@ body.sidebar-resizing * {
   background: var(--crit-line-focus-bg);
   border-left-color: var(--crit-brand);
 }
-.diff-container.unified .diff-line.focused .diff-gutter-num { background: var(--crit-line-focus-bg); }
+.diff-container.unified .diff-line.focused .diff-gutter-num:first-child,
+.diff-container.unified .diff-line.focused .diff-gutter-num:last-child {
+  background: var(--crit-line-focus-bg);
+}
 .diff-container.unified .diff-line.selected,
 .diff-container.unified .diff-line.form-selected { background: var(--crit-brand-subtle); }
 .diff-container.unified .diff-gutter {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3715,6 +3715,7 @@ body.sidebar-resizing * {
   background: var(--crit-line-focus-bg);
   border-left-color: var(--crit-brand);
 }
+.diff-container.unified .diff-line.focused .diff-gutter-num { background: var(--crit-line-focus-bg); }
 .diff-container.unified .diff-line.selected,
 .diff-container.unified .diff-line.form-selected { background: var(--crit-brand-subtle); }
 .diff-container.unified .diff-gutter {
@@ -3760,6 +3761,7 @@ body.sidebar-resizing * {
   background: var(--crit-line-focus-bg);
   border-left-color: var(--crit-brand);
 }
+.diff-split-row.focused .diff-split-side .diff-gutter-num { background: var(--crit-line-focus-bg); }
 .diff-split-side .diff-gutter-num { min-width: 44px; }
 .diff-split-side.deletion .diff-gutter-num { background: var(--crit-diff-del-gutter); }
 .diff-split-side.addition .diff-gutter-num { background: var(--crit-diff-add-gutter); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -599,9 +599,12 @@ body {
 }
 
 .line-block.selected,
-.line-block.form-selected,
-.line-block.focused {
+.line-block.form-selected {
   background: var(--crit-brand-subtle);
+}
+
+.line-block.focused {
+  background: var(--crit-line-focus-bg);
 }
 
 .line-block.line-block-added {
@@ -643,7 +646,7 @@ body {
 }
 
 .diff-line.focused, .diff-split-row.focused {
-  background: var(--crit-brand-subtle);
+  background: var(--crit-line-focus-bg);
 }
 
 /* ===== Gutter ===== */

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -645,7 +645,8 @@ body {
   animation: change-flash 1s ease-out;
 }
 
-.diff-line.focused, .diff-split-row.focused {
+.diff-line.focused,
+.diff-split-row.focused {
   background: var(--crit-line-focus-bg);
 }
 
@@ -3714,6 +3715,7 @@ body.sidebar-resizing * {
 .diff-container.unified .diff-line.addition { background: var(--crit-diff-add-bg); }
 .diff-container.unified .diff-line.deletion { background: var(--crit-diff-del-bg); }
 .diff-container.unified .diff-line.has-comment { background: var(--crit-comment-range-bg); }
+.diff-container.unified .diff-line.focused { background: var(--crit-line-focus-bg); }
 .diff-container.unified .diff-line.selected,
 .diff-container.unified .diff-line.form-selected { background: var(--crit-brand-subtle); }
 .diff-container.unified .diff-gutter {
@@ -3755,6 +3757,7 @@ body.sidebar-resizing * {
 .diff-split-side.empty { background: var(--crit-editor-bg-card); }
 .diff-split-side.selected,
 .diff-split-side.form-selected { background: var(--crit-brand-subtle); }
+.diff-split-row.focused .diff-split-side { background: var(--crit-line-focus-bg); }
 .diff-split-side .diff-gutter-num { min-width: 44px; }
 .diff-split-side.deletion .diff-gutter-num { background: var(--crit-diff-del-gutter); }
 .diff-split-side.addition .diff-gutter-num { background: var(--crit-diff-add-gutter); }

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -26,7 +26,7 @@
   --crit-brand-hover:   #94bcfb;
   --crit-brand-subtle:  rgba(133, 170, 248, 0.10);
   --crit-brand-bg:      rgba(133, 170, 248, 0.15);
-  --crit-line-focus-bg: rgba(133, 170, 248, 0.18);
+  --crit-line-focus-bg: rgba(133, 170, 248, 0.10);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -187,7 +187,7 @@
     --crit-brand-hover:   #396ec6;
     --crit-brand-subtle:  rgba(41,96,188,0.08);
     --crit-brand-bg:      rgba(41,96,188,0.12);
-    --crit-line-focus-bg: rgba(41,96,188,0.18);
+    --crit-line-focus-bg: rgba(41,96,188,0.10);
     --crit-brand-cta:       #3a72d4;
     --crit-brand-cta-hover: #3568c8;
 
@@ -318,7 +318,7 @@
   --crit-brand-hover:   #94bcfb;
   --crit-brand-subtle:  rgba(133, 170, 248, 0.10);
   --crit-brand-bg:      rgba(133, 170, 248, 0.15);
-  --crit-line-focus-bg: rgba(133, 170, 248, 0.18);
+  --crit-line-focus-bg: rgba(133, 170, 248, 0.10);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -448,7 +448,7 @@
   --crit-brand-hover:   #396ec6;
   --crit-brand-subtle:  rgba(41,96,188,0.08);
   --crit-brand-bg:      rgba(41,96,188,0.12);
-  --crit-line-focus-bg: rgba(41,96,188,0.18);
+  --crit-line-focus-bg: rgba(41,96,188,0.10);
   --crit-brand-cta:       #3a72d4;
   --crit-brand-cta-hover: #3568c8;
 

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -26,6 +26,7 @@
   --crit-brand-hover:   #94bcfb;
   --crit-brand-subtle:  rgba(133, 170, 248, 0.10);
   --crit-brand-bg:      rgba(133, 170, 248, 0.15);
+  --crit-line-focus-bg: rgba(133, 170, 248, 0.18);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -186,6 +187,7 @@
     --crit-brand-hover:   #396ec6;
     --crit-brand-subtle:  rgba(41,96,188,0.08);
     --crit-brand-bg:      rgba(41,96,188,0.12);
+    --crit-line-focus-bg: rgba(41,96,188,0.18);
     --crit-brand-cta:       #3a72d4;
     --crit-brand-cta-hover: #3568c8;
 
@@ -316,6 +318,7 @@
   --crit-brand-hover:   #94bcfb;
   --crit-brand-subtle:  rgba(133, 170, 248, 0.10);
   --crit-brand-bg:      rgba(133, 170, 248, 0.15);
+  --crit-line-focus-bg: rgba(133, 170, 248, 0.18);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -445,6 +448,7 @@
   --crit-brand-hover:   #396ec6;
   --crit-brand-subtle:  rgba(41,96,188,0.08);
   --crit-brand-bg:      rgba(41,96,188,0.12);
+  --crit-line-focus-bg: rgba(41,96,188,0.18);
   --crit-brand-cta:       #3a72d4;
   --crit-brand-cta-hover: #3568c8;
 


### PR DESCRIPTION
## Summary
- The j/k keyboard nav highlight shared `--crit-brand-subtle` (8% opacity in light mode), which was invisible against white backgrounds.
- Introduce dedicated `--crit-line-focus-bg` at 18% brand-color opacity, defined in all 4 theme blocks.
- Apply to `.line-block.focused` and `.diff-line.focused` / `.diff-split-row.focused`. `.selected` / `.form-selected` still use `--crit-brand-subtle`.

## Test plan
- [x] `bash scripts/check-css-vars.sh` — clean
- [x] `go test ./...` — pass
- [ ] Visual: light mode shows clear highlight on j/k navigation

See also: tomasz-tomczyk/crit-web#(see linked)

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)