### PR TITLE
fix: block DNS-rebinding with Host header validation

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -404,6 +404,8 @@ func runServe(args []string) {
 		daemonFatal(pipe, "Error creating server: %v", err)
 	}
 
+	srv.SetListenHost(sc.host)
+
 	// Set config-dependent fields for the settings panel
 	srv.cfg = sc.cfg
 	cwd, _ := resolvedCWD()

--- a/config.go
+++ b/config.go
@@ -156,9 +156,9 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if project.Port != 0 {
 		merged.Port = project.Port
 	}
-	if project.Host != "" {
-		merged.Host = project.Host
-	}
+	// Security: host is intentionally NOT merged from project config.
+	// A malicious repo setting host to "0.0.0.0" would disable the
+	// DNS-rebinding defense. Use --host flag or CRIT_HOST env var instead.
 	if projectPresence.NoOpen {
 		merged.NoOpen = project.NoOpen
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -113,6 +113,17 @@ func TestMergeConfigs(t *testing.T) {
 	}
 }
 
+func TestMergeConfigsHostGlobalOnly(t *testing.T) {
+	// A project config must not override host — doing so would let a malicious
+	// repo disable the DNS-rebinding defense by setting host to "0.0.0.0".
+	global := Config{Host: "127.0.0.1"}
+	project := Config{Host: "0.0.0.0"}
+	merged := mergeConfigs(global, project, configPresence{})
+	if merged.Host != "127.0.0.1" {
+		t.Errorf("host = %q, want global value %q (project must not override)", merged.Host, "127.0.0.1")
+	}
+}
+
 func TestBaseBranchConfig(t *testing.T) {
 	t.Run("loadConfigFile parses base_branch", func(t *testing.T) {
 		dir := t.TempDir()

--- a/main_test.go
+++ b/main_test.go
@@ -593,13 +593,13 @@ func TestResolveServerConfig_HostPrecedence(t *testing.T) {
 		}
 	})
 
-	t.Run("config wins when no CLI flag or env var", func(t *testing.T) {
+	t.Run("global config wins when no CLI flag or env var", func(t *testing.T) {
 		defaultBranchOverride = ""
 		defaultBranchOnce = sync.Once{}
 
 		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"host": "10.0.0.1"}`), 0644)
 		homeDir := t.TempDir()
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"host": "10.0.0.1"}`), 0644)
 		setHome(t, homeDir)
 		t.Setenv("CRIT_HOST", "")
 
@@ -612,7 +612,30 @@ func TestResolveServerConfig_HostPrecedence(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if sc.host != "10.0.0.1" {
-			t.Errorf("host = %q, want 10.0.0.1 (config file)", sc.host)
+			t.Errorf("host = %q, want 10.0.0.1 (global config)", sc.host)
+		}
+	})
+
+	t.Run("project config cannot override host", func(t *testing.T) {
+		defaultBranchOverride = ""
+		defaultBranchOnce = sync.Once{}
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"host": "0.0.0.0"}`), 0644)
+		homeDir := t.TempDir()
+		setHome(t, homeDir)
+		t.Setenv("CRIT_HOST", "")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := resolveServerConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.host != "127.0.0.1" {
+			t.Errorf("host = %q, want 127.0.0.1 (project config must not override host)", sc.host)
 		}
 	})
 

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
 	"os/exec"
 	"path/filepath"
@@ -53,6 +54,12 @@ type Server struct {
 	reviewPath        string
 	cliArgs           []string     // positional file args; flags (--pr, --range, etc.) are not preserved
 	prList            *prListCache // 60s cache for picker "Other PRs"
+
+	// listenHost is the host the server is bound to (e.g. "127.0.0.1" or
+	// "0.0.0.0"). Set via SetListenHost after construction. When set to a
+	// loopback address, ServeHTTP enforces that the request Host header is
+	// also a loopback hostname, blocking DNS-rebinding attacks.
+	listenHost string
 
 	// shutdownCtx is the daemon's signal-handled context; child operations
 	// (e.g. runAgentCmd subprocesses) derive their context from this so a
@@ -119,7 +126,48 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, authToken
 	return s, nil
 }
 
+// SetListenHost records the host the server is bound to. Call once after
+// construction, before serving requests. When the host is a loopback address,
+// ServeHTTP rejects requests whose Host header is not also a loopback address,
+// preventing DNS-rebinding attacks. When the host is non-loopback (e.g.
+// "0.0.0.0"), the check is skipped — the user has explicitly opted into
+// network exposure.
+func (s *Server) SetListenHost(host string) {
+	s.listenHost = host
+}
+
+// isLoopbackHost reports whether host (no port) is a loopback address.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// checkHost returns true if the request is allowed to proceed. When the server
+// is bound to a loopback address, the request's Host header must also resolve
+// to a loopback hostname — this is the canonical DNS-rebinding defense.
+func (s *Server) checkHost(r *http.Request) bool {
+	if s.listenHost == "" || !isLoopbackHost(s.listenHost) {
+		return true
+	}
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	} else {
+		// SplitHostPort fails when there's no port (e.g. "Host: [::1]").
+		// Strip IPv6 brackets so ParseIP can recognise the address.
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	return isLoopbackHost(host)
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !s.checkHost(r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	s.mux.ServeHTTP(w, r)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -73,6 +73,98 @@ func TestGetSession(t *testing.T) {
 	}
 }
 
+func TestHostCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		listenHost string
+		reqHost    string
+		wantCode   int
+	}{
+		// No listenHost set (test/default): all requests pass through.
+		{"no listen host, no req host", "", "", 200},
+		{"no listen host, evil.com", "", "evil.com", 200},
+
+		// listenHost is loopback: only loopback Host headers allowed.
+		{"loopback listen, localhost", "127.0.0.1", "localhost:3000", 200},
+		{"loopback listen, 127.0.0.1", "127.0.0.1", "127.0.0.1:3000", 200},
+		{"loopback listen, ::1 with port", "127.0.0.1", "[::1]:3000", 200},
+		{"loopback listen, ::1 bare", "127.0.0.1", "[::1]", 200},
+		{"loopback listen, evil.com", "127.0.0.1", "evil.com", 403},
+		{"loopback listen, evil.com no port", "127.0.0.1", "evil.com:80", 403},
+
+		// listenHost is non-loopback (user opted into LAN exposure): no check.
+		{"lan listen, evil.com", "0.0.0.0", "evil.com", 200},
+		{"lan listen, localhost", "0.0.0.0", "localhost:3000", 200},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestServer(t)
+			s.SetListenHost(tt.listenHost)
+			req := httptest.NewRequest("GET", "/api/session", nil)
+			if tt.reqHost != "" {
+				req.Host = tt.reqHost
+			}
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, req)
+			if w.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"127.0.0.2", true},
+		{"0.0.0.0", false},
+		{"evil.com", false},
+		{"192.168.1.1", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isLoopbackHost(tt.host); got != tt.want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}
+
+// TestHostCheckDefaultWiring verifies that the default host resolution ("127.0.0.1")
+// arms the DNS-rebinding guard. This catches regressions where the SetListenHost
+// call is dropped from the production wiring path.
+func TestHostCheckDefaultWiring(t *testing.T) {
+	// Simulate the production path: no --host flag, no CRIT_HOST env, default config.
+	// resolveHost("", "127.0.0.1") is what applyConfigDefaults produces.
+	effectiveHost := resolveHost("", "127.0.0.1")
+	if !isLoopbackHost(effectiveHost) {
+		t.Fatalf("default host %q is not loopback — guard would not be armed", effectiveHost)
+	}
+
+	s, _ := newTestServer(t)
+	s.SetListenHost(effectiveHost)
+
+	req := httptest.NewRequest("GET", "/api/session", nil)
+	req.Host = "evil.com"
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 403 {
+		t.Errorf("default wiring: Host: evil.com got status %d, want 403", w.Code)
+	}
+
+	req2 := httptest.NewRequest("GET", "/api/session", nil)
+	req2.Host = "localhost:3000"
+	w2 := httptest.NewRecorder()
+	s.ServeHTTP(w2, req2)
+	if w2.Code != 200 {
+		t.Errorf("default wiring: Host: localhost:3000 got status %d, want 200", w2.Code)
+	}
+}
+
 func TestGetSession_MethodNotAllowed(t *testing.T) {
 	s, _ := newTestServer(t)
 	req := httptest.NewRequest("POST", "/api/session", nil)


### PR DESCRIPTION
## Summary
- Adds Host header validation in `ServeHTTP`: when the server is bound to a loopback address (the default), requests with a non-loopback `Host` header are rejected with 403 — the canonical DNS-rebinding defense
- Makes `host` config global-only (like `agent_cmd`): a project-level `.crit.config.json` can no longer set `host: "0.0.0.0"` to silently disable the protection
- No effect on `--host` flag, `CRIT_HOST` env var, or global `~/.crit.config.json` — those paths still work as before

## Why

While a crit daemon is running, a malicious webpage could use DNS rebinding to flip its domain to `127.0.0.1`, making the browser treat it as same-origin and enabling cross-origin reads of local file content and writes to the comment API. The `Host` header still carries the attacker's domain name, which is what we check.

The check is skipped when the listen host is non-loopback (e.g. `0.0.0.0`) — users who explicitly opt into LAN exposure aren't affected.

## Review
- [x] Code review: passed (go-expert)
- [x] Parity audit: N/A (no frontend changes)
- [x] Security: Host check not bypassable via empty Host, `X-Forwarded-Host`, absolute-URI requests, or crafted lookalike names (`localhost.evil.com`, `127.0.0.1.evil.com`)

## Test plan
- `TestHostCheck`: 10 table-driven subtests covering no-listenHost / loopback-listen / LAN-listen × loopback Host / evil Host / bare IPv6
- `TestIsLoopbackHost`: 8 subtests including full `127.x.x.x` range, `::1`, empty string
- `TestHostCheckDefaultWiring`: walks the production wiring path (`resolveHost` → `SetListenHost` → guard fires)
- `TestMergeConfigsHostGlobalOnly`: asserts project config cannot override host
- `TestResolveServerConfig_HostPrecedence`: updated — global config sets host, project config cannot

🤖 Generated with [Claude Code](https://claude.com/claude-code)