### PR TITLE
feat: refresh waiting-modal tips

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6424,6 +6424,9 @@
     if (shareURL && !authUserName) {
       extra.push('Run <kbd>crit auth login</kbd> to link shared reviews with your account.');
     }
+    if (shareURL) {
+      extra.push('Create a team on <kbd>' + shareURL.replace(/^https?:\/\//, '') + '</kbd> to group and secure your shared reviews.');
+    }
     window.crit.shared.startTipRotation(extra);
   }
 

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -600,13 +600,14 @@
   var _lastTip = '';
   var _baseTips = [
     'Press <kbd>?</kbd> to see all keyboard shortcuts.',
-    'Comments support full Markdown.',
     'Press <kbd>@</kbd> to reference other files in your comments.',
     'Select text and press <kbd>c</kbd> to comment on your selection.',
-    'Use the filter pill to toggle between open and resolved comments.',
     'Use <kbd>crit pull</kbd> to load existing GitHub PR comments into your local review.',
     'Use <kbd>crit push</kbd> to post your comments as a GitHub PR review. Add <kbd>--dry-run</kbd> to preview first.',
-    'Pin comments persist across rounds until you resolve them.',
+    'Comments persist across rounds until you resolve them.',
+    'Run <kbd>crit</kbd> with a URL to review your local website visually.',
+    'Run <kbd>crit overview.html</kbd> to review an artifact HTML file visually.',
+    'Ask your agent to review your work with Crit and leave comments with it.',
     'Enjoying Crit? A GitHub star or sharing it with colleagues helps a lot!',
   ];
 


### PR DESCRIPTION
## Summary
- Remove "full Markdown" and "filter pill" tips
- Drop "Pin" prefix from persistence tip
- Add tips for design mode (`crit <url>`) and preview mode (`crit overview.html`)
- Add tip encouraging agent-driven reviews
- Add conditional tip about team creation when `share_url` is configured

## Test plan
- Tips are static strings — visual verification only
- ESLint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)