### PR TITLE
feat: set document title and tab badge for live/preview modes

### DIFF
--- a/frontend/__tests__/live-mode.sse.test.js
+++ b/frontend/__tests__/live-mode.sse.test.js
@@ -82,6 +82,39 @@ test('applyRoundStart re-fetches comments so replies posted mid-round appear', a
   assert.equal(reloads, 1, 'round-start must re-fetch comments to capture mid-round replies');
 });
 
+test('applyRoundStart fires tab badge when document is hidden', () => {
+  let badgeCalls = 0;
+  const state = { setTabBadge: () => { badgeCalls++; } };
+  // Simulate hidden tab: define global document with visibilityState='hidden'
+  global.document = { visibilityState: 'hidden', getElementById: () => null };
+  const ctl = create({
+    state,
+    pinsByRoute: () => ({}),
+    scheduleResolutionForPath: () => {},
+    announceLive: () => {},
+    setUIState: () => {},
+  });
+  ctl.applyRoundStart(2);
+  assert.equal(badgeCalls, 1);
+  delete global.document;
+});
+
+test('applyRoundStart skips tab badge when document is visible', () => {
+  let badgeCalls = 0;
+  const state = { setTabBadge: () => { badgeCalls++; } };
+  global.document = { visibilityState: 'visible', getElementById: () => null };
+  const ctl = create({
+    state,
+    pinsByRoute: () => ({}),
+    scheduleResolutionForPath: () => {},
+    announceLive: () => {},
+    setUIState: () => {},
+  });
+  ctl.applyRoundStart(2);
+  assert.equal(badgeCalls, 0);
+  delete global.document;
+});
+
 test('applyCommentsChanged invokes reloadComments', async () => {
   let reloads = 0;
   const ctl = create({

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -55,6 +55,46 @@
   var utils = window.crit.liveUtils;
   var inflightAPI = (window.crit && window.crit.live && window.crit.live.inflight) || null;
 
+  // ===== Tab-Ready Indicator =====
+  // Same pattern as app.js: prepends ● to document.title when a new round
+  // starts while the tab is hidden. Clears on visibilitychange → visible.
+  var BADGE_PREFIX = '\u25CF ';
+  var baseTitle = document.title;
+  var badgeActive = false;
+
+  function setDocumentTitle(nextBase) {
+    baseTitle = nextBase;
+    document.title = badgeActive ? BADGE_PREFIX + baseTitle : baseTitle;
+  }
+
+  function setTabBadge() {
+    if (badgeActive) return;
+    badgeActive = true;
+    if (!document.title.startsWith(BADGE_PREFIX)) {
+      document.title = BADGE_PREFIX + baseTitle;
+    }
+  }
+
+  function clearTabBadge() {
+    if (!badgeActive) return;
+    badgeActive = false;
+    document.title = baseTitle;
+  }
+
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') clearTabBadge();
+  });
+
+  state.setTabBadge = setTabBadge;
+
+  if (location.search.includes('test')) {
+    window.__critTabBadge = {
+      set: setTabBadge,
+      clear: clearTabBadge,
+      isActive: function () { return badgeActive; },
+    };
+  }
+
   // Dedup guards for async ops triggerable from multiple sources (button
   // click + Cmd+Enter, double-click, race between Esc-then-Save, etc.).
   // Per-id Sets for comment-scoped ops; singleton flag for finish review.
@@ -271,6 +311,15 @@
       console.warn('[live-mode] unexpected review_type:', state.session.review_type);
     }
     state.isPreview = state.session.review_type === 'preview';
+
+    if (state.isPreview) {
+      var firstFile = (state.session.files && state.session.files.length)
+        ? state.session.files[0].path : 'preview';
+      setDocumentTitle('Crit — ' + firstFile);
+    } else {
+      setDocumentTitle('Crit — ' + (state.session.origin || 'live'));
+    }
+
     // Capture proxyOrigin once for the message handler. The agent
     // posts from the proxy origin; the chrome lives on the API origin and
     // accepts only that source+origin pair.

--- a/frontend/live-mode.sse.js
+++ b/frontend/live-mode.sse.js
@@ -98,6 +98,9 @@
       // now because round transitions are agent-driven, not user-driven.
       reloadIframe();
       scheduleResolutionForPath(state.currentRoute || '/');
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible' && state.setTabBadge) {
+        state.setTabBadge();
+      }
       announceLive('Round ' + roundN + ' started.');
     }
 


### PR DESCRIPTION
## Summary
- Live mode now shows "Crit — <origin URL>" and preview mode shows "Crit — <filename>" in the browser tab title, matching code-review mode behavior
- Tab badge (● dot prefix) appears when a new round starts while the tab is hidden, cleared when the user returns — same pattern as code-review mode
- Exposes `window.__critTabBadge` test hook (gated on `?test`) for E2E testability

## Test plan
- [x] 2 unit tests: badge fires when document hidden, skips when visible
- [x] All 119 existing live-mode unit tests pass
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)