### PR TITLE
fix: skip binary files in git mode

### DIFF
--- a/session.go
+++ b/session.go
@@ -517,6 +517,7 @@ func detectVCSChanges(vcs VCS, root string, ignorePatterns []string) (branch, ba
 		return "", "", "", nil, fmt.Errorf("detecting changes: %w", err)
 	}
 	changes = filterIgnored(changes, ignorePatterns)
+	changes = filterBinary(changes)
 
 	if len(changes) == 0 {
 		return "", "", "", nil, ErrNoChangedFiles
@@ -867,6 +868,17 @@ func dirIgnored(full, root string, ignorePatterns []string) bool {
 		}
 	}
 	return false
+}
+
+// filterBinary removes files with binary extensions from a change list.
+func filterBinary(changes []FileChange) []FileChange {
+	filtered := changes[:0:0]
+	for _, fc := range changes {
+		if !isBinaryExtension(strings.ToLower(filepath.Ext(fc.Path))) {
+			filtered = append(filtered, fc)
+		}
+	}
+	return filtered
 }
 
 // isBinaryExtension returns true for file extensions that are typically binary.
@@ -2012,6 +2024,7 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 		return fmt.Errorf("detecting changes: %w", err)
 	}
 	changes = filterIgnored(changes, ignorePatterns)
+	changes = filterBinary(changes)
 
 	// Build new file entries, preserving comments
 	var newFiles []*FileEntry

--- a/session_focus.go
+++ b/session_focus.go
@@ -456,6 +456,7 @@ func (s *Session) buildFilesForWorkingTree(vcs VCS, repoRoot string) ([]*FileEnt
 		return nil, "", err
 	}
 	changes = filterIgnored(changes, ignorePatterns)
+	changes = filterBinary(changes)
 	out := make([]*FileEntry, 0, len(changes))
 	for _, fc := range changes {
 		fe := &FileEntry{
@@ -701,6 +702,7 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 	}
 
 	changes = filterIgnored(changes, snap.ignorePatterns)
+	changes = filterBinary(changes)
 
 	for _, fc := range changes {
 		fi := SessionFileInfo{

--- a/session_test.go
+++ b/session_test.go
@@ -760,6 +760,35 @@ func TestDetectFileType(t *testing.T) {
 	}
 }
 
+func TestFilterBinary(t *testing.T) {
+	changes := []FileChange{
+		{Path: "main.go", Status: "modified"},
+		{Path: "lib.dylib", Status: "untracked"},
+		{Path: "README.md", Status: "added"},
+		{Path: "image.PNG", Status: "added"},
+		{Path: "archive.tar.gz", Status: "untracked"},
+		{Path: "Makefile", Status: "modified"},
+		{Path: ".gitignore", Status: "modified"},
+	}
+	got := filterBinary(changes)
+	want := []string{"main.go", "README.md", "Makefile", ".gitignore"}
+	if len(got) != len(want) {
+		t.Fatalf("filterBinary returned %d files, want %d", len(got), len(want))
+	}
+	for i, fc := range got {
+		if fc.Path != want[i] {
+			t.Errorf("filterBinary[%d].Path = %q, want %q", i, fc.Path, want[i])
+		}
+	}
+}
+
+func TestFilterBinaryEmpty(t *testing.T) {
+	got := filterBinary(nil)
+	if len(got) != 0 {
+		t.Errorf("filterBinary(nil) returned %d files, want 0", len(got))
+	}
+}
+
 func TestSession_CritJSONPath_Default(t *testing.T) {
 	s := newTestSession(t)
 	want := filepath.Join(s.RepoRoot, ".crit")

--- a/watch.go
+++ b/watch.go
@@ -98,6 +98,7 @@ func (s *Session) RefreshFileList() {
 
 	// Apply ignore patterns
 	changes = filterIgnored(changes, s.IgnorePatterns)
+	changes = filterBinary(changes)
 
 	// Snapshot existing files under read lock
 	s.mu.RLock()


### PR DESCRIPTION
## Summary
- `isBinaryExtension()` was only checked in file mode's `walkDirectory`. Git mode processed binary files at all 5 sites that build file lists, causing browser crashes on large binaries (e.g. 1.1M-line `.dylib`).
- Added `filterBinary()` and applied at all `filterIgnored()` call sites: `detectVCSChanges`, `RefreshFileList`, `ChangeBaseBranch`, and two focus-mode builders in `session_focus.go`.
- Added `TestFilterBinary` / `TestFilterBinaryEmpty`.

## Test plan
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass (gofmt, golangci-lint, tests, ESLint, Stylelint)
- [x] Code review: passed (go-expert + red team)
- [x] Red team caught 2 missed call sites in `session_focus.go` — fixed before ship

Closes CRI-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)