### PR TITLE
fix(watch): rescan CLI dir args between rounds so files created by the agent appear in the UI

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -503,6 +503,110 @@ func (s *Session) handleRoundCompleteGit() {
 	s.finishRoundComplete(edits)
 }
 
+// refreshFilesFromCLIDirs re-walks the original CLI arguments and appends any
+// newly-discovered files to s.Files. Mirrors the construction loop in
+// NewSessionFromFiles so file-mode picks up files created by the agent between
+// rounds without requiring a daemon restart.
+//
+// Discovery only — does not remove entries for files that disappeared. See the
+// "Out of scope" note in the originating bug brief for the deletion-handling
+// rationale.
+//
+// Must only be called from the single watcher goroutine (watchFileMtimes), so
+// the read-snapshot / write-append sequence cannot interleave with another
+// round-complete handler.
+func (s *Session) refreshFilesFromCLIDirs() {
+	s.mu.RLock()
+	mode := s.Mode
+	cliArgs := append([]string(nil), s.CLIArgs...)
+	ignorePatterns := append([]string(nil), s.IgnorePatterns...)
+	repoRoot := s.RepoRoot
+	baseRef := s.BaseRef
+	vcs := s.VCS
+	existing := make(map[string]struct{}, len(s.Files))
+	for _, f := range s.Files {
+		existing[f.AbsPath] = struct{}{}
+	}
+	s.mu.RUnlock()
+
+	if mode != "files" || len(cliArgs) == 0 {
+		return
+	}
+
+	expandedPaths, err := expandAndDedupPaths(cliArgs, ignorePatterns)
+	if err != nil {
+		// Best-effort: a missing or unreadable CLI arg between rounds (e.g.
+		// the user deleted a watched dir) shouldn't abort the round.
+		return
+	}
+
+	var newFiles []*FileEntry
+	for _, absPath := range expandedPaths {
+		if _, ok := existing[absPath]; ok {
+			continue
+		}
+
+		relPath := absPath
+		if repoRoot != "" {
+			if rel, relErr := filepath.Rel(repoRoot, absPath); relErr == nil {
+				slash := filepath.ToSlash(rel)
+				if strings.HasPrefix(slash, "../") || slash == ".." {
+					relPath = filepath.ToSlash(absPath)
+				} else {
+					relPath = slash
+				}
+			}
+		}
+
+		data, readErr := os.ReadFile(absPath)
+		if readErr != nil {
+			continue
+		}
+
+		fe := &FileEntry{
+			Path:      relPath,
+			AbsPath:   absPath,
+			Status:    "modified",
+			FileType:  detectFileType(absPath),
+			Content:   string(data),
+			FileHash:  fileHash(data),
+			Comments:  []Comment{},
+			Generated: isGenerated(relPath, s.generatedRules),
+		}
+
+		if vcs != nil {
+			hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, repoRoot)
+			if diffErr == nil {
+				fe.DiffHunks = hunks
+			}
+		}
+
+		newFiles = append(newFiles, fe)
+	}
+
+	if len(newFiles) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	// Re-check membership under the write lock: another writer (or this same
+	// helper from a future round) could have appended the same path between
+	// our RLock snapshot and now. Cheap O(n) over s.Files — file lists in
+	// files-mode are small.
+	have := make(map[string]struct{}, len(s.Files))
+	for _, f := range s.Files {
+		have[f.AbsPath] = struct{}{}
+	}
+	for _, fe := range newFiles {
+		if _, ok := have[fe.AbsPath]; ok {
+			continue
+		}
+		s.Files = append(s.Files, fe)
+		have[fe.AbsPath] = struct{}{}
+	}
+	s.mu.Unlock()
+}
+
 // handleRoundCompleteFiles handles round completion in files mode.
 // Re-reads files, carries forward unresolved comments.
 // Must only be called from the single watcher goroutine (watchFileMtimes).
@@ -510,6 +614,11 @@ func (s *Session) handleRoundCompleteFiles() {
 	s.mu.RLock()
 	edits := s.lastRoundEdits
 	s.mu.RUnlock()
+
+	// Pick up files the agent created inside watched CLI dir args before
+	// re-reading existing contents, so the new files participate in the
+	// rest of the round-complete pipeline (snapshot capture, SSE notify).
+	s.refreshFilesFromCLIDirs()
 
 	s.loadResolvedComments()
 	s.carryForwardComments()

--- a/watch.go
+++ b/watch.go
@@ -503,6 +503,54 @@ func (s *Session) handleRoundCompleteGit() {
 	s.finishRoundComplete(edits)
 }
 
+// relPathFromRoot returns a slash-separated path relative to repoRoot, falling
+// back to the absolute path when the result would escape the root.
+func relPathFromRoot(absPath, repoRoot string) string {
+	if repoRoot == "" {
+		return absPath
+	}
+	rel, err := filepath.Rel(repoRoot, absPath)
+	if err != nil {
+		return filepath.ToSlash(absPath)
+	}
+	slash := filepath.ToSlash(rel)
+	if strings.HasPrefix(slash, "../") || slash == ".." {
+		return filepath.ToSlash(absPath)
+	}
+	return slash
+}
+
+// buildFileEntry reads absPath from disk and constructs a FileEntry suitable
+// for appending to s.Files. Returns nil if the file cannot be read.
+func (s *Session) buildFileEntry(absPath, repoRoot, baseRef string, vcs VCS) *FileEntry {
+	relPath := relPathFromRoot(absPath, repoRoot)
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil
+	}
+
+	fe := &FileEntry{
+		Path:      relPath,
+		AbsPath:   absPath,
+		Status:    "modified",
+		FileType:  detectFileType(absPath),
+		Content:   string(data),
+		FileHash:  fileHash(data),
+		Comments:  []Comment{},
+		Generated: isGenerated(relPath, s.generatedRules),
+	}
+
+	if vcs != nil {
+		hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, repoRoot)
+		if diffErr == nil {
+			fe.DiffHunks = hunks
+		}
+	}
+
+	return fe
+}
+
 // refreshFilesFromCLIDirs re-walks the original CLI arguments and appends any
 // newly-discovered files to s.Files. Mirrors the construction loop in
 // NewSessionFromFiles so file-mode picks up files created by the agent between
@@ -535,8 +583,6 @@ func (s *Session) refreshFilesFromCLIDirs() {
 
 	expandedPaths, err := expandAndDedupPaths(cliArgs, ignorePatterns)
 	if err != nil {
-		// Best-effort: a missing or unreadable CLI arg between rounds (e.g.
-		// the user deleted a watched dir) shouldn't abort the round.
 		return
 	}
 
@@ -545,43 +591,9 @@ func (s *Session) refreshFilesFromCLIDirs() {
 		if _, ok := existing[absPath]; ok {
 			continue
 		}
-
-		relPath := absPath
-		if repoRoot != "" {
-			if rel, relErr := filepath.Rel(repoRoot, absPath); relErr == nil {
-				slash := filepath.ToSlash(rel)
-				if strings.HasPrefix(slash, "../") || slash == ".." {
-					relPath = filepath.ToSlash(absPath)
-				} else {
-					relPath = slash
-				}
-			}
+		if fe := s.buildFileEntry(absPath, repoRoot, baseRef, vcs); fe != nil {
+			newFiles = append(newFiles, fe)
 		}
-
-		data, readErr := os.ReadFile(absPath)
-		if readErr != nil {
-			continue
-		}
-
-		fe := &FileEntry{
-			Path:      relPath,
-			AbsPath:   absPath,
-			Status:    "modified",
-			FileType:  detectFileType(absPath),
-			Content:   string(data),
-			FileHash:  fileHash(data),
-			Comments:  []Comment{},
-			Generated: isGenerated(relPath, s.generatedRules),
-		}
-
-		if vcs != nil {
-			hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, repoRoot)
-			if diffErr == nil {
-				fe.DiffHunks = hunks
-			}
-		}
-
-		newFiles = append(newFiles, fe)
 	}
 
 	if len(newFiles) == 0 {
@@ -589,10 +601,6 @@ func (s *Session) refreshFilesFromCLIDirs() {
 	}
 
 	s.mu.Lock()
-	// Re-check membership under the write lock: another writer (or this same
-	// helper from a future round) could have appended the same path between
-	// our RLock snapshot and now. Cheap O(n) over s.Files — file lists in
-	// files-mode are small.
 	have := make(map[string]struct{}, len(s.Files))
 	for _, f := range s.Files {
 		have[f.AbsPath] = struct{}{}

--- a/watch_test.go
+++ b/watch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -1553,4 +1554,125 @@ func TestOnLiveRoundStart_OnlyForLiveAndPreviewReviews(t *testing.T) {
 	if s3.ReviewRound != 2 {
 		t.Fatalf("ReviewRound = %d, want 2", s3.ReviewRound)
 	}
+}
+
+// TestHandleRoundCompleteFiles_DiscoversNewFiles is the regression for the
+// bug brief: in files mode, when the agent creates a new file inside a
+// CLI-arg directory between rounds, that file must appear in the session
+// (and in the /api/session response) once the round completes — without a
+// daemon restart.
+//
+// Drives the scenario through the HTTP surface end-to-end:
+//  1. Build a session over a temp dir as the CLI arg.
+//  2. Attach a real Server and start the file watcher goroutine.
+//  3. Write a new file into the watched dir.
+//  4. POST /api/round-complete (same path the agent hits via SignalRoundComplete).
+//  5. Poll GET /api/session until the new file appears.
+func TestHandleRoundCompleteFiles_DiscoversNewFiles(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, t.TempDir())
+
+	// Run from the temp dir so resolveGitContext() (called inside
+	// NewSessionFromFiles) doesn't pick up the surrounding crit repo's VCS,
+	// which would set RepoRoot to crit's root and turn paths like
+	// /tmp/.../existing.md into absolute-path Rel() fallbacks.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	watched := filepath.Join(tmp, "review_target")
+	if err := os.MkdirAll(watched, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existingPath := filepath.Join(watched, "existing.md")
+	writeFile(t, existingPath, "# pre-existing\n")
+
+	session, err := NewSessionFromFiles([]string{watched}, nil)
+	if err != nil {
+		t.Fatalf("NewSessionFromFiles: %v", err)
+	}
+	session.CLIArgs = []string{watched}
+	// Pin review-file identity to the temp HOME so sidecar writes during
+	// round-complete don't litter ~/.crit during tests.
+	session.ReviewFilePath = filepath.Join(tmp, ".crit-review")
+
+	srv, err := NewServer(session, frontendFS, "", false, "", "tester", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetSession(session)
+	t.Cleanup(func() { quiesceSession(t, session) })
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go session.watchFileMtimes(stop)
+
+	// Sanity: the existing file is present before any round-complete.
+	if names := sessionFilePaths(t, srv); !containsString(names, "existing.md") {
+		t.Fatalf("pre-condition: existing.md missing from /api/session, got %v", names)
+	}
+	newFile := "new_from_agent.md"
+	if containsString(sessionFilePaths(t, srv), newFile) {
+		t.Fatalf("pre-condition: %s should not be in session before it's written", newFile)
+	}
+
+	// Agent action: create a new file inside the watched dir.
+	writeFile(t, filepath.Join(watched, newFile), "# brand new\n")
+
+	// Trigger the round-complete transition the agent uses.
+	req := httptest.NewRequest("POST", "/api/round-complete", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("/api/round-complete status = %d, want 200", w.Code)
+	}
+
+	// Round-complete runs on the watcher goroutine; poll the session API
+	// until the new file appears (or we time out). 3s is plenty — the
+	// handler is in-process file I/O, no network.
+	deadline := time.Now().Add(3 * time.Second)
+	var lastPaths []string
+	for time.Now().Before(deadline) {
+		lastPaths = sessionFilePaths(t, srv)
+		if containsString(lastPaths, newFile) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("expected %s to appear in /api/session after round-complete; got %v", newFile, lastPaths)
+}
+
+// sessionFilePaths issues GET /api/session and returns the list of file paths
+// from the response. Test helper.
+func sessionFilePaths(t *testing.T, srv *Server) []string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/session", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("GET /api/session status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp SessionInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal /api/session: %v", err)
+	}
+	out := make([]string, 0, len(resp.Files))
+	for _, f := range resp.Files {
+		out = append(out, f.Path)
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Files mode walked watched dirs only once at session construction. Files an agent created inside a CLI-arg dir between rounds were invisible until the daemon was restarted (git mode already rescans via `RefreshFileList` in `handleRoundCompleteGit`) <-- This is a common workflow of mine that I prompting in the comments about certain paragraph to be a separate file instead of a section. 
- Add `refreshFilesFromCLIDirs` in `watch.go`: re-runs `expandAndDedupPaths(s.CLIArgs, s.IgnorePatterns)`, diffs against existing `s.Files` by `AbsPath`, and appends new `FileEntry`s mirroring the construction loop in `NewSessionFromFiles`.
- Call it from `handleRoundCompleteFiles` before `rereadFileContents` so newly-discovered files participate in snapshot capture and SSE notification.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] `go test -race -run TestHandleRoundCompleteFiles_DiscoversNewFiles` — race-clean
- [x] Regression test (`TestHandleRoundCompleteFiles_DiscoversNewFiles`) fails when the new `refreshFilesFromCLIDirs` call is commented out, passes when it's in
- [ ] Manual: `crit ./some-dir/`, have an agent create a new file inside, hit Finish Review, confirm the new file appears in the UI without restarting the daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)