### PR TITLE
refactor: audit cleanup — consolidate helpers, remove dead CSS, fix preview

### DIFF
--- a/frontend/__tests__/check-design-vars.test.js
+++ b/frontend/__tests__/check-design-vars.test.js
@@ -18,16 +18,12 @@ const REQUIRED_VARS = [
   '--crit-design-ancestor-menu-hover-bg',
   '--crit-design-mode-btn-active-bg',
   '--crit-design-mode-btn-active-fg',
-  // Phase D markers + drifted tray + re-anchor
+  // Phase D markers + re-anchor
   '--crit-design-marker-bg',
   '--crit-design-marker-fg',
   '--crit-design-marker-border',
   '--crit-design-marker-shadow',
   '--crit-design-marker-focus-ring',
-  '--crit-design-drifted-recoverable-bg',
-  '--crit-design-drifted-recoverable-fg',
-  '--crit-design-drifted-lost-bg',
-  '--crit-design-drifted-lost-fg',
   '--crit-design-reanchor-active-outline',
 ];
 

--- a/frontend/__tests__/crit-comment-card-helpers.test.js
+++ b/frontend/__tests__/crit-comment-card-helpers.test.js
@@ -3,14 +3,11 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const helpers = require('../crit-comment-card-helpers.js');
 
-test('escapeHtml escapes &, <, >, "', () => {
+test('escapeHtml escapes &, <, >, ", and single quotes', () => {
   assert.equal(helpers.escapeHtml('a & b'), 'a &amp; b');
   assert.equal(helpers.escapeHtml('<script>'), '&lt;script&gt;');
   assert.equal(helpers.escapeHtml('"x"'), '&quot;x&quot;');
-});
-
-test('escapeHtml does NOT escape single quotes (matches app.js)', () => {
-  assert.equal(helpers.escapeHtml("it's"), "it's");
+  assert.equal(helpers.escapeHtml("it's"), 'it&#39;s');
 });
 
 test('escapeHtml handles null/undefined', () => {

--- a/frontend/__tests__/crit-shared.test.js
+++ b/frontend/__tests__/crit-shared.test.js
@@ -10,9 +10,10 @@ const fn = new Function('window', 'document', src + '\nreturn window;');
 fn(sandbox.window, sandbox.document);
 const shared = sandbox.window.crit.shared;
 
-test('escapeHTML escapes <, >, &, "', () => {
+test('escapeHTML escapes <, >, &, ", and single quotes', () => {
   assert.equal(shared.escapeHTML('<a href="x">&</a>'),
     '&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;');
+  assert.equal(shared.escapeHTML("it's"), 'it&#39;s');
 });
 
 test('escapeHTML returns empty string for null/undefined', () => {

--- a/frontend/__tests__/design-mode.composer.test.js
+++ b/frontend/__tests__/design-mode.composer.test.js
@@ -1,6 +1,17 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+
+// chipLabel and escapeHTML now delegate to shared modules at runtime.
+// In Node.js test context, set up the globals before requiring the composer.
+const helpers = require('../crit-comment-card-helpers.js');
+globalThis.window = globalThis.window || globalThis;
+globalThis.window.crit = globalThis.window.crit || {};
+globalThis.window.crit.commentCardHelpers = helpers;
+globalThis.window.crit.shared = { escapeHTML: helpers.escapeHtml };
+
+// Now require the composer — it will pick up the globals.
+delete require.cache[require.resolve('../design-mode.composer.js')];
 const { renderComposerHTML, chipLabel } = require('../design-mode.composer.js');
 
 test('renderComposerHTML escapes user-controlled fields', () => {

--- a/frontend/__tests__/design-mode.row.test.js
+++ b/frontend/__tests__/design-mode.row.test.js
@@ -1,6 +1,16 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+
+// chipLabel now delegates to crit-comment-card-helpers.js at runtime.
+// Set up the globals before requiring design-mode.row.js.
+const helpers = require('../crit-comment-card-helpers.js');
+globalThis.window = globalThis.window || globalThis;
+globalThis.window.crit = globalThis.window.crit || {};
+globalThis.window.crit.commentCardHelpers = helpers;
+
+// Clear require cache so the module picks up the globals.
+delete require.cache[require.resolve('../design-mode.row.js')];
 const { chipLabel, renderDesignPinRow } = require('../design-mode.row.js');
 
 test('chipLabel handles missing fields', () => {
@@ -24,7 +34,7 @@ test('chipLabel falls back to outer_html text when no accessible_name', () => {
 
 test('chipLabel falls back to tag name as a last resort', () => {
   assert.equal(chipLabel({ tag_chain: ['SECTION'] }), '<section>');
-  assert.equal(chipLabel({}), 'element');
+  assert.equal(chipLabel({}), 'pin');
 });
 
 test('chipLabel truncates long values to 60 chars + ellipsis', () => {

--- a/frontend/crit-comment-card-helpers.js
+++ b/frontend/crit-comment-card-helpers.js
@@ -19,16 +19,15 @@
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
 
-  // escapeHtml — byte-identical to app.js's escapeHtml (escapes &, <, >, ").
-  // Does NOT escape single quotes; design rows that need that should use the
-  // row-local variant (see design-mode.row.js chipLabel handling).
-  function escapeHtml(str) {
-    return String(str == null ? '' : str)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
-  }
+  // escapeHtml — delegates to the canonical window.crit.shared.escapeHTML.
+  // Alias preserves the lowercase-h export name for existing consumers.
+  var escapeHtml = (typeof window !== 'undefined' && window.crit && window.crit.shared)
+    ? window.crit.shared.escapeHTML
+    : function (str) {
+        return String(str == null ? '' : str)
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+      };
 
   // relativeTime — byte-identical to app.js's relativeTime.
   function relativeTime(dateStr) {
@@ -69,6 +68,22 @@
     return 'comment:' + kind + ':' + commentId;
   }
 
+  // chipLabel — canonical design-pin label heuristic. Prefers accessible_name,
+  // then a short slice of textContent extracted from outer_html, then the leaf
+  // tag from tag_chain, then a.role, and finally falls back to 'pin'.
+  function chipLabel(a) {
+    var name = (a.accessible_name || '').trim();
+    if (name) return name.length > 60 ? name.slice(0, 60) + '…' : name;
+    var html = a.outer_html || '';
+    var text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (text) return text.length > 60 ? text.slice(0, 60) + '…' : text;
+    var chain = Array.isArray(a.tag_chain) ? a.tag_chain : [];
+    var tag = chain.length ? chain[chain.length - 1] : '';
+    if (tag) return '<' + tag.toLowerCase() + '>';
+    if (a.role) return a.role;
+    return 'pin';
+  }
+
   // Standard class strings. These are deliberately simple constants so that
   // both renderers stay in sync if we tweak them later. Adding a class here
   // does NOT make every existing card pick it up — call sites still need to
@@ -82,6 +97,7 @@
 
   return {
     escapeHtml: escapeHtml,
+    chipLabel: chipLabel,
     relativeTime: relativeTime,
     formatTime: formatTime,
     formKeyFor: formKeyFor,

--- a/frontend/crit-settings-panes.js
+++ b/frontend/crit-settings-panes.js
@@ -27,14 +27,9 @@
 (function () {
   'use strict';
 
-  function escapeHTML(s) {
-    if (s === null || s === undefined) return '';
-    return String(s)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
-  }
+  // escapeHTML — delegates to the canonical window.crit.shared.escapeHTML.
+  // crit-shared.js loads before this file per index.html script order.
+  var escapeHTML = window.crit.shared.escapeHTML;
 
   // Each shortcut declares which modes it actually fires in. The renderer
   // filters out entries that don't apply to the current mode so design-mode

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -7,16 +7,17 @@
 (function () {
   'use strict';
 
-  // escapeHTML mirrors app.js's escapeHtml (lowercase h) semantics: escapes
-  // &, <, >, " — not single quotes. Phase B does not touch app.js, so we
-  // duplicate the logic here under the camelCase public name.
+  // escapeHTML — canonical HTML escaper for the entire frontend. Escapes
+  // &, <, >, ", and ' (single quote). Safe in both content and attribute
+  // contexts.
   function escapeHTML(s) {
     if (s === null || s === undefined) return '';
     return String(s)
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   async function fetchJSON(url, opts) {

--- a/frontend/design-mode.composer.js
+++ b/frontend/design-mode.composer.js
@@ -8,25 +8,17 @@
     root.crit.design.composer = api;
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
-  function escapeHTML(s) {
-    return String(s == null ? '' : s)
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-  }
+  // escapeHTML — delegates to the canonical window.crit.shared.escapeHTML.
+  var escapeHTML = (typeof window !== 'undefined' && window.crit && window.crit.shared)
+    ? window.crit.shared.escapeHTML
+    : function (s) { return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;'); };
 
-  // Tidewave-style chip label: prefer accessible_name, then a short slice of
-  // textContent extracted from outer_html, then fall back to the leaf tag.
-  function chipLabel(a) {
-    var name = (a.accessible_name || '').trim();
-    if (name) return name.length > 60 ? name.slice(0, 60) + '…' : name;
-    var html = a.outer_html || '';
-    // crude text extract: strip tags, collapse whitespace.
-    var text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
-    if (text) return text.length > 60 ? text.slice(0, 60) + '…' : text;
-    var chain = Array.isArray(a.tag_chain) ? a.tag_chain : [];
-    var tag = chain.length ? chain[chain.length - 1] : '';
-    return tag ? '<' + tag.toLowerCase() + '>' : 'element';
-  }
+  // chipLabel is the canonical version from crit-comment-card-helpers.js.
+  var chipLabel = (typeof window !== 'undefined' && window.crit && window.crit.commentCardHelpers)
+    ? window.crit.commentCardHelpers.chipLabel
+    : function () { return 'pin'; };
 
   function renderComposerHTML(a) {
     var label = chipLabel(a);

--- a/frontend/design-mode.menu.js
+++ b/frontend/design-mode.menu.js
@@ -8,11 +8,12 @@
     root.crit.design.menu = api;
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
-  function escapeHTML(s) {
-    return String(s == null ? '' : s)
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-  }
+  // escapeHTML — delegates to the canonical window.crit.shared.escapeHTML.
+  var escapeHTML = (typeof window !== 'undefined' && window.crit && window.crit.shared)
+    ? window.crit.shared.escapeHTML
+    : function (s) { return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;'); };
   function renderAncestorMenuHTML(options) {
     var items = options.map(function (o) {
       return '<button type="button" class="crit-design-ancestor-menu-item" data-level="' + o.level + '">' + escapeHTML(o.label) + '</button>';

--- a/frontend/design-mode.row.js
+++ b/frontend/design-mode.row.js
@@ -27,20 +27,10 @@
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
 
-  // Mirrors design-mode.composer.js's chip label heuristic, kept in sync but
-  // duplicated to avoid module-load ordering surprises.
-  function chipLabel(a) {
-    var name = (a.accessible_name || '').trim();
-    if (name) return name.length > 60 ? name.slice(0, 60) + '…' : name;
-    var html = a.outer_html || '';
-    var text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
-    if (text) return text.length > 60 ? text.slice(0, 60) + '…' : text;
-    var chain = Array.isArray(a.tag_chain) ? a.tag_chain : [];
-    var tag = chain.length ? chain[chain.length - 1] : '';
-    if (tag) return '<' + tag.toLowerCase() + '>';
-    if (a.role) return a.role;
-    return 'pin';
-  }
+  // chipLabel — canonical version from crit-comment-card-helpers.js.
+  var chipLabel = (typeof window !== 'undefined' && window.crit && window.crit.commentCardHelpers)
+    ? window.crit.commentCardHelpers.chipLabel
+    : function () { return 'pin'; };
 
   function formatTimeFallback(s) {
     if (!s) return '';

--- a/frontend/style-design.css
+++ b/frontend/style-design.css
@@ -228,12 +228,6 @@
   background: var(--crit-design-mode-btn-active-bg);
   color: var(--crit-design-mode-btn-active-fg);
 }
-.crit-design-mode-btn[disabled],
-.crit-design-mode-btn-disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
 .crit-design-composer-host {
   padding: 8px;
 }
@@ -250,15 +244,6 @@
   overflow: hidden;
   box-shadow: 0 0 0 2px var(--crit-brand-subtle);
 }
-.crit-design-composer-header {
-  padding: 8px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--crit-brand);
-  font-family: var(--crit-font-mono);
-  background: var(--crit-brand-subtle);
-  border-bottom: 1px solid var(--crit-design-composer-border);
-}
 .crit-design-composer-meta {
   display: flex;
   flex-wrap: wrap;
@@ -267,15 +252,6 @@
   padding: 6px 14px 0;
   font-size: 11px;
   color: var(--crit-editor-fg-muted);
-}
-.crit-design-composer-thumb {
-  display: block;
-  margin: 8px 14px 0;
-  max-width: calc(100% - 28px);
-  max-height: 180px;
-  border: 1px solid var(--crit-design-composer-border);
-  border-radius: var(--crit-r-sm);
-  background: #fff;
 }
 .crit-design-composer-chip {
   display: inline-block;
@@ -369,15 +345,6 @@ body.hide-resolved .crit-design-comment-row-wrap:has(.resolved-card) {
   display: none;
 }
 
-.crit-design-comment-route-badge {
-  font-size: 11px;
-  color: var(--crit-editor-fg-muted);
-  font-family: var(--crit-font-mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 16ch;
-}
 .crit-design-comment-chip {
   display: inline-block;
   max-width: 18ch;
@@ -398,24 +365,6 @@ body.hide-resolved .crit-design-comment-row-wrap:has(.resolved-card) {
   border: 1px solid var(--crit-border);
   border-radius: var(--crit-r-sm);
 }
-.crit-design-comment-html-preview {
-  margin: 0;
-  padding: 4px;
-  background: var(--crit-editor-code-bg);
-  font-family: var(--crit-font-mono);
-  font-size: 11px;
-  white-space: pre-wrap;
-  word-break: break-all;
-  max-height: 80px;
-  overflow: auto;
-}
-.crit-design-comment-selector {
-  font-family: var(--crit-font-mono);
-  font-size: 10px;
-  color: var(--crit-editor-fg-muted);
-  word-break: break-all;
-}
-
 /* Per-reply Edit/Delete affordance buttons inside design replies inherit
    the shared `.reply-actions button` chrome — no overrides needed. The
    class hooks `.crit-design-reply-edit` / `.crit-design-reply-delete` are
@@ -473,46 +422,6 @@ body.hide-resolved .crit-design-comment-row-wrap:has(.resolved-card) {
    strikethrough/opacity override that lived here was a half-baked
    replacement and led to inconsistent visuals between modes. */
 
-/* ---- Phase D: drifted tray ---- */
-.crit-design-drifted-tray {
-  list-style: none;
-  margin: 0; padding: 8px 0;
-  display: flex; flex-direction: column; gap: 6px;
-}
-.crit-design-drifted-row {
-  display: grid;
-  grid-template-columns: max-content max-content 1fr max-content;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border: 1px solid var(--crit-border, rgba(127,127,127,0.25));
-  border-radius: 6px;
-}
-.crit-design-drifted-route {
-  font-family: var(--crit-font-mono);
-  font-size: 11px;
-  color: var(--crit-editor-fg-muted);
-}
-.crit-design-drifted-badge {
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 999px;
-}
-.crit-design-drifted-badge--recoverable {
-  background: var(--crit-design-drifted-recoverable-bg);
-  color: var(--crit-design-drifted-recoverable-fg);
-}
-.crit-design-drifted-badge--lost {
-  background: var(--crit-design-drifted-lost-bg);
-  color: var(--crit-design-drifted-lost-fg);
-}
-.crit-design-drifted-body {
-  font-size: 12px;
-  color: var(--crit-editor-fg-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .crit-design-reanchor-btn {
   font-size: 12px;
   padding: 2px 8px;
@@ -589,11 +498,8 @@ body.hide-resolved .crit-design-comment-row-wrap:has(.resolved-card) {
 }
 
 /* ---- Phase E: :focus-visible across all interactive design-mode elements ---- */
-.crit-design-toolbar button:focus-visible,
-.crit-design-toolbar [role="radio"]:focus-visible,
 .crit-design-thread button:focus-visible,
 .crit-design-thread [tabindex="0"]:focus-visible,
-.crit-design-drifted-row button:focus-visible,
 .crit-design-ancestor-menu-item:focus-visible,
 .crit-design-skip-link:focus-visible,
 .crit-design-reanchor-btn:focus-visible,

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -204,10 +204,6 @@
   --crit-design-marker-border:         rgba(255,255,255,0.18);
   --crit-design-marker-shadow:         0 1px 3px rgba(0,0,0,0.5);
   --crit-design-marker-focus-ring:     #fbbf24;
-  --crit-design-drifted-recoverable-bg: rgba(251, 191, 36, 0.15);
-  --crit-design-drifted-recoverable-fg: #fbbf24;
-  --crit-design-drifted-lost-bg:        rgba(247, 118, 142, 0.15);
-  --crit-design-drifted-lost-fg:        #f7768e;
   --crit-design-reanchor-active-outline: #f59e0b;
 
   /* ---- Phase E: drift-this-round, focus, tooltip, marker flash, menu hl ---- */
@@ -399,10 +395,6 @@
     --crit-design-marker-border:         rgba(0,0,0,0.15);
     --crit-design-marker-shadow:         0 1px 2px rgba(0,0,0,0.25);
     --crit-design-marker-focus-ring:     #b45309;
-    --crit-design-drifted-recoverable-bg: #fef3c7;
-    --crit-design-drifted-recoverable-fg: #78350f;
-    --crit-design-drifted-lost-bg:        #fee2e2;
-    --crit-design-drifted-lost-fg:        #7f1d1d;
     --crit-design-reanchor-active-outline: #d97706;
 
     /* ---- Phase E ---- */
@@ -594,10 +586,6 @@
   --crit-design-marker-border:         rgba(255,255,255,0.18);
   --crit-design-marker-shadow:         0 1px 3px rgba(0,0,0,0.5);
   --crit-design-marker-focus-ring:     #fbbf24;
-  --crit-design-drifted-recoverable-bg: rgba(251, 191, 36, 0.15);
-  --crit-design-drifted-recoverable-fg: #fbbf24;
-  --crit-design-drifted-lost-bg:        rgba(247, 118, 142, 0.15);
-  --crit-design-drifted-lost-fg:        #f7768e;
   --crit-design-reanchor-active-outline: #f59e0b;
 
   /* ---- Phase E ---- */
@@ -788,10 +776,6 @@
   --crit-design-marker-border:         rgba(0,0,0,0.15);
   --crit-design-marker-shadow:         0 1px 2px rgba(0,0,0,0.25);
   --crit-design-marker-focus-ring:     #b45309;
-  --crit-design-drifted-recoverable-bg: #fef3c7;
-  --crit-design-drifted-recoverable-fg: #78350f;
-  --crit-design-drifted-lost-bg:        #fee2e2;
-  --crit-design-drifted-lost-fg:        #7f1d1d;
   --crit-design-reanchor-active-outline: #d97706;
 
   /* ---- Phase E ---- */

--- a/preview.go
+++ b/preview.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,14 +41,14 @@ func looksLikePreviewArgs(args []string) bool {
 
 // connectToPreviewDaemon attaches the current CLI to an already-running preview
 // daemon for key, blocking on its review session.
-func connectToPreviewDaemon(key string) bool {
+func connectToPreviewDaemon(key string, noOpen bool) bool {
 	entry, alive := findAliveSession(key)
 	if !alive {
 		return false
 	}
 	fmt.Fprintf(os.Stderr, "[crit] connected to preview daemon at http://localhost:%d\n", entry.Port)
 	fmt.Fprintf(os.Stderr, "[crit] open http://localhost:%d/preview\n", entry.Port)
-	if !daemonHasBrowser(entry) {
+	if !noOpen && !daemonHasBrowser(entry) {
 		go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
 	}
 	runReviewClient(entry)
@@ -178,8 +179,7 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 		`<script src="/agent-mutation-batcher.js"></script>` +
 		`<script src="/agent-resolution.js"></script>` +
 		`<script src="/agent-reanchor-state.js"></script>` +
-		`<script src="/crit-agent.js"></script>` +
-		`<link rel="stylesheet" href="/agent-marker.css">`
+		`<script src="/crit-agent.js"></script>`
 
 	// Inject before last </body>
 	idx := bytes.LastIndex(bytes.ToLower(body), []byte("</body>"))
@@ -198,13 +198,30 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 
 // runPreview is the entry point for `crit preview <file.html>`.
 func runPreview(args []string) {
+	fs := flag.NewFlagSet("preview", flag.ExitOnError)
+	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
+	fs.Parse(args)
+
+	remaining := fs.Args()
 	rawPath := ""
-	for _, a := range args {
+	for _, a := range remaining {
 		if len(a) > 0 && a[0] != '-' {
 			rawPath = a
 			break
 		}
 	}
+
+	// Also respect config file setting.
+	cwd, err := resolvedCWD()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	cfg := LoadConfig(cwd)
+	if cfg.NoOpen {
+		*noOpen = true
+	}
+
 	if rawPath == "" {
 		fmt.Fprintln(os.Stderr, "Usage: crit preview <file.html>")
 		os.Exit(1)
@@ -222,13 +239,8 @@ func runPreview(args []string) {
 		os.Exit(1)
 	}
 
-	cwd, err := resolvedCWD()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
 	key := previewSessionKey(cwd, absPath)
-	if connectToPreviewDaemon(key) {
+	if connectToPreviewDaemon(key, *noOpen) {
 		return
 	}
 
@@ -244,7 +256,9 @@ func runPreview(args []string) {
 
 	installDaemonSignalHandler(entry.PID)
 
-	go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
+	if !*noOpen {
+		go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
+	}
 
 	runReviewClient(entry)
 }

--- a/preview_test.go
+++ b/preview_test.go
@@ -205,8 +205,8 @@ func TestHandlePreviewContent_InjectsAgent(t *testing.T) {
 	if !strings.Contains(body, "agent-protocol.js") {
 		t.Error("agent-protocol.js not injected")
 	}
-	if !strings.Contains(body, "agent-marker.css") {
-		t.Error("agent-marker.css not injected")
+	if strings.Contains(body, "agent-marker.css") {
+		t.Error("agent-marker.css should not be injected (loaded dynamically by crit-agent.js)")
 	}
 	// Verify injection is before </body>
 	agentIdx := strings.Index(body, "crit-agent.js")


### PR DESCRIPTION
## Summary
- Extract `chipLabel` into `crit-comment-card-helpers.js` to fix divergent fallbacks between composer and row
- Add single-quote escaping to canonical `escapeHTML`, remove 4 duplicate definitions
- Remove ~12 dead CSS classes from `style-design.css` (phase C/D skeletons) and 4 orphaned theme variables
- Remove redundant `agent-marker.css` `<link>` from `preview.go` (loaded dynamically by `crit-agent.js`)
- Add `--no-open` flag support to `runPreview`

## Review
- [x] Code review: passed (independent Go + frontend reviewers)
- [x] Pre-commit: gofmt, golangci-lint, go test, ESLint, Stylelint, CSS vars check

## Test plan
- All Go tests pass (34s)
- All 73 JS unit tests pass
- CSS variable checker confirms no dead/missing vars
- See also: tomasz-tomczyk/crit-web#222 — mermaid version alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)