### PR TITLE
fix: next_command for live/preview modes includes subcommand prefix

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -348,7 +348,7 @@ func createLiveSession(sc *serverConfig) (*Session, error) {
 		ReviewRound: 1,
 		ReviewType:  "live",
 		Origin:      sc.liveOrigin,
-		CLIArgs:     []string{sc.liveOrigin},
+		CLIArgs:     []string{"live", sc.liveOrigin},
 		// awaitingFirstReview must be true so the daemon-client's first
 		// /api/review-cycle call does NOT fire SignalRoundComplete at boot.
 		// Without this gate the watcher bumps ReviewRound from 1 to 2 before
@@ -550,7 +550,14 @@ func runServe(args []string) {
 	}
 	sc.reviewPath = resolveServeReviewPath(sc.outputDir, sc.planDir, key)
 	srv.reviewPath = sc.reviewPath
-	srv.cliArgs = sc.files
+	switch {
+	case sc.liveOrigin != "":
+		srv.cliArgs = []string{"live", sc.liveOrigin}
+	case sc.previewFile != "":
+		srv.cliArgs = []string{"preview", sc.previewFile}
+	default:
+		srv.cliArgs = sc.files
+	}
 	sessionArgs := sc.files
 	if sc.liveOrigin != "" {
 		sessionArgs = []string{liveSessionArgsTag, sc.liveOrigin}
@@ -680,9 +687,12 @@ func runServe(args []string) {
 		return
 	}
 	applySessionOverrides(session, sc)
-	if sc.liveOrigin != "" {
-		session.CLIArgs = []string{sc.liveOrigin}
-	} else {
+	switch {
+	case sc.liveOrigin != "":
+		session.CLIArgs = []string{"live", sc.liveOrigin}
+	case sc.previewFile != "":
+		session.CLIArgs = []string{"preview", sc.previewFile}
+	default:
 		session.CLIArgs = sc.files
 	}
 

--- a/live_test.go
+++ b/live_test.go
@@ -1088,15 +1088,8 @@ func TestLiveSession_ReinvokeCommandIncludesOrigin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createLiveSession: %v", err)
 	}
-	// Simulate the post-creation override that runServe does.
-	if sc.liveOrigin != "" {
-		sess.CLIArgs = []string{sc.liveOrigin}
-	} else {
-		sess.CLIArgs = sc.files
-	}
-
 	got := sess.ReinvokeCommand()
-	want := "crit http://localhost:4000"
+	want := "crit live http://localhost:4000"
 	if got != want {
 		t.Errorf("ReinvokeCommand() = %q, want %q", got, want)
 	}

--- a/preview.go
+++ b/preview.go
@@ -75,7 +75,7 @@ func createPreviewSession(sc *serverConfig) (*Session, error) {
 		ReviewRound:         1,
 		ReviewType:          "preview",
 		Origin:              sc.previewFile,
-		CLIArgs:             []string{sc.previewFile},
+		CLIArgs:             []string{"preview", sc.previewFile},
 		awaitingFirstReview: true,
 		subscribers:         make(map[chan SSEEvent]struct{}),
 		roundComplete:       make(chan struct{}, 1),

--- a/server_test.go
+++ b/server_test.go
@@ -638,6 +638,8 @@ func TestReviewCycle_NextCommand(t *testing.T) {
 		{"unknown leading-dash arg formats verbatim", []string{"--pr", "42"}, "crit --pr 42"},
 		{"non-ASCII arg passes through", []string{"résumé.md"}, "crit résumé.md"},
 		{"single quote in arg is escaped", []string{"it's.md"}, `crit 'it'\''s.md'`},
+		{"live mode", []string{"live", "http://localhost:4000"}, "crit live http://localhost:4000"},
+		{"preview mode", []string{"preview", "/tmp/mock.html"}, "crit preview /tmp/mock.html"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `srv.cliArgs` was always set to `sc.files` (empty for live/preview), so `buildNextCommand` returned bare `crit` instead of `crit live <url>` or `crit preview <file>` — the agent would re-invoke in git-review mode instead of continuing the session
- Also fixes `Session.CLIArgs` being overwritten post-creation for preview mode (`createPreviewSession` set it correctly but the post-init override clobbered it)

## Test plan
- [x] Added live/preview cases to `TestReviewCycle_NextCommand`
- [x] Updated `TestLiveSession_ReinvokeCommandIncludesOrigin` to match new behavior
- [x] Full test suite passes (`go test ./...`)
- [x] Pre-commit hooks pass (gofmt, golangci-lint, tests, ESLint, Stylelint, CSS vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)