### PR TITLE
fix: forward noOpen flag to preview daemon, fix stale env var in tests

### DIFF
--- a/daemon_test.go
+++ b/daemon_test.go
@@ -816,23 +816,23 @@ func TestReadDaemonLog(t *testing.T) {
 }
 
 func TestOpenReadyPipe_NoEnvVar(t *testing.T) {
-	t.Setenv("_CRIT_READY_FD", "")
-	os.Unsetenv("_CRIT_READY_FD")
+	t.Setenv("_CRIT_READY_STDOUT", "")
+	os.Unsetenv("_CRIT_READY_STDOUT")
 
 	pipe := openReadyPipe()
 	if pipe != nil {
 		pipe.Close()
-		t.Error("expected nil when _CRIT_READY_FD is not set")
+		t.Error("expected nil when _CRIT_READY_STDOUT is not set")
 	}
 }
 
 func TestOpenReadyPipe_WrongValue(t *testing.T) {
-	t.Setenv("_CRIT_READY_FD", "99")
+	t.Setenv("_CRIT_READY_STDOUT", "99")
 
 	pipe := openReadyPipe()
 	if pipe != nil {
 		pipe.Close()
-		t.Error("expected nil when _CRIT_READY_FD is not 3")
+		t.Error("expected nil when _CRIT_READY_STDOUT is not 3")
 	}
 }
 

--- a/preview.go
+++ b/preview.go
@@ -207,9 +207,7 @@ func runPreview(args []string) {
 		os.Exit(1)
 	}
 	cfg := LoadConfig(cwd)
-	if cfg.NoOpen {
-		*noOpen = true
-	}
+	noOpenResolved := *noOpen || cfg.NoOpen
 
 	if rawPath == "" {
 		fmt.Fprintln(os.Stderr, "Usage: crit preview <file.html>")
@@ -229,7 +227,7 @@ func runPreview(args []string) {
 	}
 
 	key := previewSessionKey(cwd, absPath)
-	if connectToPreviewDaemon(key, *noOpen) {
+	if connectToPreviewDaemon(key, noOpenResolved) {
 		return
 	}
 
@@ -237,6 +235,7 @@ func runPreview(args []string) {
 	daemonArgs = appendCommonDaemonFlags(daemonArgs, commonDaemonFlags{
 		port:     resolvePort(*port, cfg.Port),
 		host:     resolveHost(*host, cfg.Host),
+		noOpen:   noOpenResolved,
 		quiet:    *quiet || cfg.Quiet,
 		shareURL: resolveShareURL(*shareURL, cfg, ""),
 	})
@@ -251,7 +250,7 @@ func runPreview(args []string) {
 
 	installDaemonSignalHandler(entry.PID)
 
-	if !*noOpen {
+	if !noOpenResolved {
 		go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
 	}
 


### PR DESCRIPTION
## Summary
- `preview.go` omitted `noOpen` from `commonDaemonFlags`, so `crit preview --no-open`
  still opened a browser tab from the daemon side. Applied the same `noOpenResolved`
  pattern used by `live.go` and `main.go`.
- `daemon_test.go`: `TestOpenReadyPipe_NoEnvVar` and `TestOpenReadyPipe_WrongValue`
  referenced `_CRIT_READY_FD` but production code checks `_CRIT_READY_STDOUT`. Tests
  passed accidentally. Fixed to use the correct env var.

## Review
- [x] Code review: passed (release audit + post-fix review)
- [x] Pre-commit checks: gofmt, golangci-lint, go test, eslint, stylelint

## Test plan
- `go test -race ./...` — all passing
- `golangci-lint run ./...` — 0 issues
- `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)