### PR TITLE
fix: use configured host in daemon startup messages

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -568,6 +568,7 @@ func runServe(args []string) {
 	if err := writeSessionFile(key, sessionEntry{
 		PID:        os.Getpid(),
 		Port:       addr.Port,
+		Host:       sc.host,
 		CWD:        cwd,
 		Args:       sessionArgs,
 		Branch:     branch,
@@ -629,11 +630,12 @@ func runServe(args []string) {
 		// macOS `open` is idempotent enough that the duplicate is harmless,
 		// but routing both to the same URL prevents the browser from briefly
 		// opening / first when the daemon spawns the open before the parent.
-		openURL := fmt.Sprintf("http://localhost:%d", addr.Port)
+		dh := hostForDisplay(sc.host)
+		openURL := fmt.Sprintf("http://%s:%d", dh, addr.Port)
 		if sc.liveOrigin != "" {
-			openURL = fmt.Sprintf("http://localhost:%d/live", addr.Port)
+			openURL = fmt.Sprintf("http://%s:%d/live", dh, addr.Port)
 		} else if sc.previewFile != "" {
-			openURL = fmt.Sprintf("http://localhost:%d/preview", addr.Port)
+			openURL = fmt.Sprintf("http://%s:%d/preview", dh, addr.Port)
 		}
 		go openBrowser(openURL)
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -55,11 +55,32 @@ var browserClient = &http.Client{Timeout: 2 * time.Second}
 type sessionEntry struct {
 	PID        int      `json:"pid"`
 	Port       int      `json:"port"`
+	Host       string   `json:"host,omitempty"`
 	CWD        string   `json:"cwd"`
 	Args       []string `json:"args,omitempty"`
 	Branch     string   `json:"branch"`
 	ReviewPath string   `json:"review_path"`
 	StartedAt  string   `json:"started_at"`
+}
+
+// displayHost returns the host suitable for user-facing URLs.
+// Falls back to "localhost" for the default 127.0.0.1 binding or
+// when host is empty (older session files).
+func (e sessionEntry) displayHost() string {
+	return hostForDisplay(e.Host)
+}
+
+// baseURL returns the HTTP base URL for connecting to this daemon.
+func (e sessionEntry) baseURL() string {
+	return fmt.Sprintf("http://%s:%d", e.displayHost(), e.Port)
+}
+
+// hostForDisplay maps a listen host to a user-facing hostname.
+func hostForDisplay(host string) string {
+	if host == "" || host == "127.0.0.1" {
+		return "localhost"
+	}
+	return host
 }
 
 // resolvedCWD returns the current working directory with symlinks resolved.

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -77,6 +77,44 @@ func TestSessionKey_Length(t *testing.T) {
 	}
 }
 
+func TestSessionEntry_DisplayHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"", "localhost"},
+		{"127.0.0.1", "localhost"},
+		{"0.0.0.0", "0.0.0.0"},
+		{"::", "::"},
+		{"192.168.1.10", "192.168.1.10"},
+	}
+	for _, tt := range tests {
+		e := sessionEntry{Host: tt.host, Port: 3000}
+		if got := e.displayHost(); got != tt.want {
+			t.Errorf("displayHost(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestSessionEntry_BaseURL(t *testing.T) {
+	tests := []struct {
+		host string
+		port int
+		want string
+	}{
+		{"", 3000, "http://localhost:3000"},
+		{"127.0.0.1", 4567, "http://localhost:4567"},
+		{"0.0.0.0", 8080, "http://0.0.0.0:8080"},
+		{"192.168.1.10", 3000, "http://192.168.1.10:3000"},
+	}
+	for _, tt := range tests {
+		e := sessionEntry{Host: tt.host, Port: tt.port}
+		if got := e.baseURL(); got != tt.want {
+			t.Errorf("baseURL(host=%q, port=%d) = %q, want %q", tt.host, tt.port, got, tt.want)
+		}
+	}
+}
+
 func TestSessionFileRoundTrip(t *testing.T) {
 	home := t.TempDir()
 	setHome(t, home)

--- a/live.go
+++ b/live.go
@@ -129,11 +129,11 @@ func connectToLiveDaemon(key string) bool {
 	if !alive {
 		return false
 	}
-	fmt.Fprintf(os.Stderr, "[crit] connected to live daemon at http://localhost:%d (proxy :%d)\n",
-		entry.Port, entry.Port+1)
-	fmt.Fprintf(os.Stderr, "[crit] open http://localhost:%d/live\n", entry.Port)
+	fmt.Fprintf(os.Stderr, "[crit] connected to live daemon at %s (proxy :%d)\n",
+		entry.baseURL(), entry.Port+1)
+	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.baseURL())
 	if !daemonHasBrowser(entry) {
-		go openBrowser(fmt.Sprintf("http://localhost:%d/live", entry.Port))
+		go openBrowser(entry.baseURL() + "/live")
 	}
 	runReviewClient(entry)
 	return true
@@ -206,13 +206,13 @@ func runLive(args []string) {
 
 	fmt.Fprintf(os.Stderr, "[crit] starting daemon on :%d (api), :%d (proxy)\n",
 		entry.Port, entry.Port+1)
-	fmt.Fprintf(os.Stderr, "[crit] open http://localhost:%d/live\n", entry.Port)
+	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.baseURL())
 
 	installDaemonSignalHandler(entry.PID)
 
 	// 4. Open browser.
 	if !noOpenResolved {
-		go openBrowser(fmt.Sprintf("http://localhost:%d/live", entry.Port))
+		go openBrowser(entry.baseURL() + "/live")
 	}
 
 	// 5. Block until review complete.

--- a/main.go
+++ b/main.go
@@ -1705,9 +1705,9 @@ func resolvePlanSlug(name string, content []byte) string {
 func connectOrStartDaemon(key string, args []string, noOpen bool) (sessionEntry, bool) {
 	entry, alive := findAliveSession(key)
 	if alive {
-		fmt.Fprintf(os.Stderr, "Connected to crit daemon at http://localhost:%d\n", entry.Port)
+		fmt.Fprintf(os.Stderr, "Connected to crit daemon at %s\n", entry.baseURL())
 		if !noOpen && !daemonHasBrowser(entry) {
-			go openBrowser(fmt.Sprintf("http://localhost:%d", entry.Port))
+			go openBrowser(entry.baseURL())
 		}
 		return entry, false
 	}
@@ -1718,7 +1718,7 @@ func connectOrStartDaemon(key string, args []string, noOpen bool) (sessionEntry,
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stderr, "Started crit daemon at http://localhost:%d (PID %d)\n", entry.Port, entry.PID)
+	fmt.Fprintf(os.Stderr, "Started crit daemon at %s (PID %d)\n", entry.baseURL(), entry.PID)
 	hintMissingIntegrations()
 	return entry, true
 }
@@ -1958,9 +1958,9 @@ func runPlanHook() {
 	weStartedDaemon := false
 
 	if alive {
-		fmt.Fprintf(os.Stderr, "crit plan-hook: connected to daemon at http://localhost:%d\n", entry.Port)
+		fmt.Fprintf(os.Stderr, "crit plan-hook: connected to daemon at %s\n", entry.baseURL())
 		if !daemonHasBrowser(entry) {
-			go openBrowser(fmt.Sprintf("http://localhost:%d", entry.Port))
+			go openBrowser(entry.baseURL())
 		}
 	} else {
 		entry, err = startDaemon(key, daemonArgs)
@@ -1968,7 +1968,7 @@ func runPlanHook() {
 			fmt.Fprintf(os.Stderr, "crit plan-hook: error starting daemon: %v\n", err)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "crit plan-hook: started daemon at http://localhost:%d (PID %d)\n", entry.Port, entry.PID)
+		fmt.Fprintf(os.Stderr, "crit plan-hook: started daemon at %s (PID %d)\n", entry.baseURL(), entry.PID)
 		weStartedDaemon = true
 	}
 
@@ -2107,10 +2107,10 @@ func runReview(args []string) {
 	weStartedDaemon := false
 
 	if alive {
-		fmt.Fprintf(os.Stderr, "Connected to crit daemon at http://localhost:%d\n", entry.Port)
+		fmt.Fprintf(os.Stderr, "Connected to crit daemon at %s\n", entry.baseURL())
 		// Re-open browser if no browser tab is connected (user closed it)
 		if !sc.noOpen && !daemonHasBrowser(entry) {
-			go openBrowser(fmt.Sprintf("http://localhost:%d", entry.Port))
+			go openBrowser(entry.baseURL())
 		}
 	} else {
 		// Pre-flight: in default git mode (no files, no focus, no plan), surface
@@ -2129,7 +2129,7 @@ func runReview(args []string) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Fprintf(os.Stderr, "Started crit daemon at http://localhost:%d (PID %d)\n", entry.Port, entry.PID)
+		fmt.Fprintf(os.Stderr, "Started crit daemon at %s (PID %d)\n", entry.baseURL(), entry.PID)
 		if !sc.noIntegrationCheck {
 			hintMissingIntegrations()
 		}

--- a/preview.go
+++ b/preview.go
@@ -45,10 +45,10 @@ func connectToPreviewDaemon(key string, noOpen bool) bool {
 	if !alive {
 		return false
 	}
-	fmt.Fprintf(os.Stderr, "[crit] connected to preview daemon at http://localhost:%d\n", entry.Port)
-	fmt.Fprintf(os.Stderr, "[crit] open http://localhost:%d/preview\n", entry.Port)
+	fmt.Fprintf(os.Stderr, "[crit] connected to preview daemon at %s\n", entry.baseURL())
+	fmt.Fprintf(os.Stderr, "[crit] open %s/preview\n", entry.baseURL())
 	if !noOpen && !daemonHasBrowser(entry) {
-		go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
+		go openBrowser(entry.baseURL() + "/preview")
 	}
 	runReviewClient(entry)
 	return true
@@ -246,12 +246,12 @@ func runPreview(args []string) {
 	}
 
 	fmt.Fprintf(os.Stderr, "[crit] preview mode: %s\n", filepath.Base(absPath))
-	fmt.Fprintf(os.Stderr, "[crit] open http://localhost:%d/preview\n", entry.Port)
+	fmt.Fprintf(os.Stderr, "[crit] open %s/preview\n", entry.baseURL())
 
 	installDaemonSignalHandler(entry.PID)
 
 	if !noOpenResolved {
-		go openBrowser(fmt.Sprintf("http://localhost:%d/preview", entry.Port))
+		go openBrowser(entry.baseURL() + "/preview")
 	}
 
 	runReviewClient(entry)


### PR DESCRIPTION
## Summary
- `CRIT_HOST` / `--host` / config `host` was respected for binding but all
  user-facing messages and browser-open URLs hardcoded `localhost`
- Add `Host` field to `sessionEntry` (persisted in session JSON, `omitempty`
  for backward compat) with `displayHost()`/`baseURL()` helpers
- Replace all hardcoded `http://localhost` URLs across main.go, live.go,
  preview.go, and cli_serve.go

## Test plan
- [x] Table-driven tests for `displayHost()` and `baseURL()`
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass (gofmt, golangci-lint, tests, ESLint, Stylelint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)