### PR TITLE
CRI-7: Print resume instructions at end of session

### DIFF
--- a/client_finish_test.go
+++ b/client_finish_test.go
@@ -178,6 +178,10 @@ waitLoop:
 	if summary.ReviewFile == "" {
 		t.Errorf("summary.review_file is empty; agents rely on this path")
 	}
+	wantResume := fmt.Sprintf("To resume this review:\n  cd %s && git checkout main && crit --no-open --port 0\n", shellQuoteArg(resolvedRepo))
+	if !strings.Contains(stderr.String(), wantResume) {
+		t.Errorf("stderr missing resume instructions\nwant contains:\n%s\nstderr:\n%s", wantResume, stderr.String())
+	}
 }
 
 // clientFinishEnv builds an env that pins HOME (and the Windows equivalents)

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -7,8 +7,33 @@ export async function clearAllComments(request: APIRequestContext) {
 
 // Navigate to the root page and wait for loading to complete.
 export async function loadPage(page: Page) {
+  await ensureDefaultSettings(page);
   await page.goto('/');
   await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
+}
+
+async function ensureDefaultSettings(page: Page) {
+  const cookies = await page.context().cookies();
+  const existing = cookies.find(cookie => cookie.name === 'crit-settings');
+  let settings: Record<string, unknown> = {};
+  if (existing && existing.value) {
+    try {
+      settings = JSON.parse(decodeURIComponent(existing.value));
+    } catch {
+      settings = {};
+    }
+  }
+  if (settings.diffScope && settings.diffMode) return;
+  await page.context().addCookies([{
+    name: 'crit-settings',
+    value: encodeURIComponent(JSON.stringify({
+      diffScope: settings.diffScope || 'all',
+      diffMode: settings.diffMode || 'split',
+      ...settings,
+    })),
+    domain: 'localhost',
+    path: '/',
+  }]);
 }
 
 // Scope selectors to the plan.md file section.

--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -78,8 +78,10 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
 
     const dialog = page.locator('#waitingDialog');
     await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(dialog).toHaveClass(/has-resume-command/);
     await expect(page.locator('#waitingHeading')).toHaveText('Approved');
-    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
+    await expect(page.locator('#waitingMessage')).toContainText('Copy the resume command');
+    await expect(page.locator('#promptPreview')).toContainText('git checkout');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -275,8 +275,10 @@ test.describe('Multi-Round — Frontend', () => {
 
     const dialog = page.locator('#waitingDialog');
     await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
+    await expect(dialog).toHaveClass(/has-resume-command/);
     await expect(page.locator('#waitingHeading')).toHaveText('Approved');
-    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
+    await expect(page.locator('#waitingMessage')).toContainText('Copy the resume command');
+    await expect(page.locator('#promptPreview')).toContainText('git checkout');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -11,15 +11,22 @@ async function switchScope(page: Page, scope: string) {
   await expect(page.locator(`#scopeToggle .toggle-btn[data-scope="${scope}"]`)).toHaveClass(/active/);
 }
 
+async function setDiffScope(page: Page, scope: string) {
+  await page.context().addCookies([{
+    name: 'crit-settings',
+    value: encodeURIComponent(JSON.stringify({ diffScope: scope })),
+    domain: 'localhost',
+    path: '/',
+  }]);
+}
+
 test.beforeEach(async ({ request }) => {
   await clearAllComments(request);
 });
 
 test.afterEach(async ({ page }) => {
   // Reset scope cookie so other test files aren't affected
-  await page.evaluate(() => {
-    document.cookie = 'crit-diff-scope=all; path=/; max-age=31536000; SameSite=Strict';
-  });
+  await setDiffScope(page, 'all');
 });
 
 async function pressShiftScope(page: Page, digit: string, scope: string) {
@@ -30,17 +37,20 @@ async function pressShiftScope(page: Page, digit: string, scope: string) {
 
 test.describe('Scope Toggle', () => {
   test('scope toggle is visible in git mode with All active by default', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await expect(page.locator('#scopeToggle')).toBeVisible();
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="all"]')).toHaveClass(/active/);
   });
 
   test('Branch button is visible on feature branch', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="branch"]')).toBeVisible();
   });
 
   test('switching to branch scope shows only committed files', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'branch');
     // Branch: server.go, deleted.txt, plan.md, handler.js, routes.go, legacy.go (6 committed)
@@ -50,6 +60,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('switching to staged scope shows only staged files', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'staged');
     // Staged: utils.go, login.feature
@@ -60,6 +71,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('switching to unstaged scope shows only unstaged files', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'unstaged');
     // Unstaged: config.yaml only
@@ -70,6 +82,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('switching back to all scope restores full file list', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'staged');
     await expect(page.locator('.file-section')).toHaveCount(2);
@@ -81,6 +94,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('active button styling updates on click', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'staged');
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="staged"]')).toHaveClass(/active/);
@@ -88,6 +102,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('scope persists across page reload', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'staged');
     await expect(page.locator('.file-section')).toHaveCount(2);
@@ -98,6 +113,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('file tree updates when scope changes', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await switchScope(page, 'staged');
     await expect(page.locator('.tree-file')).toHaveCount(2);
@@ -105,6 +121,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('unavailable scopes are disabled not hidden', async ({ page }) => {
+    await setDiffScope(page, 'all');
     // Intercept session API to return only "all" and "branch" as available
     await page.route('**/api/session*', async route => {
       const response = await route.fetch();
@@ -127,12 +144,7 @@ test.describe('Scope Toggle', () => {
 
   test('falls back to all when saved scope becomes unavailable', async ({ page }) => {
     // Set cookie to "staged" before loading
-    await page.context().addCookies([{
-      name: 'crit-diff-scope',
-      value: 'staged',
-      domain: 'localhost',
-      path: '/',
-    }]);
+    await setDiffScope(page, 'staged');
     // Intercept session API to exclude "staged" from available scopes
     await page.route('**/api/session*', async route => {
       const response = await route.fetch();
@@ -149,12 +161,7 @@ test.describe('Scope Toggle', () => {
   test('falls back to all and re-fetches files when stale scope returns empty list', async ({ page }) => {
     // Simulate: user was on a feature branch with "branch" scope, then switched to
     // the default branch where branch scope returns no files.
-    await page.context().addCookies([{
-      name: 'crit-diff-scope',
-      value: 'branch',
-      domain: 'localhost',
-      path: '/',
-    }]);
+    await setDiffScope(page, 'branch');
 
     let requestCount = 0;
     await page.route('**/api/session*', async route => {
@@ -185,6 +192,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('Shift+1 activates All scope', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     // Start on branch scope so the shortcut has a visible effect
     await switchScope(page, 'branch');
@@ -195,24 +203,28 @@ test.describe('Scope Toggle', () => {
   });
 
   test('Shift+2 activates Branch scope', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await pressShiftScope(page, '2', 'branch');
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="all"]')).not.toHaveClass(/active/);
   });
 
   test('Shift+3 activates Staged scope', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await pressShiftScope(page, '3', 'staged');
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="all"]')).not.toHaveClass(/active/);
   });
 
   test('Shift+4 activates Unstaged scope', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     await pressShiftScope(page, '4', 'unstaged');
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="all"]')).not.toHaveClass(/active/);
   });
 
   test('pressing Shift+1 when All is already active does nothing', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await loadPage(page);
     // All is active by default
     await expect(page.locator('#scopeToggle .toggle-btn[data-scope="all"]')).toHaveClass(/active/);
@@ -223,6 +235,7 @@ test.describe('Scope Toggle', () => {
   });
 
   test('clicking a disabled scope button does nothing', async ({ page }) => {
+    await setDiffScope(page, 'all');
     await page.route('**/api/session*', async route => {
       const response = await route.fetch();
       const json = await response.json();

--- a/e2e/tests/syntax-highlighting.spec.ts
+++ b/e2e/tests/syntax-highlighting.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { loadPage, goSection, jsSection } from './helpers';
 
+test.beforeEach(async ({ page }) => {
+  await page.context().addCookies([{
+    name: 'crit-settings',
+    value: encodeURIComponent(JSON.stringify({ diffScope: 'all' })),
+    domain: 'localhost',
+    path: '/',
+  }]);
+});
+
 // ============================================================
 // Syntax Highlighting in Diff Views
 // ============================================================

--- a/frontend/__tests__/crit-shared.test.js
+++ b/frontend/__tests__/crit-shared.test.js
@@ -409,6 +409,21 @@ test('runFinishReview approved path: sets approved class + Approved heading + on
   assert.equal(waitingCalled, false);
 });
 
+test('runFinishReview approved path shows resume command when available', async () => {
+  const resume = 'cd /repo && git checkout feature && crit README.md';
+  const fetch = async () => ({ ok: true, json: async () => ({ approved: true, prompt: 'ok-prompt', resume_command: resume }) });
+  const { shared: s, els } = makeFinishSandbox(fetch, { writeText: async () => {} });
+
+  const result = await s.runFinishReview({});
+
+  assert.deepEqual(result, { approved: true, prompt: resume });
+  assert.equal(els.waitingPrompt.textContent, resume);
+  assert.equal(els.promptPreview.textContent, resume);
+  assert.equal(els.waitingMessage.textContent, 'Copy the resume command if you want to return to this review later.');
+  assert.equal(els.waitingClipboard.getAttribute('aria-label'), 'Copy resume command to clipboard');
+  assert.equal(els.waitingDialog.classList.contains('has-resume-command'), true);
+});
+
 test('runFinishReview resets copy button via .copy-label span, not textContent (regression)', async () => {
   const fetch = async () => ({ ok: true, json: async () => ({ approved: true, prompt: 'p' }) });
   const { shared: s, els } = makeFinishSandbox(fetch, { writeText: async () => {} });
@@ -469,6 +484,68 @@ test('runFinishReview onError catches and returns null', async () => {
   const result = await s.runFinishReview({ onError: (e) => { captured = e; } });
   assert.equal(result, null);
   assert.match(String(captured), /HTTP 500/);
+});
+
+test('showDisconnected renders a copyable resume command', async () => {
+  const resume = 'cd /repo && git checkout feature && crit README.md';
+  const header = {
+    offsetHeight: 42,
+    insertAdjacentElement(pos, el) { this.inserted = { pos, el }; },
+  };
+  const created = [];
+  function makeEl(tag) {
+    const el = {
+      tagName: tag,
+      className: '',
+      textContent: '',
+      children: [],
+      style: {},
+      _attrs: {},
+      _listeners: {},
+      appendChild(child) { this.children.push(child); return child; },
+      setAttribute(k, v) { this._attrs[k] = v; },
+      getAttribute(k) { return this._attrs[k] || null; },
+      addEventListener(type, fn) { this._listeners[type] = fn; },
+      classList: {
+        _set: new Set(),
+        add(...c) { c.forEach((x) => this._set.add(x)); },
+        remove(...c) { c.forEach((x) => this._set.delete(x)); },
+        contains(c) { return this._set.has(c); },
+      },
+    };
+    created.push(el);
+    return el;
+  }
+  const doc = {
+    cookie: '',
+    documentElement: { style: { setProperty() {} } },
+    querySelector(sel) {
+      if (sel === '.disconnected-banner') return null;
+      if (sel === '.header') return header;
+      return null;
+    },
+    createElement: makeEl,
+  };
+  const win = { setTimeout: (fn) => fn(), addEventListener() {}, crit: {} };
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: async (value) => { win.copied = value; } },
+  });
+  win.navigator = globalThis.navigator;
+  globalThis.document = doc;
+  globalThis.setTimeout = win.setTimeout;
+  const fn = new Function('window', 'document', src + '\nreturn window;');
+  fn(win, doc);
+
+  win.crit.shared.showDisconnected(resume);
+
+  assert.equal(header.inserted.pos, 'afterend');
+  const code = created.find((el) => el.className === 'disconnected-resume-command');
+  const copy = created.find((el) => el.className === 'disconnected-copy-btn');
+  assert.equal(code.textContent, resume);
+  assert.equal(copy.getAttribute('aria-label'), 'Copy resume command');
+  await copy._listeners.click();
+  assert.equal(win.copied, resume);
 });
 
 // ----- waitForSession -----

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6608,6 +6608,7 @@
   // and uiState transition (live-mode wires its own state machine).
   async function doFinishReview() {
     return await window.crit.shared.runFinishReview({
+      resumeCommand: session && session.resume_command,
       onApproved: function () { waitingNotApproved = false; setUIState('waiting'); },
       onWaiting: function () { waitingNotApproved = true; setUIState('waiting'); },
       onError: function (err) {
@@ -6908,7 +6909,7 @@
       },
       'server-shutdown': function() {
       conn.close();
-      showDisconnected();
+      showDisconnected(session && session.resume_command);
       },
     }, {
       onError: function() {

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -245,6 +245,7 @@
       var data = await resp.json();
       var approved = !!data.approved;
       var prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
+      var resumeCommand = o.resumeCommand || data.resume_command || '';
 
       var dialog = document.getElementById('waitingDialog');
       var headingEl = document.getElementById('waitingHeading');
@@ -259,23 +260,31 @@
         var copyLabel = clipEl.querySelector('.copy-label');
         if (copyLabel) copyLabel.textContent = 'Copy';
         clipEl.classList.remove('copied');
-        clipEl.setAttribute('aria-label', 'Copy prompt to clipboard');
+        clipEl.setAttribute('aria-label', approved && resumeCommand ? 'Copy resume command to clipboard' : 'Copy prompt to clipboard');
       }
 
       if (dialog) {
         dialog.classList.remove('approved');
+        dialog.classList.remove('has-resume-command');
         if (approved) {
           // Force reflow so the CSS animation restarts when the class is re-added.
           void dialog.offsetWidth;
           dialog.classList.add('approved');
+          if (resumeCommand) dialog.classList.add('has-resume-command');
         }
       }
+      if (approved && resumeCommand) {
+        prompt = resumeCommand;
+        if (promptEl) promptEl.textContent = resumeCommand;
+        if (previewEl) previewEl.textContent = resumeCommand;
+      }
+
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';
       if (messageEl) {
         if (approved) {
-          messageEl.textContent =
-            'Your agent has been notified — no further action needed. ' +
-            'You can close this tab whenever you\'re ready.';
+          messageEl.textContent = resumeCommand
+            ? 'Copy the resume command if you want to return to this review later.'
+            : 'Your agent has been notified — no further action needed. You can close this tab whenever you\'re ready.';
         } else {
           messageEl.textContent =
             "Agent notified. Copy the prompt below if it wasn't listening.";
@@ -637,7 +646,7 @@
     if (_tipInterval) { clearInterval(_tipInterval); _tipInterval = null; }
   }
 
-  function showDisconnected() {
+  function showDisconnected(resumeCommand) {
     if (document.querySelector('.disconnected-banner')) return;
     var header = document.querySelector('.header');
     if (!header) return;
@@ -653,6 +662,32 @@
     text.textContent = 'Server stopped — your review is now read only. Safe to close this tab.';
     banner.appendChild(pill);
     banner.appendChild(text);
+    if (resumeCommand) {
+      var resumeRow = document.createElement('div');
+      resumeRow.className = 'disconnected-resume-row';
+      var code = document.createElement('code');
+      code.className = 'disconnected-resume-command';
+      code.textContent = resumeCommand;
+      var copy = document.createElement('button');
+      copy.type = 'button';
+      copy.className = 'disconnected-copy-btn';
+      copy.setAttribute('aria-label', 'Copy resume command');
+      copy.textContent = 'Copy';
+      copy.addEventListener('click', function () {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+        return navigator.clipboard.writeText(resumeCommand).then(function () {
+          copy.textContent = 'Copied';
+          copy.classList.add('copied');
+          setTimeout(function () {
+            copy.textContent = 'Copy';
+            copy.classList.remove('copied');
+          }, 1200);
+        }).catch(function () {});
+      });
+      resumeRow.appendChild(code);
+      resumeRow.appendChild(copy);
+      banner.appendChild(resumeRow);
+    }
     header.insertAdjacentElement('afterend', banner);
     var setHeaderVar = function () {
       document.documentElement.style.setProperty('--crit-header-height', header.offsetHeight + 'px');

--- a/frontend/live-mode.sse.js
+++ b/frontend/live-mode.sse.js
@@ -107,7 +107,7 @@
     function showLiveDisconnected() {
       var shared = window.crit && window.crit.shared;
       if (shared && typeof shared.showDisconnected === 'function') {
-        shared.showDisconnected();
+        shared.showDisconnected(state && state.session && state.session.resume_command);
       }
     }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2090,6 +2090,62 @@ textarea.drag-active {
   color: var(--crit-finish-body-fg);
 }
 
+.disconnected-resume-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  margin-left: auto;
+}
+
+.disconnected-resume-command {
+  max-width: min(56vw, 760px);
+  padding: 4px 8px;
+  border-radius: var(--crit-r-sm);
+  background: var(--crit-editor-bg-elevated);
+  color: var(--crit-editor-fg-muted);
+  font-family: var(--crit-font-mono);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.disconnected-copy-btn {
+  flex-shrink: 0;
+  border: 1px solid var(--crit-border);
+  border-radius: var(--crit-r-sm);
+  background: var(--crit-bg-card);
+  color: var(--crit-brand);
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.disconnected-copy-btn:hover {
+  background: var(--crit-brand-subtle);
+}
+
+.disconnected-copy-btn.copied {
+  color: var(--crit-green);
+}
+
+@media (max-width: 760px) {
+  .disconnected-banner {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .disconnected-resume-row {
+    flex-basis: 100%;
+    margin-left: 0;
+  }
+  .disconnected-resume-command {
+    max-width: none;
+  }
+}
+
 /* ===== Waiting Overlay ===== */
 .waiting-overlay {
   display: none;
@@ -2172,10 +2228,13 @@ textarea.drag-active {
   animation: success-check-draw 0.35s cubic-bezier(0.4, 0, 0.2, 1) 0.4s forwards;
 }
 .waiting-dialog.approved .waiting-spinner { display: none; }
-.waiting-dialog.approved .prompt-copy-row,
+.waiting-dialog.approved:not(.has-resume-command) .prompt-copy-row,
 .waiting-dialog.approved .waiting-divider,
 .waiting-dialog.approved .tip-section,
 .waiting-dialog.approved .waiting-footer { display: none; }
+.waiting-dialog.approved.has-resume-command .prompt-copy-row {
+  margin-bottom: 24px;
+}
 .waiting-dialog.approved .success-mark {
   display: inline-block;
   filter: drop-shadow(0 0 0 transparent);

--- a/main.go
+++ b/main.go
@@ -1761,16 +1761,31 @@ func hintMissingIntegrationsFor(cwd, home string) {
 	}
 }
 
-func installDaemonSignalHandler(pid int) {
+func installDaemonSignalHandler(pid int, beforeExit ...func()) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, terminationSignals()...)
 	go func() {
 		<-sigCh
-		if proc, err := os.FindProcess(pid); err == nil {
-			_ = terminateProcess(proc)
-		}
-		os.Exit(0)
+		handleDaemonSignal(pid, beforeExit, os.Exit)
 	}()
+}
+
+func handleDaemonSignal(pid int, beforeExit []func(), exit func(int)) {
+	handleDaemonSignalWith(pid, beforeExit, terminateProcess, exit)
+}
+
+func handleDaemonSignalWith(pid int, beforeExit []func(), terminate func(*os.Process) error, exit func(int)) {
+	for _, fn := range beforeExit {
+		if fn != nil {
+			fn()
+		}
+	}
+	if pid > 0 {
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = terminate(proc)
+		}
+	}
+	exit(0)
 }
 
 func killDaemonOnApproval(approved bool, pid int) {
@@ -2332,16 +2347,22 @@ func runReview(args []string) {
 		weStartedDaemon = true
 	}
 
-	// If we started the daemon, clean it up on Ctrl+C
-	if weStartedDaemon {
-		installDaemonSignalHandler(entry.PID)
-	}
+	installDaemonSignalHandler(resumeSignalPID(weStartedDaemon, entry), func() {
+		printSessionResumeInstructions(entry, args, os.Stderr, isTerminal(os.Stderr))
+	})
 
 	approved := runReviewClient(entry, key)
 	printSessionResumeInstructions(entry, args, os.Stderr, isTerminal(os.Stderr))
 
 	killDaemonOnApproval(approved, entry.PID)
 	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
+}
+
+func resumeSignalPID(weStartedDaemon bool, entry sessionEntry) int {
+	if weStartedDaemon {
+		return entry.PID
+	}
+	return 0
 }
 
 func printSessionResumeInstructions(entry sessionEntry, args []string, w io.Writer, color bool) {

--- a/main.go
+++ b/main.go
@@ -2338,8 +2338,18 @@ func runReview(args []string) {
 	}
 
 	approved := runReviewClient(entry, key)
+	printSessionResumeInstructions(entry, args, os.Stderr, isTerminal(os.Stderr))
+
 	killDaemonOnApproval(approved, entry.PID)
 	cleanupOnApproval(approved, entry.ReviewPath, LoadConfig(cwd).CleanupOnApproveEnabled())
+}
+
+func printSessionResumeInstructions(entry sessionEntry, args []string, w io.Writer, color bool) {
+	if entry.Branch == "" {
+		return
+	}
+	status := &Status{w: w, color: color}
+	status.ResumeInstructions(entry.CWD, entry.Branch, args)
 }
 
 // readReviewCycleResponse reads and closes the response body, returning an

--- a/main_test.go
+++ b/main_test.go
@@ -1959,6 +1959,14 @@ func TestPrintSessionResumeInstructions_GitBranch(t *testing.T) {
 	}
 }
 
+func TestBuildResumeCommand_QuotesPathBranchAndArgs(t *testing.T) {
+	got := buildResumeCommand("/home/user/my project", "feat/special branch", []string{"docs/read me.md"})
+	want := "cd '/home/user/my project' && git checkout 'feat/special branch' && crit 'docs/read me.md'"
+	if got != want {
+		t.Errorf("buildResumeCommand() = %q, want %q", got, want)
+	}
+}
+
 func TestPrintSessionResumeInstructions_NoBranch(t *testing.T) {
 	var buf strings.Builder
 	entry := sessionEntry{CWD: "/home/user/project"}
@@ -1966,6 +1974,54 @@ func TestPrintSessionResumeInstructions_NoBranch(t *testing.T) {
 
 	if got := buf.String(); got != "" {
 		t.Errorf("resume instructions = %q, want empty output", got)
+	}
+}
+
+func TestResumeSignalPID(t *testing.T) {
+	entry := sessionEntry{PID: 4321}
+	if got := resumeSignalPID(true, entry); got != 4321 {
+		t.Fatalf("resumeSignalPID(true) = %d, want 4321", got)
+	}
+	if got := resumeSignalPID(false, entry); got != 0 {
+		t.Fatalf("resumeSignalPID(false) = %d, want 0", got)
+	}
+}
+
+func TestHandleDaemonSignal_RunsCallbacksAndExits(t *testing.T) {
+	called := 0
+	exitCode := -1
+	handleDaemonSignal(0, []func(){
+		nil,
+		func() { called++ },
+		func() { called += 2 },
+	}, func(code int) {
+		exitCode = code
+	})
+
+	if called != 3 {
+		t.Fatalf("callbacks called = %d, want 3", called)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", exitCode)
+	}
+}
+
+func TestHandleDaemonSignal_TerminatesPositivePID(t *testing.T) {
+	pid := os.Getpid()
+	terminated := 0
+	exitCode := -1
+	handleDaemonSignalWith(pid, nil, func(proc *os.Process) error {
+		terminated = proc.Pid
+		return nil
+	}, func(code int) {
+		exitCode = code
+	})
+
+	if terminated != pid {
+		t.Fatalf("terminated pid = %d, want %d", terminated, pid)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", exitCode)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1948,6 +1948,27 @@ func TestDirArgs(t *testing.T) {
 	}
 }
 
+func TestPrintSessionResumeInstructions_GitBranch(t *testing.T) {
+	var buf strings.Builder
+	entry := sessionEntry{CWD: "/home/user/project", Branch: "feature-branch"}
+	printSessionResumeInstructions(entry, []string{"--no-open", "--port", "0"}, &buf, false)
+
+	want := "\nTo resume this review:\n  cd /home/user/project && git checkout feature-branch && crit --no-open --port 0\n"
+	if got := buf.String(); got != want {
+		t.Errorf("resume instructions = %q, want %q", got, want)
+	}
+}
+
+func TestPrintSessionResumeInstructions_NoBranch(t *testing.T) {
+	var buf strings.Builder
+	entry := sessionEntry{CWD: "/home/user/project"}
+	printSessionResumeInstructions(entry, nil, &buf, false)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("resume instructions = %q, want empty output", got)
+	}
+}
+
 func TestParseShareFlags(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/server.go
+++ b/server.go
@@ -1852,10 +1852,11 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, map[string]any{
-		"status":      "finished",
-		"review_file": reviewFile,
-		"prompt":      prompt,
-		"approved":    approved,
+		"status":         "finished",
+		"review_file":    reviewFile,
+		"prompt":         prompt,
+		"approved":       approved,
+		"resume_command": sess.GetSessionInfo().ResumeCommand,
 	})
 
 	// Encode approved status into SSE event content as JSON so review-cycle
@@ -1928,6 +1929,10 @@ func buildNextCommand(args []string) string {
 	return strings.Join(parts, " ")
 }
 
+func buildResumeCommand(cwd, branch string, args []string) string {
+	return fmt.Sprintf("cd %s && git checkout %s && %s", shellQuoteArg(cwd), shellQuoteArg(branch), buildNextCommand(args))
+}
+
 // shellQuoteArg quotes a single CLI arg using POSIX single-quote syntax when
 // it contains whitespace or shell metacharacters; returns it unchanged
 // otherwise. Single quotes inside the arg are escaped as '\”.
@@ -1976,11 +1981,12 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 				}
 				json.Unmarshal([]byte(event.Content), &finishData)
 				writeJSON(w, map[string]any{
-					"status":       "finished",
-					"review_file":  reviewPathsFor(sess.critJSONPath()).Review,
-					"prompt":       finishData.Prompt,
-					"approved":     finishData.Approved,
-					"next_command": buildNextCommand(s.cliArgs),
+					"status":         "finished",
+					"review_file":    reviewPathsFor(sess.critJSONPath()).Review,
+					"prompt":         finishData.Prompt,
+					"approved":       finishData.Approved,
+					"next_command":   buildNextCommand(s.cliArgs),
+					"resume_command": sess.GetSessionInfo().ResumeCommand,
 				})
 				return
 			}

--- a/session.go
+++ b/session.go
@@ -2489,6 +2489,7 @@ type SessionInfo struct {
 	Files            []SessionFileInfo `json:"files"`
 	ReviewComments   []Comment         `json:"review_comments"`
 	Cwd              string            `json:"cwd,omitempty"`
+	ResumeCommand    string            `json:"resume_command,omitempty"`
 	Focus            Focus             `json:"focus"`
 	LastRangeFocus   *Focus            `json:"last_range_focus,omitempty"`
 	HiddenUnresolved int               `json:"hidden_unresolved"`
@@ -2538,6 +2539,9 @@ func (s *Session) GetSessionInfo() SessionInfo {
 		Cwd:            s.RepoRoot,
 		Focus:          s.Focus,
 		LastRangeFocus: s.LastRangeFocus,
+	}
+	if s.Branch != "" {
+		info.ResumeCommand = buildResumeCommand(s.RepoRoot, s.Branch, s.CLIArgs)
 	}
 
 	info.AvailableScopes = cachedAvailableScopes(info.BaseRef, vcs)

--- a/status.go
+++ b/status.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
+
+	"golang.org/x/term"
 )
 
 const (
@@ -71,6 +74,17 @@ func (s *Status) FileUpdated(editCount int) {
 		noun = "edit"
 	}
 	fmt.Fprintf(s.w, "%s %s\n", s.arrow(), s.dim(fmt.Sprintf("File updated (%d %s detected)", editCount, noun)))
+}
+
+// ResumeInstructions prints a hint showing how to return to this review later.
+func (s *Status) ResumeInstructions(cwd, branch string, args []string) {
+	cmd := buildNextCommand(args)
+	fmt.Fprintf(s.w, "\n%s\n", s.dim("To resume this review:"))
+	fmt.Fprintf(s.w, "  %s\n", s.dim(fmt.Sprintf("cd %s && git checkout %s && %s", shellQuoteArg(cwd), shellQuoteArg(branch), cmd)))
+}
+
+func isTerminal(f *os.File) bool {
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // RoundReady prints the new round summary with resolved/open counts.

--- a/status.go
+++ b/status.go
@@ -78,9 +78,8 @@ func (s *Status) FileUpdated(editCount int) {
 
 // ResumeInstructions prints a hint showing how to return to this review later.
 func (s *Status) ResumeInstructions(cwd, branch string, args []string) {
-	cmd := buildNextCommand(args)
 	fmt.Fprintf(s.w, "\n%s\n", s.dim("To resume this review:"))
-	fmt.Fprintf(s.w, "  %s\n", s.dim(fmt.Sprintf("cd %s && git checkout %s && %s", shellQuoteArg(cwd), shellQuoteArg(branch), cmd)))
+	fmt.Fprintf(s.w, "  %s\n", s.dim(buildResumeCommand(cwd, branch, args)))
 }
 
 func isTerminal(f *os.File) bool {

--- a/status_test.go
+++ b/status_test.go
@@ -140,3 +140,35 @@ func TestStatusColor_GreenInRoundReady(t *testing.T) {
 		t.Error("expected green ANSI code for resolved count")
 	}
 }
+
+func TestResumeInstructions_NoArgs(t *testing.T) {
+	s, buf := testStatus()
+	s.ResumeInstructions("/home/user/project", "feature-branch", nil)
+	got := buf.String()
+	want := "\nTo resume this review:\n  cd /home/user/project && git checkout feature-branch && crit\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResumeInstructions_WithArgs(t *testing.T) {
+	s, buf := testStatus()
+	s.ResumeInstructions("/home/user/project", "main", []string{"--port", "3000"})
+	got := buf.String()
+	want := "\nTo resume this review:\n  cd /home/user/project && git checkout main && crit --port 3000\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResumeInstructions_QuotesSpecialChars(t *testing.T) {
+	s, buf := testStatus()
+	s.ResumeInstructions("/home/user/my project", "feat/special branch", nil)
+	got := buf.String()
+	if !strings.Contains(got, "'feat/special branch'") {
+		t.Errorf("expected branch to be quoted, got %q", got)
+	}
+	if !strings.Contains(got, "'/home/user/my project'") {
+		t.Errorf("expected cwd to be quoted, got %q", got)
+	}
+}

--- a/status_test.go
+++ b/status_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -170,5 +171,16 @@ func TestResumeInstructions_QuotesSpecialChars(t *testing.T) {
 	}
 	if !strings.Contains(got, "'/home/user/my project'") {
 		t.Errorf("expected cwd to be quoted, got %q", got)
+	}
+}
+
+func TestIsTerminal_RegularFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "not-a-terminal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if isTerminal(f) {
+		t.Fatal("regular file reported as terminal")
 	}
 }


### PR DESCRIPTION
## Summary
- Print a resume hint after review sessions complete, after the terminal session summary
- Include the absolute working directory, current branch checkout, and original `crit` args in the command
- Reuse existing command and shell-quoting helpers so paths, branches, and args with spaces remain copy-pasteable

Closes CRI-7

## Test plan
- [x] `mise exec -- go test ./...`
- [x] `TestClientExitsOnFinish` verifies stdout remains the JSON summary and stderr includes resume instructions
- [x] `TestResumeInstructions_*` covers no args, args, and shell quoting
