### PR TITLE
fix: prevent scope re-fetch from leaking files in range mode

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1052,11 +1052,17 @@
           b.classList.add('disabled');
         }
       });
+      // Range focus pins the file list to BaseSHA..HeadSHA server-side;
+      // working-tree scopes (branch/staged/unstaged) don't apply. Skip
+      // the scope re-fetch — the initial /api/session response is already
+      // correct, and the scope toggle will be hidden once the range chrome
+      // renders.
+      const inRangeFocus = session.focus && session.focus.kind === 'range';
       if (diffScope === null) {
         // First launch — prefer "branch" (committed changes only) over "all"
         // (which includes untracked files and can overwhelm large repos).
         diffScope = scopes.indexOf('branch') !== -1 ? 'branch' : 'all';
-        if (diffScope !== 'all') {
+        if (diffScope !== 'all' && !inRangeFocus) {
           const corrected = await fetchWhenReady('/api/session?scope=' + enc(diffScope));
           session = corrected;
           reviewComments = corrected.review_comments || [];

--- a/session_focus.go
+++ b/session_focus.go
@@ -672,6 +672,18 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 		return s.GetSessionInfo()
 	}
 
+	// Range focus already pins the file list to BaseSHA..HeadSHA via
+	// buildFilesForFocus. Working-tree scopes (branch, staged, unstaged) are
+	// meaningless in this mode — they would run git diff against HEAD instead
+	// of the range's head SHA, leaking files outside the range. Delegate to
+	// GetSessionInfo which returns the pre-built range-scoped file list.
+	s.mu.RLock()
+	inRange := s.Focus.Kind == FocusRange
+	s.mu.RUnlock()
+	if inRange && commit == "" {
+		return s.GetSessionInfo()
+	}
+
 	snap := s.snapshotForScoped()
 
 	info := SessionInfo{


### PR DESCRIPTION
## Summary
- The recent default-scope change (PR #614) introduced a `scope=branch` re-fetch on first launch
- In range mode (`--range A..B`), this bypassed the range focus and returned files from HEAD, leaking files outside the range (e.g. `c.txt` visible when only `b.txt` should be)
- Server-side: `GetSessionInfoScoped` now delegates to `GetSessionInfo()` in range focus, which returns the pre-built range-scoped file list
- Frontend: skip the scope re-fetch when session is in range focus — the initial response is already correctly scoped

## Review
- [x] All 12 range-mode E2E tests pass locally
- [x] Unit tests pass (`go test ./...`)

## Test plan
- `npx playwright test --project range-mode` — 12 passed
- Specifically verified: `range-loading.rangemode.spec.ts:10` (c.txt hidden) and `focus-picker.rangemode.spec.ts:64` (focus switch rebuilds file list correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)