### PR TITLE
feat: shadow DOM host fallback for live/preview pin mode

### DIFF
--- a/e2e/fixtures/shadow-dom-sample.html
+++ b/e2e/fixtures/shadow-dom-sample.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Shadow DOM Sample — Crit Preview Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8f9fa; color: #1a1a1a; }
+    h1 { margin-bottom: 1rem; }
+    p { margin-bottom: 1rem; line-height: 1.5; max-width: 60ch; }
+    .card { background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem; max-width: 480px; }
+    .card h2 { font-size: 1.1rem; margin-bottom: 0.5rem; }
+    button.open-dialog { padding: 0.5rem 1rem; background: #2563eb; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+    button.open-dialog:hover { background: #1d4ed8; }
+  </style>
+</head>
+<body>
+  <h1>Shadow DOM Components</h1>
+  <p>
+    This page has three components that use Shadow DOM.
+    Try pinning comments on them in crit preview mode:
+    <code>crit preview shadow-dom-sample.html</code>
+  </p>
+
+  <!-- 1. Regular light-DOM card (for comparison) -->
+  <div class="card">
+    <h2>Regular Card (light DOM)</h2>
+    <p>This card is in the light DOM. You can pin directly to any element inside it.</p>
+  </div>
+
+  <!-- 2. Shadow DOM tooltip component -->
+  <tooltip-hint id="tip-host">
+    Hover me for a tooltip
+  </tooltip-hint>
+
+  <br><br>
+
+  <!-- 3. Shadow DOM floating dialog (Dan's use case) -->
+  <floating-dialog id="dialog-host"></floating-dialog>
+
+  <br><br>
+
+  <!-- 4. Shadow DOM custom button -->
+  <fancy-button id="btn-host"></fancy-button>
+
+  <script>
+    // --- Tooltip component ---
+    class TooltipHint extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <style>
+            :host { display: inline-block; position: relative; cursor: help;
+                    padding: 0.4rem 0.8rem; background: #e0f2fe; border-radius: 4px; font-size: 0.9rem; }
+            .tip { display: none; position: absolute; bottom: 110%; left: 50%; transform: translateX(-50%);
+                   background: #1e293b; color: #fff; padding: 0.4rem 0.8rem; border-radius: 6px;
+                   font-size: 0.8rem; white-space: nowrap; pointer-events: none; }
+            :host(:hover) .tip { display: block; }
+          </style>
+          <slot></slot>
+          <div class="tip">I'm a shadow DOM tooltip!</div>
+        `;
+      }
+    }
+    customElements.define('tooltip-hint', TooltipHint);
+
+    // --- Floating dialog component (Dan's use case) ---
+    class FloatingDialog extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <style>
+            :host { display: block; max-width: 480px; }
+            .trigger { padding: 0.5rem 1rem; background: #2563eb; color: #fff; border: none;
+                       border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+            .trigger:hover { background: #1d4ed8; }
+            .overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.3); z-index: 999; }
+            .dialog { display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+                      background: #fff; border-radius: 12px; padding: 1.5rem; min-width: 320px;
+                      box-shadow: 0 20px 60px rgba(0,0,0,0.2); z-index: 1000; }
+            .dialog h3 { margin-bottom: 0.75rem; font-size: 1rem; }
+            .dialog p { margin-bottom: 1rem; font-size: 0.9rem; color: #555; line-height: 1.5; }
+            .dialog input { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 6px;
+                            font-size: 0.9rem; margin-bottom: 1rem; }
+            .dialog .actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
+            .dialog button { padding: 0.4rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+            .dialog .cancel { background: #e5e7eb; color: #374151; }
+            .dialog .confirm { background: #2563eb; color: #fff; }
+            :host([open]) .overlay, :host([open]) .dialog { display: block; }
+          </style>
+          <button class="trigger" id="open-btn">Open Floating Dialog</button>
+          <div class="overlay" id="overlay"></div>
+          <div class="dialog" role="dialog" aria-label="Sample dialog">
+            <h3>Floating Dialog</h3>
+            <p>This is a shadow DOM dialog — the kind Dan was working on. In crit, clicking anywhere
+               on this component pins a comment to the host element.</p>
+            <input type="text" placeholder="Type something...">
+            <div class="actions">
+              <button class="cancel" id="cancel-btn">Cancel</button>
+              <button class="confirm" id="confirm-btn">Confirm</button>
+            </div>
+          </div>
+        `;
+        shadow.getElementById('open-btn').addEventListener('click', () => this.setAttribute('open', ''));
+        shadow.getElementById('cancel-btn').addEventListener('click', () => this.removeAttribute('open'));
+        shadow.getElementById('confirm-btn').addEventListener('click', () => this.removeAttribute('open'));
+        shadow.getElementById('overlay').addEventListener('click', () => this.removeAttribute('open'));
+      }
+    }
+    customElements.define('floating-dialog', FloatingDialog);
+
+    // --- Custom button component ---
+    class FancyButton extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <style>
+            :host { display: inline-block; }
+            button { padding: 0.6rem 1.2rem; background: linear-gradient(135deg, #8b5cf6, #6d28d9);
+                     color: #fff; border: none; border-radius: 8px; font-size: 0.9rem; cursor: pointer;
+                     transition: transform 0.1s; }
+            button:active { transform: scale(0.97); }
+            .counter { margin-top: 0.3rem; font-size: 0.75rem; color: #6b7280; text-align: center; }
+          </style>
+          <button id="fancy-btn">Click me</button>
+          <div class="counter">Clicks: <span id="count">0</span></div>
+        `;
+        let n = 0;
+        shadow.getElementById('fancy-btn').addEventListener('click', () => {
+          n++;
+          shadow.getElementById('count').textContent = String(n);
+        });
+      }
+    }
+    customElements.define('fancy-button', FancyButton);
+  </script>
+</body>
+</html>

--- a/e2e/tests/agent.livemode.spec.ts
+++ b/e2e/tests/agent.livemode.spec.ts
@@ -413,7 +413,7 @@ test.describe('live-mode agent — shadow DOM host fallback', () => {
         return sel?.dom_anchor?.accessible_name || null;
       }),
       { timeout: 5_000 },
-    ).toContain('div');
+    ).toMatch(/^<[\w-]+>\s*›/);
     // No error toast — shadow fallback is silent.
     const errorMsgs = await page.evaluate(() => {
       const log = (window as unknown as { __critLiveMessages?: { type: string; kind?: string }[] })

--- a/e2e/tests/agent.livemode.spec.ts
+++ b/e2e/tests/agent.livemode.spec.ts
@@ -358,12 +358,12 @@ test.describe('live-mode agent — focus-state protocol', () => {
   });
 });
 
-test.describe('live-mode agent — shadow DOM error surface', () => {
+test.describe('live-mode agent — shadow DOM host fallback', () => {
   test.beforeEach(async ({ request }) => {
     await clearAllLivePins(request);
   });
 
-  test('clicking inside shadow DOM emits agent-error and does not pin', async ({ page }) => {
+  test('clicking inside shadow DOM pins to the shadow host', async ({ page }) => {
     await waitForAgentReady(page);
     await page.evaluate(() => {
       (window as unknown as { __critLiveMessages?: unknown[] }).__critLiveMessages = [];
@@ -385,7 +385,6 @@ test.describe('live-mode agent — shadow DOM error surface', () => {
           .__critAgentState?.mode;
       }),
     ).toBe('pin');
-    // Clear the message log so the agent-error we observe is the new one.
     await page.evaluate(() => {
       (window as unknown as { __critLiveMessages?: unknown[] }).__critLiveMessages = [];
     });
@@ -404,63 +403,24 @@ test.describe('live-mode agent — shadow DOM error surface', () => {
         clientY: rect.top + rect.height / 2,
       }));
     });
+    // Should emit a selection anchored to the shadow host with enriched
+    // accessible_name showing the deep element context.
     await expect.poll(
       () => page.evaluate(() => {
-        const log = (window as unknown as { __critLiveMessages?: { type: string; kind?: string }[] })
+        const log = (window as unknown as { __critLiveMessages?: { type: string; dom_anchor?: { accessible_name?: string } }[] })
           .__critLiveMessages || [];
-        return log.find((m) => m.type === 'agent-error' && m.kind === 'shadow-dom') || null;
+        const sel = log.find((m) => m.type === 'selection');
+        return sel?.dom_anchor?.accessible_name || null;
       }),
       { timeout: 5_000 },
-    ).not.toBeNull();
-    // No selection event was emitted.
-    const sel = await page.evaluate(() => {
-      const log = (window as unknown as { __critLiveMessages?: { type: string }[] })
+    ).toContain('div');
+    // No error toast — shadow fallback is silent.
+    const errorMsgs = await page.evaluate(() => {
+      const log = (window as unknown as { __critLiveMessages?: { type: string; kind?: string }[] })
         .__critLiveMessages || [];
-      return log.find((m) => m.type === 'selection') || null;
+      return log.filter((m) => m.type === 'agent-error' && m.kind === 'shadow-dom');
     });
-    expect(sel).toBeNull();
-  });
-
-  test('shadow-DOM agent-error surfaces a toast in chrome', async ({ page }) => {
-    await waitForAgentReady(page);
-    await page.evaluate(() => {
-      (window as unknown as { __critLiveMessages?: unknown[] }).__critLiveMessages = [];
-    });
-    await setIframeRoute(page, '/widgets');
-    await expect(getIframe(page).locator('#widgets-title')).toBeVisible();
-    await expect.poll(
-      () => page.evaluate(() => {
-        const log = (window as unknown as { __critLiveMessages?: { type: string }[] })
-          .__critLiveMessages;
-        return Array.isArray(log) && log.some((e) => e.type === 'agent-ready');
-      }),
-      { timeout: 15_000 },
-    ).toBe(true);
-    await enterPinMode(page);
-    await expect.poll(
-      () => getIframe(page).locator('body').evaluate(() => {
-        return (window as unknown as { __critAgentState?: { mode?: string } })
-          .__critAgentState?.mode;
-      }),
-    ).toBe('pin');
-    await getIframe(page).locator('body').evaluate(() => {
-      const host = document.getElementById('shadow-host') as HTMLElement | null;
-      const sr = host?.shadowRoot;
-      const btn = sr?.getElementById('shadow-btn') as HTMLElement | null;
-      if (!btn) throw new Error('shadow-btn not found');
-      const rect = btn.getBoundingClientRect();
-      btn.dispatchEvent(new MouseEvent('click', {
-        bubbles: true, cancelable: true, composed: true, button: 0,
-        clientX: rect.left + rect.width / 2,
-        clientY: rect.top + rect.height / 2,
-      }));
-    });
-    // Chrome's handleAgentError pipes agent-error through showToast, which
-    // since aaa0600 lives in crit.shared and renders into .mini-toast-host
-    // with .mini-toast nodes (unified across code-review + live-mode).
-    const toast = page.locator('.mini-toast');
-    await expect(toast.first()).toBeVisible({ timeout: 5_000 });
-    await expect(toast.first()).toContainText(/shadow-dom/);
+    expect(errorMsgs).toHaveLength(0);
   });
 });
 

--- a/frontend/crit-agent.js
+++ b/frontend/crit-agent.js
@@ -417,7 +417,9 @@
     state.pointer.x = ev.clientX;
     state.pointer.y = ev.clientY;
     var t = topElementAt(ev.clientX, ev.clientY);
-    showOverlayFor(t);
+    var deep = deepestElementFromEvent(ev);
+    var visual = (deep && isInShadowDOM(deep)) ? deep : t;
+    showOverlayFor(visual);
   }
 
   function attachHoverListeners() {
@@ -475,21 +477,21 @@
     if (!target) return;
     ev.preventDefault();
     ev.stopPropagation();
-    // Use the event's composedPath() to detect shadow-DOM clicks: browsers
-    // retarget elementFromPoint() to the shadow host (target above), but the
-    // event's actual path includes the inner element. If the deepest element
-    // in the path lives inside a shadow tree, refuse to pin.
+    // Shadow DOM fallback: browsers retarget elementFromPoint() to the shadow
+    // host, so `target` is already the host element. If the real click landed
+    // inside a shadow tree (detected via composedPath), pin to the host instead
+    // of rejecting — the user still gets to comment on the component.
     var deep = deepestElementFromEvent(ev);
-    if (deep && isInShadowDOM(deep)) {
-      postToParent({ type: A2C.AGENT_ERROR, kind: 'shadow-dom', message: "can't pin inside shadow DOM" });
-      return;
-    }
-    if (isInShadowDOM(target)) {
-      postToParent({ type: A2C.AGENT_ERROR, kind: 'shadow-dom', message: "can't pin inside shadow DOM" });
-      return;
-    }
+    var shadowFallback = (deep && isInShadowDOM(deep)) || isInShadowDOM(target);
     var anchor = buildDOMAnchorFor(target);
-    showOverlayFor(target);
+    if (shadowFallback && deep && deep !== target) {
+      var hostTag = (target.tagName || '').toLowerCase();
+      var deepName = utils.accessibleNameFor(deep);
+      var deepRole = utils.roleFor(deep);
+      var label = deepName || deepRole || (deep.tagName || '').toLowerCase();
+      if (label) anchor.accessible_name = '<' + hostTag + '> › ' + label;
+    }
+    showOverlayFor(shadowFallback && deep ? deep : target);
     state.pendingSelection = { target: target, anchor: anchor, pointer: { x: ev.clientX, y: ev.clientY } };
     emitSelection();
   }

--- a/frontend/crit-agent.js
+++ b/frontend/crit-agent.js
@@ -417,7 +417,7 @@
     state.pointer.x = ev.clientX;
     state.pointer.y = ev.clientY;
     var t = topElementAt(ev.clientX, ev.clientY);
-    var deep = deepestElementFromEvent(ev);
+    var deep = (t && t.shadowRoot) ? deepestElementFromEvent(ev) : null;
     var visual = (deep && isInShadowDOM(deep)) ? deep : t;
     showOverlayFor(visual);
   }


### PR DESCRIPTION
## Summary
- Shadow DOM clicks now pin to the shadow host instead of being rejected with an error toast
- Hover overlay tracks the actual deep element (via composedPath) so users see what they're targeting
- Composer chip shows host + deep element context (e.g. `<floating-dialog> › Confirm`)
- Includes sample HTML fixture with shadow DOM components for manual testing

## Review
- [x] Code review: passed (2 warnings fixed, 0 blockers)
- [x] Intent audit: clean

## Test plan
- E2E tests updated: shadow DOM click now asserts selection + enriched accessible_name
- Manual testing with shadow-dom-sample.html (tooltip, floating dialog, custom button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)