### PR TITLE
fix: skip file permission assertion on Windows

### DIFF
--- a/integration_routing_test.go
+++ b/integration_routing_test.go
@@ -648,7 +648,7 @@ func TestInstallCodexPluginConfigDefaultsNewFileTo0600(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %o, want 0600", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Summary
- Guard the `0o600` permission assertion in `TestInstallCodexPluginConfigDefaultsNewFileTo0600` with `runtime.GOOS != "windows"` because Windows doesn't support Unix file permissions (`os.WriteFile` with 0600 results in 0666 on Windows)
- Fixes a pre-existing CI failure on Windows

## Test plan
- Verified the test passes locally on macOS
- CI will confirm Windows runner no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)