### PR TITLE
feat: add resolve/unresolve button to sidebar comment cards

### DIFF
--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -343,7 +343,7 @@ test.describe('Comments Panel — Git Mode', () => {
     await switchToDocumentView(page);
     await page.keyboard.press('Shift+C');
 
-    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id]`) }).first();
+    const card = page.locator('.panel-comment-block .comment-card[data-comment-id]').first();
     await card.locator('.comment-actions button[title="Resolve"]').click();
 
     // Card gets resolved-card class and button changes to Unresolve
@@ -365,7 +365,7 @@ test.describe('Comments Panel — Git Mode', () => {
     await page.locator('#commentsFilterPill .toggle-btn[data-filter="resolved"]').click();
     await expect(panelCards(page)).toHaveCount(1);
 
-    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id="${comment.id}"]`) });
+    const card = page.locator(`.panel-comment-block .comment-card[data-comment-id="${comment.id}"]`);
     await card.locator('.comment-actions button[title="Unresolve"]').click();
 
     // Switch to "open" filter — comment is now unresolved so it appears there
@@ -382,7 +382,7 @@ test.describe('Comments Panel — Git Mode', () => {
     await switchToDocumentView(page);
     await page.keyboard.press('Shift+C');
 
-    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id]`) }).first();
+    const card = page.locator('.panel-comment-block .comment-card[data-comment-id]').first();
     await card.locator('.comment-actions button[title="Resolve"]').click();
 
     // Wait for resolve to complete before checking negative
@@ -403,7 +403,7 @@ test.describe('Comments Panel — Git Mode', () => {
     await loadPage(page);
     await page.keyboard.press('Shift+C');
 
-    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id="${comment.id}"]`) });
+    const card = page.locator(`.panel-comment-block .comment-card[data-comment-id="${comment.id}"]`);
     await expect(card.locator('.comment-actions button[title="Resolve"]')).toBeVisible();
 
     await card.locator('.comment-actions button[title="Resolve"]').click();

--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -325,4 +325,65 @@ test.describe('Comments Panel — Git Mode', () => {
     await expect(card.locator('.carried-forward-label')).toHaveCount(0);
     await expect(card.locator('.resolve-btn--active')).toHaveCount(0);
   });
+
+  test('panel comment card shows Resolve button', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Resolve from panel');
+    await loadPage(page);
+    await page.keyboard.press('Shift+C');
+
+    const card = panelCards(page).first();
+    await expect(card.locator('.comment-actions button[title="Resolve"]')).toBeVisible();
+  });
+
+  test('clicking Resolve in panel resolves the comment', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Panel resolve test');
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await page.keyboard.press('Shift+C');
+
+    await panelCards(page).first().locator('.comment-actions button[title="Resolve"]').click();
+
+    // Card gets resolved-card class and button changes to Unresolve
+    await expect(panelCards(page).first()).toHaveClass(/resolved-card/);
+    await expect(panelCards(page).first().locator('.comment-actions button[title="Unresolve"]')).toBeVisible();
+  });
+
+  test('clicking Unresolve in panel unresolves the comment', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    const comment = await addComment(request, mdPath, 1, 'Panel unresolve test');
+    await request.fetch(`/api/comment/${comment.id}/resolve?path=${encodeURIComponent(mdPath)}`, {
+      method: 'PUT',
+      data: { resolved: true },
+    });
+    await loadPage(page);
+    await page.keyboard.press('Shift+C');
+
+    // Switch to resolved filter to see the resolved comment
+    await page.locator('#commentsFilterPill .toggle-btn[data-filter="resolved"]').click();
+    await expect(panelCards(page)).toHaveCount(1);
+
+    await panelCards(page).first().locator('.comment-actions button[title="Unresolve"]').click();
+
+    // Switch to "open" filter — comment is now unresolved so it appears there
+    await page.locator('#commentsFilterPill .toggle-btn[data-filter="open"]').click();
+    await expect(panelCards(page)).toHaveCount(1);
+    await expect(panelCards(page).first()).not.toHaveClass(/resolved-card/);
+    await expect(panelCards(page).first().locator('.comment-actions button[title="Resolve"]')).toBeVisible();
+  });
+
+  test('clicking Resolve button does not trigger scroll-to-inline navigation', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'No scroll on resolve');
+    await loadPage(page);
+    await switchToDocumentView(page);
+    await page.keyboard.press('Shift+C');
+
+    await panelCards(page).first().locator('.comment-actions button[title="Resolve"]').click();
+
+    // The inline comment card should NOT receive the highlight animation
+    const inlineCard = page.locator('.comment-block:not(.panel-comment-block) .comment-card[data-comment-id]').first();
+    await expect(inlineCard).not.toHaveClass(/comment-card-highlight/);
+  });
 });

--- a/e2e/tests/comments-panel.spec.ts
+++ b/e2e/tests/comments-panel.spec.ts
@@ -343,11 +343,12 @@ test.describe('Comments Panel — Git Mode', () => {
     await switchToDocumentView(page);
     await page.keyboard.press('Shift+C');
 
-    await panelCards(page).first().locator('.comment-actions button[title="Resolve"]').click();
+    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id]`) }).first();
+    await card.locator('.comment-actions button[title="Resolve"]').click();
 
     // Card gets resolved-card class and button changes to Unresolve
-    await expect(panelCards(page).first()).toHaveClass(/resolved-card/);
-    await expect(panelCards(page).first().locator('.comment-actions button[title="Unresolve"]')).toBeVisible();
+    await expect(card).toHaveClass(/resolved-card/);
+    await expect(card.locator('.comment-actions button[title="Unresolve"]')).toBeVisible();
   });
 
   test('clicking Unresolve in panel unresolves the comment', async ({ page, request }) => {
@@ -364,13 +365,14 @@ test.describe('Comments Panel — Git Mode', () => {
     await page.locator('#commentsFilterPill .toggle-btn[data-filter="resolved"]').click();
     await expect(panelCards(page)).toHaveCount(1);
 
-    await panelCards(page).first().locator('.comment-actions button[title="Unresolve"]').click();
+    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id="${comment.id}"]`) });
+    await card.locator('.comment-actions button[title="Unresolve"]').click();
 
     // Switch to "open" filter — comment is now unresolved so it appears there
     await page.locator('#commentsFilterPill .toggle-btn[data-filter="open"]').click();
     await expect(panelCards(page)).toHaveCount(1);
-    await expect(panelCards(page).first()).not.toHaveClass(/resolved-card/);
-    await expect(panelCards(page).first().locator('.comment-actions button[title="Resolve"]')).toBeVisible();
+    await expect(card).not.toHaveClass(/resolved-card/);
+    await expect(card.locator('.comment-actions button[title="Resolve"]')).toBeVisible();
   });
 
   test('clicking Resolve button does not trigger scroll-to-inline navigation', async ({ page, request }) => {
@@ -380,10 +382,32 @@ test.describe('Comments Panel — Git Mode', () => {
     await switchToDocumentView(page);
     await page.keyboard.press('Shift+C');
 
-    await panelCards(page).first().locator('.comment-actions button[title="Resolve"]').click();
+    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id]`) }).first();
+    await card.locator('.comment-actions button[title="Resolve"]').click();
+
+    // Wait for resolve to complete before checking negative
+    await expect(card).toHaveClass(/resolved-card/);
 
     // The inline comment card should NOT receive the highlight animation
     const inlineCard = page.locator('.comment-block:not(.panel-comment-block) .comment-card[data-comment-id]').first();
     await expect(inlineCard).not.toHaveClass(/comment-card-highlight/);
+  });
+
+  test('panel resolve works for review-level comments', async ({ page, request }) => {
+    const resp = await request.post('/api/comments', {
+      data: { body: 'Review-level resolve test' },
+    });
+    expect(resp.ok()).toBeTruthy();
+    const comment = await resp.json();
+
+    await loadPage(page);
+    await page.keyboard.press('Shift+C');
+
+    const card = panelCards(page).filter({ has: page.locator(`[data-comment-id="${comment.id}"]`) });
+    await expect(card.locator('.comment-actions button[title="Resolve"]')).toBeVisible();
+
+    await card.locator('.comment-actions button[title="Resolve"]').click();
+    await expect(card).toHaveClass(/resolved-card/);
+    await expect(card.locator('.comment-actions button[title="Unresolve"]')).toBeVisible();
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6085,6 +6085,7 @@
     renderFileByPath(filePath);
     updateCommentCount();
     updateTreeCommentBadges();
+    renderCommentsPanel();
   }
 
   // ===== Review-Level (General) Comments =====

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6835,12 +6835,26 @@
       showReplyInput: false,
     });
 
+    // Resolve/unresolve button — works for both file and review comments
+    const scope = isGeneral ? 'review' : 'file';
+    const resolveAction = isResolved ? 'unresolve' : 'resolve';
+    const resolveBtn = document.createElement('button');
+    resolveBtn.className = 'resolve-btn' + (isResolved ? ' resolve-btn--active' : '');
+    resolveBtn.title = isResolved ? 'Unresolve' : 'Resolve';
+    resolveBtn.setAttribute('aria-label', isResolved ? 'Unresolve thread' : 'Resolve thread');
+    resolveBtn.innerHTML = (isResolved ? ICON_UNRESOLVE : ICON_RESOLVE) + '<span>' + (isResolved ? 'Unresolve' : 'Resolve') + '</span>';
+    resolveBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      toggleResolveStatus(comment.id, scope, resolveAction, filePath || null);
+    });
+    parts.actions.appendChild(resolveBtn);
+
     if (isGeneral) {
-      // General comments are edited/resolved/deleted from the inline
-      // Review Conversation section. Panel cards navigate + flash the inline card,
-      // matching the line-comment behaviour.
       parts.wrapper.style.cursor = 'pointer';
-      parts.wrapper.addEventListener('click', function() { scrollToReviewComment(comment.id); });
+      parts.wrapper.addEventListener('click', function(e) {
+        if (e.target.closest('.comment-actions')) return;
+        scrollToReviewComment(comment.id);
+      });
     } else {
       // File comments are clickable to scroll to inline location
       parts.wrapper.style.cursor = 'pointer';

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6845,7 +6845,10 @@
     resolveBtn.innerHTML = (isResolved ? ICON_UNRESOLVE : ICON_RESOLVE) + '<span>' + (isResolved ? 'Unresolve' : 'Resolve') + '</span>';
     resolveBtn.addEventListener('click', function(e) {
       e.stopPropagation();
-      toggleResolveStatus(comment.id, scope, resolveAction, filePath || null);
+      if (resolveBtn.disabled) return;
+      resolveBtn.disabled = true;
+      toggleResolveStatus(comment.id, scope, resolveAction, filePath || null)
+        .finally(function() { resolveBtn.disabled = false; });
     });
     parts.actions.appendChild(resolveBtn);
 


### PR DESCRIPTION
## Summary
- Adds Resolve/Unresolve button to every comment card in the comments sidebar panel
- Works for both file-scoped and review-level comments
- Uses the same `resolve-btn` styling and `toggleResolveStatus` handler as the inline diff view

## Test plan
- [ ] Open the comments sidebar panel
- [ ] Verify unresolved comments show a "Resolve" button
- [ ] Click Resolve — comment moves to resolved state, button changes to "Unresolve"
- [ ] Click Unresolve — comment returns to open state
- [ ] Verify clicking the button does not trigger scroll-to-inline navigation
- [ ] Verify resolve/unresolve works for both file comments and review-level comments