### PR TITLE
fix: restore brand tint on target branch chip

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -77,9 +77,9 @@ body {
   gap: 6px;
   font-family: var(--crit-font-mono);
   font-size: 12px;
-  color: var(--crit-pill-fg);
-  background: var(--crit-pill-bg);
-  border: 1px solid var(--crit-pill-border);
+  color: var(--crit-brand);
+  background: var(--crit-brand-subtle);
+  border: 1px solid var(--crit-brand-bg);
   padding: 3px 10px;
   border-radius: 6px;
   height: 24px;

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -33,7 +33,6 @@
   /* ---- Header pill tokens (neutral chip palette) ---- */
   --crit-pill-bg:        #21262d;
   --crit-pill-bg-hover:  #2a3038;
-  --crit-pill-fg:        #c9d1d9;
   --crit-pill-fg-muted:  #8b949e;
   --crit-pill-border:    #30363d;
   --crit-rail-fg:        #7d8590;
@@ -259,7 +258,6 @@
     /* ---- Header pill tokens (neutral chip palette) ---- */
     --crit-pill-bg:        #f6f8fa;
     --crit-pill-bg-hover:  #eef1f4;
-    --crit-pill-fg:        #1f2328;
     --crit-pill-fg-muted:  #59636e;
     --crit-pill-border:    #d0d7de;
     --crit-rail-fg:        #59636e;
@@ -455,7 +453,6 @@
   /* ---- Header pill tokens (neutral chip palette) ---- */
   --crit-pill-bg:        #21262d;
   --crit-pill-bg-hover:  #2a3038;
-  --crit-pill-fg:        #c9d1d9;
   --crit-pill-fg-muted:  #8b949e;
   --crit-pill-border:    #30363d;
   --crit-rail-fg:        #7d8590;
@@ -650,7 +647,6 @@
   /* ---- Header pill tokens (neutral chip palette) ---- */
   --crit-pill-bg:        #f6f8fa;
   --crit-pill-bg-hover:  #eef1f4;
-  --crit-pill-fg:        #1f2328;
   --crit-pill-fg-muted:  #59636e;
   --crit-pill-border:    #d0d7de;
   --crit-rail-fg:        #59636e;


### PR DESCRIPTION
## Summary
- Change `.header-chip` base styles from neutral `--crit-pill-*` tokens to brand tokens (`--crit-brand`, `--crit-brand-subtle`, `--crit-brand-bg`)
- Remove now-unused `--crit-pill-fg` CSS variable from all 4 theme blocks

Closes CRI-22

## Review
- [x] Code review: passed
- [x] Parity audit: N/A — crit-web has no `.header-chip` element

## Test plan
- Pre-commit hooks pass (Stylelint, CSS var check, ESLint, Go tests)
- Brand vars confirmed defined in all 4 theme blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)