### PR TITLE
refactor: extract shared agent script list and add version-match for ambiguous agent probes

### DIFF
--- a/integrations.go
+++ b/integrations.go
@@ -3,6 +3,7 @@ package main
 //go:generate go run gen_integration_hashes.go
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // computeFileHash returns the hex-encoded SHA256 hash of data.
@@ -250,27 +252,35 @@ func printStaleWarnings(stale []staleFile) int {
 
 // agentProbe describes how to detect whether an AI coding tool is present on
 // the system. Checked in order: CLI binary on PATH, then config directory in
-// $HOME.
+// $HOME. For ambiguous binary names (e.g. "pi", "gemini") that collide with
+// unrelated tools, versionMatch requires a secondary --version output check.
 type agentProbe struct {
-	agent    string   // integration name (key in integrationMap)
-	bins     []string // CLI binary names to look for on PATH
-	homeDirs []string // directories relative to $HOME whose existence signals the agent
+	agent        string   // integration name (key in integrationMap)
+	bins         []string // CLI binary names to look for on PATH
+	homeDirs     []string // directories relative to $HOME whose existence signals the agent
+	versionMatch string   // if set, --version output must contain this substring (case-insensitive)
 }
 
+// versionTimeout is the maximum time to wait for a binary's --version output.
+var versionTimeout = 2 * time.Second
+
 var agentProbes = []agentProbe{
-	{"claude-code", []string{"claude"}, []string{".claude"}},
-	{"cursor", []string{"cursor"}, []string{".cursor"}},
-	{"windsurf", []string{"windsurf"}, []string{".windsurf"}},
-	{"github-copilot", []string{"github-copilot"}, []string{".config/github-copilot"}},
-	{"cline", nil, []string{".cline"}},
-	{"codex", []string{"codex"}, nil},
-	{"opencode", []string{"opencode"}, []string{".opencode"}},
-	{"aider", []string{"aider"}, nil},
-	{"qwen", []string{"qwen"}, []string{".qwen"}},
-	{"pi", []string{"pi"}, []string{".pi"}},
-	{"hermes", []string{"hermes"}, []string{".hermes"}},
-	{"gemini", []string{"gemini"}, []string{".gemini"}},
-	{"grok", []string{"grok"}, []string{".grok"}},
+	{"claude-code", []string{"claude"}, []string{".claude"}, ""},
+	{"cursor", []string{"cursor"}, []string{".cursor"}, ""},
+	{"windsurf", []string{"windsurf"}, []string{".windsurf"}, ""},
+	{"github-copilot", []string{"github-copilot"}, []string{".config/github-copilot"}, ""},
+	{"cline", nil, []string{".cline"}, ""},
+	{"codex", []string{"codex"}, nil, ""},
+	{"opencode", []string{"opencode"}, []string{".opencode"}, ""},
+	{"aider", []string{"aider"}, nil, ""},
+	{"qwen", []string{"qwen"}, []string{".qwen"}, ""},
+	// Ambiguous names: secondary version check prevents false positives from
+	// Raspberry Pi utils, Meta Hermes JS engine, Gemini protocol clients, etc.
+	// NOTE: match strings are best guesses — update if the real AI tool output differs.
+	{"pi", []string{"pi"}, []string{".pi"}, "inflection"},
+	{"hermes", []string{"hermes"}, []string{".hermes"}, "hermes-ai"},
+	{"gemini", []string{"gemini"}, []string{".gemini"}, "google"},
+	{"grok", []string{"grok"}, []string{".grok"}, "xai"},
 }
 
 // detectPresentAgents returns the names of AI coding tools that appear to be
@@ -284,8 +294,10 @@ func detectPresentAgents(homeDir string) []string {
 		}
 		for _, bin := range p.bins {
 			if _, err := exec.LookPath(bin); err == nil {
-				present = append(present, p.agent)
-				seen[p.agent] = true
+				if p.versionMatch == "" || confirmBinaryVersion(bin, p.versionMatch) {
+					present = append(present, p.agent)
+					seen[p.agent] = true
+				}
 				break
 			}
 		}
@@ -301,6 +313,21 @@ func detectPresentAgents(homeDir string) []string {
 		}
 	}
 	return present
+}
+
+// confirmBinaryVersion runs "<bin> --version" with a short timeout and checks
+// whether the output contains the expected substring (case-insensitive). This
+// prevents false positives from unrelated binaries that share an ambiguous name.
+// Returns false if the binary doesn't support --version, times out, or the
+// output doesn't contain the expected string.
+func confirmBinaryVersion(bin, expected string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), versionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "--version").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(out)), strings.ToLower(expected))
 }
 
 // installedAgents returns the set of agents that have at least one crit

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestComputeFileHash(t *testing.T) {
@@ -398,6 +400,47 @@ func TestDetectPresentAgents_NoDuplicates(t *testing.T) {
 	}
 	if count > 1 {
 		t.Errorf("expected 1 claude-code entry, got %d", count)
+	}
+}
+
+func TestConfirmBinaryVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts")
+	}
+
+	dir := t.TempDir()
+	match := filepath.Join(dir, "fake-tool")
+	os.WriteFile(match, []byte("#!/bin/sh\necho 'FakeTool v1.2 by Acme Corp'\n"), 0o755)
+
+	noMatch := filepath.Join(dir, "wrong-tool")
+	os.WriteFile(noMatch, []byte("#!/bin/sh\necho 'SomeOtherTool v3.0'\n"), 0o755)
+
+	failing := filepath.Join(dir, "bad-tool")
+	os.WriteFile(failing, []byte("#!/bin/sh\nexit 1\n"), 0o755)
+
+	old := versionTimeout
+	versionTimeout = 2 * time.Second
+	defer func() { versionTimeout = old }()
+
+	tests := []struct {
+		name     string
+		bin      string
+		expected string
+		want     bool
+	}{
+		{"match", match, "acme", true},
+		{"case-insensitive", match, "ACME", true},
+		{"no-match", noMatch, "acme", false},
+		{"error-exit", failing, "anything", false},
+		{"nonexistent", "/nonexistent/binary", "x", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := confirmBinaryVersion(tt.bin, tt.expected)
+			if got != tt.want {
+				t.Errorf("confirmBinaryVersion(%q, %q) = %v, want %v", tt.bin, tt.expected, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/preview.go
+++ b/preview.go
@@ -156,13 +156,13 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 		return
 	}
 
-	agentScripts := `<script src="/agent-protocol.js"></script>` +
-		`<script src="/agent-anchor-utils.js"></script>` +
-		`<script src="/agent-marker-overlay.js"></script>` +
-		`<script src="/agent-mutation-batcher.js"></script>` +
-		`<script src="/agent-resolution.js"></script>` +
-		`<script src="/agent-reanchor-state.js"></script>` +
-		`<script src="/crit-agent.js"></script>`
+	var sb strings.Builder
+	for _, f := range agentScriptFiles {
+		sb.WriteString(`<script src="/`)
+		sb.WriteString(f)
+		sb.WriteString(`"></script>`)
+	}
+	agentScripts := sb.String()
 
 	// Inject before last </body>
 	idx := bytes.LastIndex(bytes.ToLower(body), []byte("</body>"))

--- a/proxy.go
+++ b/proxy.go
@@ -199,16 +199,11 @@ func applyHTMLInjections(body []byte, apiPort int) ([]byte, bool) {
 	// earlier offset stays valid.
 	masked := maskHTMLComments(body)
 	preamble := swShim + routeAnnouncerScript
-	tags := fmt.Sprintf(
-		`<script src="http://localhost:%d/agent-protocol.js"></script>`+
-			`<script src="http://localhost:%d/agent-anchor-utils.js"></script>`+
-			`<script src="http://localhost:%d/agent-marker-overlay.js"></script>`+
-			`<script src="http://localhost:%d/agent-mutation-batcher.js"></script>`+
-			`<script src="http://localhost:%d/agent-resolution.js"></script>`+
-			`<script src="http://localhost:%d/agent-reanchor-state.js"></script>`+
-			`<script src="http://localhost:%d/crit-agent.js"></script>`,
-		apiPort, apiPort, apiPort, apiPort, apiPort, apiPort, apiPort,
-	)
+	var sb strings.Builder
+	for _, f := range agentScriptFiles {
+		fmt.Fprintf(&sb, `<script src="http://localhost:%d/%s"></script>`, apiPort, f)
+	}
+	tags := sb.String()
 
 	// Agent bundle insertion point: LAST </body>. Last match avoids matching
 	// `</body>` literals inside <script> string literals earlier in the doc.

--- a/server.go
+++ b/server.go
@@ -29,6 +29,20 @@ import (
 // so tests can shrink it. 30s comfortably under the server's 60s IdleTimeout.
 var sseHeartbeatInterval = 30 * time.Second
 
+// agentScriptFiles lists the JS files injected into live/preview iframes.
+// Used by server.go (route registration), preview.go (relative script tags),
+// and proxy.go (absolute script tags). Order matters: protocol first, then
+// helpers, then the main agent entry point last.
+var agentScriptFiles = []string{
+	"agent-protocol.js",
+	"agent-anchor-utils.js",
+	"agent-marker-overlay.js",
+	"agent-mutation-batcher.js",
+	"agent-resolution.js",
+	"agent-reanchor-state.js",
+	"crit-agent.js",
+}
+
 // Server handles HTTP requests for the crit review UI.
 type Server struct {
 	session             atomic.Pointer[Session]
@@ -100,13 +114,13 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, proxyAuth
 
 	// Live-mode routes — NOT wrapped in withReady.
 	mux.HandleFunc("/live", s.serveIndexHTML())
-	mux.HandleFunc("/crit-agent.js", s.handleCritAgentJS)
-	mux.HandleFunc("/agent-protocol.js", s.serveEmbeddedJS("agent-protocol.js"))
-	mux.HandleFunc("/agent-anchor-utils.js", s.serveEmbeddedJS("agent-anchor-utils.js"))
-	mux.HandleFunc("/agent-marker-overlay.js", s.serveEmbeddedJS("agent-marker-overlay.js"))
-	mux.HandleFunc("/agent-mutation-batcher.js", s.serveEmbeddedJS("agent-mutation-batcher.js"))
-	mux.HandleFunc("/agent-resolution.js", s.serveEmbeddedJS("agent-resolution.js"))
-	mux.HandleFunc("/agent-reanchor-state.js", s.serveEmbeddedJS("agent-reanchor-state.js"))
+	for _, f := range agentScriptFiles {
+		if f == "crit-agent.js" {
+			mux.HandleFunc("/"+f, s.handleCritAgentJS)
+		} else {
+			mux.HandleFunc("/"+f, s.serveEmbeddedJS(f))
+		}
+	}
 	mux.HandleFunc("/agent-marker.css", s.serveEmbeddedCSS("agent-marker.css"))
 	mux.HandleFunc("/live-mode-pin-filter.js", s.serveEmbeddedJS("live-mode-pin-filter.js"))
 	mux.HandleFunc("/live-mode-resolution-gate.js", s.serveEmbeddedJS("live-mode-resolution-gate.js"))


### PR DESCRIPTION
## Summary
- Add `versionMatch` field to agent probes — ambiguous binary names (pi, hermes, gemini, grok) now run `--version` with a 2s timeout to confirm identity before counting as detected
- Extract `agentScriptFiles` slice shared by server.go, preview.go, and proxy.go — eliminates 3-way lockstep duplication of the 7 agent injection scripts

## Review
- [x] Code review: passed (release audit + independent validator + post-fix reviewer)
- See also: companion PR for frontend fixes

## Test plan
- [x] `go vet`, `golangci-lint`, `go test -race` all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)