### PR TITLE
fix: use session host for internal HTTP calls instead of hardcoded 127.0.0.1

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -348,7 +348,7 @@ func isDaemonAlive(s sessionEntry) bool {
 	}
 	// HTTP health probe — ensures the port belongs to our daemon, not a reused PID.
 	// We validate the response body to guard against a non-crit process on the same port.
-	resp, err := aliveClient.Get(fmt.Sprintf("http://127.0.0.1:%d/api/health", s.Port))
+	resp, err := aliveClient.Get(s.baseURL() + "/api/health")
 	if err != nil {
 		return false
 	}
@@ -369,7 +369,7 @@ func isDaemonAlive(s sessionEntry) bool {
 // Uses a pointer to distinguish "field missing" (older daemon) from "false".
 // When the field is missing, assumes a browser is connected (safe default).
 func daemonHasBrowser(s sessionEntry) bool {
-	resp, err := browserClient.Get(fmt.Sprintf("http://127.0.0.1:%d/api/health", s.Port))
+	resp, err := browserClient.Get(s.baseURL() + "/api/health")
 	if err != nil {
 		return true // can't reach daemon, assume browser exists
 	}

--- a/focus_cli.go
+++ b/focus_cli.go
@@ -276,7 +276,7 @@ func probeDaemonFocusReal() *Focus {
 	var rangeFoci []*Focus
 	var workingFoci []*Focus
 	for _, sess := range sessions {
-		f := fetchSessionFocus(client, sess.Port)
+		f := fetchSessionFocus(client, sess.Host, sess.Port)
 		if f == nil {
 			continue
 		}
@@ -304,8 +304,8 @@ func probeDaemonFocusReal() *Focus {
 // fetchSessionFocus queries one daemon's /api/session and returns its Focus
 // (nil on any error). Factored out so probeDaemonFocusReal can iterate over
 // every matching daemon without ballooning its complexity.
-func fetchSessionFocus(client *http.Client, port int) *Focus {
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", port))
+func fetchSessionFocus(client *http.Client, host string, port int) *Focus {
+	resp, err := client.Get(fmt.Sprintf("http://%s:%d/api/session", hostForDisplay(host), port))
 	if err != nil {
 		return nil
 	}

--- a/focus_cli_test.go
+++ b/focus_cli_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -162,6 +166,53 @@ func TestFocusKeyArgs_Range(t *testing.T) {
 	if len(got) != 1 || got[0] != "range:abc..def" {
 		t.Errorf("got %v want [range:abc..def]", got)
 	}
+}
+
+func TestFetchSessionFocus(t *testing.T) {
+	rangeFocus := &Focus{Kind: FocusRange, BaseSHA: "abc", HeadSHA: "def"}
+
+	t.Run("returns focus from daemon", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{"focus": rangeFocus})
+		}))
+		defer srv.Close()
+		port, _ := strconv.Atoi(srv.URL[len("http://127.0.0.1:"):])
+		got := fetchSessionFocus(&http.Client{}, "", port)
+		if got == nil || got.Kind != FocusRange {
+			t.Fatalf("got %+v want range focus", got)
+		}
+	})
+
+	t.Run("returns nil on error", func(t *testing.T) {
+		got := fetchSessionFocus(&http.Client{}, "", 1)
+		if got != nil {
+			t.Fatalf("got %+v want nil", got)
+		}
+	})
+
+	t.Run("returns nil on non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+		port, _ := strconv.Atoi(srv.URL[len("http://127.0.0.1:"):])
+		got := fetchSessionFocus(&http.Client{}, "", port)
+		if got != nil {
+			t.Fatalf("got %+v want nil", got)
+		}
+	})
+
+	t.Run("returns nil when no focus", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{"mode": "git"})
+		}))
+		defer srv.Close()
+		port, _ := strconv.Atoi(srv.URL[len("http://127.0.0.1:"):])
+		got := fetchSessionFocus(&http.Client{}, "", port)
+		if got != nil {
+			t.Fatalf("got %+v want nil", got)
+		}
+	})
 }
 
 func TestFocusKeyArgs_FallsBackToFiles(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1989,10 +1989,11 @@ func runPlanHook() {
 //
 // On connection errors (e.g. "connection refused"), the daemon log is consulted
 // to surface the actual init failure instead of the misleading network error.
-func waitForDaemonReady(client *http.Client, port int, sessionKey string) (statusCode int, body []byte, err error) {
+func waitForDaemonReady(client *http.Client, host string, port int, sessionKey string) (statusCode int, body []byte, err error) {
+	base := fmt.Sprintf("http://%s:%d", hostForDisplay(host), port)
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
-		resp, reqErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/session", port))
+		resp, reqErr := client.Get(base + "/api/session")
 		if reqErr != nil {
 			if sessionKey != "" {
 				if msg := readDaemonLog(sessionKey); msg != "" {
@@ -2019,13 +2020,13 @@ func runReviewClientRaw(entry sessionEntry, sessionKey string) (approved bool, p
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	if _, _, err := waitForDaemonReady(client, entry.Port, sessionKey); err != nil {
+	if _, _, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
 		return false, "crit daemon was unreachable; plan was not reviewed."
 	}
 
 	resp, err := client.Post(
-		fmt.Sprintf("http://127.0.0.1:%d/api/review-cycle", entry.Port),
+		entry.baseURL()+"/api/review-cycle",
 		"application/json",
 		nil,
 	)
@@ -2183,7 +2184,7 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
 	// Wait for the server to finish initializing before calling review-cycle.
-	statusCode, body, err := waitForDaemonReady(client, entry.Port, sessionKey)
+	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -2201,7 +2202,7 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 	}
 
 	resp, err := client.Post(
-		fmt.Sprintf("http://127.0.0.1:%d/api/review-cycle", entry.Port),
+		entry.baseURL()+"/api/review-cycle",
 		"application/json",
 		nil,
 	)

--- a/main_test.go
+++ b/main_test.go
@@ -1442,7 +1442,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		os.WriteFile(filepath.Join(sessDir, "testkey123.log"), []byte("Error: not in a git repository"), 0600)
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, port, "testkey123")
+		_, _, err = waitForDaemonReady(client, "", port, "testkey123")
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}
@@ -1460,7 +1460,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		ln.Close()
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, port, "")
+		_, _, err = waitForDaemonReady(client, "", port, "")
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}


### PR DESCRIPTION
## Summary
- Health probes, readiness polling, focus probing, and review-cycle calls all hardcoded `127.0.0.1`. When `--host` binds to a non-loopback IP, internal calls fail with connection refused.
- Now uses `baseURL()` or `hostForDisplay()` consistently with the stored session Host field.

## Review
- [x] Code review: passed (release-audit validator + independent review agent)
- [x] Pre-commit: go vet, golangci-lint, go test all pass

## Test plan
- Existing daemon_test.go updated with new host parameter
- `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)