### PR TITLE
feat: warn when directory args may cause slow loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -2130,6 +2130,11 @@ func runReview(args []string) {
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Started crit daemon at %s (PID %d)\n", entry.baseURL(), entry.PID)
+		if dirs := dirArgs(sc.files); len(dirs) > 0 {
+			fmt.Fprintf(os.Stderr, "\nNote: scanning %s — file paths are intended for reviewing a small set of\n"+
+				"documents or plans. To review code changes, run `crit` with no arguments\n"+
+				"on a feature branch.\n\n", strings.Join(dirs, ", "))
+		}
 		if !sc.noIntegrationCheck {
 			hintMissingIntegrations()
 		}
@@ -2222,6 +2227,17 @@ func runReviewClient(entry sessionEntry) (approved bool) {
 		return result.Approved
 	}
 	return false
+}
+
+// dirArgs returns the subset of paths that are directories.
+func dirArgs(paths []string) []string {
+	var dirs []string
+	for _, p := range paths {
+		if info, err := os.Stat(p); err == nil && info.IsDir() {
+			dirs = append(dirs, p)
+		}
+	}
+	return dirs
 }
 
 // TODO: runStop, runStatus, and other subcommands use DetectVCS("") for auto-detection.

--- a/main_test.go
+++ b/main_test.go
@@ -1514,6 +1514,38 @@ func TestPlural(t *testing.T) {
 	}
 }
 
+func TestDirArgs(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "subdir")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmp, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  int
+	}{
+		{"empty", nil, 0},
+		{"files only", []string{file}, 0},
+		{"dirs only", []string{dir}, 1},
+		{"mixed", []string{file, dir}, 1},
+		{"nonexistent", []string{"/no/such/path"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dirArgs(tt.paths)
+			if len(got) != tt.want {
+				t.Errorf("dirArgs(%v) returned %d dirs, want %d", tt.paths, len(got), tt.want)
+			}
+		})
+	}
+}
+
 func TestParseShareFlags(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- When running `crit .` or any command with directory arguments, print a note
  explaining that file paths are intended for reviewing a small set of documents
  or plans, and suggesting `crit` with no args on a feature branch for code review.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (CLI-only change)

## Test plan
- Verified build and full test suite pass
- `crit .` in a repo prints the note after daemon startup
- `crit file.md` (non-directory arg) prints no note

🤖 Generated with [Claude Code](https://claude.com/claude-code)