### PR TITLE
fix: prevent flash timer stacking and extract agent name formatter

### DIFF
--- a/frontend/__tests__/agent-marker-overlay.test.js
+++ b/frontend/__tests__/agent-marker-overlay.test.js
@@ -182,24 +182,8 @@ test('setMarkersTabindex toggles all markers atomically', () => {
   assert.equal(m2._attrs.tabindex, '0');
 });
 
-test('marker keyboard handler fires on Enter and Space', () => {
-  // Verify the wiring contract: when the agent attaches a keydown handler,
-  // Enter and Space both trigger the post.
-  const handlers = {};
-  const el = {
-    addEventListener: (t, fn) => { (handlers[t] = handlers[t] || []).push(fn); },
-  };
-  let posted = null;
-  const post = (m) => (posted = m);
-  el.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      post({ type: 'pin-clicked', pin_id: 'p1' });
-    }
-  });
-  handlers.keydown[0]({ key: 'Enter', preventDefault() {} });
-  assert.deepEqual(posted, { type: 'pin-clicked', pin_id: 'p1' });
-  posted = null;
-  handlers.keydown[0]({ key: ' ', preventDefault() {} });
-  assert.deepEqual(posted, { type: 'pin-clicked', pin_id: 'p1' });
-});
+// TODO: This test previously reimplemented the keyboard handler locally instead
+// of exercising the real handler from crit-agent.js (which runs inside the iframe
+// and wires up during initialization). It passed regardless of what the real code
+// did. Replace with an E2E test in e2e/ that verifies Enter/Space on markers in
+// live-mode triggers pin-clicked via the actual iframe agent wiring.

--- a/frontend/crit-agent.js
+++ b/frontend/crit-agent.js
@@ -21,6 +21,8 @@
   var resolutionAPI = window.crit && window.crit.agent && window.crit.agent.resolution;
   var ReanchorStateCtor = window.crit && window.crit.agent && window.crit.agent.reanchorState && window.crit.agent.reanchorState.ReanchorState;
 
+  var _flashTimer = null; // Track flash-marker timeout to prevent stacking
+
   // Derive the API origin (where the chrome lives) from the agent <script> tag URL.
   // This is the only origin we accept inbound messages from and post to.
   function guessApiOriginFromAgentTag() {
@@ -274,8 +276,10 @@
     var entry = byId.get ? byId.get(pinId) : byId[pinId];
     if (!entry || !entry.el) return;
     try {
+      if (_flashTimer) { clearTimeout(_flashTimer); _flashTimer = null; }
       entry.el.classList.add('crit-live-marker--flash');
-      setTimeout(function () {
+      _flashTimer = setTimeout(function () {
+        _flashTimer = null;
         try { entry.el.classList.remove('crit-live-marker--flash'); } catch (_) { /* noop */ }
       }, 1500);
     } catch (_) { /* noop */ }

--- a/frontend/crit-settings-panes.js
+++ b/frontend/crit-settings-panes.js
@@ -207,6 +207,10 @@
     dark: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M14.438 10.148c.19-.425-.321-.787-.748-.601A5.5 5.5 0 0 1 6.453 2.31c.186-.427-.176-.938-.6-.748a6.501 6.501 0 1 0 8.585 8.586Z"/></svg>',
   };
 
+  function formatAgentName(slug) {
+    return slug.replace(/\b\w/g, function (c) { return c.toUpperCase(); }).replace(/-/g, ' ');
+  }
+
   function renderSettingsTab(pane, opts) {
     if (!pane) return;
     opts = opts || {};
@@ -346,7 +350,7 @@
           var undismissedStale = stale.filter(function (si) { return !si.hash || dismissedMap[si.agent] !== si.hash; });
           if (undismissedStale.length > 0) {
             var si = undismissedStale[0];
-            var name = si.agent.replace(/\b\w/g, function (c) { return c.toUpperCase(); }).replace(/-/g, ' ');
+            var name = formatAgentName(si.agent);
             html += '<div class="config-card config-card--yellow"><div class="config-card-header">';
             html += '<span class="config-card-icon" style="color:var(--crit-yellow)">&#9888;</span>';
             html += '<span class="config-card-title">AI Integration</span>';
@@ -371,7 +375,7 @@
             html += '</div>';
           } else if (current.length > 0 || stale.length > 0) {
             var best = current[0] || stale[0];
-            var nm = best.agent.replace(/\b\w/g, function (c) { return c.toUpperCase(); }).replace(/-/g, ' ');
+            var nm = formatAgentName(best.agent);
             html += '<div class="config-card config-card--green"><div class="config-card-header">';
             html += '<span class="config-card-icon" style="color:var(--crit-green)">&#10003;</span>';
             html += '<span class="config-card-title">AI Integration</span>';
@@ -399,7 +403,7 @@
         var undismissed = missingAgents.filter(function (a) { return !dismissedMap['missing:' + a]; });
         if (undismissed.length > 0) {
           undismissed.forEach(function (agent) {
-            var name = agent.replace(/\b\w/g, function (c) { return c.toUpperCase(); }).replace(/-/g, ' ');
+            var name = formatAgentName(agent);
             html += '<div class="config-card config-card--blue"><div class="config-card-header">';
             html += '<span class="config-card-icon" style="color:var(--crit-brand)">&#128161;</span>';
             html += '<span class="config-card-title">Integration Available</span>';


### PR DESCRIPTION
## Summary
- Fix flash timer stacking in `onFlashMarker` — rapid clicks no longer truncate the animation
- Extract `formatAgentName()` helper replacing 3 identical inline transforms
- Remove fake keyboard handler test that didn't exercise real code (TODO for E2E coverage)

## Review
- [x] Code review: passed (release audit + independent validator + post-fix reviewer)
- See also: companion PR for Go backend fixes

## Test plan
- [x] JS syntax check passes, 12/12 unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)