### PR TITLE
Improve the mobile review layout

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2918,6 +2918,9 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
   .change-nav { display: none; }
   .scope-toggle { display: none !important; }
   .diff-mode-toggle { display: none !important; }
+  .main-layout { overflow-x: hidden; }
+  .document-wrapper { max-width: 100vw; }
+  .line-content { padding-right: 12px; }
 
   /* Force split rows to stack vertically on mobile */
   .diff-split-row { flex-direction: column; }


### PR DESCRIPTION
This tightens the small-screen review layout by preventing the main flex container from adding horizontal page overflow, keeping the document wrapper within the viewport, and reducing right-side line padding on mobile. It focuses on the file review area so mobile sessions are easier to read without changing the desktop layout. Closes #527.
