### PR TITLE
fix: split nested list items into individual line blocks

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -444,6 +444,17 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 - **Week 1**: Middleware + key model
 - **Week 2**: Validation endpoint + tests
 - **Week 3**: Dashboard UI for key management
+
+## Nested Tasks
+
+- Top alpha
+  - Nested alpha-one
+  - Nested alpha-two
+- Top beta
+  - Nested beta-one
+    - Deep beta-one-a
+  - Nested beta-two
+- Top gamma
 MDFILE
 
 # Modify routes.go: change beginning and end, leave large middle gap (>20 unchanged lines)

--- a/e2e/tests/markdown.spec.ts
+++ b/e2e/tests/markdown.spec.ts
@@ -107,6 +107,42 @@ test.describe('Markdown Rendering — plan.md', () => {
     await expect(section.locator('blockquote', { hasText: 'rate-limit' })).toBeVisible();
   });
 
+  test('nested bullet items are split into individually-commentable line blocks', async ({ page }) => {
+    const section = mdSection(page);
+
+    // Each nested bullet from the "Nested Tasks" fixture should produce its own
+    // .line-block with a unique data-start-line, so users can comment on each
+    // nested item independently. Match by visible text rather than line number,
+    // because plan.md line offsets shift with fixture edits.
+    const items = [
+      'Top alpha',
+      'Nested alpha-one',
+      'Nested alpha-two',
+      'Top beta',
+      'Nested beta-one',
+      'Deep beta-one-a',
+      'Nested beta-two',
+      'Top gamma',
+    ];
+
+    const startLines = new Set<string>();
+    for (const text of items) {
+      // Find the .line-block that directly contains this item's bullet text.
+      // Use a tight locator: a line-block whose visible text contains the item label.
+      const block = section.locator('.line-block', { hasText: text }).first();
+      await expect(block).toBeVisible();
+      const startLine = await block.getAttribute('data-start-line');
+      expect(startLine, `block for "${text}" must expose data-start-line`).not.toBeNull();
+      startLines.add(startLine!);
+    }
+
+    // Each item lives in its own block — distinct data-start-line values.
+    expect(startLines.size).toBe(items.length);
+
+    // The nested wrapper class is present, confirming semantic nesting was preserved.
+    await expect(section.locator('.line-block ul.crit-list-wrapper').first()).toBeVisible();
+  });
+
   test('line gutters exist in DOM with visible line numbers', async ({ page }) => {
     const section = mdSection(page);
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1058,45 +1058,170 @@
   }
 
   // Handle a list token (bullet or ordered) — split into per-item blocks.
-  function handleListToken(tokens, i, token, md, blocks, sourceLines, coveredUpTo, blockEnd) {
+  // Recurses into nested lists so each nested item is independently commentable.
+  // Nested-item blocks are rendered with semantic nesting preserved
+  // (e.g. <ul><li><ul><li>content</li></ul></li></ul>) with outer wrappers
+  // marked .crit-list-wrapper so CSS suppresses their bullets.
+  function handleListToken(tokens, i, _token, md, blocks, sourceLines, coveredUpTo, blockEnd) {
     const listCloseIdx = findCloseToken(tokens, i);
-    const listTag = token.type === 'bullet_list_open' ? 'ul' : 'ol';
-    let j = i + 1;
 
-    while (j < listCloseIdx) {
-      if (tokens[j].type === 'list_item_open') {
-        const itemMap = tokens[j].map;
-        const itemCloseIdx = findCloseToken(tokens, j);
+    splitListInto(tokens, i, listCloseIdx, md, blocks, sourceLines, coveredUpTo, function(html) {
+      return html;
+    });
 
-        if (itemMap) {
-          addGapLineBlocks(blocks, sourceLines, coveredUpTo, itemMap[0]);
-          let effectiveEnd = itemMap[1];
-          while (effectiveEnd > itemMap[0] + 1 && sourceLines[effectiveEnd - 1].trim() === '') {
-            effectiveEnd--;
-          }
-
-          const itemTokens = tokens.slice(j, itemCloseIdx + 1);
-          const startAttr = listTag === 'ol' && tokens[j].info ? ' start="' + tokens[j].info + '"' : '';
-          const itemHtml = '<' + listTag + startAttr + '>' +
-            md.renderer.render(itemTokens, md.options, {}) +
-            '</' + listTag + '>';
-
-          blocks.push({
-            startLine: itemMap[0] + 1,
-            endLine: effectiveEnd,
-            html: itemHtml,
-            isEmpty: false
-          });
-          coveredUpTo = effectiveEnd;
-        }
-        j = itemCloseIdx + 1;
-      } else {
-        j++;
-      }
+    // After splitListInto, blocks have been pushed and coveredUpTo updated
+    // implicitly via the last block's endLine. Recompute coveredUpTo from blocks.
+    if (blocks.length > 0) {
+      coveredUpTo = Math.max(coveredUpTo, blocks[blocks.length - 1].endLine);
     }
 
     coveredUpTo = addGapLineBlocks(blocks, sourceLines, coveredUpTo, blockEnd);
     return { nextIndex: listCloseIdx + 1, coveredUpTo: coveredUpTo };
+  }
+
+  // Recursively split a list (between listOpenIdx and listCloseIdx) into blocks.
+  // `wrap(innerHtml)` wraps the innermost item HTML with any enclosing list/li
+  // chrome from outer (parent) lists, preserving semantic nesting.
+  // Pushes blocks to `blocks` and emits gap-line blocks between items.
+  // Returns the line number through which content has been emitted (last block's endLine).
+  function splitListInto(tokens, listOpenIdx, listCloseIdx, md, blocks, sourceLines, coveredUpTo, wrap) {
+    const listOpen = tokens[listOpenIdx];
+    const listTag = listOpen.type === 'bullet_list_open' ? 'ul' : 'ol';
+    let j = listOpenIdx + 1;
+
+    while (j < listCloseIdx) {
+      if (tokens[j].type !== 'list_item_open') { j++; continue; }
+      const itemOpenIdx = j;
+      const itemCloseIdx = findCloseToken(tokens, j);
+      const itemMap = tokens[itemOpenIdx].map;
+
+      if (!itemMap) { j = itemCloseIdx + 1; continue; }
+
+      addGapLineBlocks(blocks, sourceLines, coveredUpTo, itemMap[0]);
+      coveredUpTo = itemMap[0];
+
+      // Find nested lists within this item (direct children only).
+      const nestedRanges = findDirectNestedLists(tokens, itemOpenIdx, itemCloseIdx);
+
+      // For ordered lists, preserve numbering across split blocks via start=N.
+      // markdown-it stores the numeric marker on the list_item_open token's info.
+      const itemStartAttr = (listTag === 'ol' && tokens[itemOpenIdx].info)
+        ? ' start="' + tokens[itemOpenIdx].info + '"'
+        : '';
+
+      // The "lead" portion: tokens between item_open and the first nested list (or item_close).
+      const firstNested = nestedRanges.length > 0 ? nestedRanges[0] : null;
+      const leadEndTokenIdx = firstNested ? firstNested.openIdx : itemCloseIdx;
+
+      // Determine source-line range for the lead.
+      const leadStartLine = itemMap[0] + 1;
+      let leadEndLine;
+      if (firstNested) {
+        const nestedFirstMap = tokens[firstNested.openIdx].map;
+        leadEndLine = nestedFirstMap ? nestedFirstMap[0] : itemMap[1];
+      } else {
+        leadEndLine = itemMap[1];
+        // Trim trailing blank lines (markdown-it often claims a trailing blank).
+        while (leadEndLine > leadStartLine && sourceLines[leadEndLine - 1].trim() === '') {
+          leadEndLine--;
+        }
+      }
+
+      // Render lead content: re-use renderer over tokens [item_open .. leadEndTokenIdx-1] + item_close synthetic.
+      // Easiest: render the tokens between item_open+1 and leadEndTokenIdx (exclusive) as inline content,
+      // then wrap in <li>.
+      const leadInnerTokens = tokens.slice(itemOpenIdx + 1, leadEndTokenIdx);
+      const leadInnerHtml = md.renderer.render(leadInnerTokens, md.options, {});
+      const leadLiClass = tokens[itemOpenIdx].attrGet && tokens[itemOpenIdx].attrGet('class');
+      const leadLiAttr = leadLiClass ? ' class="' + escapeAttr(leadLiClass) + '"' : '';
+      const leadInnerWrapped = '<' + listTag + itemStartAttr + '>' +
+        '<li' + leadLiAttr + '>' + leadInnerHtml + '</li>' +
+        '</' + listTag + '>';
+
+      if (leadEndLine > leadStartLine - 1) {
+        blocks.push({
+          startLine: leadStartLine,
+          endLine: leadEndLine,
+          html: wrap(leadInnerWrapped),
+          isEmpty: false
+        });
+        coveredUpTo = leadEndLine;
+      }
+
+      // Recurse into each nested list. Build a wrap-fn that wraps the child HTML
+      // in this item's <listTag><li class="crit-list-wrapper">...</li></listTag>,
+      // then through the parent wrap.
+      for (let n = 0; n < nestedRanges.length; n++) {
+        const nested = nestedRanges[n];
+        const childWrap = function(innerHtml) {
+          // Outer wrappers: marker-suppressed <li> so we don't get phantom bullets.
+          return wrap(
+            '<' + listTag + ' class="crit-list-wrapper">' +
+            '<li class="crit-list-wrapper">' + innerHtml + '</li>' +
+            '</' + listTag + '>'
+          );
+        };
+        coveredUpTo = splitListInto(tokens, nested.openIdx, nested.closeIdx, md, blocks, sourceLines, coveredUpTo, childWrap);
+      }
+
+      // Trailing content after last nested list (rare): handle it as another lead-style block.
+      if (nestedRanges.length > 0) {
+        const lastNested = nestedRanges[nestedRanges.length - 1];
+        const trailStartTokenIdx = lastNested.closeIdx + 1;
+        if (trailStartTokenIdx < itemCloseIdx) {
+          // Find first mapped token for trailing source-line range.
+          const trailStartLine = coveredUpTo;
+          let trailEndLine = itemMap[1];
+          while (trailEndLine > trailStartLine && sourceLines[trailEndLine - 1].trim() === '') {
+            trailEndLine--;
+          }
+          if (trailEndLine > trailStartLine) {
+            const trailInnerTokens = tokens.slice(trailStartTokenIdx, itemCloseIdx);
+            const trailInnerHtml = md.renderer.render(trailInnerTokens, md.options, {});
+            const trailWrapped = '<' + listTag + '>' +
+              '<li>' + trailInnerHtml + '</li>' +
+              '</' + listTag + '>';
+            blocks.push({
+              startLine: trailStartLine + 1,
+              endLine: trailEndLine,
+              html: wrap(trailWrapped),
+              isEmpty: false
+            });
+            coveredUpTo = trailEndLine;
+          }
+        }
+      }
+
+      j = itemCloseIdx + 1;
+    }
+
+    return coveredUpTo;
+  }
+
+  // Find direct-child nested lists within an item (not lists nested inside paragraphs etc.).
+  // Returns array of {openIdx, closeIdx} for each direct nested list_open token.
+  function findDirectNestedLists(tokens, itemOpenIdx, itemCloseIdx) {
+    const result = [];
+    let depth = 0;
+    for (let k = itemOpenIdx + 1; k < itemCloseIdx; k++) {
+      const t = tokens[k];
+      if (t.nesting === 1) {
+        if (depth === 0 && (t.type === 'bullet_list_open' || t.type === 'ordered_list_open')) {
+          const closeIdx = findCloseToken(tokens, k);
+          result.push({ openIdx: k, closeIdx: closeIdx });
+          k = closeIdx; // skip past
+          continue;
+        }
+        depth++;
+      } else if (t.nesting === -1) {
+        if (depth > 0) depth--;
+      }
+    }
+    return result;
+  }
+
+  function escapeAttr(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   }
 
   // Handle a table token — split into per-row blocks.

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -977,6 +977,21 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   list-style-type: '  \2022  ';
 }
 
+/* Outer wrappers added when a nested list item is split into its own line block.
+   They preserve semantic nesting (so CSS indentation works) without rendering
+   their own bullet/marker. */
+.line-content ul.crit-list-wrapper,
+.line-content ol.crit-list-wrapper {
+  padding-left: 24px;
+  margin: 0;
+}
+.line-content li.crit-list-wrapper {
+  list-style: none;
+}
+.line-content ul.crit-list-wrapper > li.crit-list-wrapper {
+  list-style-type: none;
+}
+
 .line-content table {
   width: 100%;
   border-collapse: collapse;

--- a/test/notification-plan.md
+++ b/test/notification-plan.md
@@ -139,7 +139,11 @@ signed with the user's webhook secret. Receivers should verify this before proce
 - [ ] GET /notifications feed with cursor pagination
 - [ ] POST /notifications/:id/read and POST /notifications/read-all
 - [ ] Email delivery via SES
-- [ ] Webhook delivery with HMAC signature verification
+- [ ] Webhook delivery with HMAC signature verification, supporting:
+  - `POST /webhooks/:id` → 2xx success, persist `delivered_at`.
+  - `POST /webhooks/:id` → 4xx client error, mark `dead` and stop retrying.
+  - `POST /webhooks/:id` → 5xx / timeout, schedule retry with backoff.
+  - `DELETE /webhooks/:id` → owner-only, requires `X-Internal-Token`.
 - [ ] Retry worker with exponential backoff
 - [ ] Integration tests for the delivery pipeline
 - [ ] Runbook: how to inspect and manually retry stuck deliveries

--- a/test/test-plan-v2.md
+++ b/test/test-plan-v2.md
@@ -137,7 +137,11 @@ signed with the user's webhook secret. Receivers should verify this before proce
 - [ ] GET /notifications feed with cursor pagination
 - [ ] POST /notifications/:id/read and POST /notifications/read-all
 - [ ] Email delivery via SES
-- [ ] Webhook delivery with HMAC signature verification
+- [ ] Webhook delivery with HMAC signature verification, supporting:
+  - `POST /webhooks/:id` → 2xx success, persist `delivered_at`.
+  - `POST /webhooks/:id` → 4xx client error, mark `dead` and stop retrying.
+  - `POST /webhooks/:id` → 5xx / timeout, schedule retry with backoff.
+  - `DELETE /webhooks/:id` → owner-only, requires `X-Internal-Token`.
 - [ ] Retry worker with exponential backoff
 - [ ] Integration tests for the delivery pipeline
 - [ ] Runbook: how to inspect and manually retry stuck deliveries


### PR DESCRIPTION
## Summary
- Each nested bullet/numbered item now becomes its own commentable line block, instead of the parent item swallowing the entire nested subtree.
- Recursive splitter in `handleListToken` wraps each nested block in `<ul>/<ol>` so list indentation is preserved semantically (no flattened margins).
- Added `.crit-list-wrapper` CSS to suppress phantom outer markers.

## Review
- [x] Code review: passed (4 polish NOTEs, no blockers)
- [x] Intent audit: CLEAN

## Test plan
- New e2e test asserts each nested item gets its own `.line-block` with a distinct `data-start-line` and the wrapper class is present.
- `go test -race ./...` clean; gofmt + golangci-lint clean.
- Manual: `make test-diff` — MVP Checklist webhook item now has individually-selectable sub-bullets.

## Follow-ups
- Port the same fix to `crit-web/assets/js/document-renderer.js` and matching CSS in `crit-web/assets/css/app.css` (parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)