### PR TITLE
fix: restore "Copied" feedback on review-complete copy prompt button

### DIFF
--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -40,6 +40,36 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     await expect(prompt).toContainText('crit');
   });
 
+  test('copy prompt button shows "Copied" feedback then reverts', async ({ page, request }) => {
+    // Add a comment so the prompt is non-empty
+    const filePath = await getTestFilePath(request);
+    await request.post(`/api/file/comments?path=${encodeURIComponent(filePath)}`, {
+      data: { start_line: 1, end_line: 1, body: 'Copy feedback test' },
+    });
+
+    await page.reload();
+    await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
+
+    await page.locator('#finishBtn').click();
+    await expect(page.locator('#waitingOverlay')).toHaveClass(/active/);
+
+    const copyBtn = page.locator('#waitingClipboard');
+    const label = copyBtn.locator('.copy-label');
+
+    // Clipboard API may not be available in headless — grant permission
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    await copyBtn.click();
+
+    // Label should change to "Copied" and button should get .copied class
+    await expect(label).toHaveText('Copied');
+    await expect(copyBtn).toHaveClass(/copied/);
+
+    // Should revert after timeout
+    await expect(label).toHaveText('Copy', { timeout: 5_000 });
+    await expect(copyBtn).not.toHaveClass(/copied/);
+  });
+
   test('finish review with no comments shows "no feedback" message', async ({ page }) => {
     await page.locator('#finishBtn').click();
 

--- a/frontend/__tests__/crit-shared.test.js
+++ b/frontend/__tests__/crit-shared.test.js
@@ -343,20 +343,34 @@ function makeFinishSandbox(fetchImpl, clipboardImpl) {
     return {
       textContent: '', innerHTML: '', offsetWidth: 0,
       style: {},
+      _attrs: {},
+      setAttribute(k, v) { this._attrs[k] = v; },
+      getAttribute(k) { return this._attrs[k] || null; },
       classList: {
         _set: new Set(),
         add(...c) { c.forEach((x) => this._set.add(x)); },
         remove(...c) { c.forEach((x) => this._set.delete(x)); },
         contains(c) { return this._set.has(c); },
       },
+      querySelector() { return null; },
     };
   }
+  const copyLabel = makeEl();
+  copyLabel.textContent = 'Copy';
+  const clipEl = makeEl();
+  clipEl._attrs['aria-label'] = 'Copy prompt to clipboard';
+  clipEl.querySelector = function (sel) {
+    if (sel === '.copy-label') return copyLabel;
+    return null;
+  };
   const els = {
     waitingDialog: makeEl(),
     waitingHeading: makeEl(),
     waitingMessage: makeEl(),
-    waitingClipboard: makeEl(),
+    waitingClipboard: clipEl,
     waitingPrompt: makeEl(),
+    promptPreview: makeEl(),
+    _copyLabel: copyLabel,
   };
   const win = {};
   const doc = { cookie: '', getElementById: (id) => els[id] || null };
@@ -388,9 +402,29 @@ test('runFinishReview approved path: sets approved class + Approved heading + on
   assert.equal(els.waitingHeading.textContent, 'Approved');
   assert.equal(els.waitingPrompt.textContent, 'ok-prompt');
   assert.equal(els.waitingDialog.classList.contains('approved'), true);
-  assert.equal(els.waitingClipboard.textContent, 'Copy prompt');
+  assert.equal(els._copyLabel.textContent, 'Copy');
+  assert.equal(els.waitingClipboard.classList.contains('copied'), false);
+  assert.equal(els.waitingClipboard.getAttribute('aria-label'), 'Copy prompt to clipboard');
   assert.equal(approvedArg, 'ok-prompt');
   assert.equal(waitingCalled, false);
+});
+
+test('runFinishReview resets copy button via .copy-label span, not textContent (regression)', async () => {
+  const fetch = async () => ({ ok: true, json: async () => ({ approved: true, prompt: 'p' }) });
+  const { shared: s, els } = makeFinishSandbox(fetch, { writeText: async () => {} });
+  // Simulate a prior "Copied" state
+  els._copyLabel.textContent = 'Copied';
+  els.waitingClipboard.classList.add('copied');
+  els.waitingClipboard.setAttribute('aria-label', 'Copied');
+
+  await s.runFinishReview({});
+
+  // The reset must target the .copy-label span, not clobber the parent's textContent
+  assert.equal(els._copyLabel.textContent, 'Copy');
+  assert.equal(els.waitingClipboard.classList.contains('copied'), false);
+  assert.equal(els.waitingClipboard.getAttribute('aria-label'), 'Copy prompt to clipboard');
+  // querySelector must still work (DOM structure preserved)
+  assert.ok(els.waitingClipboard.querySelector('.copy-label'), '.copy-label span still accessible');
 });
 
 test('runFinishReview not-approved path: leaves approved class off + uses default prompt fallback', async () => {

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -256,8 +256,10 @@
       if (promptEl) promptEl.textContent = prompt;
       if (previewEl) previewEl.textContent = prompt;
       if (clipEl) {
-        clipEl.textContent = 'Copy prompt';
-        clipEl.classList.remove('clipboard-confirm');
+        var copyLabel = clipEl.querySelector('.copy-label');
+        if (copyLabel) copyLabel.textContent = 'Copy';
+        clipEl.classList.remove('copied');
+        clipEl.setAttribute('aria-label', 'Copy prompt to clipboard');
       }
 
       if (dialog) {

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -705,14 +705,14 @@
         var text = p ? p.textContent : '';
         try {
           await navigator.clipboard.writeText(text);
-          clip.textContent = '✓ Copied';
+          var label = clip.querySelector('.copy-label');
+          if (label) label.textContent = 'Copied';
+          clip.classList.add('copied');
           clip.setAttribute('aria-label', 'Copied');
-          clip.classList.remove('clipboard-confirm');
-          void clip.offsetWidth;
-          clip.classList.add('clipboard-confirm');
           setTimeout(function () {
-            clip.textContent = 'Copy prompt';
-            clip.setAttribute('aria-label', 'Copy prompt');
+            if (label) label.textContent = 'Copy';
+            clip.classList.remove('copied');
+            clip.setAttribute('aria-label', 'Copy prompt to clipboard');
           }, 2000);
         } catch (_) {}
       });


### PR DESCRIPTION
## Summary
- `runFinishReview` in `crit-shared.js` reset the copy prompt button with `clipEl.textContent = 'Copy prompt'`, which destroyed the inner SVG+span DOM structure. After that, the click handler's `querySelector('.copy-label')` returned null and the "Copied" text/color feedback silently failed.
- Also fixed stale `clipboard-confirm` class references (renamed to `copied` during an earlier button redesign) in both `crit-shared.js` and `live-mode.js`.

## Test plan
- Manually verified the copy prompt button shows "Copied" (green) and reverts after 2s in both code-review and live mode
- Pre-commit hooks pass (gofmt, golangci-lint, go test, ESLint, Stylelint, CSS vars check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)