### PR TITLE
fix: re-sync pin mode to agent after round transition

### DIFF
--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -1835,6 +1835,13 @@
         pinBtn.removeAttribute('title');
       }
     }
+    // After a round transition the iframe reloads and the new agent starts
+    // in navigate mode. If the user was in pin mode, re-sync so the agent
+    // honours pin clicks without requiring a manual navigate→pin toggle.
+    if (state.mode === 'pin') {
+      postToAgent({ type: 'set-mode', value: 'pin' });
+      postToAgent({ type: 'set-marker-tabindex', value: -1 });
+    }
     pushPinsToAgent();
 
     // Register as the active ContentRenderer so chrome modules (comment


### PR DESCRIPTION
## Summary
- When a new round starts in live/preview mode, the iframe reloads and the injected agent restarts in navigate mode
- If the user was in pin mode, clicks did nothing until they toggled navigate→pin manually
- `handleAgentReady` now re-sends `set-mode` to the new agent, preserving pin mode across round transitions

## Test plan
- Manually tested: start preview, switch to pin mode, trigger round-complete, verify pin mode stays active and pin clicks work immediately
- Unit tests pass (119/120, 1 pre-existing failure unrelated)
- Go tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)