### PR TITLE
fix: delete dead codexPluginSourceRoot, use logPrefix consistently

### DIFF
--- a/cli_install.go
+++ b/cli_install.go
@@ -829,13 +829,6 @@ func samePath(a, b string) bool {
 	return absA == absB
 }
 
-func codexPluginSourceRoot(global bool, home string) string {
-	if global {
-		return filepath.Join(home, ".codex", "plugins", "crit")
-	}
-	return filepath.Join("plugins", "crit")
-}
-
 const codexPluginEmbeddedPrefix = "integrations/codex/plugin/crit/"
 
 //nolint:unparam // global is passed for symmetry with other install* funcs; activation always targets ~/.codex

--- a/main.go
+++ b/main.go
@@ -2099,7 +2099,7 @@ func runPlanReviewHook(logPrefix, sessionID string, content []byte, emitDecision
 	weStartedDaemon := false
 
 	if alive {
-		fmt.Fprintf(os.Stderr, "crit plan-hook: connected to daemon at %s\n", entry.baseURL())
+		fmt.Fprintf(os.Stderr, "%s: connected to daemon at %s\n", logPrefix, entry.baseURL())
 		if !daemonHasBrowser(entry) {
 			go openBrowser(entry.baseURL())
 		}
@@ -2110,7 +2110,7 @@ func runPlanReviewHook(logPrefix, sessionID string, content []byte, emitDecision
 			emitDecision(false, fmt.Sprintf("Crit could not start the review UI: %v", err))
 			return
 		}
-		fmt.Fprintf(os.Stderr, "crit plan-hook: started daemon at %s (PID %d)\n", entry.baseURL(), entry.PID)
+		fmt.Fprintf(os.Stderr, "%s: started daemon at %s (PID %d)\n", logPrefix, entry.baseURL(), entry.PID)
 		weStartedDaemon = true
 	}
 


### PR DESCRIPTION
## Summary
- Remove unused `codexPluginSourceRoot` function (zero callers, superseded
  by `codexPluginMarketplaceSourcePath` / `codexPluginEmbeddedPrefix`)
- Replace two hardcoded `"crit plan-hook:"` prefixes in `runPlanReviewHook`
  with the `logPrefix` parameter so Codex mode logs the correct prefix

## Review
- [x] Pre-release audit: validated findings (P1)
- [x] Pre-commit: gofmt, golangci-lint, tests, eslint, stylelint all pass

## Test plan
- `go vet`, `go build`, `golangci-lint run`, `go test` all pass
- Codex plan-hook stderr now uses the passed logPrefix instead of hardcoded value

🤖 Generated with [Claude Code](https://claude.com/claude-code)