### PR TITLE
feat: add heading anchor links with copy-to-clipboard

### DIFF
--- a/e2e/tests/heading-anchors.singlefile.spec.ts
+++ b/e2e/tests/heading-anchors.singlefile.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { loadPage } from './helpers';
+
+test.describe('Heading Anchors — Single File Mode', () => {
+  test('headings have id attributes matching their slug', async ({ page }) => {
+    await loadPage(page);
+
+    const heading = page.locator('h2#overview');
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('Overview');
+
+    const subheading = page.locator('h3#step-1-auth-middleware');
+    await expect(subheading).toBeVisible();
+  });
+
+  test('navigating to a hash URL scrolls to the heading', async ({ page, baseURL }) => {
+    await loadPage(page);
+
+    // Navigate to anchor
+    await page.goto(baseURL + '/#timeline');
+    const target = page.locator('h2#timeline');
+    await expect(target).toBeInViewport({ timeout: 3000 });
+  });
+
+  test('clicking an in-page anchor link scrolls to the heading', async ({ page }) => {
+    await loadPage(page);
+
+    // hashchange: programmatically set hash and verify scroll
+    await page.evaluate(() => { window.location.hash = '#open-questions'; });
+    const target = page.locator('h2#open-questions');
+    await expect(target).toBeInViewport({ timeout: 3000 });
+  });
+
+  test('all headings get id attributes', async ({ page }) => {
+    await loadPage(page);
+
+    const headingsWithId = page.locator('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]');
+    await expect(async () => {
+      const count = await headingsWithId.count();
+      expect(count).toBeGreaterThanOrEqual(5);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test('link icon appears on heading hover', async ({ page }) => {
+    await loadPage(page);
+
+    const heading = page.locator('h2#overview');
+    await expect(heading).toBeVisible();
+
+    const anchor = heading.locator('.heading-anchor');
+    await expect(anchor).toHaveCSS('opacity', '0');
+
+    await heading.hover();
+    await expect(anchor).toHaveCSS('opacity', '1');
+  });
+
+  test('clicking link icon updates URL hash and copies to clipboard', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await loadPage(page);
+
+    const heading = page.locator('h2#overview');
+    await heading.hover();
+    const anchor = heading.locator('.heading-anchor');
+    await anchor.click();
+
+    const hash = await page.evaluate(() => window.location.hash);
+    expect(hash).toBe('#overview');
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain('#overview');
+  });
+});

--- a/frontend/__tests__/heading-anchors.test.js
+++ b/frontend/__tests__/heading-anchors.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+// Load crit-line-blocks.js in a fake-browser shim.
+const src = fs.readFileSync(path.join(__dirname, '..', 'crit-line-blocks.js'), 'utf8');
+const fn = new Function('window', 'document', src + '\nreturn window;');
+const sandbox = {
+  window: {
+    crit: {
+      commentCardHelpers: {
+        escapeHtml: function(s) {
+          return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+      }
+    },
+    hljs: {
+      getLanguage: function() { return null; },
+      highlight: function() { return { value: '' }; }
+    }
+  },
+  document: {}
+};
+fn(sandbox.window, sandbox.document);
+const { slugifyHeading } = sandbox.window.crit.lineBlocks;
+
+// --- slugifyHeading ---
+
+test('slugifyHeading lowercases and replaces spaces with hyphens', () => {
+  assert.equal(slugifyHeading('Hello World'), 'hello-world');
+});
+
+test('slugifyHeading strips non-alphanumeric non-hyphen non-space chars', () => {
+  assert.equal(slugifyHeading('Making HTTP requests by framework'), 'making-http-requests-by-framework');
+});
+
+test('slugifyHeading handles special characters', () => {
+  assert.equal(slugifyHeading('What\'s new in v2.0?'), 'whats-new-in-v20');
+});
+
+test('slugifyHeading collapses multiple spaces/hyphens', () => {
+  assert.equal(slugifyHeading('foo  --  bar'), 'foo-bar');
+});
+
+test('slugifyHeading trims leading and trailing hyphens', () => {
+  assert.equal(slugifyHeading(' Hello '), 'hello');
+  assert.equal(slugifyHeading('---hello---'), 'hello');
+});
+
+test('slugifyHeading handles inline code and markup in heading text', () => {
+  assert.equal(slugifyHeading('Using `fetch()` for APIs'), 'using-fetch-for-apis');
+});
+
+test('slugifyHeading preserves unicode letters', () => {
+  assert.equal(slugifyHeading('Über cool héading'), 'über-cool-héading');
+});
+
+test('slugifyHeading handles empty string', () => {
+  assert.equal(slugifyHeading(''), '');
+});
+
+test('slugifyHeading matches GitHub-style slug for typical headings', () => {
+  assert.equal(slugifyHeading('Getting Started'), 'getting-started');
+  assert.equal(slugifyHeading('API Reference (v3)'), 'api-reference-v3');
+  assert.equal(slugifyHeading('1. First Step'), '1-first-step');
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -247,6 +247,26 @@
     }
   });
 
+  // Add id attributes and anchor links to headings
+  const HEADING_LINK_SVG = '<svg class="heading-anchor-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a2.002 2.002 0 0 0 0 2.83Z"></path></svg>';
+  documentMd.renderer.rules.heading_open = function(tokens, idx, options, _env, self) {
+    const token = tokens[idx];
+    const inline = tokens[idx + 1];
+    if (inline && inline.type === 'inline') {
+      const slug = window.crit.lineBlocks.slugifyHeading(inline.content);
+      if (slug) token.attrSet('id', slug);
+    }
+    return self.renderToken(tokens, idx, options);
+  };
+  documentMd.renderer.rules.heading_close = function(tokens, idx, options, _env, self) {
+    const openIdx = idx - 2;
+    const id = openIdx >= 0 ? tokens[openIdx].attrGet('id') : null;
+    if (id) {
+      return '<a class="heading-anchor" href="#' + id + '" aria-label="Link to this heading">' + HEADING_LINK_SVG + '</a>' + self.renderToken(tokens, idx, options);
+    }
+    return self.renderToken(tokens, idx, options);
+  };
+
   // ===== Cookie helpers (persist across random ports on 127.0.0.1) =====
   function setCookie(name, value) {
     document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000; SameSite=Strict';
@@ -1081,6 +1101,7 @@
     updateViewedCount();
     restoreDrafts();
     applyHideResolved();
+    scrollToHashHeading();
   }
 
   // Show/hide the Toggle Diff button and Split/Unified toggle in file mode
@@ -7834,6 +7855,32 @@
     window.addEventListener('scroll', tocScrollHandler, { passive: true });
     tocScrollHandler();
   }
+
+  // ===== Hash Navigation (heading anchors) =====
+  function scrollToHashHeading() {
+    const hash = window.location.hash;
+    if (!hash || hash === '#') return;
+    const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+    if (!target) return;
+    const headerHeight = (document.querySelector('.header')?.offsetHeight || 49) + 8;
+    const y = target.getBoundingClientRect().top + window.scrollY - headerHeight;
+    window.scrollTo({ top: y, behavior: 'instant' });
+  }
+  window.addEventListener('hashchange', scrollToHashHeading);
+
+  document.addEventListener('click', function(e) {
+    const anchor = e.target.closest('.heading-anchor');
+    if (!anchor) return;
+    e.preventDefault();
+    const hash = anchor.getAttribute('href');
+    const url = anchor.href;
+    history.replaceState(null, '', hash);
+    scrollToHashHeading();
+    navigator.clipboard.writeText(url).then(function() {
+      anchor.classList.add('heading-anchor-copied');
+      setTimeout(function() { anchor.classList.remove('heading-anchor-copied'); }, 1500);
+    }).catch(function() {});
+  });
 
   // ===== Mermaid =====
   function getMermaidTheme() {

--- a/frontend/crit-line-blocks.js
+++ b/frontend/crit-line-blocks.js
@@ -9,6 +9,14 @@
     : function(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); };
   var hljs = (typeof window !== 'undefined') ? window.hljs : null;
 
+  function slugifyHeading(text) {
+    return text
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s-]/gu, '')
+      .replace(/[\s-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
   // Split highlighted HTML into per-line strings, preserving open spans across lines.
   function splitHighlightedCode(html) {
     var result = [];
@@ -486,7 +494,8 @@
     handleFenceToken: handleFenceToken,
     handleListToken: handleListToken,
     handleTableToken: handleTableToken,
-    handleBlockquoteToken: handleBlockquoteToken
+    handleBlockquoteToken: handleBlockquoteToken,
+    slugifyHeading: slugifyHeading
   };
   if (typeof window !== 'undefined') {
     window.crit = window.crit || {};

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1028,6 +1028,33 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
 .line-content h4 { font-size: 1.05rem; }
 .line-content h5 { font-size: 0.95rem; color: var(--crit-editor-fg-secondary); }
 
+.line-content h1,
+.line-content h2,
+.line-content h3,
+.line-content h4,
+.line-content h5,
+.line-content h6 { position: relative; }
+
+.line-content .heading-anchor {
+  opacity: 0;
+  margin-left: 6px;
+  color: var(--crit-editor-fg-secondary);
+  text-decoration: none;
+  border: none !important;
+  border-bottom: none !important;
+  transition: opacity 0.15s;
+}
+.line-content .heading-anchor:hover { color: var(--crit-brand); }
+.line-content h1:hover .heading-anchor,
+.line-content h2:hover .heading-anchor,
+.line-content h3:hover .heading-anchor,
+.line-content h4:hover .heading-anchor,
+.line-content h5:hover .heading-anchor,
+.line-content h6:hover .heading-anchor { opacity: 1; }
+
+.heading-anchor-icon { display: inline-block; fill: currentColor; }
+.heading-anchor-copied { opacity: 1; color: var(--crit-green); }
+
 .line-content p {
   margin: 4px 0;
 }


### PR DESCRIPTION
## Summary
- Add GitHub-style anchor IDs to markdown headings (slugified from heading text)
- Show a link icon on hover; clicking copies the anchor URL and scrolls to the heading
- Hash navigation works on page load and hashchange
- Add `slugifyHeading` to `crit-line-blocks.js` with 9 unit tests
- Add 6 E2E tests covering IDs, scroll, hover, and clipboard copy

## Review
- [x] Code review: passed
- [x] Parity audit: crit-web port ready (separate PR)

## Test plan
- Unit tests: `node --test frontend/__tests__/heading-anchors.test.js` (9 passing)
- E2E tests: `heading-anchors.singlefile.spec.ts` (6 passing)
- Existing TOC tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)