### PR TITLE
fix: harden heading anchor links — dedup IDs, a11y focus, clean CSS

### DIFF
--- a/frontend/__tests__/heading-anchors.test.js
+++ b/frontend/__tests__/heading-anchors.test.js
@@ -65,3 +65,46 @@ test('slugifyHeading matches GitHub-style slug for typical headings', () => {
   assert.equal(slugifyHeading('API Reference (v3)'), 'api-reference-v3');
   assert.equal(slugifyHeading('1. First Step'), '1-first-step');
 });
+
+// --- Duplicate heading dedup (mirrors the Map-based counter in app.js heading_open) ---
+
+// Helper: simulates the dedup logic used in app.js heading_open renderer
+function dedupSlug(baseSlug, counter) {
+  const count = counter.get(baseSlug) || 0;
+  const slug = count === 0 ? baseSlug : baseSlug + '-' + count;
+  counter.set(baseSlug, count + 1);
+  return slug;
+}
+
+test('duplicate headings get unique IDs (GitHub-style -1, -2 suffix)', () => {
+  const counter = new Map();
+  const slug1 = dedupSlug(slugifyHeading('Examples'), counter);
+  const slug2 = dedupSlug(slugifyHeading('Examples'), counter);
+  const slug3 = dedupSlug(slugifyHeading('Examples'), counter);
+  assert.equal(slug1, 'examples');
+  assert.equal(slug2, 'examples-1');
+  assert.equal(slug3, 'examples-2');
+});
+
+test('different headings do not interfere with each other', () => {
+  const counter = new Map();
+  const slug1 = dedupSlug(slugifyHeading('Setup'), counter);
+  const slug2 = dedupSlug(slugifyHeading('Usage'), counter);
+  const slug3 = dedupSlug(slugifyHeading('Setup'), counter);
+  assert.equal(slug1, 'setup');
+  assert.equal(slug2, 'usage');
+  assert.equal(slug3, 'setup-1');
+});
+
+test('counter resets between render passes (fresh Map)', () => {
+  const counter1 = new Map();
+  const first = dedupSlug(slugifyHeading('Examples'), counter1);
+  dedupSlug(slugifyHeading('Examples'), counter1);
+
+  // Simulate new render pass — fresh counter
+  const counter2 = new Map();
+  const fresh = dedupSlug(slugifyHeading('Examples'), counter2);
+
+  assert.equal(first, 'examples');
+  assert.equal(fresh, 'examples', 'fresh render should produce same ID as first render');
+});

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -249,12 +249,19 @@
 
   // Add id attributes and anchor links to headings
   const HEADING_LINK_SVG = '<svg class="heading-anchor-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a2.002 2.002 0 0 0 0 2.83Z"></path></svg>';
+  // Track seen heading slugs per render pass to dedup duplicates (GitHub-style: examples, examples-1, examples-2)
+  const headingSlugCounter = new Map();
   documentMd.renderer.rules.heading_open = function(tokens, idx, options, _env, self) {
     const token = tokens[idx];
     const inline = tokens[idx + 1];
     if (inline && inline.type === 'inline') {
-      const slug = window.crit.lineBlocks.slugifyHeading(inline.content);
-      if (slug) token.attrSet('id', slug);
+      const baseSlug = window.crit.lineBlocks.slugifyHeading(inline.content);
+      if (baseSlug) {
+        const count = headingSlugCounter.get(baseSlug) || 0;
+        const slug = count === 0 ? baseSlug : baseSlug + '-' + count;
+        headingSlugCounter.set(baseSlug, count + 1);
+        token.attrSet('id', slug);
+      }
     }
     return self.renderToken(tokens, idx, options);
   };
@@ -1204,6 +1211,7 @@
 
   // ===== Markdown Parsing =====
   function parseMarkdown(content) {
+    headingSlugCounter.clear();
     const tokens = documentMd.parse(content, {});
     const blocks = buildLineBlocks(tokens, documentMd, content);
     const tocItems = extractTocItems(tokens);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1040,11 +1040,16 @@ body.dragging .line-comment-gutter.drag-range:not(.drag-endpoint) .line-add { op
   margin-left: 6px;
   color: var(--crit-editor-fg-secondary);
   text-decoration: none;
-  border: none !important;
-  border-bottom: none !important;
+  border: none;
+  border-bottom: none;
   transition: opacity 0.15s;
 }
 .line-content .heading-anchor:hover { color: var(--crit-brand); }
+.line-content .heading-anchor:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--crit-brand);
+  outline-offset: 1px;
+}
 .line-content h1:hover .heading-anchor,
 .line-content h2:hover .heading-anchor,
 .line-content h3:hover .heading-anchor,


### PR DESCRIPTION
## Summary
- Deduplicate heading IDs: repeated heading text now gets `-1`, `-2` suffixes (matching GitHub behavior), fixing broken anchor navigation.
- Add `:focus-visible` style so keyboard users can see heading anchor links (WCAG 2.4.7).
- Remove unnecessary `!important` on `.heading-anchor` border overrides.

## Review
- [x] Code review: passed (release-audit validator + independent review agent)
- [x] Pre-commit: all checks pass

## Test plan
- 3 new unit tests for heading ID dedup (12 total, all pass)
- New E2E spec `heading-anchors.singlefile.spec.ts` already covers the feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)