### PR TITLE
fix: open comments panel when starting a pin comment

### DIFF
--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -1705,6 +1705,12 @@
       showToast('selection too large to save');
       return;
     }
+    if (!state.commentsPanelOpen && panelCtl) {
+      panelCtl.applyCommentsPanelOpen(true);
+      if (shared && shared.setSetting) {
+        try { shared.setSetting('live_commentsPanelOpen', true); } catch (_) {}
+      }
+    }
     var host = ensureComposerHost();
     host.innerHTML = window.crit.live.composer.renderComposerHTML(domAnchor);
     host.dataset.active = '1';


### PR DESCRIPTION
## Summary
- When the comments panel is closed in live/preview mode and the user clicks to place a pin, the composer form was created inside the hidden panel — invisible to the user
- Now auto-opens the panel (and persists the preference) before mounting the composer

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (live-mode.js is crit-only)

## Test plan
- Open live mode, close comments panel, switch to pin mode, click an element — panel opens with composer visible
- Verify preference persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)