### PR TITLE
feat: vim-style visual line mode (V) for multi-line comments

### DIFF
--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -501,9 +501,7 @@ test.describe('Keyboard Visual Line Mode — Markdown', () => {
 
     // Multiple blocks should now have .selected.
     const selected = section.locator('.line-block.selected');
-    await expect(async () => {
-      expect(await selected.count()).toBeGreaterThan(1);
-    }).toPass();
+    await expect.poll(() => selected.count()).toBeGreaterThan(1);
 
     // Capture the furthest expansion line before opening the form
     const lastFocused = page.locator('.line-block.kb-nav.focused');
@@ -538,7 +536,7 @@ test.describe('Keyboard Visual Line Mode — Markdown', () => {
     await page.keyboard.press('j');
 
     // Selection is active across multiple blocks
-    expect(await section.locator('.line-block.selected').count()).toBeGreaterThan(1);
+    await expect.poll(() => section.locator('.line-block.selected').count()).toBeGreaterThan(1);
 
     // Capture the line currently focused (the furthest expansion)
     const beforeFocus = await page.locator('.line-block.kb-nav.focused').getAttribute('data-start-line');

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -468,6 +468,105 @@ test.describe('Keyboard Escape Behavior', () => {
 });
 
 // ============================================================
+// Visual Line Mode (V)
+// ============================================================
+test.describe('Keyboard Visual Line Mode — Markdown', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await clearFocus(page);
+  });
+
+  test('V enters visual mode; j extends selection; c opens form spanning the range', async ({ page, request }) => {
+    const section = mdSection(page);
+    const lineBlocks = section.locator('.line-block.kb-nav');
+    await expect(lineBlocks.first()).toBeAttached();
+
+    // Focus the first line-block
+    await lineBlocks.first().hover();
+    await page.keyboard.press('j');
+    const firstFocused = page.locator('.line-block.kb-nav.focused');
+    await expect(firstFocused).toHaveCount(1);
+    const anchorStart = parseInt((await firstFocused.getAttribute('data-start-line'))!);
+    const filePath = await firstFocused.getAttribute('data-file-path');
+
+    // Enter visual mode — anchor block becomes selected
+    await page.keyboard.press('Shift+V');
+    await expect(firstFocused).toHaveClass(/selected/);
+
+    // Extend selection downward with j
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+
+    // Multiple blocks should now have .selected.
+    const selected = section.locator('.line-block.selected');
+    await expect(async () => {
+      expect(await selected.count()).toBeGreaterThan(1);
+    }).toPass();
+
+    // Capture the furthest expansion line before opening the form
+    const lastFocused = page.locator('.line-block.kb-nav.focused');
+    const expansionEnd = parseInt((await lastFocused.getAttribute('data-end-line'))!);
+
+    // Open form on the selection
+    await page.keyboard.press('c');
+    const form = page.locator('.comment-form');
+    await expect(form).toBeVisible();
+
+    // Submit the comment and verify its persisted line range via the API.
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('multi-line via V');
+    await page.locator('.comment-form .btn-primary').click();
+    await expect(section.locator('.comment-card').filter({ hasText: 'multi-line via V' })).toBeVisible();
+
+    const resp = await request.get(`/api/file/comments?path=${encodeURIComponent(filePath!)}`);
+    const data = await resp.json() as Array<{ body: string; start_line: number; end_line: number }>;
+    const created = data.find((c) => c.body === 'multi-line via V');
+    expect(created).toBeDefined();
+    expect(created.start_line).toBe(anchorStart);
+    expect(created.end_line).toBe(expansionEnd);
+  });
+
+  test('Escape clears visual selection and keeps focus on current block', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlocks = section.locator('.line-block.kb-nav');
+    await lineBlocks.first().hover();
+    await page.keyboard.press('j');
+    await page.keyboard.press('Shift+V');
+    await page.keyboard.press('j');
+    await page.keyboard.press('j');
+
+    // Selection is active across multiple blocks
+    expect(await section.locator('.line-block.selected').count()).toBeGreaterThan(1);
+
+    // Capture the line currently focused (the furthest expansion)
+    const beforeFocus = await page.locator('.line-block.kb-nav.focused').getAttribute('data-start-line');
+
+    await page.keyboard.press('Escape');
+
+    // Selection cleared
+    await expect(section.locator('.line-block.selected')).toHaveCount(0);
+
+    // Focused block stays at the furthest expansion (issue spec)
+    const afterFocus = await page.locator('.line-block.kb-nav.focused').getAttribute('data-start-line');
+    expect(afterFocus).toBe(beforeFocus);
+  });
+
+  test('V again exits visual mode (toggle)', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlocks = section.locator('.line-block.kb-nav');
+    await lineBlocks.first().hover();
+    await page.keyboard.press('j');
+    await page.keyboard.press('Shift+V');
+    await expect(section.locator('.line-block.selected').first()).toBeAttached();
+
+    await page.keyboard.press('Shift+V');
+    await expect(section.locator('.line-block.selected')).toHaveCount(0);
+  });
+});
+
+// ============================================================
 // Shortcuts Disabled When Typing
 // ============================================================
 test.describe('Shortcuts Disabled When Typing', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3888,6 +3888,7 @@
       // Clear any stale unified-diff drag state so it can't bleed into render paths.
       unifiedVisualStart = null;
       unifiedVisualEnd = null;
+      document.body.classList.add('visual-mode');
       refreshVisualSelectionVisuals(fp);
       return true;
     }
@@ -3898,6 +3899,7 @@
       activeFilePath = fp;
       selectionStart = lineNum;
       selectionEnd = lineNum;
+      document.body.classList.add('visual-mode');
       refreshVisualSelectionVisuals(fp);
       return true;
     }
@@ -3908,6 +3910,7 @@
     if (!visualMode) return;
     const fp = visualMode.filePath;
     visualMode = null;
+    document.body.classList.remove('visual-mode');
     if (clearSelection) {
       selectionStart = null;
       selectionEnd = null;
@@ -8737,12 +8740,14 @@
               }
               if (lastBlockIndex >= 0) {
                 visualMode = null;
+                document.body.classList.remove('visual-mode');
                 openForm({ filePath: fp, afterBlockIndex: lastBlockIndex, startLine: selectionStart, endLine: selectionEnd, editingId: null });
               }
             }
           } else {
             const side = visualMode.anchorSide;
             visualMode = null;
+            document.body.classList.remove('visual-mode');
             openForm({ filePath: fp, afterBlockIndex: null, startLine: selectionStart, endLine: selectionEnd, editingId: null, side: side || undefined });
           }
           return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3885,6 +3885,9 @@
       activeFilePath = fp;
       selectionStart = startLine;
       selectionEnd = endLine;
+      // Clear any stale unified-diff drag state so it can't bleed into render paths.
+      unifiedVisualStart = null;
+      unifiedVisualEnd = null;
       refreshVisualSelectionVisuals(fp);
       return true;
     }
@@ -3935,8 +3938,13 @@
     } else {
       if (!focusedElement.dataset.diffLineNum) return;
       // Don't extend across sides (old vs new) — selection must stay contiguous.
+      // Crossing sides exits visual mode (mirrors the cross-file branch above)
+      // so the focused-block / selection coupling stays visible to the user.
       const side = focusedElement.dataset.diffSide || '';
-      if (side !== visualMode.anchorSide) return;
+      if (side !== visualMode.anchorSide) {
+        exitVisualMode(true);
+        return;
+      }
       const ln = parseInt(focusedElement.dataset.diffLineNum);
       selectionStart = Math.min(visualMode.anchorStartLine, ln);
       selectionEnd = Math.max(visualMode.anchorEndLine, ln);
@@ -8721,14 +8729,16 @@
           if (visualMode.kind === 'markdown') {
             const file = getFileByPath(fp);
             if (file && file.lineBlocks) {
-              let lastBlockIndex = 0;
+              let lastBlockIndex = -1;
               for (let i = 0; i < file.lineBlocks.length; i++) {
                 if (file.lineBlocks[i].startLine >= selectionStart && file.lineBlocks[i].endLine <= selectionEnd) {
                   lastBlockIndex = i;
                 }
               }
-              visualMode = null;
-              openForm({ filePath: fp, afterBlockIndex: lastBlockIndex, startLine: selectionStart, endLine: selectionEnd, editingId: null });
+              if (lastBlockIndex >= 0) {
+                visualMode = null;
+                openForm({ filePath: fp, afterBlockIndex: lastBlockIndex, startLine: selectionStart, endLine: selectionEnd, editingId: null });
+              }
             }
           } else {
             const side = visualMode.anchorSide;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -359,6 +359,9 @@
   let focusedFilePath = null;
   let focusedElement = null; // currently focused navigable element
   let navElements = []; // cached .kb-nav list, rebuilt on render
+  // Vim-style visual line mode (entered with V).
+  // { kind: 'markdown'|'diff', filePath, anchorStartLine, anchorEndLine, anchorSide }
+  let visualMode = null;
   let changeGroups = [];      // [{elements: [DOM], filePath: string}]
   let currentChangeIdx = -1;
 
@@ -3866,6 +3869,107 @@
       if (commentsMap[ln]) result.push(...commentsMap[ln]);
     }
     return result;
+  }
+
+  // ===== Visual Line Mode (vim-style) =====
+  // Anchors on the currently focused block; j/k extend the range; Esc clears it.
+  function enterVisualMode() {
+    if (!focusedElement) return false;
+    const fp = focusedElement.dataset.filePath || focusedElement.dataset.diffFilePath;
+    if (!fp) return false;
+
+    if (focusedElement.dataset.blockIndex !== undefined && focusedElement.dataset.startLine) {
+      const startLine = parseInt(focusedElement.dataset.startLine);
+      const endLine = parseInt(focusedElement.dataset.endLine);
+      visualMode = { kind: 'markdown', filePath: fp, anchorStartLine: startLine, anchorEndLine: endLine };
+      activeFilePath = fp;
+      selectionStart = startLine;
+      selectionEnd = endLine;
+      refreshVisualSelectionVisuals(fp);
+      return true;
+    }
+    if (focusedElement.dataset.diffLineNum) {
+      const lineNum = parseInt(focusedElement.dataset.diffLineNum);
+      const side = focusedElement.dataset.diffSide || '';
+      visualMode = { kind: 'diff', filePath: fp, anchorStartLine: lineNum, anchorEndLine: lineNum, anchorSide: side };
+      activeFilePath = fp;
+      selectionStart = lineNum;
+      selectionEnd = lineNum;
+      refreshVisualSelectionVisuals(fp);
+      return true;
+    }
+    return false;
+  }
+
+  function exitVisualMode(clearSelection) {
+    if (!visualMode) return;
+    const fp = visualMode.filePath;
+    visualMode = null;
+    if (clearSelection) {
+      selectionStart = null;
+      selectionEnd = null;
+      unifiedVisualStart = null;
+      unifiedVisualEnd = null;
+      activeFilePath = null;
+      if (fp) refreshVisualSelectionVisuals(fp);
+    }
+  }
+
+  // After j/k moves focus, extend the visual selection from the anchor to the new focus.
+  function extendVisualSelection() {
+    if (!visualMode || !focusedElement) return;
+    const fp = visualMode.kind === 'markdown'
+      ? focusedElement.dataset.filePath
+      : focusedElement.dataset.diffFilePath;
+    if (fp !== visualMode.filePath) {
+      // Crossed file boundary — exit visual mode (focus already moved by j/k).
+      exitVisualMode(true);
+      return;
+    }
+    if (visualMode.kind === 'markdown') {
+      if (focusedElement.dataset.blockIndex === undefined) return;
+      const sLine = parseInt(focusedElement.dataset.startLine);
+      const eLine = parseInt(focusedElement.dataset.endLine);
+      selectionStart = Math.min(visualMode.anchorStartLine, sLine);
+      selectionEnd = Math.max(visualMode.anchorEndLine, eLine);
+    } else {
+      if (!focusedElement.dataset.diffLineNum) return;
+      // Don't extend across sides (old vs new) — selection must stay contiguous.
+      const side = focusedElement.dataset.diffSide || '';
+      if (side !== visualMode.anchorSide) return;
+      const ln = parseInt(focusedElement.dataset.diffLineNum);
+      selectionStart = Math.min(visualMode.anchorStartLine, ln);
+      selectionEnd = Math.max(visualMode.anchorEndLine, ln);
+    }
+    // Update .selected classes incrementally rather than re-rendering the whole
+    // file — re-rendering invalidates the focusedElement reference and trips
+    // the j/k stale-ref recovery (which can mis-resolve when blockIndex values
+    // collide across files).
+    refreshVisualSelectionVisuals(visualMode.filePath);
+  }
+
+  function refreshVisualSelectionVisuals(filePath) {
+    const section = document.getElementById('file-section-' + filePath);
+    if (!section) return;
+    const blocks = section.querySelectorAll('.line-block.kb-nav[data-file-path="' + filePath + '"]');
+    for (let i = 0; i < blocks.length; i++) {
+      const lb = blocks[i];
+      const sLine = parseInt(lb.dataset.startLine);
+      const eLine = parseInt(lb.dataset.endLine);
+      const inSel = selectionStart !== null && selectionEnd !== null
+        && sLine >= selectionStart && eLine <= selectionEnd;
+      lb.classList.toggle('selected', inSel);
+    }
+    const diffLines = section.querySelectorAll('[data-diff-file-path="' + filePath + '"]');
+    for (let i = 0; i < diffLines.length; i++) {
+      const dl = diffLines[i];
+      const ln = parseInt(dl.dataset.diffLineNum);
+      const side = dl.dataset.diffSide || '';
+      const sideMatches = !visualMode || visualMode.kind !== 'diff' || side === visualMode.anchorSide;
+      const inSel = sideMatches && selectionStart !== null && selectionEnd !== null
+        && ln >= selectionStart && ln <= selectionEnd;
+      dl.classList.toggle('selected', inSel);
+    }
   }
 
   // ===== Gutter Drag Selection =====
@@ -8403,6 +8507,7 @@
       { label: 'Navigation', shortcuts: [
         { key: '<kbd>j</kbd>', action: 'Next block' },
         { key: '<kbd>k</kbd>', action: 'Previous block' },
+        { key: '<kbd>Shift</kbd>+<kbd>V</kbd>', action: 'Visual line mode (extend with j/k, then c to comment)' },
         { key: '<kbd>]</kbd>', action: 'Next comment' },
         { key: '<kbd>[</kbd>', action: 'Previous comment' },
         { key: '<kbd>n</kbd>', action: 'Next change', mode: 'file mode' },
@@ -8595,10 +8700,43 @@
           focusedFilePath = focusedElement.dataset.diffFilePath;
           focusedBlockIndex = null;
         }
+        if (visualMode) extendVisualSelection();
+        break;
+      }
+      case 'V': {
+        e.preventDefault();
+        if (visualMode) {
+          // Toggle off — preserve the focus on the current expansion point.
+          exitVisualMode(true);
+        } else {
+          enterVisualMode();
+        }
         break;
       }
       case 'c': {
         e.preventDefault();
+        // Visual mode: comment on the active selection.
+        if (visualMode && selectionStart !== null && selectionEnd !== null) {
+          const fp = visualMode.filePath;
+          if (visualMode.kind === 'markdown') {
+            const file = getFileByPath(fp);
+            if (file && file.lineBlocks) {
+              let lastBlockIndex = 0;
+              for (let i = 0; i < file.lineBlocks.length; i++) {
+                if (file.lineBlocks[i].startLine >= selectionStart && file.lineBlocks[i].endLine <= selectionEnd) {
+                  lastBlockIndex = i;
+                }
+              }
+              visualMode = null;
+              openForm({ filePath: fp, afterBlockIndex: lastBlockIndex, startLine: selectionStart, endLine: selectionEnd, editingId: null });
+            }
+          } else {
+            const side = visualMode.anchorSide;
+            visualMode = null;
+            openForm({ filePath: fp, afterBlockIndex: null, startLine: selectionStart, endLine: selectionEnd, editingId: null, side: side || undefined });
+          }
+          return;
+        }
         // If text is selected, comment on the selection (with quote).
         // Otherwise fall back to the focused block.
         if (tryOpenFormFromSelection()) return;
@@ -8723,6 +8861,9 @@
         else if (activeForms.length > 0) {
           const form = activeForms[activeForms.length - 1];
           if (confirmDiscardCommentForm(form)) cancelComment(form);
+        }
+        else if (visualMode) {
+          exitVisualMode(true);
         }
         else if (selectionStart !== null) {
           const clearPath = activeFilePath;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3893,8 +3893,26 @@
       return true;
     }
     if (focusedElement.dataset.diffLineNum) {
-      const lineNum = parseInt(focusedElement.dataset.diffLineNum);
-      const side = focusedElement.dataset.diffSide || '';
+      // Split rows carry both sides — tagDiffLine on the row records whichever
+      // side existed first (left when present), but the user's intent is
+      // usually the right (new) side. Prefer right; fall back to left for
+      // deleted-only rows. Unified rows are single-side, so just read directly.
+      let lineNum, side;
+      if (focusedElement.classList.contains('diff-split-row')) {
+        const right = focusedElement.querySelector('.diff-split-side.right:not(.empty)');
+        if (right && right.dataset.diffLineNum) {
+          lineNum = parseInt(right.dataset.diffLineNum);
+          side = '';
+        } else {
+          const left = focusedElement.querySelector('.diff-split-side.left:not(.empty)');
+          if (!left || !left.dataset.diffLineNum) return false;
+          lineNum = parseInt(left.dataset.diffLineNum);
+          side = 'old';
+        }
+      } else {
+        lineNum = parseInt(focusedElement.dataset.diffLineNum);
+        side = focusedElement.dataset.diffSide || '';
+      }
       visualMode = { kind: 'diff', filePath: fp, anchorStartLine: lineNum, anchorEndLine: lineNum, anchorSide: side };
       activeFilePath = fp;
       selectionStart = lineNum;
@@ -3939,16 +3957,28 @@
       selectionStart = Math.min(visualMode.anchorStartLine, sLine);
       selectionEnd = Math.max(visualMode.anchorEndLine, eLine);
     } else {
-      if (!focusedElement.dataset.diffLineNum) return;
-      // Don't extend across sides (old vs new) — selection must stay contiguous.
-      // Crossing sides exits visual mode (mirrors the cross-file branch above)
-      // so the focused-block / selection coupling stays visible to the user.
-      const side = focusedElement.dataset.diffSide || '';
-      if (side !== visualMode.anchorSide) {
-        exitVisualMode(true);
-        return;
+      // Find the line number on the anchor side. Split rows carry both sides
+      // (and the row's dataset.diffSide is whichever side was tagged first,
+      // which is unreliable for navigation), so query the child sides directly.
+      // Rows with no line on the anchor side (e.g. a deleted-only row when
+      // we anchored on the right) are skipped silently — selection stays put,
+      // visual mode stays active, focus continues moving with j/k.
+      let ln = null;
+      if (focusedElement.classList.contains('diff-split-row')) {
+        const sideSel = visualMode.anchorSide === 'old'
+          ? '.diff-split-side.left:not(.empty)'
+          : '.diff-split-side.right:not(.empty)';
+        const sideEl = focusedElement.querySelector(sideSel);
+        if (sideEl && sideEl.dataset.diffLineNum) {
+          ln = parseInt(sideEl.dataset.diffLineNum);
+        }
+      } else if (focusedElement.dataset.diffLineNum) {
+        // Unified mode — single-side per element, must match anchor.
+        const side = focusedElement.dataset.diffSide || '';
+        if (side !== visualMode.anchorSide) return;
+        ln = parseInt(focusedElement.dataset.diffLineNum);
       }
-      const ln = parseInt(focusedElement.dataset.diffLineNum);
+      if (ln === null) return;
       selectionStart = Math.min(visualMode.anchorStartLine, ln);
       selectionEnd = Math.max(visualMode.anchorEndLine, ln);
     }
@@ -3971,15 +4001,35 @@
         && sLine >= selectionStart && eLine <= selectionEnd;
       lb.classList.toggle('selected', inSel);
     }
-    const diffLines = section.querySelectorAll('[data-diff-file-path="' + filePath + '"]');
-    for (let i = 0; i < diffLines.length; i++) {
-      const dl = diffLines[i];
-      const ln = parseInt(dl.dataset.diffLineNum);
-      const side = dl.dataset.diffSide || '';
-      const sideMatches = !visualMode || visualMode.kind !== 'diff' || side === visualMode.anchorSide;
+    // Split-mode diff sides: each side has its own line numbers + side tag.
+    // .selected only applies on the anchor-matching side (matches the render
+    // path in makeSplitRow, lines 3730 / 3772).
+    const splitSides = section.querySelectorAll('.diff-split-side[data-diff-file-path="' + filePath + '"]');
+    const anchorSide = visualMode && visualMode.kind === 'diff' ? visualMode.anchorSide : null;
+    for (let i = 0; i < splitSides.length; i++) {
+      const sEl = splitSides[i];
+      if (sEl.classList.contains('empty') || !sEl.dataset.diffLineNum) {
+        sEl.classList.toggle('selected', false);
+        continue;
+      }
+      const ln = parseInt(sEl.dataset.diffLineNum);
+      const side = sEl.dataset.diffSide || '';
+      const sideMatches = anchorSide === null || side === anchorSide;
       const inSel = sideMatches && selectionStart !== null && selectionEnd !== null
         && ln >= selectionStart && ln <= selectionEnd;
-      dl.classList.toggle('selected', inSel);
+      sEl.classList.toggle('selected', inSel);
+    }
+    // Unified-mode diff lines: single-side per element, side matches anchor.
+    const unifiedLines = section.querySelectorAll('.diff-container.unified .diff-line[data-diff-file-path="' + filePath + '"]');
+    for (let i = 0; i < unifiedLines.length; i++) {
+      const ul = unifiedLines[i];
+      if (!ul.dataset.diffLineNum) continue;
+      const ln = parseInt(ul.dataset.diffLineNum);
+      const side = ul.dataset.diffSide || '';
+      const sideMatches = anchorSide === null || side === anchorSide;
+      const inSel = sideMatches && selectionStart !== null && selectionEnd !== null
+        && ln >= selectionStart && ln <= selectionEnd;
+      ul.classList.toggle('selected', inSel);
     }
   }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -610,12 +610,13 @@ body {
 
 /* Visual line mode: recolor the focused block's left accent so it's clearly
    distinct from the default j/k cursor, signalling that j/k now extends the
-   selection instead of moving focus. Uses --crit-orange because it reads as
-   warm amber in both light (#bc4c00) and dark (#ff9e64) themes. */
+   selection instead of moving focus. Uses a dedicated --crit-visual-accent
+   so we don't conflate it with --crit-orange (modified-line indicator) or
+   --crit-yellow (modified-file badges, warning text). */
 body.visual-mode .line-block.focused,
 body.visual-mode .diff-line.focused,
 body.visual-mode .diff-split-row.focused {
-  box-shadow: inset 3px 0 0 var(--crit-orange);
+  box-shadow: inset 3px 0 0 var(--crit-visual-accent);
 }
 
 .line-block.line-block-added {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -608,6 +608,16 @@ body {
   box-shadow: inset 2px 0 0 var(--crit-brand);
 }
 
+/* Visual line mode: recolor the focused block's left accent so it's clearly
+   distinct from the default j/k cursor, signalling that j/k now extends the
+   selection instead of moving focus. Uses --crit-orange because it reads as
+   warm amber in both light (#bc4c00) and dark (#ff9e64) themes. */
+body.visual-mode .line-block.focused,
+body.visual-mode .diff-line.focused,
+body.visual-mode .diff-split-row.focused {
+  box-shadow: inset 3px 0 0 var(--crit-orange);
+}
+
 .line-block.line-block-added {
   box-shadow: inset 2px 0 0 var(--crit-green);
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -612,11 +612,22 @@ body {
    distinct from the default j/k cursor, signalling that j/k now extends the
    selection instead of moving focus. Uses a dedicated --crit-visual-accent
    so we don't conflate it with --crit-orange (modified-line indicator) or
-   --crit-yellow (modified-file badges, warning text). */
-body.visual-mode .line-block.focused,
-body.visual-mode .diff-line.focused,
-body.visual-mode .diff-split-row.focused {
+   --crit-yellow (modified-file badges, warning text).
+
+   Three render paths:
+   - markdown line-blocks: box-shadow inset (matches the default focus accent)
+   - unified diff lines: border-left-color (the .diff-line has a 3px transparent
+     left border that turns brand on focus; we override that color)
+   - split diff rows: border-left-color on the .diff-split-side children
+     (the row's focus accent lives on the side panels, not the row itself) */
+body.visual-mode .line-block.focused {
   box-shadow: inset 3px 0 0 var(--crit-visual-accent);
+}
+body.visual-mode .diff-container.unified .diff-line.focused {
+  border-left-color: var(--crit-visual-accent);
+}
+body.visual-mode .diff-split-row.focused .diff-split-side {
+  border-left-color: var(--crit-visual-accent);
 }
 
 .line-block.line-block-added {

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -63,6 +63,9 @@
   --crit-orange: #ff9e64;
   --crit-yellow: #e0af68;
   --crit-purple: #a371f7;
+  /* Visual line mode cursor accent. Distinct from --crit-orange (modified
+     line indicator) and --crit-yellow (warning / modified badges). */
+  --crit-visual-accent: #e0af68;
 
   /* ---- Borders ---- */
   --crit-border:         #232632;
@@ -224,6 +227,9 @@
     --crit-orange: #bc4c00;
     --crit-yellow: #7a5800;
     --crit-purple: #8250df;
+    /* Visual line mode cursor accent. Saturated amber tuned to read on
+       light backgrounds (the muddy --crit-yellow #7a5800 looks olive at 3px). */
+    --crit-visual-accent: #b8860b;
 
     /* ---- Borders ---- */
     --crit-border:         #d8dee4;
@@ -355,6 +361,9 @@
   --crit-orange: #ff9e64;
   --crit-yellow: #e0af68;
   --crit-purple: #a371f7;
+  /* Visual line mode cursor accent. Distinct from --crit-orange (modified
+     line indicator) and --crit-yellow (warning / modified badges). */
+  --crit-visual-accent: #e0af68;
 
   /* ---- Borders ---- */
   --crit-border:         #232632;
@@ -485,6 +494,9 @@
   --crit-orange: #bc4c00;
   --crit-yellow: #7a5800;
   --crit-purple: #8250df;
+  /* Visual line mode cursor accent. Saturated amber tuned to read on
+     light backgrounds (the muddy --crit-yellow #7a5800 looks olive at 3px). */
+  --crit-visual-accent: #b8860b;
 
   /* ---- Borders ---- */
   --crit-border:         #d8dee4;


### PR DESCRIPTION
## Summary

Adds a vim-style **visual line mode** for selecting multi-line comment ranges with the keyboard. Press **Shift+V** on a focused block to enter; **j/k** extend the selection from the anchor; **c** opens a comment form spanning the range; **Esc** or **Shift+V** again exits, leaving focus on the furthest expansion line.

Works for markdown line-blocks and diff lines (split + unified). The focused block's left accent turns amber while in visual mode so j/k clearly reads as 'extending selection' rather than 'moving focus'.

A few subtleties along the way:

- Selection visuals update in place — re-rendering the file would invalidate the focusedElement reference that j/k navigation depends on.
- New `--crit-visual-accent` theme var (dark `#e0af68`, light `#b8860b`) so we don't conflate the cursor cue with `--crit-orange` (modified-line indicator) or `--crit-yellow` (modified-file badges).
- In split-mode diff, the row's `dataset.diffSide` reflects whichever side was tagged first (left when present), which is unreliable for navigation. `extendVisualSelection` now queries the row's child `.diff-split-side` on the anchor side. Rows with no line on that side (e.g. a deleted row when anchored on the right) are skipped silently — selection stays put, visual mode stays active, focus continues moving.

Mirror PR for the hosted renderer: tomasz-tomczyk/crit-web (same branch).

## Test plan

- [x] 27 keyboard.spec.ts tests pass (3 new V-mode cases + 24 pre-existing)
- [x] go test ./... clean
- [x] Human testing of visual mode UX in dark + light themes, split + unified diff, markdown documents

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)