### PR TITLE
fix: restore marker badges and add click-to-scroll for live-mode comments

### DIFF
--- a/frontend/__tests__/agent-marker-overlay.test.js
+++ b/frontend/__tests__/agent-marker-overlay.test.js
@@ -148,14 +148,15 @@ test('applyRects hides marker when target is disconnected from DOM', () => {
   assert.equal(m.el.style.display, 'none');
 });
 
-test('applyRects hides marker when target has zero-size rect (detached element)', () => {
+test('applyRects positions marker when target is connected with zero-size rect', () => {
   const target = {
     isConnected: true,
     getBoundingClientRect: () => ({ left: 0, top: 0, width: 0, height: 0 }),
   };
   const m = { target, el: { style: {} } };
   overlay.applyRects([m]);
-  assert.equal(m.el.style.display, 'none');
+  assert.equal(m.el.style.display, '');
+  assert.equal(m.el.style.transform, 'translate(0px, 0px)');
 });
 
 test('applyRects shows marker when target is connected with non-zero rect', () => {

--- a/frontend/agent-marker-overlay.js
+++ b/frontend/agent-marker-overlay.js
@@ -80,9 +80,7 @@
     const reads = markers.map(m => {
       if (!m.target) return null;
       if (typeof m.target.isConnected !== 'undefined' && !m.target.isConnected) return null;
-      const rect = m.target.getBoundingClientRect();
-      if (rect.width === 0 && rect.height === 0) return null;
-      return rect;
+      return m.target.getBoundingClientRect();
     });
     for (let i = 0; i < markers.length; i++) {
       const m = markers[i];

--- a/frontend/crit-agent.js
+++ b/frontend/crit-agent.js
@@ -248,6 +248,7 @@
     try {
       var el = document.querySelector(selector);
       if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       el.classList.add('crit-live-pending-highlight');
       state._pendingHighlightEl = el;
       // Suppress the dashed hover overlay while the user is composing —

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -608,6 +608,9 @@
   registerInstaller(function installCommentsPanelResize() {
     if (panelCtl) panelCtl.installCommentsPanelResize();
   });
+  registerInstaller(function installPanelCardRendererClick() {
+    if (panelCtl) panelCtl.installPanelCardRendererClick();
+  });
 
 
   function startLiveTipRotation() {

--- a/frontend/live-mode.panel-render.js
+++ b/frontend/live-mode.panel-render.js
@@ -545,21 +545,25 @@
     // Navigate to comment via ContentRenderer interface. Validates that
     // scrollToAnchor + highlightAnchor work for live-mode pins when a
     // comment card is clicked in the panel.
+    var _highlightTimer = null;
     function navigateToCommentViaRenderer(comment) {
       var renderer = window.crit && window.crit.renderer && window.crit.renderer.current();
       if (!renderer) return;
+      if (_highlightTimer) { clearTimeout(_highlightTimer); _highlightTimer = null; }
       var anchor = window.crit.renderer.anchorFromComment(comment);
       renderer.scrollToAnchor(anchor).then(function () {
         renderer.highlightAnchor(anchor);
-        setTimeout(function () { renderer.clearHighlight(); }, 1000);
+        _highlightTimer = setTimeout(function () {
+          renderer.clearHighlight();
+          _highlightTimer = null;
+        }, 1000);
       });
     }
 
-    // Delegated click listener on panelBody — when a comment card is
-    // clicked, invoke the ContentRenderer scroll+highlight alongside the
-    // existing route-navigation handled by live-mode.js.
+    var _cardClickInstalled = false;
     function installPanelCardRendererClick() {
-      if (!els.panelBody) return;
+      if (!els.panelBody || _cardClickInstalled) return;
+      _cardClickInstalled = true;
       els.panelBody.addEventListener('click', function (e) {
         // Don't interfere with interactive controls
         if (e.target.closest && e.target.closest('button, a, input, textarea')) return;

--- a/frontend/live-mode.panel-render.js
+++ b/frontend/live-mode.panel-render.js
@@ -551,6 +551,7 @@
       var anchor = window.crit.renderer.anchorFromComment(comment);
       renderer.scrollToAnchor(anchor).then(function () {
         renderer.highlightAnchor(anchor);
+        setTimeout(function () { renderer.clearHighlight(); }, 1000);
       });
     }
 


### PR DESCRIPTION
## Summary
- Remove the overly aggressive zero-size rect check from `applyRects` that hid marker badges for connected elements with temporarily zero dimensions (regression from #573)
- Wire up the existing but uncalled `installPanelCardRendererClick` so clicking a comment in the panel scrolls the iframe to the pinned element with a 1s highlight
- Guard the highlight timer against rapid clicks (cancel pending timeout before starting new one)
- Add install guard to prevent duplicate delegated click listeners on panel re-init

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit/-only live-mode files, no crit-web counterpart)

## Test plan
- All 13 marker overlay unit tests pass (updated zero-size test to expect positioning instead of hiding)
- Manually verified: fresh comments show badges, clicking comment in panel scrolls iframe to pin, highlight auto-clears after 1s
- Pre-commit: gofmt, golangci-lint, go test, ESLint, Stylelint, CSS var check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)