### PR TITLE
feat(frontend): redesign waiting modal with collapsed prompt and usage tips

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7212,32 +7212,48 @@
   }
 
   // ===== Waiting Modal Tips =====
-  var waitingTips = [
-    'Press <kbd>j</kbd> / <kbd>k</kbd> to jump between files in the review.',
-    'Press <kbd>c</kbd> on any line to start an inline comment.',
-    'Drag across line numbers to select a range, then comment on the whole block.',
-    'Press <kbd>?</kbd> anywhere to see all keyboard shortcuts.',
-    'Comments support full Markdown — use fenced code blocks for suggested fixes.',
-    'Press <kbd>a</kbd> to approve, or <kbd>r</kbd> to request changes.',
-    'Use <kbd>n</kbd> / <kbd>p</kbd> to navigate between comment threads.',
-    'Press <kbd>Esc</kbd> to discard a comment draft. Press it again to confirm.',
+  const waitingTips = [
+    'Press <kbd>?</kbd> to see all keyboard shortcuts.',
+    'Comments support full Markdown.',
+    'Press <kbd>@</kbd> to reference other files in your comments.',
+    'Select text and press <kbd>c</kbd> to comment on your selection.',
+    'Use <kbd>crit pull</kbd> to load existing GitHub PR comments into your local review.',
+    'Use <kbd>crit push</kbd> to post your comments as a GitHub PR review. Add <kbd>--dry-run</kbd> to preview first.',
+    'Enjoying Crit? A GitHub star or sharing it with colleagues helps a lot!',
   ];
-  var tipInterval = null;
+  let tipInterval = null;
+  let lastTip = '';
+
+  function buildTips() {
+    const tips = waitingTips.slice();
+    if (!agentEnabled) {
+      tips.push('Set <kbd>agent_cmd</kbd> in your config to send comments directly to your AI agent for immediate feedback.');
+    }
+    if (shareURL && !authUserName) {
+      tips.push('Run <kbd>crit auth login</kbd> to link shared reviews with your account.');
+    }
+    return tips;
+  }
 
   function showRandomTip() {
-    var el = document.getElementById('tipText');
+    const el = document.getElementById('tipText');
     if (!el) return;
-    var idx = Math.floor(Math.random() * waitingTips.length);
+    const tips = buildTips();
+    let idx;
+    do {
+      idx = Math.floor(Math.random() * tips.length);
+    } while (tips[idx] === lastTip && tips.length > 1);
+    lastTip = tips[idx];
     el.style.animation = 'none';
     void el.offsetWidth;
-    el.innerHTML = waitingTips[idx];
+    el.innerHTML = tips[idx];
     el.style.animation = '';
   }
 
   function startTipRotation() {
     if (tipInterval) return;
     showRandomTip();
-    tipInterval = setInterval(showRandomTip, 6000);
+    tipInterval = setInterval(showRandomTip, 8000);
   }
 
   function stopTipRotation() {
@@ -7323,7 +7339,7 @@
           'Your agent has been notified \u2014 no further action needed. You can close this tab whenever you\u2019re ready.';
       } else {
         headingEl.textContent = 'Review Complete';
-        messageEl.textContent = 'Waiting for your agent to pick up the feedback.';
+        messageEl.textContent = 'Agent notified. Copy the prompt below if it wasn’t listening.';
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch {}
@@ -7425,11 +7441,11 @@
   });
 
   document.getElementById('waitingClipboard').addEventListener('click', async function() {
-    var prompt = document.getElementById('waitingPrompt').textContent;
+    const prompt = document.getElementById('waitingPrompt').textContent;
     try {
       await navigator.clipboard.writeText(prompt);
-      var el = document.getElementById('waitingClipboard');
-      var label = el.querySelector('.copy-label');
+      const el = document.getElementById('waitingClipboard');
+      const label = el.querySelector('.copy-label');
       label.textContent = 'Copied';
       el.classList.add('copied');
       el.setAttribute('aria-label', 'Copied');
@@ -7530,7 +7546,7 @@
         if (el && uiState === 'waiting') {
           el.innerHTML = '<span class="waiting-edits-badge"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>' + count + ' edit' + (count === 1 ? '' : 's') + '</span>';
           // Hide prompt copy row once agent starts making edits
-          var copyRow = document.getElementById('promptCopyRow');
+          const copyRow = document.getElementById('promptCopyRow');
           if (copyRow) copyRow.style.display = 'none';
           if (waitingNotApproved) {
             document.getElementById('waitingMessage').textContent = 'Waiting for your agent to finish...';

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7239,6 +7239,7 @@
     const el = document.getElementById('tipText');
     if (!el) return;
     const tips = buildTips();
+    if (tips.length === 0) return;
     let idx;
     do {
       idx = Math.floor(Math.random() * tips.length);
@@ -7317,7 +7318,7 @@
       const data = await resp.json();
       const approved = !!data.approved;
       waitingNotApproved = !approved;
-      const prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
+      const prompt = data.prompt || '';
 
       const dialog = document.getElementById('waitingDialog');
       const headingEl = document.getElementById('waitingHeading');
@@ -7545,9 +7546,11 @@
         const el = document.getElementById('waitingEdits');
         if (el && uiState === 'waiting') {
           el.innerHTML = '<span class="waiting-edits-badge"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>' + count + ' edit' + (count === 1 ? '' : 's') + '</span>';
-          // Hide prompt copy row once agent starts making edits
+          // Hide prompt copy row and divider once agent starts making edits
           const copyRow = document.getElementById('promptCopyRow');
+          const divider = document.getElementById('waitingDivider');
           if (copyRow) copyRow.style.display = 'none';
+          if (divider) divider.style.display = 'none';
           if (waitingNotApproved) {
             document.getElementById('waitingMessage').textContent = 'Waiting for your agent to finish...';
           }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7211,6 +7211,42 @@
     el.classList.toggle('all-viewed', viewed === files.length);
   }
 
+  // ===== Waiting Modal Tips =====
+  var waitingTips = [
+    'Press <kbd>j</kbd> / <kbd>k</kbd> to jump between files in the review.',
+    'Press <kbd>c</kbd> on any line to start an inline comment.',
+    'Drag across line numbers to select a range, then comment on the whole block.',
+    'Press <kbd>?</kbd> anywhere to see all keyboard shortcuts.',
+    'Comments support full Markdown — use fenced code blocks for suggested fixes.',
+    'Press <kbd>a</kbd> to approve, or <kbd>r</kbd> to request changes.',
+    'Use <kbd>n</kbd> / <kbd>p</kbd> to navigate between comment threads.',
+    'Press <kbd>Esc</kbd> to discard a comment draft. Press it again to confirm.',
+  ];
+  var tipInterval = null;
+
+  function showRandomTip() {
+    var el = document.getElementById('tipText');
+    if (!el) return;
+    var idx = Math.floor(Math.random() * waitingTips.length);
+    el.style.animation = 'none';
+    void el.offsetWidth;
+    el.innerHTML = waitingTips[idx];
+    el.style.animation = '';
+  }
+
+  function startTipRotation() {
+    if (tipInterval) return;
+    showRandomTip();
+    tipInterval = setInterval(showRandomTip, 6000);
+  }
+
+  function stopTipRotation() {
+    if (tipInterval) {
+      clearInterval(tipInterval);
+      tipInterval = null;
+    }
+  }
+
   // ===== UI State =====
   function updateHeaderRound() {
     const el = document.getElementById('headerNotify');
@@ -7221,7 +7257,7 @@
 
   function setUIState(state) {
     uiState = state;
-    if (state === 'reviewing') waitingNotApproved = false;
+    if (state === 'reviewing') { waitingNotApproved = false; stopTipRotation(); }
     const finishBtn = document.getElementById('finishBtn');
     const waitingOverlay = document.getElementById('waitingOverlay');
 
@@ -7244,8 +7280,10 @@
         finishBtn.disabled = true;
         finishBtn.classList.remove('btn-primary');
         document.getElementById('waitingEdits').textContent = '';
-        document.getElementById('waitingPrompt').style.display = '';
-        document.getElementById('waitingClipboard').style.display = '';
+        document.getElementById('promptCopyRow').style.display = '';
+        document.getElementById('waitingDivider').style.display = '';
+        document.getElementById('tipSection').style.display = '';
+        startTipRotation();
         waitingOverlay.classList.add('active');
         break;
     }
@@ -7271,8 +7309,9 @@
       const clipEl = document.getElementById('waitingClipboard');
 
       document.getElementById('waitingPrompt').textContent = prompt;
-      clipEl.textContent = 'Copy prompt';
-      clipEl.classList.remove('clipboard-confirm');
+      document.getElementById('promptPreview').textContent = prompt;
+      clipEl.querySelector('.copy-label').textContent = 'Copy';
+      clipEl.classList.remove('copied');
 
       // Replay the success-mark draw animation each time we enter approved state.
       dialog.classList.remove('approved');
@@ -7284,9 +7323,7 @@
           'Your agent has been notified \u2014 no further action needed. You can close this tab whenever you\u2019re ready.';
       } else {
         headingEl.textContent = 'Review Complete';
-        messageEl.innerHTML =
-          'Your agent has been notified. Waiting for updates\u2026' +
-          '<span class="waiting-fallback">If your agent wasn\u2019t listening, paste the prompt below.</span>';
+        messageEl.textContent = 'Waiting for your agent to pick up the feedback.';
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch {}
@@ -7388,19 +7425,19 @@
   });
 
   document.getElementById('waitingClipboard').addEventListener('click', async function() {
-    const prompt = document.getElementById('waitingPrompt').textContent;
+    var prompt = document.getElementById('waitingPrompt').textContent;
     try {
       await navigator.clipboard.writeText(prompt);
-      const el = document.getElementById('waitingClipboard');
-      el.textContent = '\u2713 Copied';
+      var el = document.getElementById('waitingClipboard');
+      var label = el.querySelector('.copy-label');
+      label.textContent = 'Copied';
+      el.classList.add('copied');
       el.setAttribute('aria-label', 'Copied');
       announceCopy();
-      el.classList.remove('clipboard-confirm');
-      void el.offsetWidth;
-      el.classList.add('clipboard-confirm');
       setTimeout(function() {
-        el.textContent = 'Copy prompt';
-        el.setAttribute('aria-label', 'Copy prompt');
+        label.textContent = 'Copy';
+        el.classList.remove('copied');
+        el.setAttribute('aria-label', 'Copy prompt to clipboard');
       }, 2000);
     } catch {}
   });
@@ -7491,12 +7528,10 @@
         const count = parseInt(data.content, 10);
         const el = document.getElementById('waitingEdits');
         if (el && uiState === 'waiting') {
-          el.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;margin-right:4px"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>Your agent made ' + count + ' edit' + (count === 1 ? '' : 's');
-          // Hide prompt and clipboard once agent starts making edits
-          const promptEl = document.getElementById('waitingPrompt');
-          const clipEl = document.getElementById('waitingClipboard');
-          if (promptEl) promptEl.style.display = 'none';
-          if (clipEl) clipEl.style.display = 'none';
+          el.innerHTML = '<span class="waiting-edits-badge"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>' + count + ' edit' + (count === 1 ? '' : 's') + '</span>';
+          // Hide prompt copy row once agent starts making edits
+          var copyRow = document.getElementById('promptCopyRow');
+          if (copyRow) copyRow.style.display = 'none';
           if (waitingNotApproved) {
             document.getElementById('waitingMessage').textContent = 'Waiting for your agent to finish...';
           }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -171,17 +171,44 @@
 
 <div class="waiting-overlay" id="waitingOverlay" role="dialog" aria-modal="true" aria-labelledby="waitingHeading">
   <div class="waiting-dialog" id="waitingDialog">
-    <div class="waiting-spinner" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
-    <svg class="success-mark" viewBox="0 0 64 64" aria-hidden="true">
-      <circle class="success-mark-ring" cx="32" cy="32" r="28"/>
-      <path class="success-mark-check" d="M19 33 L28 42 L45 23"/>
-    </svg>
-    <h3 id="waitingHeading">Review Complete</h3>
-    <p id="waitingMessage"></p>
-    <p class="waiting-edits" id="waitingEdits"></p>
-    <div class="waiting-prompt" id="waitingPrompt"></div>
-    <button class="btn btn-sm" style="margin-top: 8px;" id="waitingClipboard" aria-label="Copy prompt to clipboard"></button>
-    <button class="btn btn-sm" id="backToEditing" style="margin-top: 16px;">Back to editing</button>
+    <!-- Header -->
+    <div class="waiting-header">
+      <div class="waiting-spinner" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+      <svg class="success-mark" viewBox="0 0 64 64" aria-hidden="true">
+        <circle class="success-mark-ring" cx="32" cy="32" r="28"/>
+        <path class="success-mark-check" d="M19 33 L28 42 L45 23"/>
+      </svg>
+      <h3 id="waitingHeading">Review Complete</h3>
+      <p id="waitingMessage"></p>
+      <p class="waiting-edits" id="waitingEdits"></p>
+    </div>
+
+    <!-- Prompt copy row -->
+    <div class="prompt-copy-row" id="promptCopyRow">
+      <span class="prompt-preview" id="promptPreview"></span>
+      <button class="prompt-copy-btn" id="waitingClipboard" aria-label="Copy prompt to clipboard">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        <span class="copy-label">Copy</span>
+      </button>
+    </div>
+    <div class="prompt-full-text" id="waitingPrompt"></div>
+
+    <!-- Divider -->
+    <div class="waiting-divider" id="waitingDivider"></div>
+
+    <!-- Tip -->
+    <div class="tip-section" id="tipSection">
+      <svg class="tip-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+      <div class="tip-content">
+        <div class="tip-label">Tip</div>
+        <div class="tip-text" id="tipText"></div>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="waiting-footer">
+      <button class="btn btn-sm" id="backToEditing">Back to editing</button>
+    </div>
   </div>
 </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2187,6 +2187,7 @@ textarea.drag-active {
   font-size: 13px;
   color: var(--crit-fg-secondary);
   line-height: 1.45;
+  animation: tipFadeIn var(--crit-dur-slow) var(--crit-ease);
 }
 .tip-text kbd {
   display: inline-block;
@@ -2201,9 +2202,6 @@ textarea.drag-active {
   vertical-align: baseline;
 }
 
-.tip-text {
-  animation: tipFadeIn var(--crit-dur-slow) var(--crit-ease);
-}
 @keyframes tipFadeIn {
   from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: translateY(0); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1982,14 +1982,19 @@ textarea.drag-active {
   background: var(--crit-bg-card);
   border: 1px solid var(--crit-border);
   border-radius: 12px;
-  padding: 32px;
-  max-width: 640px;
+  max-width: 520px;
   width: 90vw;
-  text-align: center;
   box-shadow: var(--crit-shadow);
+  overflow: hidden;
 }
 .waiting-dialog h3 { font-size: 20px; color: var(--crit-green); margin-bottom: 12px; }
-.waiting-dialog p { color: var(--crit-editor-fg-secondary); font-size: 14px; margin-bottom: 8px; }
+.waiting-dialog p { font-size: 14px; color: var(--crit-editor-fg-secondary); margin-bottom: 8px; }
+
+/* -- Header section -- */
+.waiting-header {
+  padding: 24px 24px 0;
+  text-align: center;
+}
 
 .waiting-spinner {
   display: inline-flex;
@@ -2041,8 +2046,10 @@ textarea.drag-active {
   animation: success-check-draw 0.35s cubic-bezier(0.4, 0, 0.2, 1) 0.4s forwards;
 }
 .waiting-dialog.approved .waiting-spinner { display: none; }
-.waiting-dialog.approved #waitingPrompt,
-.waiting-dialog.approved #waitingClipboard { display: none; }
+.waiting-dialog.approved .prompt-copy-row,
+.waiting-dialog.approved .waiting-divider,
+.waiting-dialog.approved .tip-section,
+.waiting-dialog.approved .waiting-footer { display: none; }
 .waiting-dialog.approved .success-mark {
   display: inline-block;
   filter: drop-shadow(0 0 0 transparent);
@@ -2078,35 +2085,155 @@ textarea.drag-active {
   margin-top: 12px;
 }
 
-.waiting-fallback {
-  display: block;
-  margin-top: 8px;
-  font-size: 12px;
-  color: var(--crit-editor-fg-muted);
+/* -- Prompt copy row -- */
+.prompt-copy-row {
+  margin: 16px 24px 0;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--crit-editor-bg-elevated);
+  border: none;
+  border-radius: var(--crit-r-lg);
+  overflow: hidden;
 }
 
-.waiting-prompt {
-  background: var(--crit-editor-bg-elevated);
-  border: 1px solid var(--crit-border);
-  border-radius: 6px;
+.prompt-preview {
+  flex: 1;
+  min-width: 0;
   padding: 10px 14px;
   font-family: var(--crit-font-mono);
   font-size: 12px;
-  color: var(--crit-editor-fg);
-  margin-top: 12px;
+  line-height: 1.5;
+  color: var(--crit-editor-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+  user-select: none;
+}
+
+.prompt-copy-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--crit-brand);
+  font-family: var(--crit-font-body);
+  font-size: 12px;
+  font-weight: 500;
   cursor: pointer;
-  user-select: all;
-  word-break: break-word;
-  text-align: left;
+  transition: background var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease);
+  white-space: nowrap;
+}
+.prompt-copy-btn:hover {
+  background: var(--crit-brand-subtle);
+}
+.prompt-copy-btn.copied {
+  color: var(--crit-green);
+}
+.prompt-copy-btn svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
-
-.clipboard-confirm {
-  animation: clipboard-fade 2s ease-out forwards;
+.prompt-full-text {
+  display: none;
 }
-@keyframes clipboard-fade {
-  0% { color: var(--crit-green); }
-  100% { color: var(--crit-editor-fg-muted); }
+
+/* -- Divider -- */
+.waiting-divider {
+  height: 1px;
+  background: var(--crit-border);
+  margin: 16px 0 0;
+}
+
+/* -- Tip section -- */
+.tip-section {
+  padding: 14px 24px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-height: 52px;
+}
+
+.tip-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--crit-fg-muted);
+  margin-top: 1px;
+}
+
+.tip-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.tip-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--crit-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 2px;
+}
+
+.tip-text {
+  font-size: 13px;
+  color: var(--crit-fg-secondary);
+  line-height: 1.45;
+}
+.tip-text kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font-family: var(--crit-font-mono);
+  font-size: 11px;
+  background: var(--crit-bg-elevated);
+  border: 1px solid var(--crit-border);
+  border-radius: var(--crit-r-sm);
+  color: var(--crit-fg-primary);
+  line-height: 1.4;
+  vertical-align: baseline;
+}
+
+.tip-text {
+  animation: tipFadeIn var(--crit-dur-slow) var(--crit-ease);
+}
+@keyframes tipFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* -- Footer / actions -- */
+.waiting-footer {
+  padding: 0 24px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+/* -- Edits detected badge -- */
+.waiting-edits-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 14px 0 2px;
+  padding: 6px 12px;
+  background: var(--crit-green-subtle);
+  border: 1px solid var(--crit-green);
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--crit-green);
+}
+.waiting-edits-badge svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 /* ===== No Changes Confirmation Overlay ===== */

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -130,6 +130,9 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Green subtle ---- */
+  --crit-green-subtle: rgba(86, 211, 100, 0.10);
+
   /* ---- Finish/disconnected state ---- */
   --crit-finish-pill-bg:     rgba(86, 211, 100, 0.10);
   --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
@@ -272,6 +275,9 @@
     --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
     --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
+    /* ---- Green subtle ---- */
+    --crit-green-subtle: rgba(22, 111, 48, 0.08);
+
     /* ---- Finish/disconnected state ---- */
     --crit-finish-pill-bg:     rgba(22, 127, 48, 0.08);
     --crit-finish-pill-border: rgba(22, 127, 48, 0.18);
@@ -413,6 +419,9 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Green subtle ---- */
+  --crit-green-subtle: rgba(86, 211, 100, 0.10);
+
   /* ---- Finish/disconnected state ---- */
   --crit-finish-pill-bg:     rgba(86, 211, 100, 0.10);
   --crit-finish-pill-border: rgba(86, 211, 100, 0.20);
@@ -552,6 +561,9 @@
   --crit-yellow-subtle: rgba(122, 88, 0, 0.06);
   --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
   --crit-yellow-border: rgba(122, 88, 0, 0.16);
+
+  /* ---- Green subtle ---- */
+  --crit-green-subtle: rgba(22, 111, 48, 0.08);
 
   /* ---- Finish/disconnected state ---- */
   --crit-finish-pill-bg:     rgba(22, 127, 48, 0.08);


### PR DESCRIPTION
## Summary
- Collapse the full review prompt into a single-line copy row (Stripe API-key pattern)
- Add rotating usage tips while waiting for the agent (8s interval, no repeats)
- Conditional tips for `agent_cmd` config and `crit auth login` based on user state
- Hide prompt row and divider when agent edits are detected
- Remove dead fallback prompt string
- Add `--crit-green-subtle` theme variable

## Review
- [x] Code review: passed (frontend-expert agent)
- [x] Intent audit: clean
- [x] Parity: N/A (waiting overlay is crit-only)

## Test plan
- Manual: finish review → verify collapsed prompt with copy button
- Manual: verify tips rotate without repeats
- Manual: verify dark/light theme rendering
- Manual: verify edits-detected state hides prompt + divider

Closes CRI-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)