### PR TITLE
feat: grant all permissions to live-mode iframe

### DIFF
--- a/frontend/live-mode.js
+++ b/frontend/live-mode.js
@@ -246,7 +246,7 @@
         '<div class="crit-live-iframe-pane-inner">' +
         '<div class="crit-live-iframe-frame" id="critLiveFrame">' +
         // No `sandbox` attribute by design — see spec security section.
-        '<iframe id="critLiveIframe" title="Live target" referrerpolicy="no-referrer"></iframe>' +
+        '<iframe id="critLiveIframe" title="Live target" referrerpolicy="no-referrer" allow="*"></iframe>' +
         '<div class="crit-live-iframe-resizer" id="critLiveResizer" role="separator" aria-orientation="vertical" aria-label="Resize live viewport" tabindex="0"></div>' +
         '</div>' +
         '</div>';


### PR DESCRIPTION
## Summary
- Add `allow="*"` to the live-mode iframe element so Permissions-Policy-gated browser APIs (microphone, MIDI, camera, geolocation, etc.) work inside the proxied page
- The iframe already has no `sandbox` attribute by design; `allow="*"` aligns permission delegation with the existing security posture — users explicitly point crit at their own URL

Closes #606

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (live-mode iframe is crit-only)

## Test plan
- Build passes, all Go tests pass
- Frontend unit tests pass
- Verified the iframe element now includes `allow="*"` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)