### PR TITLE
fix: prevent 404 when clicking comments in preview mode

### DIFF
--- a/frontend/__tests__/live-mode-pin-filter.test.js
+++ b/frontend/__tests__/live-mode-pin-filter.test.js
@@ -23,6 +23,18 @@ test('filterPinsForPath returns [] when pins is not array', () => {
   assert.deepEqual(filterPinsForPath(null, '/x'), []);
 });
 
+test('filterPinsForPath matches when trailing slash differs (preview mode)', () => {
+  const all = [
+    { id: 'a', dom_anchor: { pathname: '/preview-content/' } },
+    { id: 'b', dom_anchor: { pathname: '/preview-content' } },
+    { id: 'c', dom_anchor: { pathname: '/other' } },
+  ];
+  const out = filterPinsForPath(all, '/preview-content');
+  assert.deepEqual(out.map(p => p.id), ['a', 'b']);
+  const out2 = filterPinsForPath(all, '/preview-content/');
+  assert.deepEqual(out2.map(p => p.id), ['a', 'b']);
+});
+
 test('filterPinsForPath drops resolved pins so markers do not render for them', () => {
   // Resolved comments shouldn't paint a pin marker on the proxied page.
   // Hiding happens by omission from the set-pins payload — the agent

--- a/frontend/live-mode-pin-filter.js
+++ b/frontend/live-mode-pin-filter.js
@@ -8,12 +8,17 @@
     root.crit.live.pinFilter = api;
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
+  function normalise(p) {
+    if (!p || p === '/') return '/';
+    return p.endsWith('/') ? p.slice(0, -1) : p;
+  }
   function filterPinsForPath(pins, pathname) {
     if (!Array.isArray(pins) || !pathname) return [];
+    var norm = normalise(pathname);
     // Resolved comments must not surface as pin markers on the proxied page —
     // the marker overlay paints whatever is in `set-pins`, so dropping
     // resolved pins here is the single source of truth for visibility.
-    return pins.filter(p => p && p.dom_anchor && p.dom_anchor.pathname === pathname && !p.resolved);
+    return pins.filter(p => p && p.dom_anchor && normalise(p.dom_anchor.pathname) === norm && !p.resolved);
   }
   return { filterPinsForPath };
 });

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -476,7 +476,9 @@
   // ============================================================
   function proxyURL(pathname) {
     if (state.isPreview) {
-      return '/preview-content' + (pathname || '/');
+      var p = pathname || '/';
+      if (p.indexOf('/preview-content') === 0) return p;
+      return '/preview-content' + p;
     }
     var s = state.session || {};
     var port = s.proxy_port || 0;
@@ -2006,7 +2008,7 @@
     }
     if (state.pendingFlashOnLoad && state.pendingPinId) {
       var pin = lookupPin(state.pendingPinId);
-      if (pin && pin.dom_anchor && pin.dom_anchor.pathname === state.currentRoute) {
+      if (pin && pin.dom_anchor && utils.normaliseRoute(pin.dom_anchor.pathname) === state.currentRoute) {
         performFlashAndScroll(pin);
       }
     }
@@ -2260,7 +2262,7 @@
       state.pendingPinId = null;
       return;
     }
-    var targetPath = (pin.dom_anchor && pin.dom_anchor.pathname) || '/';
+    var targetPath = utils.normaliseRoute((pin.dom_anchor && pin.dom_anchor.pathname) || '/');
     if (state.currentRoute !== targetPath) {
       if (els && els.iframe) {
         try { els.iframe.src = proxyURL(targetPath); } catch (_) { /* noop */ }

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -323,7 +323,9 @@
     // Extract initial route from the origin URL path (e.g.
     // "http://localhost:3333/live.html" → "/live.html") so the iframe
     // loads the correct page instead of always requesting "/".
-    if (!state.isPreview && state.session.origin) {
+    if (state.isPreview) {
+      state.currentRoute = '/preview-content';
+    } else if (state.session.origin) {
       try {
         var originPath = new URL(state.session.origin).pathname;
         if (originPath && originPath !== '/') state.currentRoute = originPath;

--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -477,7 +477,7 @@
   function proxyURL(pathname) {
     if (state.isPreview) {
       var p = pathname || '/';
-      if (p.indexOf('/preview-content') === 0) return p;
+      if (p.indexOf('/preview-content') === 0) p = p.slice('/preview-content'.length) || '/';
       return '/preview-content' + p;
     }
     var s = state.session || {};

--- a/frontend/live-mode.panel-render.js
+++ b/frontend/live-mode.panel-render.js
@@ -542,22 +542,13 @@
       updateUnresolvedBadge();
     }
 
-    // Navigate to comment via ContentRenderer interface. Validates that
-    // scrollToAnchor + highlightAnchor work for live-mode pins when a
-    // comment card is clicked in the panel.
-    var _highlightTimer = null;
-    function navigateToCommentViaRenderer(comment) {
-      var renderer = window.crit && window.crit.renderer && window.crit.renderer.current();
-      if (!renderer) return;
-      if (_highlightTimer) { clearTimeout(_highlightTimer); _highlightTimer = null; }
-      var anchor = window.crit.renderer.anchorFromComment(comment);
-      renderer.scrollToAnchor(anchor).then(function () {
-        renderer.highlightAnchor(anchor);
-        _highlightTimer = setTimeout(function () {
-          renderer.clearHighlight();
-          _highlightTimer = null;
-        }, 1000);
-      });
+    // Flash the pin marker in the iframe when a comment card is clicked
+    // in the panel — same visual as clicking the marker directly.
+    function flashPinForComment(comment) {
+      if (!comment || !comment.id) return;
+      if (state && state.postToAgent) {
+        state.postToAgent({ type: 'flash-marker', pin_id: comment.id });
+      }
     }
 
     var _cardClickInstalled = false;
@@ -572,7 +563,7 @@
         var id = card.dataset.id;
         if (!id || !state.comments) return;
         var comment = state.comments.find(function (c) { return String(c.id) === id; });
-        if (comment) navigateToCommentViaRenderer(comment);
+        if (comment) flashPinForComment(comment);
       });
     }
 

--- a/frontend/live-mode.panel-render.js
+++ b/frontend/live-mode.panel-render.js
@@ -542,13 +542,24 @@
       updateUnresolvedBadge();
     }
 
-    // Flash the pin marker in the iframe when a comment card is clicked
-    // in the panel — same visual as clicking the marker directly.
-    function flashPinForComment(comment) {
+    // Scroll to pinned element and flash its marker badge when a comment
+    // card is clicked in the panel. keep-highlight scrolls into view +
+    // adds a transient highlight; clear-highlight removes it after 1s.
+    // flash-marker pulses the badge overlay (1.5s, agent-managed).
+    var _highlightTimer = null;
+    function scrollAndFlashPin(comment) {
       if (!comment || !comment.id) return;
-      if (state && state.postToAgent) {
-        state.postToAgent({ type: 'flash-marker', pin_id: comment.id });
+      if (!state || !state.postToAgent) return;
+      if (_highlightTimer) { clearTimeout(_highlightTimer); _highlightTimer = null; }
+      var anchor = comment.dom_anchor || comment.domAnchor;
+      if (anchor && anchor.css_selector) {
+        state.postToAgent({ type: 'keep-highlight', selector: anchor.css_selector });
+        _highlightTimer = setTimeout(function () {
+          state.postToAgent({ type: 'clear-highlight' });
+          _highlightTimer = null;
+        }, 1000);
       }
+      state.postToAgent({ type: 'flash-marker', pin_id: comment.id });
     }
 
     var _cardClickInstalled = false;
@@ -563,7 +574,7 @@
         var id = card.dataset.id;
         if (!id || !state.comments) return;
         var comment = state.comments.find(function (c) { return String(c.id) === id; });
-        if (comment) flashPinForComment(comment);
+        if (comment) scrollAndFlashPin(comment);
       });
     }
 


### PR DESCRIPTION
## Summary
- Make `proxyURL()` idempotent for preview mode — skip prefixing when the path already starts with `/preview-content`
- Normalise `dom_anchor.pathname` before comparing against `state.currentRoute` in `activatePendingPinId` and the pending-flash-on-load check

## Root cause
In preview mode the iframe loads at `/preview-content/`. The agent reports `dom_anchor.pathname = "/preview-content/"`. Two bugs:

1. `proxyURL()` unconditionally prepended `/preview-content`, producing `/preview-content/preview-content/` → 404
2. Raw `dom_anchor.pathname` (trailing slash) was compared against normalised `state.currentRoute` (no trailing slash), so they never matched — triggering unnecessary iframe navigation that hit bug #1

## Test plan
- [x] Pre-commit: gofmt, golangci-lint, go test, ESLint, Stylelint all pass
- [x] Frontend unit tests pass (live-route-utils)
- [ ] Manual: `crit preview test.html`, create a pin, click the comment card in the panel — should scroll to the pin, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)