### PR TITLE
fix: default to branch scope on first launch

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -555,7 +555,7 @@
       renderAllFiles();
     });
   }
-  let diffScope = getSetting('diffScope', 'all'); // 'all', 'branch', 'staged', or 'unstaged'
+  let diffScope = getSetting('diffScope', null); // null = no preference saved yet
 
   // Single source of truth for hide-resolved state. Persisted via the
   // consolidated `crit-settings` cookie (not localStorage) so the setting
@@ -929,7 +929,7 @@
       '<div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>';
 
     const [sessionRes, configRes] = await Promise.all([
-      fetchWhenReady('/api/session?scope=' + enc(diffScope)),
+      fetchWhenReady('/api/session' + (diffScope ? '?scope=' + enc(diffScope) : '')),
       fetchWhenReady('/api/config'),
     ]);
 
@@ -1087,7 +1087,14 @@
           b.classList.add('disabled');
         }
       });
-      if (scopes.indexOf(diffScope) === -1) {
+      if (diffScope === null) {
+        // First launch — prefer "branch" (committed changes only) over "all"
+        // (which includes untracked files and can overwhelm large repos).
+        diffScope = scopes.indexOf('branch') !== -1 ? 'branch' : 'all';
+        const corrected = await fetchWhenReady('/api/session?scope=' + enc(diffScope));
+        session = corrected;
+        reviewComments = corrected.review_comments || [];
+      } else if (scopes.indexOf(diffScope) === -1) {
         diffScope = 'all';
         setSetting('diffScope', 'all');
         // Re-fetch session with corrected scope — the initial fetch used the

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1091,9 +1091,11 @@
         // First launch — prefer "branch" (committed changes only) over "all"
         // (which includes untracked files and can overwhelm large repos).
         diffScope = scopes.indexOf('branch') !== -1 ? 'branch' : 'all';
-        const corrected = await fetchWhenReady('/api/session?scope=' + enc(diffScope));
-        session = corrected;
-        reviewComments = corrected.review_comments || [];
+        if (diffScope !== 'all') {
+          const corrected = await fetchWhenReady('/api/session?scope=' + enc(diffScope));
+          session = corrected;
+          reviewComments = corrected.review_comments || [];
+        }
       } else if (scopes.indexOf(diffScope) === -1) {
         diffScope = 'all';
         setSetting('diffScope', 'all');


### PR DESCRIPTION
## Summary
- First-time users (no saved diffScope cookie) now default to "branch" scope when available, instead of "all" which includes untracked files
- Prevents browser crashes on repos with many untracked files (e.g. 160+ including large binaries)
- Returning users who already picked a scope keep their choice
- Smart default is not persisted — each new session re-evaluates scope availability
- Skips redundant re-fetch when the resolved default is "all" (initial scopeless fetch already returned that data)

## Review
- [x] Code review: passed (frontend-expert + red team, no blockers)
- [x] Parity audit: N/A (scope selection logic, not review page rendering)

## Test plan
- Verified: build passes, go test ./... passes, pre-commit hooks pass
- Manual: clear crit-settings cookie, open crit on a feature branch → should default to "branch" scope
- Manual: clear cookie, open crit on main branch → should default to "all" (no redundant fetch)
- Manual: existing users with saved scope preference → unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)