### PR TITLE
feat: linkify comment IDs in comment bodies

### DIFF
--- a/e2e/tests/comment-ref-links.spec.ts
+++ b/e2e/tests/comment-ref-links.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, getMdPath, switchToDocumentView, addComment } from './helpers';
+
+test.describe('Comment reference links', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToDocumentView(page);
+  });
+
+  test('bare comment ID in body renders as a .comment-ref chip', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    const c1 = await addComment(request, path, 1, 'First comment');
+    await addComment(request, path, 2, `See also ${c1.id} for context`);
+
+    await page.reload();
+    await switchToDocumentView(page);
+
+    const chips = page.locator('.comment-ref');
+    await expect(chips).toHaveCount(1);
+    await expect(chips.first()).toContainText(c1.id);
+  });
+
+  test('backtick-wrapped comment ID renders as a .comment-ref chip', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    const c1 = await addComment(request, path, 1, 'First comment');
+    await addComment(request, path, 2, `Related to \`${c1.id}\``);
+
+    await page.reload();
+    await switchToDocumentView(page);
+
+    const chips = page.locator('.comment-ref');
+    await expect(chips).toHaveCount(1);
+    await expect(chips.first()).toContainText(c1.id);
+  });
+
+  test('clicking a chip scrolls to and flashes the referenced comment card', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    const c1 = await addComment(request, path, 1, 'First comment');
+    await addComment(request, path, 5, `See ${c1.id} above`);
+
+    await page.reload();
+    await switchToDocumentView(page);
+
+    const chip = page.locator('.comment-ref').first();
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    const targetCard = page.locator(`.comment-card[data-comment-id="${c1.id}"]`);
+    await expect(targetCard).toBeVisible();
+    await expect(targetCard).toHaveClass(/comment-ref-flash/);
+  });
+
+  test('clicking chip with ID absent from page does not throw', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    // Reference a non-existent ID — scrollToCommentRef should be a no-op
+    await addComment(request, path, 1, 'See c_000000 for details');
+
+    await page.reload();
+    await switchToDocumentView(page);
+
+    const chip = page.locator('.comment-ref').first();
+    await expect(chip).toBeVisible();
+
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await chip.click();
+    expect(errors).toHaveLength(0);
+  });
+
+  test('comment IDs inside code blocks are not linkified', async ({ page, request }) => {
+    const path = await getMdPath(request);
+    // Fenced code block — should not be processed by linkifyCommentRefsInDom
+    await addComment(request, path, 1, '```\nc_aabbcc\n```');
+
+    await page.reload();
+    await switchToDocumentView(page);
+
+    await expect(page.locator('.comment-ref')).toHaveCount(0);
+  });
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -37,11 +37,11 @@
   };
 
   // Override code_inline so backtick-wrapped comment IDs render as the same chip.
-  var defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, env, self) {
+  const defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, _env, self) {
     return self.renderToken(tokens, idx, options);
   };
   commentMd.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
-    var content = tokens[idx].content;
+    const content = tokens[idx].content;
     if (/^(c|r|rp)_[a-f0-9]{6,}$/.test(content)) {
       return '<span class="comment-ref comment-ref-code" data-ref-id="' + escapeHtml(content) + '">' + escapeHtml(content) + '</span>';
     }
@@ -49,23 +49,23 @@
   };
 
   function linkifyCommentRefsInDom(el) {
-    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
-    var textNodes = [];
-    var node;
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+    const textNodes = [];
+    let node;
     while ((node = walker.nextNode())) {
       // skip text inside code/pre elements and already-linked chips
       if (node.parentNode.closest('code, pre, .comment-ref')) continue;
       textNodes.push(node);
     }
-    var re = /((?:c|r|rp)_[a-f0-9]{6,})/g;
+    const re = /((?:c|r|rp)_[a-f0-9]{6,})/g;
     textNodes.forEach(function(tn) {
       if (!re.test(tn.nodeValue)) { re.lastIndex = 0; return; }
       re.lastIndex = 0;
-      var frag = document.createDocumentFragment();
-      var last = 0, m;
+      const frag = document.createDocumentFragment();
+      let last = 0, m;
       while ((m = re.exec(tn.nodeValue)) !== null) {
         if (m.index > last) frag.appendChild(document.createTextNode(tn.nodeValue.slice(last, m.index)));
-        var span = document.createElement('span');
+        const span = document.createElement('span');
         span.className = 'comment-ref';
         span.dataset.refId = m[1];
         span.textContent = m[1];
@@ -80,10 +80,10 @@
   // Scroll/expand/flash a comment card located anywhere in the document, given just its id.
   // Distinct from scrollToComment(commentId, filePath) below — that one needs filePath context.
   function scrollToCommentRef(id) {
-    var card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
+    const card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
     if (!card) return;
     // Make sure any containing <details> file section is open
-    var section = card.closest('details');
+    const section = card.closest('details');
     if (section && !section.open) section.open = true;
     if (card.classList.contains('collapsed')) {
       card.classList.remove('collapsed');
@@ -97,7 +97,7 @@
   }
 
   document.addEventListener('click', function(e) {
-    var ref = e.target.closest && e.target.closest('.comment-ref');
+    const ref = e.target.closest && e.target.closest('.comment-ref');
     if (!ref) return;
     e.preventDefault();
     scrollToCommentRef(ref.dataset.refId);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -90,8 +90,10 @@
       if (typeof commentCollapseOverrides !== 'undefined') commentCollapseOverrides[id] = false;
     }
     card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.remove('comment-ref-flash');
+    void card.offsetWidth;
     card.classList.add('comment-ref-flash');
-    setTimeout(function() { card.classList.remove('comment-ref-flash'); }, 1200);
+    setTimeout(function() { card.classList.remove('comment-ref-flash'); }, 1650);
   }
 
   document.addEventListener('click', function(e) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -36,28 +36,6 @@
     return '<span class="file-ref">' + escapeHtml(path) + '</span>';
   };
 
-  // ===== Comment Reference Inline Rule =====
-  // Linkify bare comment IDs (c_, r_, rp_ + 6+ hex chars) in comment bodies.
-  commentMd.inline.ruler.push('comment_ref', function(state, silent) {
-    var start = state.pos;
-    var src = state.src;
-    var m = /^(c|r|rp)_[a-f0-9]{6,}/.exec(src.slice(start));
-    if (!m) return false;
-    if (start > 0 && /[a-zA-Z0-9_]/.test(src[start - 1])) return false;
-    var end = start + m[0].length;
-    if (end < src.length && /[a-zA-Z0-9_]/.test(src[end])) return false;
-    if (!silent) {
-      var token = state.push('comment_ref', '', 0);
-      token.content = m[0];
-    }
-    state.pos = end;
-    return true;
-  });
-  commentMd.renderer.rules.comment_ref = function(tokens, idx) {
-    var id = tokens[idx].content;
-    return '<span class="comment-ref" data-ref-id="' + escapeHtml(id) + '">' + escapeHtml(id) + '</span>';
-  };
-
   // Override code_inline so backtick-wrapped comment IDs render as the same chip.
   var defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, env, self) {
     return self.renderToken(tokens, idx, options);
@@ -69,6 +47,35 @@
     }
     return defaultCodeInline(tokens, idx, options, env, self);
   };
+
+  function linkifyCommentRefsInDom(el) {
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+    var textNodes = [];
+    var node;
+    while ((node = walker.nextNode())) {
+      // skip text inside code/pre elements and already-linked chips
+      if (node.parentNode.closest('code, pre, .comment-ref')) continue;
+      textNodes.push(node);
+    }
+    var re = /((?:c|r|rp)_[a-f0-9]{6,})/g;
+    textNodes.forEach(function(tn) {
+      if (!re.test(tn.nodeValue)) { re.lastIndex = 0; return; }
+      re.lastIndex = 0;
+      var frag = document.createDocumentFragment();
+      var last = 0, m;
+      while ((m = re.exec(tn.nodeValue)) !== null) {
+        if (m.index > last) frag.appendChild(document.createTextNode(tn.nodeValue.slice(last, m.index)));
+        var span = document.createElement('span');
+        span.className = 'comment-ref';
+        span.dataset.refId = m[1];
+        span.textContent = m[1];
+        frag.appendChild(span);
+        last = m.index + m[0].length;
+      }
+      if (last < tn.nodeValue.length) frag.appendChild(document.createTextNode(tn.nodeValue.slice(last)));
+      tn.parentNode.replaceChild(frag, tn);
+    });
+  }
 
   // Scroll/expand/flash a comment card located anywhere in the document, given just its id.
   // Distinct from scrollToComment(commentId, filePath) below — that one needs filePath context.
@@ -5415,6 +5422,7 @@
     const bodyEl = document.createElement('div');
     bodyEl.className = 'comment-body';
     bodyEl.innerHTML = commentMd.render(comment.body, filePath ? buildCommentEnv(comment, filePath) : undefined);
+    linkifyCommentRefsInDom(bodyEl);
 
     card.appendChild(header);
 
@@ -5611,6 +5619,7 @@
       replyBody.className = 'reply-body';
       replyBody.dataset.rawBody = reply.body;
       replyBody.innerHTML = commentMd.render(reply.body);
+      linkifyCommentRefsInDom(replyBody);
       replyEl.appendChild(replyBody);
 
       repliesContainer.appendChild(replyEl);
@@ -6956,6 +6965,7 @@
       const descBody = document.createElement('div');
       descBody.className = 'pr-panel-description-body';
       descBody.innerHTML = commentMd.render(pr.pr_body);
+      linkifyCommentRefsInDom(descBody);
       descSection.appendChild(descBody);
 
       body.appendChild(descSection);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -36,6 +36,64 @@
     return '<span class="file-ref">' + escapeHtml(path) + '</span>';
   };
 
+  // ===== Comment Reference Inline Rule =====
+  // Linkify bare comment IDs (c_, r_, rp_ + 6+ hex chars) in comment bodies.
+  commentMd.inline.ruler.push('comment_ref', function(state, silent) {
+    var start = state.pos;
+    var src = state.src;
+    var m = /^(c|r|rp)_[a-f0-9]{6,}/.exec(src.slice(start));
+    if (!m) return false;
+    if (start > 0 && /[a-zA-Z0-9_]/.test(src[start - 1])) return false;
+    var end = start + m[0].length;
+    if (end < src.length && /[a-zA-Z0-9_]/.test(src[end])) return false;
+    if (!silent) {
+      var token = state.push('comment_ref', '', 0);
+      token.content = m[0];
+    }
+    state.pos = end;
+    return true;
+  });
+  commentMd.renderer.rules.comment_ref = function(tokens, idx) {
+    var id = tokens[idx].content;
+    return '<span class="comment-ref" data-ref-id="' + escapeHtml(id) + '">' + escapeHtml(id) + '</span>';
+  };
+
+  // Override code_inline so backtick-wrapped comment IDs render as the same chip.
+  var defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options);
+  };
+  commentMd.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
+    var content = tokens[idx].content;
+    if (/^(c|r|rp)_[a-f0-9]{6,}$/.test(content)) {
+      return '<span class="comment-ref comment-ref-code" data-ref-id="' + escapeHtml(content) + '">' + escapeHtml(content) + '</span>';
+    }
+    return defaultCodeInline(tokens, idx, options, env, self);
+  };
+
+  // Scroll/expand/flash a comment card located anywhere in the document, given just its id.
+  // Distinct from scrollToComment(commentId, filePath) below — that one needs filePath context.
+  function scrollToCommentRef(id) {
+    var card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
+    if (!card) return;
+    // Make sure any containing <details> file section is open
+    var section = card.closest('details');
+    if (section && !section.open) section.open = true;
+    if (card.classList.contains('collapsed')) {
+      card.classList.remove('collapsed');
+      if (typeof commentCollapseOverrides !== 'undefined') commentCollapseOverrides[id] = false;
+    }
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.add('comment-ref-flash');
+    setTimeout(function() { card.classList.remove('comment-ref-flash'); }, 1200);
+  }
+
+  document.addEventListener('click', function(e) {
+    var ref = e.target.closest && e.target.closest('.comment-ref');
+    if (!ref) return;
+    e.preventDefault();
+    scrollToCommentRef(ref.dataset.refId);
+  });
+
   // ===== Suggestion Diff Renderer =====
   function renderSuggestionDiff(suggestionContent, originalLines) {
     const sugLines = suggestionContent.replace(/\n$/, '').split('\n');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1652,28 +1652,38 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 
 /* ===== Comment Reference Chip ===== */
 .comment-ref {
-  display: inline-block;
-  padding: 0 4px;
-  border-radius: 3px;
   font-family: var(--crit-font-mono);
-  font-size: 0.85em;
-  background: var(--crit-comment-ref-bg);
+  font-size: 0.92em;
   color: var(--crit-comment-ref-color);
-  border: 1px solid var(--crit-comment-ref-border);
-  cursor: pointer;
   text-decoration: none;
-  transition: background var(--crit-dur-fast) var(--crit-ease);
-  white-space: nowrap;
+  cursor: pointer;
+  border-radius: 3px;
+  padding: 0 1px;
+  margin: 0 -1px;
+  transition:
+    color var(--crit-dur-fast) var(--crit-ease),
+    background-color 1.6s var(--crit-ease),
+    box-shadow 1.6s var(--crit-ease);
 }
 .comment-ref:hover {
-  background: var(--crit-comment-ref-hover-bg);
+  color: var(--crit-comment-ref-color-hover);
+  text-decoration: underline;
+  text-decoration-color: var(--crit-comment-ref-underline);
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+.comment-ref:focus-visible {
+  outline: 2px solid var(--crit-comment-ref-color);
+  outline-offset: 2px;
+  text-decoration: none;
 }
 .comment-ref-flash {
-  animation: comment-ref-flash 1.2s ease-out;
+  animation: comment-ref-flash 1.6s var(--crit-ease);
 }
 @keyframes comment-ref-flash {
-  0%   { box-shadow: 0 0 0 3px var(--crit-comment-ref-color); }
-  100% { box-shadow: 0 0 0 3px transparent; }
+  0%   { background-color: var(--crit-comment-ref-flash-bg); box-shadow: 0 0 0 2px var(--crit-comment-ref-flash-ring); }
+  15%  { background-color: var(--crit-comment-ref-flash-bg); box-shadow: 0 0 0 2px var(--crit-comment-ref-flash-ring); }
+  100% { background-color: transparent; box-shadow: 0 0 0 2px transparent; }
 }
 
 /* ===== Save Template Dialog ===== */

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1650,6 +1650,32 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   white-space: nowrap;
 }
 
+/* ===== Comment Reference Chip ===== */
+.comment-ref {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-family: var(--crit-font-mono);
+  font-size: 0.85em;
+  background: var(--crit-comment-ref-bg);
+  color: var(--crit-comment-ref-color);
+  border: 1px solid var(--crit-comment-ref-border);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--crit-dur-fast) var(--crit-ease);
+  white-space: nowrap;
+}
+.comment-ref:hover {
+  background: var(--crit-comment-ref-hover-bg);
+}
+.comment-ref-flash {
+  animation: comment-ref-flash 1.2s ease-out;
+}
+@keyframes comment-ref-flash {
+  0%   { box-shadow: 0 0 0 3px var(--crit-comment-ref-color); }
+  100% { box-shadow: 0 0 0 3px transparent; }
+}
+
 /* ===== Save Template Dialog ===== */
 .save-template-overlay {
   display: none;

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -293,9 +293,9 @@
     --crit-qr-bg: #fff;
 
     /* ---- Comment reference chip ---- */
-    --crit-comment-ref-color:       #0969da;
-    --crit-comment-ref-color-hover: #0550ae;
-    --crit-comment-ref-underline:   rgba(9, 105, 218, 0.40);
+    --crit-comment-ref-color:       #0550ae;
+    --crit-comment-ref-color-hover: #033d8b;
+    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
     --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
     --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -151,6 +151,12 @@
   --crit-quote-highlight-border: rgba(250, 200, 60, 0.4);
   --crit-qr-bg: #fff;
 
+  /* ---- Comment reference chip ---- */
+  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
+  --crit-comment-ref-color:     #7dcfff;
+  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
+  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
+
   --author-0-bg: rgba(110,160,230,0.15);
   --author-0-border: rgba(110,160,230,0.35);
   --author-0-fg: #7ab0f0;
@@ -284,6 +290,12 @@
     --crit-quote-highlight-bg:     rgba(250, 200, 60, 0.18);
     --crit-quote-highlight-border: rgba(200, 160, 30, 0.45);
     --crit-qr-bg: #fff;
+
+    /* ---- Comment reference chip ---- */
+    --crit-comment-ref-bg:        rgba(64, 111, 204, 0.10);
+    --crit-comment-ref-color:     #406fcc;
+    --crit-comment-ref-border:    rgba(64, 111, 204, 0.30);
+    --crit-comment-ref-hover-bg:  rgba(64, 111, 204, 0.18);
 
     --author-0-bg: rgba(26,95,160,0.10);
     --author-0-border: rgba(26,95,160,0.25);
@@ -419,6 +431,12 @@
   --crit-quote-highlight-border: rgba(250, 200, 60, 0.4);
   --crit-qr-bg: #fff;
 
+  /* ---- Comment reference chip ---- */
+  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
+  --crit-comment-ref-color:     #7dcfff;
+  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
+  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
+
   --author-0-bg: rgba(110,160,230,0.15);
   --author-0-border: rgba(110,160,230,0.35);
   --author-0-fg: #7ab0f0;
@@ -551,6 +569,12 @@
   --crit-quote-highlight-bg:     rgba(250, 200, 60, 0.18);
   --crit-quote-highlight-border: rgba(200, 160, 30, 0.45);
   --crit-qr-bg: #fff;
+
+  /* ---- Comment reference chip ---- */
+  --crit-comment-ref-bg:        rgba(64, 111, 204, 0.10);
+  --crit-comment-ref-color:     #406fcc;
+  --crit-comment-ref-border:    rgba(64, 111, 204, 0.30);
+  --crit-comment-ref-hover-bg:  rgba(64, 111, 204, 0.18);
 
   --author-0-bg: rgba(26,95,160,0.10);
   --author-0-border: rgba(26,95,160,0.25);

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -152,10 +152,11 @@
   --crit-qr-bg: #fff;
 
   /* ---- Comment reference chip ---- */
-  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
-  --crit-comment-ref-color:     #7dcfff;
-  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
-  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
+  --crit-comment-ref-color:       #85aaf8;
+  --crit-comment-ref-color-hover: #94bcfb;
+  --crit-comment-ref-underline:   rgba(133, 170, 248, 0.35);
+  --crit-comment-ref-flash-bg:    rgba(187, 128, 9, 0.35);
+  --crit-comment-ref-flash-ring:  rgba(187, 128, 9, 0.85);
 
   --author-0-bg: rgba(110,160,230,0.15);
   --author-0-border: rgba(110,160,230,0.35);
@@ -292,10 +293,11 @@
     --crit-qr-bg: #fff;
 
     /* ---- Comment reference chip ---- */
-    --crit-comment-ref-bg:        rgba(64, 111, 204, 0.10);
-    --crit-comment-ref-color:     #406fcc;
-    --crit-comment-ref-border:    rgba(64, 111, 204, 0.30);
-    --crit-comment-ref-hover-bg:  rgba(64, 111, 204, 0.18);
+    --crit-comment-ref-color:       #0969da;
+    --crit-comment-ref-color-hover: #0550ae;
+    --crit-comment-ref-underline:   rgba(9, 105, 218, 0.40);
+    --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
+    --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 
     --author-0-bg: rgba(26,95,160,0.10);
     --author-0-border: rgba(26,95,160,0.25);
@@ -432,10 +434,11 @@
   --crit-qr-bg: #fff;
 
   /* ---- Comment reference chip ---- */
-  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
-  --crit-comment-ref-color:     #7dcfff;
-  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
-  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
+  --crit-comment-ref-color:       #85aaf8;
+  --crit-comment-ref-color-hover: #94bcfb;
+  --crit-comment-ref-underline:   rgba(133, 170, 248, 0.35);
+  --crit-comment-ref-flash-bg:    rgba(187, 128, 9, 0.35);
+  --crit-comment-ref-flash-ring:  rgba(187, 128, 9, 0.85);
 
   --author-0-bg: rgba(110,160,230,0.15);
   --author-0-border: rgba(110,160,230,0.35);

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -293,9 +293,9 @@
     --crit-qr-bg: #fff;
 
     /* ---- Comment reference chip ---- */
-    --crit-comment-ref-color:       #0550ae;
-    --crit-comment-ref-color-hover: #033d8b;
-    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
+    --crit-comment-ref-color:       #0c2461;
+    --crit-comment-ref-color-hover: #071440;
+    --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
     --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
     --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -293,9 +293,9 @@
     --crit-qr-bg: #fff;
 
     /* ---- Comment reference chip ---- */
-    --crit-comment-ref-color:       #0c2461;
-    --crit-comment-ref-color-hover: #071440;
-    --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
+    --crit-comment-ref-color:       #0550ae;
+    --crit-comment-ref-color-hover: #033d8b;
+    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
     --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
     --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 
@@ -574,9 +574,9 @@
   --crit-qr-bg: #fff;
 
   /* ---- Comment reference chip ---- */
-  --crit-comment-ref-color:       #0c2461;
-  --crit-comment-ref-color-hover: #071440;
-  --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
+  --crit-comment-ref-color:       #0550ae;
+  --crit-comment-ref-color-hover: #033d8b;
+  --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
   --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
   --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -574,10 +574,11 @@
   --crit-qr-bg: #fff;
 
   /* ---- Comment reference chip ---- */
-  --crit-comment-ref-bg:        rgba(64, 111, 204, 0.10);
-  --crit-comment-ref-color:     #406fcc;
-  --crit-comment-ref-border:    rgba(64, 111, 204, 0.30);
-  --crit-comment-ref-hover-bg:  rgba(64, 111, 204, 0.18);
+  --crit-comment-ref-color:       #0c2461;
+  --crit-comment-ref-color-hover: #071440;
+  --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
+  --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
+  --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 
   --author-0-bg: rgba(26,95,160,0.10);
   --author-0-border: rgba(26,95,160,0.25);

--- a/test/test-diff.sh
+++ b/test/test-diff.sh
@@ -530,6 +530,14 @@ C5=$(curl -sf -X POST "http://127.0.0.1:$PORT/api/file/comments?path=$ENCODED_PA
     "body": "These standards are good but we should split them into a separate doc once we'\''re past MVP. Having them inline in the plan adds noise for anyone skimming the implementation steps."
   }' | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
 
+# Seed a comment that references other comments by ID — exercises comment-ref linking
+curl -sf -X POST "http://127.0.0.1:$PORT/api/file/comments?path=$ENCODED_PATH" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"start_line\": 40, \"end_line\": 40,
+    \"body\": \"Same durability concern as \`$C1\` — if we switch to SQS we resolve both issues. Also ties into the rate-limiting work from $C2.\"
+  }" > /dev/null
+
 # Seed replies on comments to exercise threading (use captured IDs)
 curl -sf -X POST "http://127.0.0.1:$PORT/api/comment/$C2/replies?path=$ENCODED_PATH" \
   -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary
- Comment IDs (`c_*`, `r_*`, `rp_*`) in comment bodies now render as monospace link chips — bare text and backtick-wrapped forms both handled
- DOM post-processing approach (markdown-it inline rule dead-code; TreeWalker post-processes after each `commentMd.render()` call)
- Click scrolls to and highlights the referenced card with a warm yellow flash; restarts on rapid double-click
- Test fixture (`test/test-diff.sh`) seeds a comment referencing other IDs for manual eyeballing

## Review
- [x] Code review: passed
- [x] Parity audit: passed (JS logic, CSS rules, theme vars all in sync with crit-web)

## Test plan
- Run `make test-diff` to verify chip rendering and click behaviour in browser
- See also: tomasz-tomczyk/crit-web#202 — hosted counterpart PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)