### PR TITLE
feat: add copy-path buttons to file headers and navbar

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -820,6 +820,18 @@
     if (session.mode === 'git' && session.branch) {
       document.getElementById('branchContext').style.display = '';
       document.getElementById('branchName').textContent = session.branch;
+      const branchCopyBtn = document.createElement('button');
+      branchCopyBtn.className = 'header-copy-path';
+      branchCopyBtn.setAttribute('aria-label', 'Copy branch name');
+      branchCopyBtn.type = 'button';
+      branchCopyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25v-7.5z"/><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25v-7.5zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25h-7.5z"/></svg>';
+      branchCopyBtn.addEventListener('click', function() {
+        navigator.clipboard.writeText(session.branch);
+        const original = branchCopyBtn.innerHTML;
+        branchCopyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>';
+        setTimeout(function() { branchCopyBtn.innerHTML = original; }, 1500);
+      });
+      document.getElementById('branchContext').appendChild(branchCopyBtn);
       // Base branch picker: show in git mode when on a feature branch
       if (session.base_ref) {
         currentBaseBranch = session.base_branch_name || '';
@@ -831,6 +843,19 @@
       document.getElementById('branchContext').style.display = '';
       document.querySelector('.branch-icon').innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>';
       document.getElementById('branchName').textContent = session.files[0].path.split('/').pop();
+      const headerCopyBtn = document.createElement('button');
+      headerCopyBtn.className = 'header-copy-path';
+      headerCopyBtn.setAttribute('aria-label', 'Copy file path');
+      headerCopyBtn.type = 'button';
+      headerCopyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25v-7.5z"/><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25v-7.5zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25h-7.5z"/></svg>';
+      headerCopyBtn.addEventListener('click', function() {
+        const abs = session.cwd ? session.cwd + '/' + session.files[0].path : session.files[0].path;
+        navigator.clipboard.writeText(abs);
+        const original = headerCopyBtn.innerHTML;
+        headerCopyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>';
+        setTimeout(function() { headerCopyBtn.innerHTML = original; }, 1500);
+      });
+      document.getElementById('branchContext').appendChild(headerCopyBtn);
     }
 
     // PR overview panel toggle
@@ -2196,13 +2221,28 @@
     header.innerHTML =
       '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
       '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-editor-fg-muted)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
-      '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
+      '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) +
+        '<button type="button" class="file-header-copy-path" aria-label="Copy file path"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25v-7.5z"/><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25v-7.5zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25h-7.5z"/></svg></button>' +
+      '</span>' +
       (showBadge ? '<span class="file-header-badge ' + escapeHtml(file.status) + '">' + escapeHtml(badgeLabel) + '</span>' : '') +
       (file.additions || file.deletions ? '<span class="file-header-stats">' +
         (file.additions ? '<span class="add">+' + file.additions + '</span>' : '') +
         (file.deletions ? '<span class="del">-' + file.deletions + '</span>' : '') +
       '</span>' : '') +
       '';
+
+    (function(filePath) {
+      const copyPathBtn = header.querySelector('.file-header-copy-path');
+      copyPathBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const abs = session.cwd ? session.cwd + '/' + filePath : filePath;
+        navigator.clipboard.writeText(abs);
+        const original = copyPathBtn.innerHTML;
+        copyPathBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>';
+        setTimeout(function() { copyPathBtn.innerHTML = original; }, 1500);
+      });
+    })(file.path);
 
     // Add document/diff toggle for markdown files that have diff hunks
     // Hide when diffActive is on (header-level rendered diff overrides per-file toggle)

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3019,6 +3019,45 @@ body.sidebar-resizing * {
   line-height: 1;
 }
 
+/* Copy path button in file header */
+.file-header-copy-path {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--crit-editor-fg-muted);
+  flex-shrink: 0;
+  line-height: 1;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.file-header:hover .file-header-copy-path,
+.file-header-copy-path:focus-visible {
+  opacity: 1;
+}
+.file-header-copy-path:hover {
+  color: var(--crit-brand);
+}
+/* Copy button in navbar (branch name / filename chip) */
+.header-copy-path {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0 0 0 4px;
+  cursor: pointer;
+  color: var(--crit-editor-fg-muted);
+  line-height: 1;
+}
+.header-copy-path:hover {
+  color: var(--crit-brand);
+}
+
 /* ===== Comments Panel (Right Sidebar) ===== */
 .comments-panel {
   width: 480px;
@@ -3515,6 +3554,9 @@ body.sidebar-resizing * {
   font-weight: 500;
   color: var(--crit-editor-fg);
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 .file-header-name .dir { color: var(--crit-editor-fg-muted); }
 .file-header-badge {


### PR DESCRIPTION
## Summary
- Copy-to-clipboard button next to each file path in the file section header
- Copies absolute path (cwd + relative), visible on hover and keyboard focus
- Copy button next to branch name (git mode) and filename (single-file mode) in navbar
- Checkmark feedback for 1.5s after copy
- See also: tomasz-tomczyk/crit-web#205

## Test plan
- Hover file header → copy icon → click → absolute path copied
- Navbar copy button → copies branch name / file path
- Click does not toggle file section collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)