### PR TITLE
fix: highlight markdown diff in document view in vcs mode

### DIFF
--- a/e2e/tests/md-toggle.spec.ts
+++ b/e2e/tests/md-toggle.spec.ts
@@ -137,18 +137,18 @@ test.describe('Markdown Document/Diff Toggle — Git Mode', () => {
     await expect(page.locator('.comment-form')).toHaveCount(0);
   });
 
-  test('document view does not show change indicators in git mode', async ({ page }) => {
+  test('document view shows change indicators in git mode', async ({ page }) => {
     const section = mdSection(page);
 
     // Switch to document view
     await section.locator('.file-header-toggle .toggle-btn[data-mode="document"]').click();
     await expect(section.locator('.document-wrapper')).toBeVisible();
 
-    // Line blocks should exist but none should have any change indicator
+    // plan.md is added on the feature branch — every line block should be marked as added
     await expect(section.locator('.line-block').first()).toBeVisible();
-    await expect(section.locator('.line-block-added, .line-block-modified, .deletion-marker')).toHaveCount(0);
+    await expect(section.locator('.line-block-added').first()).toBeVisible();
 
-    // Change navigation widget should not be visible
+    // Change navigation widget remains file-mode only
     await expect(section.locator('.change-nav')).not.toBeVisible();
   });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2689,7 +2689,7 @@
 
     const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
 
-    const changeInfo = (file.viewMode === 'document' && session.mode !== 'git') ? getChangeInfo(file) : null;
+    const changeInfo = file.viewMode === 'document' ? getChangeInfo(file) : null;
     // Build a map of afterLine -> deletion marker for quick lookup
     const deletionMarkerMap = {};
     if (changeInfo) {


### PR DESCRIPTION
## Summary

Closes #518

In vcs/git mode, switching a markdown file to the Document view rendered the file beautifully (mermaid, syntax highlighting, line numbers) but stripped all diff annotation — users had to flip back to the raw Diff view to know what changed. As called out in the issue thread, this gap was a known papercut.

The change-info computation (`getChangeInfo`) that drives added/modified/deletion markers was explicitly gated to non-git mode. That gate was the only thing preventing it from working: `diffHunks` is already populated identically in both modes, and the CSS (`.line-block-added`, `.line-block-modified`, `.deletion-marker`) already exists.

The change-nav widget stays file-mode-only — out of scope for this fix.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint`, ESLint, Stylelint, CSS-var check all clean (pre-commit)
- [x] Manually eyeballed via instance 4 of `make test-diff` (http://127.0.0.1:3004) — Document view now shows green/amber bars and deletion markers
- [x] Existing test "document view does not show change indicators in git mode" flipped to assert the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)