### PR TITLE
refactor: remove dead live-mode CSS and orphaned theme vars

### DIFF
--- a/frontend/__tests__/check-live-vars.test.js
+++ b/frontend/__tests__/check-live-vars.test.js
@@ -16,8 +16,6 @@ const REQUIRED_VARS = [
   '--crit-live-ancestor-menu-bg',
   '--crit-live-ancestor-menu-fg',
   '--crit-live-ancestor-menu-hover-bg',
-  '--crit-live-mode-btn-active-bg',
-  '--crit-live-mode-btn-active-fg',
   // Phase D markers + re-anchor
   '--crit-live-marker-bg',
   '--crit-live-marker-fg',

--- a/frontend/style-live.css
+++ b/frontend/style-live.css
@@ -224,10 +224,6 @@
 /* ============================================================
  * Phase C: composer, ancestor menu, toast, mode toggle, comment row
  * ============================================================ */
-.crit-live-mode-btn-active {
-  background: var(--crit-live-mode-btn-active-bg);
-  color: var(--crit-live-mode-btn-active-fg);
-}
 .crit-live-composer-host {
   padding: 8px;
 }
@@ -356,14 +352,6 @@ body.hide-resolved .crit-live-comment-row-wrap:has(.resolved-card) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.crit-live-comment-thumb {
-  display: block;
-  max-width: 100%;
-  max-height: 120px;
-  margin: 0 0 8px 0;
-  border: 1px solid var(--crit-border);
-  border-radius: var(--crit-r-sm);
 }
 /* Per-reply Edit/Delete affordance buttons inside live replies inherit
    the shared `.reply-actions button` chrome — no overrides needed. The

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -192,8 +192,6 @@
   --crit-live-ancestor-menu-bg:      #1a1c23;
   --crit-live-ancestor-menu-fg:      #e6e8ed;
   --crit-live-ancestor-menu-hover-bg:#2f3342;
-  --crit-live-mode-btn-active-bg:    #2d7ff9;
-  --crit-live-mode-btn-active-fg:    #ffffff;
   --crit-live-toast-bg:              #1a1c23;
   --crit-live-toast-fg:              #e6e8ed;
   --crit-live-toast-border:          #2f3342;
@@ -383,8 +381,6 @@
     --crit-live-ancestor-menu-bg:      #ffffff;
     --crit-live-ancestor-menu-fg:      #1f2328;
     --crit-live-ancestor-menu-hover-bg:#eef2f7;
-    --crit-live-mode-btn-active-bg:    #2d7ff9;
-    --crit-live-mode-btn-active-fg:    #ffffff;
     --crit-live-toast-bg:              #ffffff;
     --crit-live-toast-fg:              #1f2328;
     --crit-live-toast-border:          #d0d7de;
@@ -574,8 +570,6 @@
   --crit-live-ancestor-menu-bg:      #1a1c23;
   --crit-live-ancestor-menu-fg:      #e6e8ed;
   --crit-live-ancestor-menu-hover-bg:#2f3342;
-  --crit-live-mode-btn-active-bg:    #2d7ff9;
-  --crit-live-mode-btn-active-fg:    #ffffff;
   --crit-live-toast-bg:              #1a1c23;
   --crit-live-toast-fg:              #e6e8ed;
   --crit-live-toast-border:          #2f3342;
@@ -764,8 +758,6 @@
   --crit-live-ancestor-menu-bg:      #ffffff;
   --crit-live-ancestor-menu-fg:      #1f2328;
   --crit-live-ancestor-menu-hover-bg:#eef2f7;
-  --crit-live-mode-btn-active-bg:    #2d7ff9;
-  --crit-live-mode-btn-active-fg:    #ffffff;
   --crit-live-toast-bg:              #ffffff;
   --crit-live-toast-fg:              #1f2328;
   --crit-live-toast-border:          #d0d7de;


### PR DESCRIPTION
## Summary
- Removes two dead live-mode CSS rules the #565 audit-cleanup pass missed:
  - `.crit-live-comment-thumb` — the screenshot/thumbnail path was cut; only a negative test still references the class
  - `.crit-live-mode-btn-active` — the mode toggle uses `.active` instead
- Removes the 8 orphaned `--crit-live-mode-btn-active-*` theme vars (2 per theme block × 4) that existed only to feed the dead rule
- Drops the matching entries from `check-live-vars.test.js`

## Review
- [x] release-audit post-fix review: passed

## Test plan
- `node --test frontend/__tests__/*.test.js` — `check-live-vars.test.js` passes
- grep confirms zero remaining JS/CSS usage of either class

🤖 Generated with [Claude Code](https://claude.com/claude-code)