### PR TITLE
feat: add Pi Coding Agent integration

### DIFF
--- a/cli_install.go
+++ b/cli_install.go
@@ -134,6 +134,13 @@ var integrationMap = map[string][]integration{
 		{source: "integrations/qwen/skills/crit/SKILL.md", dest: ".qwen/skills/crit/SKILL.md", hint: "Run /crit in Qwen Code to start a review loop"},
 		{source: "integrations/qwen/skills/crit-cli/SKILL.md", dest: ".qwen/skills/crit-cli/SKILL.md", hint: "The crit-cli skill is available to Qwen Code agents when needed"},
 	},
+	"pi": {
+		// Pi auto-discovers skills in both .pi/skills/ (project-local) and
+		// ~/.pi/agent/skills/ (global). Different shape between modes, so
+		// globalDest redirects the global install to the agent/skills path.
+		{source: "integrations/pi/skills/crit/SKILL.md", dest: ".pi/skills/crit/SKILL.md", globalDest: ".pi/agent/skills/crit/SKILL.md", globalDestKind: globalDestRelHome, hint: "Run /crit in Pi to start a review loop"},
+		{source: "integrations/pi/skills/crit-cli/SKILL.md", dest: ".pi/skills/crit-cli/SKILL.md", globalDest: ".pi/agent/skills/crit-cli/SKILL.md", globalDestKind: globalDestRelHome, hint: "The crit-cli skill is available to Pi agents when needed"},
+	},
 	"hermes": {
 		// Hermes only auto-discovers skills under HERMES_HOME (default ~/.hermes/skills/).
 		// Project-local .hermes/skills/ is not loaded unless added to `external_dirs` in

--- a/integration_hashes_gen.go
+++ b/integration_hashes_gen.go
@@ -26,6 +26,8 @@ var integrationHashes = map[string]string{
 	"integrations/hermes/skills/crit/SKILL.md":             "5ebb454cbcce0843d353e50695802a5b151a65cf59c4aeb07f494d89bc65861e",
 	"integrations/opencode/SKILL.md":                       "ca9b81518527ca071cbcb72831c7331b6745fafeaa6a376cbe10f6c685df4f90",
 	"integrations/opencode/crit.md":                        "3d83ac53f2ce3dc88c128316fa91e073aee522152ec754ca9a207ba6106b4882",
+	"integrations/pi/skills/crit-cli/SKILL.md":             "cf6559531492f1a219c48e09e09420faf6e6adc59566c4537fa509813c91be20",
+	"integrations/pi/skills/crit/SKILL.md":                 "a6db7d5f3e8669febb4b4eb34d936edbb595e62a6b2a64a7ce13a86551f44d85",
 	"integrations/qwen/skills/crit-cli/SKILL.md":           "db988d282ab2eb3f0f886144eded6e6b1d12f0b8485c6a0089d72a14cfed63b8",
 	"integrations/qwen/skills/crit/SKILL.md":               "0cb405e60b12c8b43be97e3020ef64ee9700f2a94c433845c092f707b60b43d4",
 	"integrations/windsurf/crit.md":                        "22eec224e9bee78d2453be096f9137422b6e4ab3d5136bff59b12635ea1b619c",

--- a/integration_routing_test.go
+++ b/integration_routing_test.go
@@ -58,6 +58,9 @@ func TestDestFor_GlobalMode(t *testing.T) {
 		// hermes: both skills redirect to ~/.hermes/skills/.
 		{"hermes", 0, filepath.Join(home, ".hermes/skills/crit/SKILL.md")},
 		{"hermes", 1, filepath.Join(home, ".hermes/skills/crit-cli/SKILL.md")},
+		// pi: both skills redirect to ~/.pi/agent/skills/.
+		{"pi", 0, filepath.Join(home, ".pi/agent/skills/crit/SKILL.md")},
+		{"pi", 1, filepath.Join(home, ".pi/agent/skills/crit-cli/SKILL.md")},
 	}
 	for _, tc := range cases {
 		f := integrationMap[tc.tool][tc.fileIdx]
@@ -109,6 +112,7 @@ func TestIntegrationMap_SnapshotGlobalRouting(t *testing.T) {
 		"cline":          {{"Cline/Rules/crit.md", globalDestDocuments}},
 		"gemini":         {{".gemini/skills/crit-cli/SKILL.md", globalDestRelHome}, {".gemini/commands/crit.toml", globalDestRelHome}, {".gemini/policies/crit.toml", globalDestRelHome}},
 		"hermes":         {{".hermes/skills/crit/SKILL.md", globalDestRelHome}, {".hermes/skills/crit-cli/SKILL.md", globalDestRelHome}},
+		"pi":             {{".pi/agent/skills/crit/SKILL.md", globalDestRelHome}, {".pi/agent/skills/crit-cli/SKILL.md", globalDestRelHome}},
 	}
 	for tool, files := range expected {
 		got := integrationMap[tool]

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -20,6 +20,7 @@ Safe to re-run. Existing files are skipped (use `--force` to overwrite).
 | GitHub Copilot | `crit install github-copilot` | `.github/skills/crit/SKILL.md` + `.github/skills/crit-cli/SKILL.md` | `~/.agents/skills/crit/SKILL.md` + `~/.agents/skills/crit-cli/SKILL.md` |
 | OpenCode | `crit install opencode` | `.opencode/commands/crit.md` + `.opencode/skills/crit/SKILL.md` | `~/.opencode/commands/crit.md` + `~/.agents/skills/crit/SKILL.md` |
 | Codex | `crit install codex` | `.agents/skills/crit/SKILL.md` + `.agents/skills/crit-cli/SKILL.md` | `~/.agents/skills/crit/SKILL.md` + `~/.agents/skills/crit-cli/SKILL.md` |
+| Pi | `crit install pi` | `.pi/skills/crit/SKILL.md` + `.pi/skills/crit-cli/SKILL.md` | `~/.pi/agent/skills/crit/SKILL.md` + `~/.pi/agent/skills/crit-cli/SKILL.md` |
 | Qwen Code | `crit install qwen` | `.qwen/skills/crit/SKILL.md` + `.qwen/skills/crit-cli/SKILL.md` | `~/.qwen/skills/crit/SKILL.md` + `~/.qwen/skills/crit-cli/SKILL.md` |
 | Hermes | `crit install hermes` | `.hermes/skills/crit/SKILL.md` + `.hermes/skills/crit-cli/SKILL.md` (requires adding `.hermes/skills` to `external_dirs` in `~/.hermes/config.yaml`) | `~/.hermes/skills/crit/SKILL.md` + `~/.hermes/skills/crit-cli/SKILL.md` |
 | Windsurf | `crit install windsurf` | `.windsurf/rules/crit.md` | (not supported — Windsurf only allows a single shared `global_rules.md`) |

--- a/integrations/pi/skills/crit-cli/SKILL.md
+++ b/integrations/pi/skills/crit-cli/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: crit-cli
+description: Use when an agent needs to author or reply to crit inline comments programmatically (including multi-agent workflows commenting on shared code/plans/docs/proposals), publish or unpublish a crit review with crit share, sync a crit review to or from a GitHub PR, or read/interpret a crit review JSON file. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow. Not for invoking an interactive review loop — that's the `crit` skill.
+user-invocable: false
+---
+
+# Crit CLI Reference
+
+> If a plan was just written and the user said "crit" or "review", use the `$crit` skill instead — it covers the full review loop. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
+
+Comments have three scopes:
+
+- **Line comments** (`scope: "line"`) — tied to specific lines, stored in `files.<path>.comments`
+- **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
+- **Review comments** (`scope: "review"`) — general feedback, stored in the top-level `review_comments` array
+
+The review file path is shown by `crit status`.
+
+## Review file format
+
+```json
+{
+  "review_comments": [
+    {
+      "id": "r_f1e2d3",
+      "body": "Overall the architecture looks good",
+      "scope": "review",
+      "author": "User Name",
+      "resolved": false,
+      "replies": [
+        { "id": "rp_b4a5c6", "body": "Thanks, addressed the minor issues", "author": "Hermes" }
+      ]
+    }
+  ],
+  "files": {
+    "path/to/file.go": {
+      "comments": [
+        {
+          "id": "c_a1b2c3",
+          "start_line": 5,
+          "end_line": 10,
+          "body": "Comment text",
+          "quote": "the specific words selected",
+          "anchor": "The sessions table needs a complete rewrite...",
+          "author": "User Name",
+          "resolved": false,
+          "replies": [
+            { "id": "rp_c7d8e9", "body": "Fixed by extracting to helper", "author": "Hermes" }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Field rules:
+- `resolved`: `false` or **missing** — both mean unresolved. Only `true` means resolved.
+- `quote` (optional): the specific text the reviewer selected — narrows scope within the line range. Focus changes on the quoted text rather than the entire range.
+- `anchor` (line comments): full text of the commented lines when placed. When edits shift line numbers, locate content by anchor rather than trusting `start_line`/`end_line`.
+- `drifted: true`: original content was removed or heavily rewritten — line numbers are approximate at best.
+- Before acting on a comment, check `replies` — if you've already replied, the reviewer may be following up rather than requesting a new change.
+
+## Authoring comments
+
+```bash
+# Review-level (general feedback)
+crit comment --author 'Hermes' '<body>'
+
+# File-level (whole file, no line numbers)
+crit comment --author 'Hermes' <path> '<body>'
+
+# Line (single line or range)
+crit comment --author 'Hermes' <path>:<line> '<body>'
+crit comment --author 'Hermes' <path>:<start>-<end> '<body>'
+
+# Reply to an existing comment
+crit comment --reply-to <id> --author 'Hermes' '<body>'
+```
+
+Hard rules:
+- **Always pass `--author 'Hermes'`** so comments are attributed correctly.
+- **Always single-quote the body** — double quotes break on backticks and shell metachars.
+- **Line numbers reference the file on disk** (1-indexed), not diff line numbers.
+- **Reply bodies support markdown** — use code fences and inline code where helpful.
+- **Only pass `--resolve` when the user explicitly asks.** Never resolve proactively. Same rule applies to the `resolve` field in `--json` mode.
+
+## Bulk commenting (3+ comments)
+
+Use `--json` for atomicity (single write, no partial state) and speed (one process). The JSON can come from stdin or `--file <path>`:
+
+```bash
+# stdin — fine for short, single-line bodies:
+echo '[
+  {"body": "overall feedback", "scope": "review"},
+  {"path": "session.go", "body": "restructure", "scope": "file"},
+  {"file": "src/auth.go", "line": 42, "body": "Missing null check"},
+  {"file": "src/auth.go", "line": "50-55", "body": "Extract to helper"},
+  {"reply_to": "c_a1b2c3", "body": "Fixed — added null check"},
+  {"reply_to": "r_f1e2d3", "body": "Done"}
+]' | crit comment --json --author 'Hermes'
+```
+
+**For multi-paragraph bodies, prefer `--file`.** A literal newline inside a `"body"` string breaks JSON parsing, and shell-quoted heredocs make this easy to introduce by accident. Write the JSON to a temp file (use your file-edit tool), then:
+
+```bash
+crit comment --json --file /tmp/crit-bulk.json --author 'Hermes'
+```
+
+`--file -` is an explicit "read stdin" if you ever need it.
+
+Per-entry schema:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `file` / `path` | string | line/file comments | Relative path. `path` alone (no `line`) → file-level. |
+| `line` | int/string | line comments | `42` or `"45-47"` |
+| `end_line` | int | optional | Defaults to `line` |
+| `body` | string | always | |
+| `author` | string | optional | Per-entry override; falls back to `--author` |
+| `scope` | string | optional | `"review"` / `"file"` — usually inferred |
+| `reply_to` | string | replies | Comment ID (`c_…` or `r_…`) |
+| `resolve` | bool | optional | Only when user explicitly asks |
+
+Scope inference (when `scope` omitted): has `reply_to` → reply; no `file`/`path` and no `line` → review-level; `path` but no `line` → file-level; `file`/`path` + `line` → line.
+
+## Multi-file disambiguation
+
+Comment IDs are unique per session, but the same ID can collide across files. If `crit comment` errors with "comment found in multiple files", disambiguate with `--path`:
+
+```bash
+crit comment --reply-to c_a1b2c3 --path src/auth.go --author 'Hermes' 'Fixed the null check'
+```
+
+In `--json` mode, set the `file` field on the entry. Review-level IDs (`r_…`) are globally unique and never need this.
+
+## Plan-mode comments
+
+Plan reviews (via `crit plan` or the ExitPlanMode hook) store the review file in `~/.crit/plans/<slug>/`. **Always pass `--plan <slug>`** — without it, `crit comment` looks in the project root and won't find the comments. The slug is shown in the review feedback prompt.
+
+```bash
+crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Hermes' 'Updated the plan'
+```
+
+## GitHub PR Integration
+
+```bash
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]   # Post review comments as a GitHub PR review
+```
+
+Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch.
+
+`--event` values: `comment` (default), `approve`, `request-changes`. `-m` adds a review-level body message.
+
+## Sharing
+
+```bash
+crit share <file> [file...]   # Upload and print URL
+crit share --qr <file>        # Also print QR code (terminal only)
+crit unpublish                # Remove shared review
+```
+
+- **Always relay the output** — copy the URL (and QR if used) into your response. Don't make the user dig through tool output.
+- **`--qr` is terminal-only** — skip in mobile apps, web chat UIs, or anywhere Unicode block characters won't render correctly.
+- If a review file exists, comments for the shared files are included automatically.
+- **Unpublish uses the persisted delete token** in the review file — no extra args needed.

--- a/integrations/pi/skills/crit/SKILL.md
+++ b/integrations/pi/skills/crit/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: crit
+description: Review code changes or a plan with crit inline comments. Use when asked to review code, a plan, a diff, or when you want structured human feedback on your work.
+---
+
+# Review with Crit
+
+Review and revise code changes or a plan using `crit` for inline comment review.
+
+## Step 1: Determine review mode
+
+Pick whichever applies — don't ask for confirmation:
+
+1. **User argument** — user specified a file (e.g. `crit my-plan.md`) → review that file
+2. **Recent plan** — no argument, but a plan was written earlier in this conversation → `crit <plan-file>`
+3. **Branch review** — otherwise → bare `crit`. Auto-detects uncommitted changes or branch-vs-default-branch diff. Works on clean branches.
+4. **PR or commit range** — user asked to review a specific GitHub PR or commit range → `crit --pr <num|url>` or `crit --range <baseSHA>..<headSHA>`. Boots crit in *range mode*, scoping the review to a fixed range of commits rather than the working tree.
+
+## Step 2: Launch crit and block until review completes
+
+**CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
+
+Run `crit` in the foreground and block until it exits:
+
+```bash
+crit <plan-file>   # specific file
+crit               # git mode
+```
+
+If a crit server is already running from earlier in this conversation, `crit` automatically connects to it. Starting from scratch, it spawns the daemon, opens the browser, and blocks until the user clicks "Finish Review".
+
+`crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`). Relay it verbatim:
+
+> **"Crit is open at http://localhost:<port>. Leave inline comments, then click Finish Review."**
+
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
+
+## Step 3: Read the review output
+
+When `crit` completes, its stdout includes the path to the review file (e.g. "Review comments are in /path/to/review.json"). Read it.
+
+The file contains structured JSON. Three comment types:
+- `review_comments` (top-level, `r_`-prefixed IDs) — general feedback
+- File comments (per-file `comments` array, no `start_line`/`end_line`) — about the file as a whole
+- Line comments (per-file `comments` array, with `start_line`/`end_line`) — about specific lines
+
+Identify all comments where `resolved` is `false` or missing.
+
+When a comment has these fields:
+- `quote`: the specific text the reviewer selected — focus your changes on the quoted text rather than the entire line range
+- `anchor`: use it to locate the current position of the content; line numbers may be stale after edits
+- `drifted: true`: original content was removed or heavily rewritten — line numbers are approximate at best
+
+## Step 4: Address each review comment
+
+For each unresolved comment:
+
+1. Understand what the comment asks for
+2. If it contains a suggestion block, apply that specific change
+3. Revise the referenced file (plan or code file from the diff)
+4. Reply with what you did: `crit comment --reply-to <id> --author 'Pi' '<what you did>'` (reply bodies support markdown)
+5. **Do not pass `--resolve`.** Resolving is the reviewer's call. Only add `--resolve` if the user explicitly asks.
+
+Editing the plan file triggers Crit's live reload — the user sees changes in the browser immediately.
+
+### When replying to multiple comments
+
+Use `--json` for a single bulk call instead of one invocation per comment:
+
+```bash
+echo '[
+  {"reply_to": "c_a1b2c3", "body": "Fixed"},
+  {"reply_to": "c_d4e5f6", "body": "Refactored as suggested"}
+]' | crit comment --json --author 'Pi'
+```
+
+**If there are zero review comments**: inform the user no changes were requested and stop.
+
+## Step 5: Signal completion and start next round
+
+**CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
+
+When Step 2's `crit` command exits with feedback, it prints `Next round: crit <args>` to stdout. Run that command verbatim — the daemon is keyed by args, so mismatched args spawn a new daemon instead of reconnecting.
+
+On subsequent calls, `crit` automatically signals round-complete first, then blocks until the next "Finish Review" click.
+
+Tell the user: **"Changes applied. Review the diff in your browser and click Finish Review when ready."**
+
+**Do NOT proceed until `crit` completes.** When it does, return to Step 3. If the user finishes with zero comments, the review is approved — stop the loop and proceed.
+
+## Sharing
+
+If the user asks for a URL, a shareable link, or to share the review:
+
+```bash
+crit share <file>
+```
+
+**Always relay the full output to the user** — copy the URL directly into your response. Don't make them dig through tool output.
+
+To remove a shared review:
+
+```bash
+crit unpublish
+```
+
+### QR codes
+
+Only use `--qr` in real terminal environments with monospace rendering. Skip it in mobile apps or web chat UIs — Unicode block characters won't render.
+
+```bash
+crit share --qr <file>
+```


### PR DESCRIPTION
## Summary
- Adds `crit install pi` for Pi Coding Agent (https://pi.dev)
- Project install writes to `.pi/skills/crit/SKILL.md` + `.pi/skills/crit-cli/SKILL.md` — auto-discovered by Pi
- Global install (`cd ~ && crit install pi`) writes to `~/.pi/agent/skills/` — Pi's personal skill discovery path (distinct from the project path)
- Skill files mirror the Hermes integration with the author label switched to `Pi`

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (no review-page surface touched)

## Test plan
- [x] `go build` / `gofmt` / `golangci-lint` clean
- [x] `go test -race ./...` passes
- [x] `TestDestFor_GlobalMode` and `TestIntegrationMap_SnapshotGlobalRouting` updated
- [x] `go generate ./...` re-run — `integration_hashes_gen.go` updated

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)