### PR TITLE
ci: test Windows jobs on VS 2026 preview image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   unit-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
 
@@ -261,7 +261,7 @@ jobs:
           retention-days: 7
 
   e2e-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     env:
       # Stop Git Bash from auto-converting POSIX-looking arguments to Windows
       # paths when invoking native binaries (crit.exe, taskkill, powershell).


### PR DESCRIPTION
## Summary
- Switch `unit-windows` and `e2e-windows` from `windows-latest` to `windows-2025-vs2026`
- GitHub will migrate `windows-latest` to VS 2026 between June 8-15 — this tests the new image early
- If CI passes, we're good. If not, we can pin to `windows-2022` before the forced migration

## Test plan
- [ ] `unit-windows` job passes
- [ ] `e2e-windows` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)