### PR TITLE
fix: remove scrollIntoView on pin highlight that hijacked scroll-driven pages

### DIFF
--- a/frontend/crit-agent.js
+++ b/frontend/crit-agent.js
@@ -250,7 +250,6 @@
     try {
       var el = document.querySelector(selector);
       if (!el) return;
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       el.classList.add('crit-live-pending-highlight');
       state._pendingHighlightEl = el;
       // Suppress the dashed hover overlay while the user is composing —


### PR DESCRIPTION
## Summary
- Removed `el.scrollIntoView()` call in `onKeepHighlight` (crit-agent.js)
- On pages that hijack scroll events (slide decks, single-page apps), the call caused unintended navigation when placing a pin
- The scroll was unnecessary — users can only click elements already visible in the viewport

## Test plan
- Verified with Playwright: placed pin on slide 3 of a scroll-hijacking deck, confirmed iframe body no longer drifts (was +18px, now 0)
- Existing live-mode E2E tests unaffected (build + pre-commit passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)