### PR TITLE
security: make share_url global-only to prevent auth token exfiltration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ crit/
 8. **Real-time output** — review file written on every comment change (200ms debounce)
 9. **File watching** — git mode polls `git status --porcelain`; files mode polls mtimes; reloads via SSE
 10. **Localhost by default** — server binds to `127.0.0.1` (no CORS headers needed). Configurable via `--host` / `CRIT_HOST` / `host` config key (e.g. `0.0.0.0` for LAN). No auth, so non-loopback binds are explicit opt-in.
-11. **Two-level config** — `~/.crit.config.json` (global) merged with `.crit.config.json` (project), CLI flags override both. `agent_cmd` is global-only (prevents malicious repos from hijacking the agent command)
+11. **Two-level config** — `~/.crit.config.json` (global) merged with `.crit.config.json` (project), CLI flags override both. `agent_cmd`, `auth_token`, and `share_url` are global-only (prevents malicious repos from hijacking the agent command or redirecting share requests to steal auth tokens)
 12. **Headless CLI comment** — `crit comment` writes directly to the review file without starting the server; SSE notifies any running server
 13. **Comment threading** — comments support nested replies and a `resolved` boolean. Review file schema nests replies inside each comment's `replies` array.
 14. **Centralized review storage** — `~/.crit/reviews/<key>.json` keyed by cwd + branch (git mode) or cwd + args (file mode)
@@ -118,7 +118,7 @@ Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to the configured VCS user name if not set
-- `agent_cmd` is **global config only**; project-level config cannot override (security)
+- `agent_cmd`, `auth_token`, and `share_url` are **global config only**; project-level config cannot override (security — prevents malicious repos from hijacking the agent command or redirecting share requests to an attacker-controlled host)
 - `cleanup_on_approve` (default: `true`) — auto-delete review file when reviewer approves with no unresolved comments
 - `ignore_patterns` are unioned (global + project both apply); types: `*.ext`, `dir/`, `exact.file`, `path/*.ext`
 - `vcs` selects backend: `"git"` (default), `"sl"` (sapling), or `"jj"` (Jujutsu)

--- a/cli_dispatch.go
+++ b/cli_dispatch.go
@@ -119,7 +119,7 @@ Precedence (highest to lowest):
 Available keys:
   port              int       Port to listen on (default: random)
   no_open           bool      Don't auto-open browser (default: false)
-  share_url         string    Share service URL
+  share_url         string    Share service URL (global config only)
   quiet             bool      Suppress status output (default: false)
   output            string    Output directory for review file
   author            string    Your name for comments (default: git config user.name)
@@ -129,7 +129,7 @@ Available keys:
   agent_cmd              string    Shell command to send comments to an AI agent (e.g. "claude -p")
   auth_token             string    Authentication token for crit-web share service
 
-Note: agent_cmd and auth_token are global-only (~/.crit.config.json).
+Note: agent_cmd, auth_token, and share_url are global-only (~/.crit.config.json).
 Project-level .crit.config.json cannot override them for security reasons.
 
 Ignore pattern syntax:

--- a/config.go
+++ b/config.go
@@ -162,9 +162,6 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if projectPresence.NoOpen {
 		merged.NoOpen = project.NoOpen
 	}
-	if project.ShareURL != "" {
-		merged.ShareURL = project.ShareURL
-	}
 	if projectPresence.Quiet {
 		merged.Quiet = project.Quiet
 	}
@@ -189,10 +186,11 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if projectPresence.CleanupOnApprove {
 		merged.CleanupOnApprove = project.CleanupOnApprove
 	}
-	// Security: agent_cmd is intentionally NOT merged from project config.
-	// It must remain global-only to prevent untrusted project configs from
-	// overriding the agent command.
-	// auth_token is global-only (like agent_cmd) — project config cannot override
+	// Security: agent_cmd, auth_token, and share_url are intentionally NOT merged
+	// from project config. They must remain global-only: agent_cmd to prevent
+	// untrusted repos from hijacking the agent command; auth_token and share_url
+	// to prevent a malicious repo's .crit.config.json from redirecting share
+	// requests (and the bearer token) to an attacker-controlled host.
 	// Union ignore patterns
 	merged.IgnorePatterns = append(merged.IgnorePatterns, project.IgnorePatterns...)
 	return merged
@@ -201,8 +199,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 // LoadConfig loads and merges configuration from all sources.
 // projectDir is the repo root (or cwd if not in a git repo).
 // Runtime defaults (share_url, ignore_patterns) are applied when no config
-// file explicitly sets those fields. To disable defaults, set them to
-// empty values in a config file (e.g. "share_url": "", "ignore_patterns": []).
+// file explicitly sets those fields. share_url is global-only — project config
+// cannot override it. To suppress the share_url default, set it to "" in
+// ~/.crit.config.json.
 func LoadConfig(projectDir string) Config {
 	// 1. Global config
 	global, globalPresence, err := loadConfigFile(globalConfigPath())
@@ -226,8 +225,9 @@ func LoadConfig(projectDir string) Config {
 	// 3. Merge global + project
 	merged := mergeConfigs(global, project, projectPresence)
 
-	// 4. Apply runtime defaults for fields not explicitly set in any config file
-	if !globalPresence.ShareURL && !projectPresence.ShareURL {
+	// 4. Apply runtime defaults for fields not explicitly set in any config file.
+	// share_url is global-only, so only globalPresence controls whether the default applies.
+	if !globalPresence.ShareURL {
 		merged.ShareURL = "https://crit.md"
 	}
 	if !globalPresence.IgnorePatterns && !projectPresence.IgnorePatterns {

--- a/config.go
+++ b/config.go
@@ -133,7 +133,7 @@ func loadConfigFile(path string) (Config, configPresence, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return cfg, presence, fmt.Errorf("parsing %s: %w", path, err)
 	}
-	_, presence.ShareURL = raw["share_url"]
+	_, presence.ShareURL = raw["share_url"] // for global config only; project-side ShareURL presence is intentionally ignored by mergeConfigs
 	_, presence.IgnorePatterns = raw["ignore_patterns"]
 	_, presence.NoOpen = raw["no_open"]
 	_, presence.Quiet = raw["quiet"]

--- a/config_test.go
+++ b/config_test.go
@@ -336,19 +336,53 @@ func TestLoadConfigRuntimeDefaults(t *testing.T) {
 }
 
 func TestLoadConfigRuntimeDefaultsOverriddenByEmptyValues(t *testing.T) {
-	// Config explicitly sets share_url to "" and ignore_patterns to [] — no defaults
+	// Project config sets ignore_patterns to [] — overrides the runtime default.
+	// share_url is global-only and cannot be suppressed via project config.
 	homeDir := t.TempDir()
 	setHome(t, homeDir)
 	projectDir := t.TempDir()
 	os.WriteFile(filepath.Join(projectDir, ".crit.config.json"),
-		[]byte(`{"share_url": "", "ignore_patterns": []}`), 0644)
+		[]byte(`{"ignore_patterns": []}`), 0644)
 
 	cfg := LoadConfig(projectDir)
-	if cfg.ShareURL != "" {
-		t.Errorf("ShareURL = %q, want empty (explicitly overridden)", cfg.ShareURL)
+	// share_url is global-only — project config cannot suppress the runtime default
+	if cfg.ShareURL != "https://crit.md" {
+		t.Errorf("ShareURL = %q, want runtime default https://crit.md (project cannot override)", cfg.ShareURL)
 	}
 	if len(cfg.IgnorePatterns) != 0 {
 		t.Errorf("IgnorePatterns = %v, want empty (explicitly overridden)", cfg.IgnorePatterns)
+	}
+}
+
+func TestLoadConfigShareURLProjectIgnored(t *testing.T) {
+	// share_url in project config must be ignored — only global config may set it.
+	// Prevents a malicious repo from redirecting crit share (and the auth token)
+	// to an attacker-controlled host.
+	homeDir := t.TempDir()
+	setHome(t, homeDir)
+	os.WriteFile(filepath.Join(homeDir, ".crit.config.json"),
+		[]byte(`{"share_url": "https://trusted.example.com"}`), 0644)
+	projectDir := t.TempDir()
+	os.WriteFile(filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"share_url": "https://attacker.example.com"}`), 0644)
+
+	cfg := LoadConfig(projectDir)
+	if cfg.ShareURL != "https://trusted.example.com" {
+		t.Errorf("ShareURL = %q, want global value (project override must be ignored)", cfg.ShareURL)
+	}
+}
+
+func TestLoadConfigShareURLProjectCannotSuppressDefault(t *testing.T) {
+	// share_url: "" in project config must not suppress the runtime default.
+	homeDir := t.TempDir()
+	setHome(t, homeDir)
+	projectDir := t.TempDir()
+	os.WriteFile(filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"share_url": ""}`), 0644)
+
+	cfg := LoadConfig(projectDir)
+	if cfg.ShareURL != "https://crit.md" {
+		t.Errorf("ShareURL = %q, want runtime default https://crit.md", cfg.ShareURL)
 	}
 }
 
@@ -627,6 +661,16 @@ func TestMergeConfigs_AgentCmdProjectIgnored(t *testing.T) {
 	merged := mergeConfigs(global, project, configPresence{})
 	if merged.AgentCmd != "" {
 		t.Errorf("project agent_cmd should be ignored, got %q", merged.AgentCmd)
+	}
+}
+
+func TestMergeConfigs_ShareURLProjectIgnored(t *testing.T) {
+	// share_url in project config must not override global — prevents token exfiltration
+	global := Config{ShareURL: "https://crit.md"}
+	project := Config{ShareURL: "https://attacker.example.com"}
+	merged := mergeConfigs(global, project, configPresence{ShareURL: true})
+	if merged.ShareURL != "https://crit.md" {
+		t.Errorf("project share_url should be ignored, got %q", merged.ShareURL)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -650,10 +650,11 @@ func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 		defaultBranchOverride = ""
 		defaultBranchOnce = sync.Once{}
 
-		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
 		homeDir := t.TempDir()
 		setHome(t, homeDir)
+		// share_url is global-only; write to global config
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
 		t.Setenv("CRIT_SHARE_URL", "https://env.example.com")
 
 		origDir, _ := os.Getwd()
@@ -673,10 +674,11 @@ func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 		defaultBranchOverride = ""
 		defaultBranchOnce = sync.Once{}
 
-		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
 		homeDir := t.TempDir()
 		setHome(t, homeDir)
+		// share_url is global-only; write to global config
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
 		t.Setenv("CRIT_SHARE_URL", "https://env.example.com")
 
 		origDir, _ := os.Getwd()
@@ -692,14 +694,15 @@ func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 		}
 	})
 
-	t.Run("config used when no CLI or env", func(t *testing.T) {
+	t.Run("global config used when no CLI or env", func(t *testing.T) {
 		defaultBranchOverride = ""
 		defaultBranchOnce = sync.Once{}
 
-		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
 		homeDir := t.TempDir()
 		setHome(t, homeDir)
+		// share_url is global-only; project config cannot set it
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"share_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
 		os.Unsetenv("CRIT_SHARE_URL")
 
 		origDir, _ := os.Getwd()
@@ -711,7 +714,7 @@ func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if sc.shareURL != "https://config.example.com" {
-			t.Errorf("shareURL = %q, want config value", sc.shareURL)
+			t.Errorf("shareURL = %q, want global config value", sc.shareURL)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- A malicious repo's `.crit.config.json` could set `share_url` to an attacker-controlled host. Running `crit share` inside that repo would then send the user's auth bearer token to the attacker.
- `share_url` now follows the same global-only pattern already used for `agent_cmd` and `auth_token`: `mergeConfigs()` no longer applies the project value, and the runtime default check uses only `globalPresence.ShareURL`.
- Updated `cli_dispatch.go` help text and `CLAUDE.md`/`AGENTS.md` to document `share_url` as global-only alongside `agent_cmd` and `auth_token`.
- Added 4 new tests: `TestMergeConfigs_ShareURLProjectIgnored`, `TestLoadConfigShareURLProjectIgnored`, `TestLoadConfigShareURLProjectCannotSuppressDefault`, and updated `TestResolveServerConfig_ShareURLPrecedence` to use global config.
- Added clarifying comment on `configPresence.ShareURL` noting that the project-side presence bit is intentionally inert in `mergeConfigs`.

## Review
- [x] Code review: passed (go-expert + red team — no blockers)
- [x] Intent audit: CLEAN
- [x] Parity audit: N/A (no frontend changes)
- [x] Security scan: PASS — `handleShare` uses `s.shareURL` from trusted merged config, not `CritJSON.ShareURL`; review files live in `~/.crit/reviews/` (not project-controlled)

## Test plan
- `go test -race ./...` passes
- `golangci-lint` clean
- New tests cover: project override ignored, project empty-string cannot suppress default, attacker host scenario, unit-level merge guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)