### PR TITLE
ci: run frontend/test-diff-render.mjs in test-frontend target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           node-version: 22
       - name: Run frontend smoke tests
-        run: node frontend/test-markdown-patch.mjs
+        run: make test-frontend
 
   nix:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:
 
 test-frontend:
 	node frontend/test-markdown-patch.mjs
+	node frontend/test-diff-render.mjs
 
 setup-hooks:
 	git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary
- `frontend/test-diff-render.mjs` (a cache-integrity bug-repro test) existed but never ran in CI — the Makefile's `test-frontend` target only invoked `test-markdown-patch.mjs`, and the workflow called that file by name.
- `Makefile`: `test-frontend` now runs both .mjs files; either failure aborts the target.
- `.github/workflows/test.yml`: `test-frontend` job invokes `make test-frontend` instead of the .mjs file directly — single source of truth, no future drift.

## Review
- [x] Code review: passed (release-audit + post-fix review)
- [x] Parity audit: N/A

## Test plan
- `make test-frontend` runs both tests (30 + 4 passed, exit 0)
- Verified intentional break in test-diff-render.mjs causes non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)