### PR TITLE
feat: add `crit stats` command for lifetime review statistics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,13 +133,14 @@ Two-level JSON config files, merged (project overrides global):
 - **Global**: `~/.crit.config.json` — user-wide defaults
 - **Project**: `.crit.config.json` in repo root — per-project overrides
 
-Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`.
+Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `disable_stats`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to the configured VCS user name if not set
 - `agent_cmd`, `auth_token`, `share_url`, and `proxy_auth` are **global config only**; project-level config cannot override (security — prevents malicious repos from hijacking the agent command or redirecting share requests to an attacker-controlled host)
 - `proxy_auth` (default: `false`) — when `true`, share/pull/unpublish use browser popup relay instead of direct CLI HTTP. Global-only for security.
 - `cleanup_on_approve` (default: `true`) — auto-delete review file when reviewer approves with no unresolved comments
+- `disable_stats` (default: `false`) — disable session stats recording to `~/.crit/stats.json`
 - `ignore_patterns` are unioned (global + project both apply); types: `*.ext`, `dir/`, `exact.file`, `path/*.ext`
 - `vcs` selects backend: `"git"` (default), `"sl"` (sapling), or `"jj"` (Jujutsu)
 - `auth_*` keys hold cached hosted-crit-web credentials (set by `crit auth`); treat as secrets

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ crit landing.html                 # review a static HTML file
 
 ```bash
 crit status                       # show review file path and daemon status
+crit stats                        # show lifetime review statistics
 crit cleanup                      # delete stale review files
 ```
 

--- a/cli_dispatch.go
+++ b/cli_dispatch.go
@@ -31,6 +31,7 @@ var commandDispatch = map[string]func([]string){
 	"auth":      runAuth,
 	"stop":      runStop,
 	"status":    runStatus,
+	"stats":     runStats,
 	"cleanup":   runCleanup,
 	"_serve":    runServe,
 }
@@ -70,6 +71,7 @@ Setup & management:
   crit install <agent>                       Install integration for an AI coding tool
   crit check                                 Check integrations (staleness + missing)
   crit status [--json]                       Print session info
+  crit stats [--json]                        Show lifetime review statistics
   crit stop [--all]                          Stop the daemon
   crit cleanup [--days N] [--force]          Delete stale review files (default: 7 days)
   crit config [--generate]                   Show resolved configuration
@@ -173,6 +175,7 @@ Available keys:
   no_integration_check   bool      Skip integration staleness check (default: false)
   no_update_check        bool      Disable update check on startup (default: false)
   cleanup_on_approve     bool      Auto-delete review file when approved (default: true)
+  disable_stats          bool      Disable session stats recording (default: false)
   agent_cmd              string    Shell command to send comments to an AI agent (e.g. "claude -p")
   auth_token             string    Authentication token for crit-web share service
 

--- a/cli_serve.go
+++ b/cli_serve.go
@@ -568,6 +568,8 @@ func runServe(args []string) {
 	if sc.previewFile != "" {
 		sessionArgs = []string{"preview", sc.previewFile}
 	}
+	sessionStartedAt := time.Now().UTC()
+	srv.sessionStartedAt = sessionStartedAt
 	if err := writeSessionFile(key, sessionEntry{
 		PID:        os.Getpid(),
 		Port:       addr.Port,
@@ -576,7 +578,7 @@ func runServe(args []string) {
 		Args:       sessionArgs,
 		Branch:     branch,
 		ReviewPath: sc.reviewPath,
-		StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		StartedAt:  sessionStartedAt.Format(time.RFC3339),
 	}); err != nil {
 		daemonFatal(pipe, "Error writing session file: %v", err)
 	}
@@ -788,6 +790,10 @@ func runServe(args []string) {
 	}
 
 	session.WriteFiles()
+
+	if !srv.statsRecorded && !srv.cfg.DisableStats {
+		recordSessionStats(session, srv.author, sessionStartedAt)
+	}
 
 	if session.ReviewFilePath != "" {
 		fmt.Fprintf(os.Stderr, "Review file: %s\n", reviewPathsFor(session.ReviewFilePath).Review)

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	AuthUserEmail      string   `json:"auth_user_email,omitempty"`
 	AuthUserID         string   `json:"auth_user_id,omitempty"`
 	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
+	DisableStats       bool     `json:"disable_stats,omitempty"`
 	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl", "jj"
 	ShareConsented     bool     `json:"share_consented,omitempty"`
 }
@@ -101,6 +102,7 @@ type generatedConfig struct {
 	IgnorePatterns     []string `json:"ignore_patterns"`
 	NoIntegrationCheck bool     `json:"no_integration_check"`
 	NoUpdateCheck      bool     `json:"no_update_check"`
+	DisableStats       bool     `json:"disable_stats"`
 	AgentCmd           string   `json:"agent_cmd"`
 	CleanupOnApprove   bool     `json:"cleanup_on_approve"`
 	VCS                string   `json:"vcs"`

--- a/server.go
+++ b/server.go
@@ -87,6 +87,13 @@ type Server struct {
 	// runners) that must complete before the daemon writes the review file
 	// during shutdown. The shutdown path Wait()s on this with a timeout.
 	bgWG sync.WaitGroup
+
+	// sessionStartedAt records when the daemon started, used by stats recording.
+	sessionStartedAt time.Time
+	// statsRecorded is set after the first stats write so shutdown doesn't
+	// double-count. Accessed only from handleFinish (serialized by HTTP) and
+	// the shutdown path (after the server has stopped), so no mutex needed.
+	statsRecorded bool
 }
 
 // NewServer creates a Server with the given session and configuration.
@@ -1868,6 +1875,11 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 		if unresolvedComments > 0 {
 			s.status.WaitingForAgent()
 		}
+	}
+
+	if approved && !s.statsRecorded && !s.sessionStartedAt.IsZero() && !s.cfg.DisableStats {
+		recordSessionStats(sess, s.author, s.sessionStartedAt)
+		s.statsRecorded = true
 	}
 
 }

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type statsFile struct {
+	Totals   statsTotals     `json:"totals"`
+	Sessions []sessionRecord `json:"sessions"`
+}
+
+type statsTotals struct {
+	Sessions int `json:"sessions"`
+	Duration int `json:"duration_seconds"`
+	Files    int `json:"files_reviewed"`
+	Comments int `json:"comments_submitted"`
+}
+
+type sessionRecord struct {
+	StartedAt string   `json:"started_at"`
+	EndedAt   string   `json:"ended_at"`
+	Duration  int      `json:"duration_seconds"`
+	Files     int      `json:"files_reviewed"`
+	Comments  int      `json:"comments_submitted"`
+	Branch    string   `json:"branch,omitempty"`
+	Mode      string   `json:"mode"`
+	Rounds    int      `json:"rounds"`
+	ReviewKey string   `json:"review_key,omitempty"`
+	Args      []string `json:"args,omitempty"`
+}
+
+func statsFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".crit", "stats.json"), nil
+}
+
+func loadStats() (statsFile, error) {
+	path, err := statsFilePath()
+	if err != nil {
+		return statsFile{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return statsFile{}, nil
+		}
+		return statsFile{}, fmt.Errorf("reading stats file: %w", err)
+	}
+	var sf statsFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return statsFile{}, fmt.Errorf("parsing stats file: %w", err)
+	}
+	return sf, nil
+}
+
+// appendSession is not safe against concurrent writers (two daemons finishing
+// in the same millisecond window could lose an update). Acceptable: the window
+// is tiny and stats are best-effort.
+func appendSession(rec sessionRecord) error {
+	sf, err := loadStats()
+	if err != nil {
+		return err
+	}
+
+	sf.Sessions = append(sf.Sessions, rec)
+	sf.Totals.Sessions++
+	sf.Totals.Duration += rec.Duration
+	sf.Totals.Files += rec.Files
+	sf.Totals.Comments += rec.Comments
+
+	path, err := statsFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating stats directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding stats: %w", err)
+	}
+
+	return atomicWriteFile(path, data, 0o644)
+}
+
+// sessionActivity returns file count and user comment count under a single lock.
+func sessionActivity(sess *Session, author string) (files, comments int) {
+	sess.mu.RLock()
+	defer sess.mu.RUnlock()
+
+	files = len(sess.Files)
+	for _, c := range sess.reviewComments {
+		if c.Author == author {
+			comments++
+		}
+	}
+	for _, f := range sess.Files {
+		for _, c := range f.Comments {
+			if c.Author == author {
+				comments++
+			}
+		}
+	}
+	return
+}
+
+// recordSessionStats builds a sessionRecord from the current session state and
+// appends it to ~/.crit/stats.json. Called from handleFinish (on approve) and
+// during daemon shutdown. Skips sessions with no meaningful activity.
+func recordSessionStats(sess *Session, author string, startedAt time.Time) {
+	now := time.Now().UTC()
+	duration := int(math.Round(now.Sub(startedAt).Seconds()))
+
+	files, comments := sessionActivity(sess, author)
+
+	if comments == 0 && files == 0 {
+		return
+	}
+
+	mode := sess.Mode
+	if sess.ReviewType != "" {
+		mode = sess.ReviewType
+	}
+
+	rec := sessionRecord{
+		StartedAt: startedAt.UTC().Format(time.RFC3339),
+		EndedAt:   now.Format(time.RFC3339),
+		Duration:  duration,
+		Files:     files,
+		Comments:  comments,
+		Branch:    sess.Branch,
+		Mode:      mode,
+		Rounds:    sess.GetReviewRound(),
+		Args:      sess.CLIArgs,
+	}
+
+	if sess.ReviewFilePath != "" {
+		rec.ReviewKey = filepath.Base(sess.ReviewFilePath)
+	}
+
+	if err := appendSession(rec); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to record session stats: %v\n", err)
+	}
+}
+
+// --- CLI output ---
+
+func runStats(args []string) {
+	jsonOutput := false
+	for _, a := range args {
+		if a == "--json" {
+			jsonOutput = true
+		}
+	}
+
+	sf, err := loadStats()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonOutput {
+		data, _ := json.MarshalIndent(sf, "", "  ")
+		fmt.Println(string(data))
+		return
+	}
+
+	if sf.Totals.Sessions == 0 {
+		fmt.Println("No review sessions recorded yet.")
+		return
+	}
+
+	fmt.Println(formatTotalsLine(sf.Totals))
+
+	if insights := computeInsights(sf.Sessions); len(insights) > 0 {
+		fmt.Println()
+		for _, ins := range insights {
+			fmt.Println(ins)
+		}
+	}
+}
+
+func formatTotalsLine(t statsTotals) string {
+	return fmt.Sprintf("%d %s · %s · %d %s · %d %s",
+		t.Sessions, pluralize(t.Sessions, "session", "sessions"),
+		formatDuration(t.Duration),
+		t.Files, pluralize(t.Files, "file", "files"),
+		t.Comments, pluralize(t.Comments, "comment", "comments"),
+	)
+}
+
+func formatDuration(seconds int) string {
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	hours := seconds / 3600
+	minutes := (seconds % 3600) / 60
+	if hours == 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	if minutes == 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dh %dm", hours, minutes)
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+func computeInsights(sessions []sessionRecord) []string {
+	if len(sessions) < 2 {
+		return nil
+	}
+
+	var insights []string
+
+	if day := busiestDay(sessions); day != "" {
+		insights = append(insights, fmt.Sprintf("You review most on %ss.", day))
+	}
+
+	if branch, dur := longestSession(sessions); branch != "" {
+		insights = append(insights, fmt.Sprintf("Longest session: %s on %s.", formatDuration(dur), branch))
+	}
+
+	return insights
+}
+
+func busiestDay(sessions []sessionRecord) string {
+	counts := make(map[time.Weekday]int)
+	for _, s := range sessions {
+		t, err := time.Parse(time.RFC3339, s.StartedAt)
+		if err != nil {
+			continue
+		}
+		counts[t.Weekday()]++
+	}
+	if len(counts) == 0 {
+		return ""
+	}
+
+	var best time.Weekday
+	bestCount := 0
+	// Deterministic iteration order.
+	for d := time.Sunday; d <= time.Saturday; d++ {
+		if counts[d] > bestCount {
+			bestCount = counts[d]
+			best = d
+		}
+	}
+	return best.String()
+}
+
+func longestSession(sessions []sessionRecord) (string, int) {
+	var bestBranch string
+	var bestDur int
+	for _, s := range sessions {
+		if s.Duration > bestDur {
+			bestDur = s.Duration
+			bestBranch = s.Branch
+		}
+	}
+	if bestBranch == "" {
+		// All sessions had empty branch — try to find any with mode info.
+		for _, s := range sessions {
+			if s.Duration >= bestDur && s.Mode != "" {
+				bestBranch = s.Mode + " mode"
+				bestDur = s.Duration
+			}
+		}
+	}
+	if bestBranch == "" {
+		return "", 0
+	}
+	return bestBranch, bestDur
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadStats_MissingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	sf, err := loadStats()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sf.Totals.Sessions != 0 {
+		t.Errorf("expected 0 sessions, got %d", sf.Totals.Sessions)
+	}
+	if len(sf.Sessions) != 0 {
+		t.Errorf("expected empty sessions slice, got %d", len(sf.Sessions))
+	}
+}
+
+func TestAppendSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rec := sessionRecord{
+		StartedAt: "2026-05-27T10:00:00Z",
+		EndedAt:   "2026-05-27T10:15:00Z",
+		Duration:  900,
+		Files:     12,
+		Comments:  5,
+		Branch:    "feat/auth",
+		Mode:      "git",
+		Rounds:    2,
+		ReviewKey: "abc123",
+	}
+
+	if err := appendSession(rec); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+
+	sf, err := loadStats()
+	if err != nil {
+		t.Fatalf("load after first append: %v", err)
+	}
+	if sf.Totals.Sessions != 1 {
+		t.Errorf("expected 1 session, got %d", sf.Totals.Sessions)
+	}
+	if sf.Totals.Duration != 900 {
+		t.Errorf("expected 900s duration, got %d", sf.Totals.Duration)
+	}
+	if sf.Totals.Files != 12 {
+		t.Errorf("expected 12 files, got %d", sf.Totals.Files)
+	}
+	if sf.Totals.Comments != 5 {
+		t.Errorf("expected 5 comments, got %d", sf.Totals.Comments)
+	}
+	if len(sf.Sessions) != 1 {
+		t.Fatalf("expected 1 session record, got %d", len(sf.Sessions))
+	}
+	if sf.Sessions[0].Branch != "feat/auth" {
+		t.Errorf("expected branch feat/auth, got %s", sf.Sessions[0].Branch)
+	}
+
+	// Second append accumulates.
+	rec2 := sessionRecord{
+		StartedAt: "2026-05-28T14:00:00Z",
+		EndedAt:   "2026-05-28T14:30:00Z",
+		Duration:  1800,
+		Files:     8,
+		Comments:  3,
+		Mode:      "files",
+		Rounds:    1,
+	}
+	if err := appendSession(rec2); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	sf, err = loadStats()
+	if err != nil {
+		t.Fatalf("load after second append: %v", err)
+	}
+	if sf.Totals.Sessions != 2 {
+		t.Errorf("expected 2 sessions, got %d", sf.Totals.Sessions)
+	}
+	if sf.Totals.Duration != 2700 {
+		t.Errorf("expected 2700s total duration, got %d", sf.Totals.Duration)
+	}
+	if sf.Totals.Files != 20 {
+		t.Errorf("expected 20 total files, got %d", sf.Totals.Files)
+	}
+	if sf.Totals.Comments != 8 {
+		t.Errorf("expected 8 total comments, got %d", sf.Totals.Comments)
+	}
+}
+
+func TestLoadStats_CorruptFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".crit")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "stats.json"), []byte("{invalid"), 0o644)
+
+	_, err := loadStats()
+	if err == nil {
+		t.Fatal("expected error for corrupt file")
+	}
+}
+
+func TestFormatTotalsLine(t *testing.T) {
+	tests := []struct {
+		name   string
+		totals statsTotals
+		want   string
+	}{
+		{
+			name:   "singular",
+			totals: statsTotals{Sessions: 1, Duration: 45, Files: 1, Comments: 1},
+			want:   "1 session · 45s · 1 file · 1 comment",
+		},
+		{
+			name:   "plural with hours",
+			totals: statsTotals{Sessions: 47, Duration: 28380, Files: 312, Comments: 89},
+			want:   "47 sessions · 7h 53m · 312 files · 89 comments",
+		},
+		{
+			name:   "minutes only",
+			totals: statsTotals{Sessions: 3, Duration: 300, Files: 10, Comments: 2},
+			want:   "3 sessions · 5m · 10 files · 2 comments",
+		},
+		{
+			name:   "exact hours",
+			totals: statsTotals{Sessions: 5, Duration: 7200, Files: 50, Comments: 10},
+			want:   "5 sessions · 2h · 50 files · 10 comments",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTotalsLine(tt.totals)
+			if got != tt.want {
+				t.Errorf("got  %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		seconds int
+		want    string
+	}{
+		{0, "0s"},
+		{30, "30s"},
+		{59, "59s"},
+		{60, "1m"},
+		{90, "1m"},
+		{3600, "1h"},
+		{3660, "1h 1m"},
+		{28380, "7h 53m"},
+	}
+	for _, tt := range tests {
+		got := formatDuration(tt.seconds)
+		if got != tt.want {
+			t.Errorf("formatDuration(%d) = %q, want %q", tt.seconds, got, tt.want)
+		}
+	}
+}
+
+func TestBusiestDay(t *testing.T) {
+	sessions := []sessionRecord{
+		{StartedAt: "2026-05-25T10:00:00Z"}, // Monday
+		{StartedAt: "2026-05-25T14:00:00Z"}, // Monday
+		{StartedAt: "2026-05-26T10:00:00Z"}, // Tuesday
+		{StartedAt: "2026-05-27T10:00:00Z"}, // Wednesday
+	}
+	got := busiestDay(sessions)
+	if got != "Monday" {
+		t.Errorf("expected Monday, got %s", got)
+	}
+}
+
+func TestBusiestDay_Empty(t *testing.T) {
+	got := busiestDay(nil)
+	if got != "" {
+		t.Errorf("expected empty string, got %s", got)
+	}
+}
+
+func TestLongestSession(t *testing.T) {
+	sessions := []sessionRecord{
+		{Duration: 300, Branch: "fix/bug"},
+		{Duration: 4320, Branch: "feat/auth"},
+		{Duration: 600, Branch: "main"},
+	}
+	branch, dur := longestSession(sessions)
+	if branch != "feat/auth" {
+		t.Errorf("expected feat/auth, got %s", branch)
+	}
+	if dur != 4320 {
+		t.Errorf("expected 4320, got %d", dur)
+	}
+}
+
+func TestLongestSession_NoBranch(t *testing.T) {
+	sessions := []sessionRecord{
+		{Duration: 300, Mode: "files"},
+		{Duration: 600, Mode: "files"},
+	}
+	branch, dur := longestSession(sessions)
+	if branch != "files mode" {
+		t.Errorf("expected 'files mode', got %s", branch)
+	}
+	if dur != 600 {
+		t.Errorf("expected 600, got %d", dur)
+	}
+}
+
+func TestComputeInsights_TooFewSessions(t *testing.T) {
+	insights := computeInsights([]sessionRecord{{StartedAt: "2026-05-27T10:00:00Z"}})
+	if len(insights) != 0 {
+		t.Errorf("expected no insights for single session, got %v", insights)
+	}
+}
+
+func TestComputeInsights_MultipleSessions(t *testing.T) {
+	sessions := []sessionRecord{
+		{StartedAt: "2026-05-25T10:00:00Z", Duration: 300, Branch: "fix/bug"},
+		{StartedAt: "2026-05-25T14:00:00Z", Duration: 4320, Branch: "feat/auth"},
+		{StartedAt: "2026-05-27T10:00:00Z", Duration: 600, Branch: "main"},
+	}
+	insights := computeInsights(sessions)
+	if len(insights) != 2 {
+		t.Fatalf("expected 2 insights, got %d: %v", len(insights), insights)
+	}
+	if insights[0] != "You review most on Mondays." {
+		t.Errorf("unexpected day insight: %s", insights[0])
+	}
+	if insights[1] != "Longest session: 1h 12m on feat/auth." {
+		t.Errorf("unexpected longest insight: %s", insights[1])
+	}
+}
+
+func TestSessionActivity(t *testing.T) {
+	sess := &Session{
+		Files: []*FileEntry{
+			{
+				Comments: []Comment{
+					{Author: "alice"},
+					{Author: "bob"},
+					{Author: "alice"},
+				},
+			},
+			{
+				Comments: []Comment{
+					{Author: "alice"},
+				},
+			},
+		},
+		reviewComments: []Comment{
+			{Author: "alice"},
+			{Author: "bob"},
+		},
+	}
+
+	files, comments := sessionActivity(sess, "alice")
+	if files != 2 {
+		t.Errorf("expected 2 files, got %d", files)
+	}
+	if comments != 4 {
+		t.Errorf("expected 4 alice comments, got %d", comments)
+	}
+
+	_, bobComments := sessionActivity(sess, "bob")
+	if bobComments != 2 {
+		t.Errorf("expected 2 bob comments, got %d", bobComments)
+	}
+
+	_, charlieComments := sessionActivity(sess, "charlie")
+	if charlieComments != 0 {
+		t.Errorf("expected 0 charlie comments, got %d", charlieComments)
+	}
+}
+
+func TestRecordSessionStats_SkipsEmptySessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sess := &Session{Mode: "git"}
+	recordSessionStats(sess, "alice", time.Now().Add(-5*time.Minute))
+
+	// File should not exist — session had no files and no comments.
+	path := filepath.Join(home, ".crit", "stats.json")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected no stats file for empty session, but file exists")
+	}
+}
+
+func TestRecordSessionStats_WritesForActivity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	start := time.Now().Add(-10 * time.Minute)
+	sess := &Session{
+		Mode:           "git",
+		Branch:         "feat/stats",
+		ReviewFilePath: filepath.Join(home, ".crit", "reviews", "abc123"),
+		Files: []*FileEntry{
+			{Path: "main.go"},
+			{Path: "stats.go"},
+		},
+		reviewComments: []Comment{
+			{Author: "alice"},
+		},
+	}
+
+	recordSessionStats(sess, "alice", start)
+
+	sf, err := loadStats()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if sf.Totals.Sessions != 1 {
+		t.Fatalf("expected 1 session, got %d", sf.Totals.Sessions)
+	}
+	if sf.Totals.Files != 2 {
+		t.Errorf("expected 2 files, got %d", sf.Totals.Files)
+	}
+	if sf.Totals.Comments != 1 {
+		t.Errorf("expected 1 comment, got %d", sf.Totals.Comments)
+	}
+	if sf.Sessions[0].Branch != "feat/stats" {
+		t.Errorf("expected branch feat/stats, got %s", sf.Sessions[0].Branch)
+	}
+	if sf.Sessions[0].ReviewKey != "abc123" {
+		t.Errorf("expected review key abc123, got %s", sf.Sessions[0].ReviewKey)
+	}
+	if sf.Sessions[0].Duration < 590 {
+		t.Errorf("expected ~600s duration, got %d", sf.Sessions[0].Duration)
+	}
+}
+
+func TestStatsJSON_EmptyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sf, err := loadStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(sf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed statsFile
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Totals.Sessions != 0 {
+		t.Errorf("expected 0 sessions in JSON, got %d", parsed.Totals.Sessions)
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoadStats_MissingFile(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	sf, err := loadStats()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -24,7 +24,7 @@ func TestLoadStats_MissingFile(t *testing.T) {
 
 func TestAppendSession(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	rec := sessionRecord{
 		StartedAt: "2026-05-27T10:00:00Z",
@@ -99,7 +99,7 @@ func TestAppendSession(t *testing.T) {
 
 func TestLoadStats_CorruptFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	dir := filepath.Join(home, ".crit")
 	os.MkdirAll(dir, 0o755)
@@ -287,7 +287,7 @@ func TestSessionActivity(t *testing.T) {
 
 func TestRecordSessionStats_SkipsEmptySessions(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	sess := &Session{Mode: "git"}
 	recordSessionStats(sess, "alice", time.Now().Add(-5*time.Minute))
@@ -301,7 +301,7 @@ func TestRecordSessionStats_SkipsEmptySessions(t *testing.T) {
 
 func TestRecordSessionStats_WritesForActivity(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	start := time.Now().Add(-10 * time.Minute)
 	sess := &Session{
@@ -345,7 +345,7 @@ func TestRecordSessionStats_WritesForActivity(t *testing.T) {
 
 func TestStatsJSON_EmptyFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	sf, err := loadStats()
 	if err != nil {


### PR DESCRIPTION
## Summary
- New `crit stats` command showing lifetime review statistics (sessions, duration, files, comments) with fun insights (busiest day, longest session)
- Stats recorded to `~/.crit/stats.json` on `/api/finish` (when approved) and daemon shutdown, with dedup to prevent double-counting
- `--json` flag for machine-readable output
- New `disable_stats` config key to opt out of recording
- Session records capture mode (git/files/live/preview), branch, args, rounds, and review key

## Test plan
- [x] Unit tests: persistence (load/append/totals), formatting, insights, session activity counting, empty/corrupt file handling
- [x] Full test suite passes (`go test -count=1 .`)
- [x] Manual e2e: built binary, ran `crit README.md`, approved, verified `crit stats --json` shows the session
- [x] Pre-commit hooks pass (gofmt, golangci-lint, tests, ESLint, Stylelint)
- [x] Code review: passed (fixed data race in session activity reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)