### PR TITLE
fix: pre-release cleanup (dead code, missing style, silent decode error)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10629,8 +10629,7 @@
     // default_sha is missing, which keeps the option discoverable so the
     // user understands why they can't reach it rather than wondering
     // where the option went.
-    const showScope = true;
-    if (showScope) {
+    {
       const activeScope = focus.diff_scope || 'layer';
       const fullStackEnabled = !!focus.default_sha;
       // Subcopy mirrors what full-stack diffs against: the literal

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -802,6 +802,7 @@ body {
 .sd-org-btn-cancel:hover { background: var(--crit-bg-card); }
 .sd-org-btn-share { background: var(--crit-green); border: 1px solid transparent; color: var(--crit-bg-page); font: inherit; font-size: 12px; font-weight: 600; padding: 7px 16px; border-radius: 6px; cursor: pointer; transition: background 100ms; line-height: 1; white-space: nowrap; }
 .sd-org-btn-share:hover { background: var(--crit-green-hover); }
+.sd-org-btn-share:disabled { opacity: 0.5; cursor: default; }
 /* Focus rings */
 .sd-org-owner-option:focus-visible,
 .sd-org-vis-option:focus-visible,

--- a/server.go
+++ b/server.go
@@ -634,7 +634,10 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		Visibility string `json:"visibility"`
 	}
 	if r.Body != nil && r.ContentLength > 0 {
-		_ = json.NewDecoder(r.Body).Decode(&shareReq)
+		if err := json.NewDecoder(r.Body).Decode(&shareReq); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
 	}
 
 	critPath := s.session.Load().critJSONPath()

--- a/server_test.go
+++ b/server_test.go
@@ -4001,6 +4001,24 @@ func TestHandleShare_ConsentRequired(t *testing.T) {
 	}
 }
 
+func TestHandleShare_MalformedBody(t *testing.T) {
+	setHome(t, t.TempDir())
+	s, _ := newTestServer(t)
+	s.shareURL = defaultShareURL
+	s.authMu.Lock()
+	s.cfg.ShareConsented = true
+	s.authMu.Unlock()
+
+	req := httptest.NewRequest("POST", "/api/share", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
 func TestConsentNeeded_AlreadyConsented(t *testing.T) {
 	setHome(t, t.TempDir())
 	s, _ := newTestServer(t)


### PR DESCRIPTION
## Summary
- Remove dead `showScope = true` feature flag wrapper in app.js (always-true branch)
- Add `:disabled` style for `.sd-org-btn-share` button (previously fell back to browser default)
- Return HTTP 400 on malformed JSON body in `handleShare` instead of silently falling back to public share

## Review
- [x] Code review: pre-release audit validated findings
- [x] Pre-commit checks: gofmt, golangci-lint, tests, ESLint, Stylelint all pass

## Test plan
- `go test ./...` passes
- `golangci-lint run ./...` — 0 issues
- Pre-commit hook passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)