### PR TITLE
feat: interactive confirmation when --share-url is passed

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,7 @@ func promptShareConsent(out io.Writer, in io.Reader) bool {
 	return strings.TrimSpace(strings.ToLower(answer)) == "y"
 }
 
+// promptShareURLConfirm asks the user to confirm sharing to a custom URL.
 func promptShareURLConfirm(out io.Writer, in io.Reader, shareURL string) bool {
 	fmt.Fprintf(out, "  Sharing to %s — continue? [y/N] ", shareURL)
 	answer, _ := bufio.NewReader(in).ReadString('\n')

--- a/main.go
+++ b/main.go
@@ -230,12 +230,20 @@ func promptShareConsent(out io.Writer, in io.Reader) bool {
 	return strings.TrimSpace(strings.ToLower(answer)) == "y"
 }
 
+func promptShareURLConfirm(out io.Writer, in io.Reader, shareURL string) bool {
+	fmt.Fprintf(out, "  Sharing to %s — continue? [y/N] ", shareURL)
+	answer, _ := bufio.NewReader(in).ReadString('\n')
+	return strings.TrimSpace(strings.ToLower(answer)) == "y"
+}
+
 func runShare(args []string) {
 	sf := parseShareFlags(args)
 
 	if len(sf.files) == 0 {
 		printShareUsage()
 	}
+
+	flagURL := sf.svcURL != ""
 
 	cfg := loadShareConfig()
 	sf.svcURL = resolveShareURL(sf.svcURL, cfg, defaultShareURL)
@@ -280,6 +288,11 @@ func runShare(args []string) {
 			fmt.Fprintf(os.Stderr, "  warning: could not save consent: %v\n", err)
 		}
 		cfg.ShareConsented = true
+	}
+	if flagURL {
+		if !promptShareURLConfirm(os.Stderr, os.Stdin, sf.svcURL) {
+			return
+		}
 	}
 	if ok {
 		runShareExisting(existingCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)

--- a/main_test.go
+++ b/main_test.go
@@ -318,6 +318,35 @@ func TestPromptShareConsent(t *testing.T) {
 	}
 }
 
+func TestPromptShareURLConfirm(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"n\n", false},
+		{"N\n", false},
+		{"\n", false},
+		{"", false},
+		{"yes\n", false},
+	}
+	for _, tt := range tests {
+		var buf strings.Builder
+		got := promptShareURLConfirm(&buf, strings.NewReader(tt.input), "https://example.com")
+		if got != tt.want {
+			t.Errorf("promptShareURLConfirm(input=%q) = %v, want %v", tt.input, got, tt.want)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "https://example.com") {
+			t.Errorf("promptShareURLConfirm did not print URL for input=%q, got %q", tt.input, out)
+		}
+		if !strings.Contains(out, "continue?") && !strings.Contains(out, "Continue?") {
+			t.Errorf("promptShareURLConfirm did not print prompt for input=%q, got %q", tt.input, out)
+		}
+	}
+}
+
 // TestRunShare_ConsentDenied verifies that answering "n" to the first-time
 // consent prompt exits cleanly without sharing.
 func TestRunShare_ConsentDenied(t *testing.T) {


### PR DESCRIPTION
## Summary
- When `--share-url` is explicitly passed on the CLI, prompt for confirmation before sharing (`Sharing to <url> — continue? [y/N]`)
- Prevents accidental shares to the wrong host
- Fires every time (not persisted like the default crit.md consent gate)
- Only triggers for `--share-url` flag, not env var or config-based URLs

## Test plan
- [x] Unit test for `promptShareURLConfirm` (y/Y/n/N/empty/EOF/yes cases)
- [x] Pre-commit hooks pass (gofmt, golangci-lint, go test)
- [x] Coverage unchanged at 70.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)