### PR TITLE
feat: add pre-commit check for unicode curly quotes in JS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 echo "Running pre-commit checks..."
@@ -52,6 +52,15 @@ if [ -f eslint.config.mjs ]; then
         echo "  FAIL: ESLint issues found"
         exit 1
     fi
+fi
+
+# Check for unicode confusables in JS (curly quotes break syntax)
+echo "  Checking for unicode confusables in JS..."
+CURLY=$(grep -rn $’[‘’“”]’ frontend/*.js 2>/dev/null | grep -v ‘\.min\.js:’ || true)
+if [ -n "$CURLY" ]; then
+    echo "  FAIL: Curly quotes found in JS files (use straight quotes):"
+    echo "$CURLY" | sed 's/^/    /'
+    exit 1
 fi
 
 # Check CSS linting

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8554,7 +8554,7 @@
       if (alreadyDismissed) {
         html += '<span class="config-card-dismissed" id="updateDismissedNote">Dismissed — will remind you on next version</span>';
       } else {
-        html += '<button type="button" class="config-card-dismiss" id="updateDismissBtn" data-dismiss-version="' + escapeHtml(cfg.latest_version) + '">Don’t remind me until next version</button>';
+        html += '<button type="button" class="config-card-dismiss" id="updateDismissBtn" data-dismiss-version="' + escapeHtml(cfg.latest_version) + '">Don\'t remind me until next version</button>';
       }
       html += '</div>';
       html += '</div>';
@@ -8635,7 +8635,7 @@
             if (intAlreadyDismissed) {
               html += '<span class="config-card-dismissed" id="integrationDismissedNote">Dismissed — will remind you when this integration changes</span>';
             } else {
-              html += '<button type="button" class="config-card-dismiss" id="integrationDismissBtn" data-agent="' + escapeHtml(si.agent) + '" data-hash="' + escapeHtml(si.hash) + '">Don’t remind me until next version</button>';
+              html += '<button type="button" class="config-card-dismiss" id="integrationDismissBtn" data-agent="' + escapeHtml(si.agent) + '" data-hash="' + escapeHtml(si.hash) + '">Don\'t remind me until next version</button>';
             }
             html += '</div>';
             html += '</div>';

--- a/frontend/crit-settings-panes.js
+++ b/frontend/crit-settings-panes.js
@@ -295,7 +295,7 @@
         if (alreadyDismissed) {
           html += '<span class="config-card-dismissed" id="updateDismissedNote">Dismissed — will remind you on next version</span>';
         } else {
-          html += '<button type="button" class="config-card-dismiss" id="updateDismissBtn" data-dismiss-version="' + esc(cfg.latest_version) + '">Don’t remind me until next version</button>';
+          html += '<button type="button" class="config-card-dismiss" id="updateDismissBtn" data-dismiss-version="' + esc(cfg.latest_version) + '">Don\'t remind me until next version</button>';
         }
         html += '</div></div></div>';
       }
@@ -373,7 +373,7 @@
               if (intAlreadyDismissed) {
                 html += '<span class="config-card-dismissed" id="integrationDismissedNote">Dismissed — will remind you when this integration changes</span>';
               } else {
-                html += '<button type="button" class="config-card-dismiss" id="integrationDismissBtn" data-agent="' + esc(si.agent) + '" data-hash="' + esc(si.hash) + '">Don’t remind me until next version</button>';
+                html += '<button type="button" class="config-card-dismiss" id="integrationDismissBtn" data-agent="' + esc(si.agent) + '" data-hash="' + esc(si.hash) + '">Don\'t remind me until next version</button>';
               }
               html += '</div></div>';
             }

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -272,10 +272,10 @@
         if (approved) {
           messageEl.textContent =
             'Your agent has been notified — no further action needed. ' +
-            'You can close this tab whenever you’re ready.';
+            'You can close this tab whenever you\'re ready.';
         } else {
           messageEl.textContent =
-            "Agent notified. Copy the prompt below if it wasn’t listening.";
+            "Agent notified. Copy the prompt below if it wasn't listening.";
         }
       }
 


### PR DESCRIPTION
## Summary
- Add a grep-based pre-commit check that catches unicode curly quotes (U+2018/2019/201C/201D) in JS files before they cause runtime SyntaxErrors that ESLint doesn't catch
- Fix 6 existing curly quote occurrences across `app.js`, `crit-shared.js`, and `crit-settings-panes.js`
- Change shebang from `#!/bin/sh` to `#!/usr/bin/env bash` for ANSI-C quoting compatibility
- Exclude `.min.js` vendored files from the check to avoid false positives

Closes CRI-73

## Test plan
- [x] Verified grep pattern catches all 4 curly quote codepoints (U+2018, U+2019, U+201C, U+201D)
- [x] Verified no curly quotes remain in JS files after fixes
- [x] Verified `.min.js` exclusion works
- [x] Go tests pass (`go test ./...`)
- [x] Code review passed (shebang fix, .min.js exclusion added during review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)