### PR TITLE
fix: wait for image upload handler before paste in flaky e2e test

### DIFF
--- a/e2e/tests/image-upload.designmode.spec.ts
+++ b/e2e/tests/image-upload.designmode.spec.ts
@@ -98,6 +98,12 @@ test.describe('design-mode reply textarea image upload', () => {
     await expect(replyTa).toBeVisible();
     await replyTa.focus();
 
+    // Wait for image upload handler (attached in requestAnimationFrame)
+    await expect.poll(
+      () => replyTa.evaluate((el: HTMLTextAreaElement & { _imageUploadsAttached?: boolean }) => el._imageUploadsAttached === true),
+      { timeout: 5_000 },
+    ).toBe(true);
+
     // Simulate paste
     await replyTa.evaluate((el) => {
       const file = new File(


### PR DESCRIPTION
## Summary
- Fix flaky `reply textarea supports image paste` e2e test that intermittently timed out on CI
- Root cause: paste handler is attached via `requestAnimationFrame` in `focusReplyTextareaFor()`, but the test dispatched the paste event before the rAF callback fired
- Fix: poll for `_imageUploadsAttached` flag on the textarea before simulating the paste event

## Test plan
- Ran the test 5x locally — all green, consistent ~750ms timing
- No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)