### PR TITLE
refactor: rename "Layer" to "This commit" in scope toggle

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10623,8 +10623,8 @@
     // "Compare against" radio section. Lives inside the popover so the
     // page header doesn't need a second toolbar row for what is a
     // relatively rare action. One-line subcopy explains what each scope
-    // means — first-time users always ask "wait, what does Layer mean?"
-    // Scope rows are always rendered in range mode — Layer is the
+    // means — first-time users always ask "wait, what does This commit mean?"
+    // Scope rows are always rendered in range mode — "This commit" is the
     // canonical default. Full stack is disabled (with explanation) when
     // default_sha is missing, which keeps the option discoverable so the
     // user understands why they can't reach it rather than wondering
@@ -10644,8 +10644,8 @@
         ' data-action="scope" data-diff-scope="layer">' +
           '<span class="stack-popover-scope-radio" aria-hidden="true"></span>' +
           '<span class="stack-popover-scope-text">' +
-            '<span class="stack-popover-scope-name">Layer</span>' +
-            '<span class="stack-popover-scope-sub">Only changes in this layer</span>' +
+            '<span class="stack-popover-scope-name">This commit</span>' +
+            '<span class="stack-popover-scope-sub">Only changes in this commit</span>' +
           '</span>' +
         '</button>'
       );


### PR DESCRIPTION
## Summary
- Replaces vague "Layer" label with "This commit" in the stack popover's compare-against radio section
- Internal wire value `layer` unchanged (API compatibility)
- Naming aligns with standard VCS terminology (Sapling, jj, ghstack all use "commit")

Closes #535

## Review
- [x] Code review: trivial rename, 4 lines changed
- [x] Parity audit: N/A (stack popover is CLI-only)

## Test plan
- [x] `go test ./...` passes
- [x] No E2E tests assert on the visible "Layer" text (they use the wire value `layer`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)