### PR TITLE
fix: surface daemon log on connection refused

### DIFF
--- a/live.go
+++ b/live.go
@@ -135,7 +135,7 @@ func connectToLiveDaemon(key string) bool {
 	if !daemonHasBrowser(entry) {
 		go openBrowser(entry.baseURL() + "/live")
 	}
-	runReviewClient(entry)
+	runReviewClient(entry, key)
 	return true
 }
 
@@ -216,7 +216,7 @@ func runLive(args []string) {
 	}
 
 	// 5. Block until review complete.
-	runReviewClient(entry)
+	runReviewClient(entry, key)
 }
 
 func checkLiveSmoke(origin string) {

--- a/main.go
+++ b/main.go
@@ -1864,7 +1864,7 @@ func runPlan(args []string) {
 		installDaemonSignalHandler(entry.PID)
 	}
 
-	approved := runReviewClient(entry)
+	approved := runReviewClient(entry, key)
 	killDaemonOnApproval(approved, entry.PID)
 	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 }
@@ -1976,7 +1976,7 @@ func runPlanHook() {
 		installDaemonSignalHandler(entry.PID)
 	}
 
-	approved, prompt := runReviewClientRaw(entry)
+	approved, prompt := runReviewClientRaw(entry, key)
 	killDaemonOnApproval(approved, entry.PID)
 	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 	emitHookDecision(approved, prompt)
@@ -1986,11 +1986,19 @@ func runPlanHook() {
 // returning 503 Service Unavailable (session not yet initialized). Returns the
 // last response status code and body, or an error if the daemon is unreachable
 // or the 5-minute deadline expires.
-func waitForDaemonReady(client *http.Client, port int) (statusCode int, body []byte, err error) {
+//
+// On connection errors (e.g. "connection refused"), the daemon log is consulted
+// to surface the actual init failure instead of the misleading network error.
+func waitForDaemonReady(client *http.Client, port int, sessionKey string) (statusCode int, body []byte, err error) {
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		resp, reqErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", port))
 		if reqErr != nil {
+			if sessionKey != "" {
+				if msg := readDaemonLog(sessionKey); msg != "" {
+					return 0, nil, fmt.Errorf("%s", msg)
+				}
+			}
 			return 0, nil, fmt.Errorf("could not reach daemon on port %d: %w", port, reqErr)
 		}
 		respBody, _ := io.ReadAll(resp.Body)
@@ -2007,11 +2015,11 @@ func waitForDaemonReady(client *http.Client, port int) (statusCode int, body []b
 
 // runReviewClientRaw is like runReviewClient but returns (approved, prompt)
 // without writing to stdout — used by runPlanHook to construct hookSpecificOutput.
-func runReviewClientRaw(entry sessionEntry) (approved bool, prompt string) {
+func runReviewClientRaw(entry sessionEntry, sessionKey string) (approved bool, prompt string) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	if _, _, err := waitForDaemonReady(client, entry.Port); err != nil {
+	if _, _, err := waitForDaemonReady(client, entry.Port, sessionKey); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
 		return false, "crit daemon was unreachable; plan was not reviewed."
 	}
@@ -2146,7 +2154,7 @@ func runReview(args []string) {
 		installDaemonSignalHandler(entry.PID)
 	}
 
-	approved := runReviewClient(entry)
+	approved := runReviewClient(entry, key)
 	killDaemonOnApproval(approved, entry.PID)
 	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
 }
@@ -2171,11 +2179,11 @@ func readReviewCycleResponse(resp *http.Response) ([]byte, error) {
 // runReviewClient connects to a running daemon/server, blocks until the user
 // finishes reviewing, prints feedback to stdout, and returns whether the
 // review was approved (no unresolved comments).
-func runReviewClient(entry sessionEntry) (approved bool) {
+func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	statusCode, body, err := waitForDaemonReady(client, entry.Port)
+	statusCode, body, err := waitForDaemonReady(client, entry.Port, sessionKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -1435,7 +1435,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		ln.Close()
 
 		dir := t.TempDir()
-		t.Setenv("HOME", dir)
+		setHome(t, dir)
 
 		sessDir := filepath.Join(dir, ".crit", "sessions")
 		os.MkdirAll(sessDir, 0700)

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1283,7 +1284,7 @@ func TestRunReviewClientRaw_WaitsForReadiness(t *testing.T) {
 	}
 
 	entry := sessionEntry{Port: port}
-	approved, _ := runReviewClientRaw(entry)
+	approved, _ := runReviewClientRaw(entry, "")
 
 	if !reviewCycleCalled.Load() {
 		t.Error("review-cycle was never called")
@@ -1323,7 +1324,7 @@ func TestRunReviewClientRaw_NoReadinessDelay(t *testing.T) {
 	}
 
 	start := time.Now()
-	approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+	approved, prompt := runReviewClientRaw(sessionEntry{Port: port}, "")
 	elapsed := time.Since(start)
 
 	if approved {
@@ -1368,7 +1369,7 @@ func TestRunReviewClientRaw_DaemonShutdownDeniesNotApproves(t *testing.T) {
 			fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
 		}
 
-		approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+		approved, prompt := runReviewClientRaw(sessionEntry{Port: port}, "")
 		if approved {
 			t.Fatal("expected approved=false on daemon shutdown, got true (silent auto-approve)")
 		}
@@ -1411,12 +1412,60 @@ func TestRunReviewClientRaw_DaemonShutdownDeniesNotApproves(t *testing.T) {
 			fmt.Sscanf(ts.URL, "http://localhost:%d", &port)
 		}
 
-		approved, prompt := runReviewClientRaw(sessionEntry{Port: port})
+		approved, prompt := runReviewClientRaw(sessionEntry{Port: port}, "")
 		if approved {
 			t.Fatal("expected approved=false on connection drop, got true (silent auto-approve)")
 		}
 		if prompt == "" {
 			t.Fatal("expected non-empty prompt explaining the failure, got empty")
+		}
+	})
+}
+
+// TestWaitForDaemonReady_SurfacesDaemonLog verifies that when the daemon is
+// unreachable (e.g. crashed during init), the error message surfaces the daemon
+// log contents instead of the misleading "connection refused" network error.
+func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
+	t.Run("surfaces daemon log on connection error", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		ln.Close()
+
+		dir := t.TempDir()
+		t.Setenv("HOME", dir)
+
+		sessDir := filepath.Join(dir, ".crit", "sessions")
+		os.MkdirAll(sessDir, 0700)
+		os.WriteFile(filepath.Join(sessDir, "testkey123.log"), []byte("Error: not in a git repository"), 0600)
+
+		client := &http.Client{Timeout: 1 * time.Second}
+		_, _, err = waitForDaemonReady(client, port, "testkey123")
+		if err == nil {
+			t.Fatal("expected error for unreachable daemon")
+		}
+		if !strings.Contains(err.Error(), "not in a git repository") {
+			t.Errorf("expected daemon log message in error, got: %v", err)
+		}
+	})
+
+	t.Run("falls back to network error when no log", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		ln.Close()
+
+		client := &http.Client{Timeout: 1 * time.Second}
+		_, _, err = waitForDaemonReady(client, port, "")
+		if err == nil {
+			t.Fatal("expected error for unreachable daemon")
+		}
+		if !strings.Contains(err.Error(), "could not reach daemon") {
+			t.Errorf("expected 'could not reach daemon' fallback, got: %v", err)
 		}
 	})
 }

--- a/preview.go
+++ b/preview.go
@@ -50,7 +50,7 @@ func connectToPreviewDaemon(key string, noOpen bool) bool {
 	if !noOpen && !daemonHasBrowser(entry) {
 		go openBrowser(entry.baseURL() + "/preview")
 	}
-	runReviewClient(entry)
+	runReviewClient(entry, key)
 	return true
 }
 
@@ -254,5 +254,5 @@ func runPreview(args []string) {
 		go openBrowser(entry.baseURL() + "/preview")
 	}
 
-	runReviewClient(entry)
+	runReviewClient(entry, key)
 }


### PR DESCRIPTION
## Summary
- When the daemon crashes during async session init after signaling readiness, the client gets "connection refused" — which hides the actual init error
- Now `waitForDaemonReady` reads the daemon log (`~/.crit/sessions/<key>.log`) on connection error and surfaces its contents as the error message
- Threads the session key through `runReviewClient` / `runReviewClientRaw` so the log can be located

Ref #593 — waiting for reporter's daemon log to confirm the root cause before closing.

## Review
- [x] Pre-commit hooks: gofmt, golangci-lint, tests, ESLint, Stylelint all pass
- [x] Parity audit: N/A (backend-only, no frontend changes)

## Test plan
- `TestWaitForDaemonReady_SurfacesDaemonLog/surfaces_daemon_log_on_connection_error` — verifies daemon log is returned as error
- `TestWaitForDaemonReady_SurfacesDaemonLog/falls_back_to_network_error_when_no_log` — verifies fallback to original error when no log exists
- Existing `TestRunReviewClientRaw_*` tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)