### PR TITLE
style: redesign drifted badge with icon and amber card border

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4327,14 +4327,34 @@ body.sidebar-resizing * {
   padding: 8px 0;
 }
 .outdated-badge {
-  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
   font-weight: 600;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--crit-badge-modified-bg);
-  color: var(--crit-yellow);
-  border: 1px solid var(--crit-yellow-border);
+  padding: 1px 7px 1px 4px;
+  border-radius: 10px;
+  background: var(--crit-drift-badge-bg);
+  color: var(--crit-drift-badge-fg);
+  border: 1px solid var(--crit-drift-badge-border);
   white-space: nowrap;
+}
+.outdated-badge::before {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  background-color: var(--crit-drift-badge-fg);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='currentColor'%3E%3Cpath d='M5.22 14.78a.75.75 0 001.06-1.06L4.56 12h8.69a.75.75 0 000-1.5H4.56l1.72-1.72a.75.75 0 00-1.06-1.06l-3 3a.75.75 0 000 1.06l3 3zM10.78 1.22a.75.75 0 00-1.06 1.06L11.44 4H2.75a.75.75 0 000 1.5h8.69l-1.72 1.72a.75.75 0 101.06 1.06l3-3a.75.75 0 000-1.06l-3-3z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='currentColor'%3E%3Cpath d='M5.22 14.78a.75.75 0 001.06-1.06L4.56 12h8.69a.75.75 0 000-1.5H4.56l1.72-1.72a.75.75 0 00-1.06-1.06l-3 3a.75.75 0 000 1.06l3 3zM10.78 1.22a.75.75 0 00-1.06 1.06L11.44 4H2.75a.75.75 0 000 1.5h8.69l-1.72 1.72a.75.75 0 101.06 1.06l3-3a.75.75 0 000-1.06l-3-3z'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+.outdated-comment .comment-card {
+  border-color: var(--crit-drift-card-border);
 }
 /* Drifted anchor context — full-width disclosure bar + line-numbered panel */
 .drifted-context {

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -130,6 +130,13 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Drifted comment ---- */
+  --crit-drift-badge-fg:     #f0a030;
+  --crit-drift-badge-bg:     rgba(240, 160, 48, 0.14);
+  --crit-drift-badge-border: rgba(240, 160, 48, 0.30);
+
+  --crit-drift-card-border:  rgba(240, 160, 48, 0.25);
+
   /* ---- Green subtle ---- */
   --crit-green-subtle: rgba(86, 211, 100, 0.10);
 
@@ -320,6 +327,13 @@
     --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
     --crit-yellow-border: rgba(122, 88, 0, 0.16);
 
+    /* ---- Drifted comment ---- */
+    --crit-drift-badge-fg:     #8a5200;
+    --crit-drift-badge-bg:     rgba(138, 82, 0, 0.09);
+    --crit-drift-badge-border: rgba(138, 82, 0, 0.22);
+
+    --crit-drift-card-border:  rgba(138, 82, 0, 0.20);
+
     /* ---- Green subtle ---- */
     --crit-green-subtle: rgba(22, 111, 48, 0.08);
 
@@ -509,6 +523,13 @@
   --crit-yellow-bg:     rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 
+  /* ---- Drifted comment ---- */
+  --crit-drift-badge-fg:     #f0a030;
+  --crit-drift-badge-bg:     rgba(240, 160, 48, 0.14);
+  --crit-drift-badge-border: rgba(240, 160, 48, 0.30);
+
+  --crit-drift-card-border:  rgba(240, 160, 48, 0.25);
+
   /* ---- Green subtle ---- */
   --crit-green-subtle: rgba(86, 211, 100, 0.10);
 
@@ -696,6 +717,12 @@
   --crit-yellow-subtle: rgba(122, 88, 0, 0.06);
   --crit-yellow-bg:     rgba(122, 88, 0, 0.1);
   --crit-yellow-border: rgba(122, 88, 0, 0.16);
+
+  /* ---- Drifted comment ---- */
+  --crit-drift-badge-fg:     #8a5200;
+  --crit-drift-badge-bg:     rgba(138, 82, 0, 0.09);
+  --crit-drift-badge-border: rgba(138, 82, 0, 0.22);
+  --crit-drift-card-border:  rgba(138, 82, 0, 0.20);
 
   /* ---- Green subtle ---- */
   --crit-green-subtle: rgba(22, 111, 48, 0.08);


### PR DESCRIPTION
## Summary
- Replaces the subtle yellow pill with a rounded pill badge featuring a bidirectional-arrow icon (CSS mask), matching Unresolve button sizing
- Drifted comment cards get a uniform amber border on all sides
- New `--crit-drift-*` theme tokens defined in all 4 theme blocks

## Test plan
- CSS variable check passes (all vars defined, no dead vars, all 4 blocks)
- Go build clean
- Visual: badge visible in both dark and light themes

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)