### PR TITLE
feat: add HEEx syntax highlighting for .heex/.leex files

### DIFF
--- a/copy-deps.js
+++ b/copy-deps.js
@@ -14,7 +14,9 @@ const langDir = "node_modules/@highlightjs/cdn-assets/languages";
 const langFiles = readdirSync(langDir).filter(f => f.endsWith(".min.js")).sort();
 const langs = langFiles.map(f => readFileSync(`${langDir}/${f}`, "utf8")).join("\n");
 const patch = readFileSync(`${dest}/highlight-markdown-patch.js`, "utf8");
-writeFileSync(`${dest}/highlight.min.js`, core + "\n" + langs + "\n" + patch);
+const heex = readFileSync("node_modules/highlightjs-heex/dist/heex.min.js", "utf8");
+const heexReg = heex + "\nhljs.registerLanguage('heex', hljsDefineHeex);";
+writeFileSync(`${dest}/highlight.min.js`, core + "\n" + langs + "\n" + patch + "\n" + heexReg);
 
 // mermaid
 cpSync("node_modules/mermaid/dist/mermaid.min.js", `${dest}/mermaid.min.js`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -966,6 +966,8 @@
     sh: 'bash',
     zig: 'zig',        // not a built-in alias in our bundle
     md: 'markdown',    // normalize: callers compare lang against 'markdown'
+    heex: 'heex',
+    leex: 'heex',
   };
   // Files identified by basename rather than extension.
   const BASENAME_LANG = {

--- a/frontend/highlight.min.js
+++ b/frontend/highlight.min.js
@@ -5289,3 +5289,7 @@ end:/;/,illegal:/[.']/,contains:[a]},{beginKeywords:"use",end:/;/,contains:[a]
     };
   });
 })();
+
+var hljsDefineHeex=function(){"use strict";return function(e){return{name:"HEEx",aliases:["heex","leex"],subLanguage:"xml",contains:[e.COMMENT("<%!--","--%>"),e.COMMENT("<%#","%>"),{begin:"<%[=]?",end:"%>",subLanguage:"elixir",excludeBegin:!0,excludeEnd:!0},{begin:/\{/,end:/\}/,subLanguage:"elixir",excludeBegin:!0,excludeEnd:!0}]}}}();
+
+hljs.registerLanguage('heex', hljsDefineHeex);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "crit.migrate-to-sanity-diff-match-patch",
+  "name": "crit.feat-heex-highlight",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,6 +7,7 @@
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "@sanity/diff-match-patch": "^3.2.0",
+        "highlightjs-heex": "^1.0.1",
         "markdown-it": "^14.1.1",
         "mermaid": "^11.14.0"
       },
@@ -2705,6 +2706,25 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/highlightjs-heex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-heex/-/highlightjs-heex-1.0.1.tgz",
+      "integrity": "sha512-tAkFBN9eW8IvyIwLaVBCLR1zJqeD++lJI62gXnPGXEQcf2kmu6xfXZIAA0XVl/kJb43MCdfjO2sXIKzXSZmzNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "highlight.js": ">=11.0.0"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@highlightjs/cdn-assets": "^11.11.1",
     "@sanity/diff-match-patch": "^3.2.0",
+    "highlightjs-heex": "^1.0.1",
     "markdown-it": "^14.1.1",
     "mermaid": "^11.14.0"
   },


### PR DESCRIPTION
## Summary
- Add HEEx (HTML+Embedded Elixir) syntax highlighting using the [`highlightjs-heex`](https://www.npmjs.com/package/highlightjs-heex) npm package
- Bundle the grammar into highlight.min.js via copy-deps.js
- Register heex/leex extensions in `EXT_OVERRIDES`

## Review
- [x] Code review: passed
- [x] Parity audit: matching changes in tomasz-tomczyk/crit-web

## Test plan
- Verified highlighting renders correctly on a real .heex file
- go test -race passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)