### PR TITLE
fix: reverse stack popover order and clarify base label

### DIFF
--- a/e2e/tests/focus-picker.rangemode.spec.ts
+++ b/e2e/tests/focus-picker.rangemode.spec.ts
@@ -37,30 +37,28 @@ test('popover lists feat-a, feat-b, feat-c', async ({ page }) => {
   await expect(page.locator('#stackPopover')).toContainText('feat-c');
 });
 
-test('popover renders the default branch as the first entry', async ({ page }) => {
+test('popover renders the default branch as the last entry (base marker)', async ({ page }) => {
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
   const dbItem = page.locator('#stackPopover .stack-popover-default');
   await expect(dbItem).toBeVisible();
-  await expect(dbItem).toContainText(/main/);
+  await expect(dbItem).toContainText(/base:.*main/);
 });
 
-test('popover order is base->head (main, feat-a, feat-b, feat-c)', async ({ page }) => {
+test('popover order is head->base (feat-c, feat-b, feat-a, base: main)', async ({ page }) => {
   await loadPage(page);
   await page.locator('#stackChipBtn').click();
-  // Wait for the post-/api/picker render — the initial "Loading…" view has no
-  // .stack-popover-item nodes, so reading evaluateAll too soon yields [].
   const items = page.locator('#stackPopover .stack-popover-item');
   await expect(items.first()).toBeVisible();
-  // 4 entries expected: main + feat-a/b/c.
+  // 4 entries expected: feat-c/b/a + base: main.
   await expect(items).toHaveCount(4);
   const labels = await items.evaluateAll((els) =>
     els.map((el) => (el as HTMLElement).innerText.replace(/\s*\(reviewing\)\s*/i, '').replace(/\s*\(full stack\)\s*/i, '').trim())
   );
-  // First entry is the default branch label.
-  expect(labels[0]).toMatch(/main/);
-  const feats = labels.filter((s) => /^feat-[abc]$/.test(s.split('\n').pop() || ''));
-  expect(feats.map((s) => (s.split('\n').pop() || '').trim())).toEqual(['feat-a', 'feat-b', 'feat-c']);
+  // Last entry is the base marker.
+  expect(labels[labels.length - 1]).toMatch(/base:.*main/);
+  const feats = labels.filter((s) => /feat-[abc]/.test(s));
+  expect(feats.map((s) => (s.match(/feat-[abc]/) || [''])[0])).toEqual(['feat-c', 'feat-b', 'feat-a']);
 });
 
 test('clicking a different stack entry switches focus and rebuilds file list', async ({ page, request }) => {

--- a/e2e/tests/stack-popover.rangemode.spec.ts
+++ b/e2e/tests/stack-popover.rangemode.spec.ts
@@ -95,7 +95,7 @@ test('default branch is rendered ONCE (no ghost duplicate stack entry)', async (
   // doesn't snapshot the empty pre-fetch DOM.
   await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
   const allLabels = await page.locator('#stackPopover .stack-popover-label').allTextContents();
-  const mainCount = allLabels.filter((s) => s.trim() === 'main').length;
+  const mainCount = allLabels.filter((s) => s.trim() === 'base: main').length;
   expect(mainCount).toBe(1);
 });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10579,44 +10579,25 @@
       return;
     }
 
-    // Filter out the default-branch entry from the linear stack — it's
-    // surfaced separately as the root marker above the tree. Use the focus's
-    // default_sha when available; fall back to per-entry default_sha (stamped
-    // by assignStackBases) so range-mode focuses without a resolved
-    // default_sha still drop the redundant ghost row.
-    // Picker already excludes the literal default branch from `stack`
-    // (see stackTipLabels in picker.go), so no need to filter — just
-    // reverse so the topmost (deepest) entry renders first.
-    const ordered = stack.slice().reverse();
-    // Prefer the repo's actual default branch name (e.g. "master") over
-    // guessing from the topmost stack entry's base_ref_name (often empty
-    // for branch-tier entries) or hardcoding 'main'.
-    // defaultBranchNameCache is populated by /api/picker.
+    const ordered = stack.slice();
     const defaultBranchName = defaultBranchNameCache || (ordered[0] && ordered[0].base_ref_name) || 'main';
 
     const parts = [];
     parts.push('<div class="stack-popover-title">Stack</div>');
 
-    // Default-branch entry — non-interactive root marker. The
-    // layer/full-stack toggle inside this popover is the canonical
-    // way to switch scopes; clicking here used to flip diff_scope but
-    // that overlapped confusingly with the toggle.
-    parts.push('<span class="stack-popover-item stack-popover-root stack-popover-default" role="presentation">' +
-      '<span class="stack-popover-tree" aria-hidden="true">\u2502 </span>' +
-      '<span class="stack-popover-label">' + escapeHtml(defaultBranchName) + '</span>' +
-      '</span>');
-
-    // Stack entries — base→head, with ├─ / └─ prefixes.
+    // Stack entries — head→base (newest at top), with ├─ / └─ prefixes.
     ordered.forEach(function(entry, i) {
       const isLast = i === ordered.length - 1;
       const tree = isLast ? '\u2514\u2500 ' : '\u251C\u2500 ';
       const isCurrent = entry.head_sha === focus.head_sha;
-      const label = entryLabel(entry, 40);
+      const label = entryLabel(entry, 34);
+      const shortSha = entry.head_sha ? entry.head_sha.slice(0, 7) : '';
       if (isCurrent) {
         parts.push('<span class="stack-popover-item stack-popover-current" aria-current="page" role="menuitem"' +
           ' data-head-sha="' + escapeHtml(entry.head_sha || '') + '">' +
           '<span class="stack-popover-tree" aria-hidden="true">' + tree + '</span>' +
           '<span class="stack-popover-label">' + escapeHtml(label) + '</span>' +
+          (shortSha ? '<span class="stack-popover-sha">' + escapeHtml(shortSha) + '</span>' : '') +
           '</span>');
       } else {
         const payload = focusPayloadFromStackEntry(entry, focus);
@@ -10628,9 +10609,16 @@
           ' aria-label="' + escapeHtml(aria) + '">' +
           '<span class="stack-popover-tree" aria-hidden="true">' + tree + '</span>' +
           '<span class="stack-popover-label">' + escapeHtml(label) + '</span>' +
+          (shortSha ? '<span class="stack-popover-sha">' + escapeHtml(shortSha) + '</span>' : '') +
           '</button>');
       }
     });
+
+    // Base marker — non-interactive root at the bottom of the tree.
+    parts.push('<span class="stack-popover-item stack-popover-root stack-popover-default" role="presentation">' +
+      '<span class="stack-popover-tree" aria-hidden="true">  </span>' +
+      '<span class="stack-popover-label">base: ' + escapeHtml(defaultBranchName) + '</span>' +
+      '</span>');
 
     // "Compare against" radio section. Lives inside the popover so the
     // page header doesn't need a second toolbar row for what is a

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4843,6 +4843,14 @@ body.sidebar-resizing * {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.stack-popover-sha {
+  flex-shrink: 0;
+  margin-left: 8px;
+  font-size: 0.75em;
+  font-family: var(--crit-font-mono);
+  color: var(--crit-editor-fg-muted);
+  opacity: 0.7;
+}
 
 /* Default-branch entry in the stack popover is a non-interactive root
    marker — it indicates "stack starts here" but doesn't trigger any


### PR DESCRIPTION
## Summary
- Stack entries now render head→base (most recent commit at top, deepest at bottom), matching the mental model from `sl log` and other stacked-diff tools
- Default branch marker moves to the bottom with explicit "base: main" label instead of bare branch name
- Short commit hashes (7 chars) appear beside each entry for visual correlation with terminal output

Closes #534

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (stack popover is CLI-only, not present in crit-web)

## Test plan
- [x] `go test ./...` passes
- [x] E2E test `focus-picker.rangemode.spec.ts` updated for new order assertions
- [x] Pre-commit hooks pass (gofmt, golangci-lint, ESLint, Stylelint, CSS vars check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)