### PR TITLE
fix: forward CLI flags to preview, live, and plan daemon modes

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -16,6 +16,33 @@ import (
 	"time"
 )
 
+type commonDaemonFlags struct {
+	port     int
+	host     string
+	noOpen   bool
+	quiet    bool
+	shareURL string
+}
+
+func appendCommonDaemonFlags(args []string, f commonDaemonFlags) []string {
+	if f.port != 0 {
+		args = append(args, "--port", strconv.Itoa(f.port))
+	}
+	if f.host != "" && f.host != "127.0.0.1" {
+		args = append(args, "--host", f.host)
+	}
+	if f.noOpen {
+		args = append(args, "--no-open")
+	}
+	if f.quiet {
+		args = append(args, "--quiet")
+	}
+	if f.shareURL != "" {
+		args = append(args, "--share-url", f.shareURL)
+	}
+	return args
+}
+
 // aliveClient is used by isDaemonAlive which is called in a loop by
 // listSessionsForCWD — a short timeout keeps listing responsive.
 var aliveClient = &http.Client{Timeout: time.Second}

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -980,3 +980,57 @@ func TestLiveSessionKey_Deterministic(t *testing.T) {
 		t.Errorf("non-deterministic: %s vs %s", k1, k2)
 	}
 }
+
+func TestAppendCommonDaemonFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		f    commonDaemonFlags
+		want []string
+	}{
+		{
+			name: "empty flags produce no args",
+			f:    commonDaemonFlags{},
+			want: []string{"--preview-file", "/tmp/x.html"},
+		},
+		{
+			name: "all flags set",
+			f: commonDaemonFlags{
+				port:     3456,
+				host:     "0.0.0.0",
+				noOpen:   true,
+				quiet:    true,
+				shareURL: "https://crit.md",
+			},
+			want: []string{"--preview-file", "/tmp/x.html",
+				"--port", "3456",
+				"--host", "0.0.0.0",
+				"--no-open",
+				"--quiet",
+				"--share-url", "https://crit.md"},
+		},
+		{
+			name: "default host 127.0.0.1 is not forwarded",
+			f:    commonDaemonFlags{host: "127.0.0.1"},
+			want: []string{"--preview-file", "/tmp/x.html"},
+		},
+		{
+			name: "port only",
+			f:    commonDaemonFlags{port: 8080},
+			want: []string{"--preview-file", "/tmp/x.html", "--port", "8080"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := []string{"--preview-file", "/tmp/x.html"}
+			got := appendCommonDaemonFlags(base, tt.f)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("arg[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/live.go
+++ b/live.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -140,8 +142,13 @@ func connectToLiveDaemon(key string) bool {
 
 // runLive is the entry point for `crit live <url>`.
 func runLive(args []string) {
+	fs := flag.NewFlagSet("live", flag.ExitOnError)
+	port := fs.Int("port", 0, "Port to listen on")
+	fs.IntVar(port, "p", 0, "Port (shorthand)")
+	fs.Parse(args)
+
 	rawURL := ""
-	for _, a := range args {
+	for _, a := range fs.Args() {
 		if len(a) > 0 && a[0] != '-' {
 			rawURL = a
 			break
@@ -159,20 +166,7 @@ func runLive(args []string) {
 	origin := u.Scheme + "://" + u.Host
 
 	// 1. Smoke test.
-	result := runSmokeTest(origin)
-	switch result.kind {
-	case smokeConnRefused, smokeNonHTML:
-		fmt.Fprintf(os.Stderr, "Error: %s\n", result.message)
-		os.Exit(1)
-	case smokeNon2xx, smokeMissingBody:
-		fmt.Fprintf(os.Stderr, "[crit] warning: %s\n", result.message)
-	}
-	if result.hasCSPFrameAncestors {
-		fmt.Fprintf(os.Stderr, "[crit] note: upstream has frame-ancestors CSP; stripped by proxy\n")
-	}
-	for _, n := range result.frameworkNotes {
-		fmt.Fprintf(os.Stderr, "[crit] note: %s\n", n)
-	}
+	checkLiveSmoke(origin)
 
 	// 2. Session key + existing daemon check.
 	cwd, err := resolvedCWD()
@@ -180,13 +174,18 @@ func runLive(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	cfg := LoadConfig(cwd)
 	key := liveSessionKey(cwd, origin)
 	if connectToLiveDaemon(key) {
 		return
 	}
 
 	// 3. Spawn daemon via _serve. startDaemon prepends "_serve" itself.
+	resolvedPort := resolvePort(*port, cfg.Port)
 	daemonArgs := []string{"--live-origin", origin}
+	if resolvedPort != 0 {
+		daemonArgs = append(daemonArgs, "--port", strconv.Itoa(resolvedPort))
+	}
 	entry, err := startDaemon(key, daemonArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start live daemon: %v\n", err)
@@ -204,4 +203,21 @@ func runLive(args []string) {
 
 	// 5. Block until review complete.
 	runReviewClient(entry)
+}
+
+func checkLiveSmoke(origin string) {
+	result := runSmokeTest(origin)
+	switch result.kind {
+	case smokeConnRefused, smokeNonHTML:
+		fmt.Fprintf(os.Stderr, "Error: %s\n", result.message)
+		os.Exit(1)
+	case smokeNon2xx, smokeMissingBody:
+		fmt.Fprintf(os.Stderr, "[crit] warning: %s\n", result.message)
+	}
+	if result.hasCSPFrameAncestors {
+		fmt.Fprintf(os.Stderr, "[crit] note: upstream has frame-ancestors CSP; stripped by proxy\n")
+	}
+	for _, n := range result.frameworkNotes {
+		fmt.Fprintf(os.Stderr, "[crit] note: %s\n", n)
+	}
 }

--- a/live.go
+++ b/live.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -145,6 +144,11 @@ func runLive(args []string) {
 	fs := flag.NewFlagSet("live", flag.ExitOnError)
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
+	host := fs.String("host", "", "Host to listen on")
+	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
+	quiet := fs.Bool("quiet", false, "Suppress status output")
+	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
+	shareURL := fs.String("share-url", "", "Share service URL")
 	fs.Parse(args)
 
 	rawURL := ""
@@ -181,11 +185,15 @@ func runLive(args []string) {
 	}
 
 	// 3. Spawn daemon via _serve. startDaemon prepends "_serve" itself.
-	resolvedPort := resolvePort(*port, cfg.Port)
+	noOpenResolved := *noOpen || cfg.NoOpen
 	daemonArgs := []string{"--live-origin", origin}
-	if resolvedPort != 0 {
-		daemonArgs = append(daemonArgs, "--port", strconv.Itoa(resolvedPort))
-	}
+	daemonArgs = appendCommonDaemonFlags(daemonArgs, commonDaemonFlags{
+		port:     resolvePort(*port, cfg.Port),
+		host:     resolveHost(*host, cfg.Host),
+		noOpen:   noOpenResolved,
+		quiet:    *quiet || cfg.Quiet,
+		shareURL: resolveShareURL(*shareURL, cfg, ""),
+	})
 	entry, err := startDaemon(key, daemonArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start live daemon: %v\n", err)
@@ -199,7 +207,9 @@ func runLive(args []string) {
 	installDaemonSignalHandler(entry.PID)
 
 	// 4. Open browser.
-	go openBrowser(fmt.Sprintf("http://localhost:%d/live", entry.Port))
+	if !noOpenResolved {
+		go openBrowser(fmt.Sprintf("http://localhost:%d/live", entry.Port))
+	}
 
 	// 5. Block until review complete.
 	runReviewClient(entry)

--- a/main.go
+++ b/main.go
@@ -1624,8 +1624,10 @@ type planConfig struct {
 	filePath      string
 	stdinExpected bool
 	port          int
+	host          string
 	noOpen        bool
 	quiet         bool
+	shareURL      string
 }
 
 func resolvePlanConfig(args []string) planConfig {
@@ -1633,16 +1635,20 @@ func resolvePlanConfig(args []string) planConfig {
 	name := fs.String("name", "", "Plan name/slug for session identification")
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
+	host := fs.String("host", "", "Host to listen on")
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
+	shareURL := fs.String("share-url", "", "Share service URL")
 	fs.Parse(args)
 
 	pc := planConfig{
-		name:   *name,
-		port:   *port,
-		noOpen: *noOpen,
-		quiet:  *quiet,
+		name:     *name,
+		port:     *port,
+		host:     *host,
+		noOpen:   *noOpen,
+		quiet:    *quiet,
+		shareURL: *shareURL,
 	}
 
 	remaining := fs.Args()
@@ -1819,7 +1825,14 @@ func runPlan(args []string) {
 	cwd, _ := resolvedCWD()
 	key := planSessionKey(cwd, slug)
 	currentPath := filepath.Join(storageDir, "current.md")
-	daemonArgs := buildPlanDaemonArgs(currentPath, storageDir, slug, pc.port, pc.noOpen, pc.quiet)
+	cfg := LoadConfig(cwd)
+	daemonArgs := buildPlanDaemonArgs(currentPath, storageDir, slug, commonDaemonFlags{
+		port:     resolvePort(pc.port, cfg.Port),
+		host:     resolveHost(pc.host, cfg.Host),
+		noOpen:   pc.noOpen || cfg.NoOpen,
+		quiet:    pc.quiet || cfg.Quiet,
+		shareURL: resolveShareURL(pc.shareURL, cfg, ""),
+	})
 
 	entry, weStartedDaemon := connectOrStartDaemon(key, daemonArgs, pc.noOpen)
 
@@ -1915,7 +1928,7 @@ func runPlanHook() {
 	cwd, _ := resolvedCWD()
 	key := planSessionKey(cwd, slug)
 	currentPath := filepath.Join(storageDir, "current.md")
-	daemonArgs := buildPlanDaemonArgs(currentPath, storageDir, slug, 0, false, false)
+	daemonArgs := buildPlanDaemonArgs(currentPath, storageDir, slug, commonDaemonFlags{})
 
 	entry, alive := findAliveSession(key)
 	weStartedDaemon := false

--- a/plans.go
+++ b/plans.go
@@ -90,17 +90,8 @@ func latestPlanVersion(dir string) int {
 	return max
 }
 
-func buildPlanDaemonArgs(currentPath, storageDir, slug string, port int, noOpen, quiet bool) []string {
-	var args []string
-	if port != 0 {
-		args = append(args, "--port", fmt.Sprintf("%d", port))
-	}
-	if noOpen {
-		args = append(args, "--no-open")
-	}
-	if quiet {
-		args = append(args, "--quiet")
-	}
+func buildPlanDaemonArgs(currentPath, storageDir, slug string, flags commonDaemonFlags) []string {
+	args := appendCommonDaemonFlags(nil, flags)
 	args = append(args, "--plan-dir", storageDir)
 	args = append(args, "--name", slug)
 	args = append(args, currentPath)

--- a/plans_test.go
+++ b/plans_test.go
@@ -225,7 +225,7 @@ func TestPlanSessionKey(t *testing.T) {
 }
 
 func TestBuildPlanDaemonArgs(t *testing.T) {
-	args := buildPlanDaemonArgs("/tmp/plans/auth-flow/current.md", "/tmp/plans/auth-flow", "auth-flow", 3000, false, false)
+	args := buildPlanDaemonArgs("/tmp/plans/auth-flow/current.md", "/tmp/plans/auth-flow", "auth-flow", commonDaemonFlags{port: 3000})
 
 	found := false
 	for _, a := range args {

--- a/preview.go
+++ b/preview.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -183,6 +184,8 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 func runPreview(args []string) {
 	fs := flag.NewFlagSet("preview", flag.ExitOnError)
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
+	port := fs.Int("port", 0, "Port to listen on")
+	fs.IntVar(port, "p", 0, "Port (shorthand)")
 	fs.Parse(args)
 
 	remaining := fs.Args()
@@ -227,7 +230,11 @@ func runPreview(args []string) {
 		return
 	}
 
+	resolvedPort := resolvePort(*port, cfg.Port)
 	daemonArgs := []string{"--preview-file", absPath}
+	if resolvedPort != 0 {
+		daemonArgs = append(daemonArgs, "--port", strconv.Itoa(resolvedPort))
+	}
 	entry, err := startDaemon(key, daemonArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start preview daemon: %v\n", err)

--- a/preview.go
+++ b/preview.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -186,6 +185,10 @@ func runPreview(args []string) {
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
+	host := fs.String("host", "", "Host to listen on")
+	quiet := fs.Bool("quiet", false, "Suppress status output")
+	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
+	shareURL := fs.String("share-url", "", "Share service URL")
 	fs.Parse(args)
 
 	remaining := fs.Args()
@@ -230,11 +233,13 @@ func runPreview(args []string) {
 		return
 	}
 
-	resolvedPort := resolvePort(*port, cfg.Port)
 	daemonArgs := []string{"--preview-file", absPath}
-	if resolvedPort != 0 {
-		daemonArgs = append(daemonArgs, "--port", strconv.Itoa(resolvedPort))
-	}
+	daemonArgs = appendCommonDaemonFlags(daemonArgs, commonDaemonFlags{
+		port:     resolvePort(*port, cfg.Port),
+		host:     resolveHost(*host, cfg.Host),
+		quiet:    *quiet || cfg.Quiet,
+		shareURL: resolveShareURL(*shareURL, cfg, ""),
+	})
 	entry, err := startDaemon(key, daemonArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start preview daemon: %v\n", err)


### PR DESCRIPTION
## Summary
- `crit preview`, `crit live`, and `crit plan` silently ignored several CLI flags that work in `crit` (review mode) — only env vars and config file values were forwarded to the daemon
- Adds `--port`/`-p`, `--host`, `--quiet`/`-q`, `--share-url`, and `--no-open` flag parsing to preview and live modes
- Adds `--host` and `--share-url` to plan mode (already had `--port`, `--no-open`, `--quiet`)
- Introduces `commonDaemonFlags` + `appendCommonDaemonFlags` helper to centralize flag→daemon forwarding across all 3 modes
- Extracts `checkLiveSmoke()` to stay under gocyclo threshold
- Adds `--no-open` support to live mode (previously always opened browser)

| Flag | review | plan | preview | live |
|------|--------|------|---------|------|
| `--port` | ✓ | ✓ was flag-only | **✓ new** | **✓ new** |
| `--host` | ✓ | **✓ new** | **✓ new** | **✓ new** |
| `--no-open` | ✓ | ✓ | ✓ was local | **✓ new** |
| `--quiet` | ✓ | ✓ was flag-only | **✓ new** | **✓ new** |
| `--share-url` | ✓ | **✓ new** | **✓ new** | **✓ new** |

## Test plan
- [x] `go test -race -count=1 ./...` passes
- [x] golangci-lint clean
- [x] Pre-commit hooks pass
- [x] New table-driven test for `appendCommonDaemonFlags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)