### PR TITLE
fix: show clear error when running crit outside a VCS repo

### DIFF
--- a/cli_serve.go
+++ b/cli_serve.go
@@ -265,16 +265,19 @@ func resolveVCSOverride(flag, config string) string {
 	return config
 }
 
-// preflightNoChangedFiles runs the git-mode change detection up front so the
-// CLI can print a clean message instead of failing inside the daemon (issue
-// #438). Returns the user-facing message to print on stderr if there are no
-// changes, or "" if the daemon should proceed normally (changes present, not
-// a VCS repo, or any other detection error — those are surfaced by the
-// daemon's normal init path).
-func preflightNoChangedFiles(sc *serverConfig) string {
+// preflightCheck runs pre-spawn checks for default git mode (no files, no
+// focus, no plan). Returns a user-facing message to print on stderr if the
+// daemon should not be spawned, or "" if everything looks fine.
+//
+// Two cases:
+//   - Not in a VCS repo at all → clear "not in a git repository" message (#593)
+//   - In a VCS repo but no changed files → "no changed files found" message (#438)
+func preflightCheck(sc *serverConfig) string {
 	vcs := DetectVCS(sc.vcsOverride)
 	if vcs == nil {
-		return ""
+		return "Not in a version-controlled repository.\n\n" +
+			"  crit              review changed files (run inside a git/sapling/jj repo)\n" +
+			"  crit <file...>    review specific file(s)\n"
 	}
 	if sc.baseBranch != "" {
 		vcs.SetDefaultBranchOverride(sc.baseBranch)

--- a/cli_serve_test.go
+++ b/cli_serve_test.go
@@ -8,11 +8,10 @@ import (
 	"testing"
 )
 
-// TestPreflightNoChangedFiles_CleanRepo verifies that running crit in a clean
-// git repo with no changes returns the user-facing message instead of letting
+// TestPreflightCheck_CleanRepo verifies that running crit in a clean
+// repo with no changes returns the user-facing message instead of letting
 // the daemon spawn and crash with a misleading "could not reach daemon" error.
-// Reproduces issue #438.
-func TestPreflightNoChangedFiles_CleanRepo(t *testing.T) {
+func TestPreflightCheck_CleanRepo(t *testing.T) {
 	dir := initTestRepo(t)
 	defaultBranchOnce = sync.Once{}
 
@@ -23,7 +22,7 @@ func TestPreflightNoChangedFiles_CleanRepo(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	sc := &serverConfig{}
-	msg := preflightNoChangedFiles(sc)
+	msg := preflightCheck(sc)
 	if msg == "" {
 		t.Fatal("expected a no-changes message, got empty string")
 	}
@@ -47,9 +46,9 @@ func TestPreflightNoChangedFiles_CleanRepo(t *testing.T) {
 	}
 }
 
-// TestPreflightNoChangedFiles_WithChanges verifies the preflight is silent
+// TestPreflightCheck_WithChanges verifies the preflight is silent
 // (returns "") when the repo has changes, so the daemon proceeds normally.
-func TestPreflightNoChangedFiles_WithChanges(t *testing.T) {
+func TestPreflightCheck_WithChanges(t *testing.T) {
 	dir := initTestRepo(t)
 	defaultBranchOnce = sync.Once{}
 
@@ -63,14 +62,14 @@ func TestPreflightNoChangedFiles_WithChanges(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	sc := &serverConfig{}
-	if msg := preflightNoChangedFiles(sc); msg != "" {
+	if msg := preflightCheck(sc); msg != "" {
 		t.Errorf("expected empty message when repo has changes, got:\n%s", msg)
 	}
 }
 
-// TestPreflightNoChangedFiles_NotARepo verifies the preflight is silent (so
-// the existing not-a-repo error path in createSession surfaces normally).
-func TestPreflightNoChangedFiles_NotARepo(t *testing.T) {
+// TestPreflightCheck_NotARepo verifies that preflightCheck returns a
+// user-facing error when run outside a VCS repo. Issue #593.
+func TestPreflightCheck_NotARepo(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()
 	if err := os.Chdir(dir); err != nil {
@@ -79,8 +78,20 @@ func TestPreflightNoChangedFiles_NotARepo(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	sc := &serverConfig{}
-	if msg := preflightNoChangedFiles(sc); msg != "" {
-		t.Errorf("expected empty message outside a repo, got:\n%s", msg)
+	msg := preflightCheck(sc)
+	if msg == "" {
+		t.Fatal("expected a not-in-repo message, got empty string")
+	}
+	if !strings.Contains(msg, "Not in a version-controlled repository") {
+		t.Errorf("missing headline; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "crit <file") {
+		t.Errorf("missing file-args hint; got:\n%s", msg)
+	}
+	for _, banned := range []string{"daemon", "port", "connection", "127.0.0.1"} {
+		if strings.Contains(strings.ToLower(msg), banned) {
+			t.Errorf("message mentions %q; should be free of networking/daemon noise:\n%s", banned, msg)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2123,11 +2123,11 @@ func runReview(args []string) {
 		}
 	} else {
 		// Pre-flight: in default git mode (no files, no focus, no plan), surface
-		// "no changed files" up front instead of letting the daemon spawn, signal
-		// readiness, then crash on init — which leaves the user with a misleading
-		// "could not reach daemon / connection refused" error. See issue #438.
+		// errors up front instead of letting the daemon spawn, signal readiness,
+		// then crash on init — which leaves the user with a misleading
+		// "could not reach daemon / connection refused" error. See #438, #593.
 		if len(sc.files) == 0 && sc.focus == nil && sc.planDir == "" {
-			if msg := preflightNoChangedFiles(sc); msg != "" {
+			if msg := preflightCheck(sc); msg != "" {
 				fmt.Fprint(os.Stderr, msg)
 				os.Exit(1)
 			}


### PR DESCRIPTION
## Summary
- Running `crit` in a non-VCS directory now shows a clear error message instead of spawning a daemon that crashes with "connection refused"
- Consolidates the two preflight checks (VCS detection + no-changed-files) into a single `preflightCheck` function
- Error message is VCS-agnostic (mentions git/sapling/jj)

## Test plan
- `TestPreflightCheck_NotARepo` — verifies error message content
- `TestPreflightCheck_CleanRepo` — verifies no-changed-files still works
- `TestPreflightCheck_WithChanges` — verifies preflight is silent when changes exist
- Manual: `cd /tmp && crit` shows clean error, exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)