### PR TITLE
fix: preserve URL path in live mode

### DIFF
--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -320,6 +320,16 @@
       setDocumentTitle('Crit — ' + (state.session.origin || 'live'));
     }
 
+    // Extract initial route from the origin URL path (e.g.
+    // "http://localhost:3333/live.html" → "/live.html") so the iframe
+    // loads the correct page instead of always requesting "/".
+    if (!state.isPreview && state.session.origin) {
+      try {
+        var originPath = new URL(state.session.origin).pathname;
+        if (originPath && originPath !== '/') state.currentRoute = originPath;
+      } catch (_) { /* malformed origin — keep default "/" */ }
+    }
+
     // Capture proxyOrigin once for the message handler. The agent
     // posts from the proxy origin; the chrome lives on the API origin and
     // accepts only that source+origin pair.

--- a/live.go
+++ b/live.go
@@ -167,7 +167,11 @@ func runLive(args []string) {
 		fmt.Fprintf(os.Stderr, "crit live: %q is not a valid http/https URL\n", rawURL)
 		os.Exit(1)
 	}
-	origin := u.Scheme + "://" + u.Host
+	// Preserve the full URL including path so the frontend can load the
+	// correct page (e.g. http://localhost:3333/live.html, not just /).
+	u.RawQuery = ""
+	u.Fragment = ""
+	origin := strings.TrimSuffix(u.String(), "/")
 
 	// 1. Smoke test.
 	checkLiveSmoke(origin)

--- a/proxy.go
+++ b/proxy.go
@@ -18,7 +18,8 @@ import (
 )
 
 // newLiveProxy builds a reverse proxy for a live-mode session.
-// upstreamOrigin is the target scheme+host+port (e.g. "http://localhost:3000").
+// upstreamOrigin is the target URL, optionally including a path prefix
+// (e.g. "http://localhost:3000" or "http://localhost:3333/live.html").
 // apiPort is the API server's port, used to construct the agent script URL.
 func newLiveProxy(upstreamOrigin string, apiPort int) (http.Handler, error) {
 	target, err := url.Parse(upstreamOrigin)


### PR DESCRIPTION
## Summary
- `crit http://localhost:3333/live.html` was stripping the path, always loading "/" in the iframe (showing directory listing)
- Now preserves the full URL path as the origin and uses it as the initial iframe route

## Review
- [x] Code review: passed (Go + frontend, no blockers)
- [x] Intent audit: clean

## Test plan
- Pre-commit: gofmt, golangci-lint, go test, ESLint, Stylelint all pass
- Manual: `crit http://localhost:3333/live.html` loads the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)