### PR TITLE
fix: hide marker badges when target element is detached or zero-size

### DIFF
--- a/frontend/__tests__/agent-marker-overlay.test.js
+++ b/frontend/__tests__/agent-marker-overlay.test.js
@@ -138,6 +138,37 @@ test('applyRects without scroll offsets behaves as before (back-compat)', () => 
   assert.deepEqual(writes, ['a:translate(5px, 10px)']);
 });
 
+test('applyRects hides marker when target is disconnected from DOM', () => {
+  const target = {
+    isConnected: false,
+    getBoundingClientRect: () => { throw new Error('should not be called'); },
+  };
+  const m = { target, el: { style: {} } };
+  overlay.applyRects([m]);
+  assert.equal(m.el.style.display, 'none');
+});
+
+test('applyRects hides marker when target has zero-size rect (detached element)', () => {
+  const target = {
+    isConnected: true,
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 0, height: 0 }),
+  };
+  const m = { target, el: { style: {} } };
+  overlay.applyRects([m]);
+  assert.equal(m.el.style.display, 'none');
+});
+
+test('applyRects shows marker when target is connected with non-zero rect', () => {
+  const target = {
+    isConnected: true,
+    getBoundingClientRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
+  };
+  const m = { target, el: { style: {} } };
+  overlay.applyRects([m]);
+  assert.equal(m.el.style.display, '');
+  assert.equal(m.el.style.transform, 'translate(10px, 20px)');
+});
+
 test('setMarkersTabindex toggles all markers atomically', () => {
   const m1 = { _attrs: { tabindex: '0' }, setAttribute(k, v) { this._attrs[k] = v; } };
   const m2 = { _attrs: { tabindex: '0' }, setAttribute(k, v) { this._attrs[k] = v; } };

--- a/frontend/agent-marker-overlay.js
+++ b/frontend/agent-marker-overlay.js
@@ -77,7 +77,13 @@
     }
     const sx = (win && typeof win.scrollX === 'number') ? win.scrollX : 0;
     const sy = (win && typeof win.scrollY === 'number') ? win.scrollY : 0;
-    const reads = markers.map(m => (m.target ? m.target.getBoundingClientRect() : null));
+    const reads = markers.map(m => {
+      if (!m.target) return null;
+      if (typeof m.target.isConnected !== 'undefined' && !m.target.isConnected) return null;
+      const rect = m.target.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return null;
+      return rect;
+    });
     for (let i = 0; i < markers.length; i++) {
       const m = markers[i];
       const r = reads[i];


### PR DESCRIPTION
## Summary
- When a pinned DOM element gets removed from the page (SPA navigation, dynamic UI), `getBoundingClientRect` on the stale reference returns a zero-rect — truthy but useless. The marker badge jumped to the top-left corner instead of hiding.
- `applyRects` now checks `isConnected` and zero-size rects before positioning, hiding the marker when its target is gone or invisible.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit/-only file, no crit-web counterpart)

## Test plan
- Unit tests: 3 new tests for disconnected, zero-size, and connected+visible cases
- All 13 marker overlay tests pass
- Full frontend test suite: 380/382 pass (2 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)