### PR TITLE
fix: fire design-round-start SSE for preview reviews

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -694,11 +694,11 @@ func runServe(args []string) {
 		session.ReviewType = "design"
 		session.Origin = sc.designOrigin
 	}
-	if session.ReviewType == "design" {
-		// Wire the design-mode round-start hook to broadcast over the same
-		// SSE channel handleEvents serves. The watcher fires this from a
-		// single goroutine after the round bump. Set before SetSession so
-		// the watcher goroutine never observes a partial assignment.
+	if session.ReviewType == "design" || session.ReviewType == "preview" {
+		// Wire the round-start hook to broadcast over the same SSE channel
+		// handleEvents serves. The watcher fires this from a single
+		// goroutine after the round bump. Set before SetSession so the
+		// watcher goroutine never observes a partial assignment.
 		session.designRoundStart = func(_, next int) {
 			session.notify(SSEEvent{Type: "design-round-start", Round: next})
 		}

--- a/session.go
+++ b/session.go
@@ -291,14 +291,15 @@ type Session struct {
 	generatedRules []generatedRule
 
 	// Design-mode runtime fields. Zero values are safe for code reviews.
-	ReviewType string // "" or "design"
+	ReviewType string // "", "design", or "preview"
 	Origin     string // upstream URL, e.g. "http://localhost:3000"
 	ProxyPort  int    // proxy server port; 0 for code reviews
 
-	// designRoundStart, when non-nil and ReviewType=="design", is invoked
-	// after ReviewRound is bumped. Production wiring sets this in runServe
-	// before SetSession; tests assign it before driving the session. Must
-	// be installed before the watcher goroutine starts — read-only after.
+	// designRoundStart, when non-nil and ReviewType is "design" or
+	// "preview", is invoked after ReviewRound is bumped. Production wiring
+	// sets this in runServe before SetSession; tests assign it before
+	// driving the session. Must be installed before the watcher goroutine
+	// starts — read-only after.
 	designRoundStart func(prevRound, newRound int)
 
 	reviewComments []Comment

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -179,7 +179,7 @@ func advanceRoundForTest(s *Session) {
 	rt := s.ReviewType
 	next := s.ReviewRound
 	s.mu.Unlock()
-	if rt == "design" && s.designRoundStart != nil {
+	if (rt == "design" || rt == "preview") && s.designRoundStart != nil {
 		s.designRoundStart(prev, next)
 	}
 }

--- a/watch.go
+++ b/watch.go
@@ -493,7 +493,7 @@ func (s *Session) handleRoundCompleteGit() {
 	rt := s.ReviewType
 	next := s.ReviewRound
 	s.mu.Unlock()
-	if rt == "design" && s.designRoundStart != nil {
+	if (rt == "design" || rt == "preview") && s.designRoundStart != nil {
 		s.designRoundStart(prev, next)
 	}
 
@@ -540,7 +540,7 @@ func (s *Session) handleRoundCompleteFiles() {
 	rt := s.ReviewType
 	nextR := s.ReviewRound
 	s.mu.Unlock()
-	if rt == "design" && s.designRoundStart != nil {
+	if (rt == "design" || rt == "preview") && s.designRoundStart != nil {
 		s.designRoundStart(prev, nextR)
 	}
 

--- a/watch_test.go
+++ b/watch_test.go
@@ -1526,7 +1526,7 @@ func TestRemapLines(t *testing.T) {
 	}
 }
 
-func TestOnDesignRoundStart_OnlyForDesignReviews(t *testing.T) {
+func TestOnDesignRoundStart_OnlyForDesignAndPreviewReviews(t *testing.T) {
 	called := 0
 	hook := func(int, int) { called++ }
 
@@ -1543,5 +1543,14 @@ func TestOnDesignRoundStart_OnlyForDesignReviews(t *testing.T) {
 	}
 	if s2.ReviewRound != 2 {
 		t.Fatalf("ReviewRound = %d, want 2", s2.ReviewRound)
+	}
+
+	s3 := &Session{ReviewType: "preview", ReviewRound: 1, designRoundStart: hook}
+	advanceRoundForTest(s3)
+	if called != 2 {
+		t.Fatalf("hook did not fire for preview review (called=%d)", called)
+	}
+	if s3.ReviewRound != 2 {
+		t.Fatalf("ReviewRound = %d, want 2", s3.ReviewRound)
 	}
 }


### PR DESCRIPTION
## Summary
- The round-reload SSE broadcast was gated on `ReviewType=="design"` only
- Preview-mode sessions never received the event, requiring manual page refresh after round bumps
- Extended the condition to also fire for `ReviewType=="preview"` across all 4 call sites

## Review
- [x] Code review: passed (go-expert, no issues)
- [x] Parity audit: N/A (backend-only)

## Test plan
- Extended existing `TestOnDesignRoundStart` to cover preview review type
- All pre-commit checks pass (gofmt, golangci-lint, go test -race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)