### PR TITLE
fix: open browser at /preview in preview mode daemon

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -614,15 +614,17 @@ func runServe(args []string) {
 	signalReadiness(pipe, addr.Port)
 
 	if !sc.noOpen {
-		// In design mode, route the auto-open to /design instead of /, so the
-		// browser lands on the design-review chrome (not the empty
-		// code-review shell). The parent CLI (runDesign) also kicks an open;
+		// In design/preview mode, route the auto-open to /design or /preview
+		// instead of /, so the browser lands on the correct chrome (not the
+		// empty code-review shell). The parent CLI also kicks an open;
 		// macOS `open` is idempotent enough that the duplicate is harmless,
 		// but routing both to the same URL prevents the browser from briefly
-		// opening / first when the daemon spawns the open before runDesign.
+		// opening / first when the daemon spawns the open before the parent.
 		openURL := fmt.Sprintf("http://localhost:%d", addr.Port)
 		if sc.designOrigin != "" {
 			openURL = fmt.Sprintf("http://localhost:%d/design", addr.Port)
+		} else if sc.previewFile != "" {
+			openURL = fmt.Sprintf("http://localhost:%d/preview", addr.Port)
 		}
 		go openBrowser(openURL)
 	}


### PR DESCRIPTION
## Summary
- The `_serve` daemon's auto-open URL only checked for design mode, falling back to `/` (code-review shell) for preview sessions
- Added `previewFile` check mirroring the existing `designOrigin` pattern so the browser opens directly at `/preview`

## Test plan
- Pre-commit: gofmt, golangci-lint, full test suite passed
- Manual: `crit preview <file.html>` opens browser at /preview tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)