### PR TITLE
fix: assert final upload URL in reply paste test

### DIFF
--- a/e2e/tests/image-upload.livemode.spec.ts
+++ b/e2e/tests/image-upload.livemode.spec.ts
@@ -120,7 +120,7 @@ test.describe('live-mode reply textarea image upload', () => {
       }));
     });
 
-    await expect(replyTa).toHaveValue(/!\[uploading…\]\(crit-pending-/);
+    await expect(replyTa).toHaveValue(/!\[.*\]\(attachments\/[a-f0-9-]+\.png\)/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Follow-up to #558: the handler-attach race was fixed but the assertion still checked for the transient "uploading…" placeholder, which completes before the assertion fires on fast CI
- Changed to assert the final upload URL pattern, matching all other image paste tests in the same file

## Test plan
- [x] Ran `npx playwright test tests/image-upload.livemode.spec.ts` — 5/5 passed
- [x] Pre-commit hooks passed (go test, golangci-lint, ESLint, Stylelint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)