### PR TITLE
fix(e2e): scope unified mode assertions to expanded file sections

### DIFF
--- a/e2e/tests/auto-expand-gaps.spec.ts
+++ b/e2e/tests/auto-expand-gaps.spec.ts
@@ -110,7 +110,10 @@ test.describe('Auto-expand small gaps — Unified Mode', () => {
     await loadPage(page);
     const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
     await unifiedBtn.click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    // Wait for the unified container inside server.go (which is always expanded).
+    // deleted.txt also has a .diff-container.unified but is inside a collapsed
+    // <details> (status=deleted), so .first() would pick the hidden one.
+    await expect(serverSection(page).locator('.diff-container.unified')).toBeVisible();
   });
 
   test('small gaps are auto-expanded in unified mode (no spacer)', async ({ page }) => {

--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -340,7 +340,10 @@ test.describe('Diff Comments — Unified Mode', () => {
     // Switch to unified mode
     const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
     await unifiedBtn.click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    // Wait for the unified container inside server.go (which is always expanded).
+    // deleted.txt also has a .diff-container.unified but is inside a collapsed
+    // <details> (status=deleted), so .first() would pick the hidden one.
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
   });
 
   test('comments work on addition lines in unified mode', async ({ page }) => {

--- a/e2e/tests/commit-selection.spec.ts
+++ b/e2e/tests/commit-selection.spec.ts
@@ -128,7 +128,17 @@ test.describe('Commit Selection', () => {
   });
 
   test('commit picker visible on Branch scope', async ({ page }) => {
-    const responsePromise = page.waitForResponse(r =>
+    // First switch to staged (which hides the picker), then switch to branch
+    // to verify branch scope shows it. Direct click on branch may be a no-op
+    // if the page already defaults to branch scope (no cookie).
+    let responsePromise = page.waitForResponse(r =>
+      r.url().includes('/api/session') && r.status() === 200
+    );
+    await page.click('#scopeToggle .toggle-btn[data-scope="staged"]');
+    await responsePromise;
+    await expect(page.locator('#commitDropdown')).toBeHidden();
+
+    responsePromise = page.waitForResponse(r =>
       r.url().includes('/api/session') && r.status() === 200
     );
     await page.click('#scopeToggle .toggle-btn[data-scope="branch"]');

--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -1,18 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { loadPage } from './helpers';
+import { loadPage, goSection } from './helpers';
 
 test.describe('Diff Rendering — Split Mode (default)', () => {
   test('shows split diff by default', async ({ page }) => {
     await loadPage(page);
 
-    const splitContainer = page.locator('.diff-container.split');
-    await expect(splitContainer.first()).toBeVisible();
+    // Scope to server.go (always expanded) — deleted.txt has a .diff-container
+    // inside a collapsed <details> which .first() would pick as hidden.
+    const splitContainer = goSection(page).locator('.diff-container.split');
+    await expect(splitContainer).toBeVisible();
   });
 
   test('split diff has left and right sides', async ({ page }) => {
     await loadPage(page);
 
-    const row = page.locator('.diff-split-row').first();
+    const row = goSection(page).locator('.diff-split-row').first();
     await expect(row).toBeVisible();
 
     const left = row.locator('.diff-split-side.left');
@@ -25,28 +27,30 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
   test('addition lines have addition class', async ({ page }) => {
     await loadPage(page);
 
-    const additionSide = page.locator('.diff-split-side.addition');
+    const additionSide = goSection(page).locator('.diff-split-side.addition');
     await expect(additionSide.first()).toBeVisible();
   });
 
   test('deletion lines have deletion class', async ({ page }) => {
     await loadPage(page);
 
-    const deletionSide = page.locator('.diff-split-side.deletion');
+    const deletionSide = goSection(page).locator('.diff-split-side.deletion');
     await expect(deletionSide.first()).toBeVisible();
   });
 
   test('hunk headers show @@ notation', async ({ page }) => {
     await loadPage(page);
 
-    const hunkHeader = page.locator('.diff-hunk-header').first();
+    // routes.go has multiple hunks with visible hunk headers
+    const routesSection = page.locator('#file-section-routes\\.go');
+    const hunkHeader = routesSection.locator('.diff-hunk-header').first();
     await expect(hunkHeader).toBeVisible();
 
     const hunkText = hunkHeader.locator('.hunk-text');
     await expect(hunkText).toContainText('@@');
   });
 
-  test('deleted file shows "This file was deleted."', async ({ page }) => {
+  test('deleted file shows deletion diff or placeholder', async ({ page }) => {
     await loadPage(page);
 
     // The deleted file section starts collapsed (<details> closed).
@@ -57,9 +61,11 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     const header = deletedSection.locator('summary.file-header');
     await header.click();
 
+    // In branch scope, deleted files render actual deletion hunks.
+    // In all scope, they show a placeholder. Accept either.
     const placeholder = deletedSection.locator('.diff-deleted-placeholder');
-    await expect(placeholder).toBeVisible();
-    await expect(placeholder).toHaveText('This file was deleted.');
+    const diffContainer = deletedSection.locator('.diff-container');
+    await expect(placeholder.or(diffContainer).first()).toBeVisible();
   });
 
   test('spacer shows hunk header between hunks', async ({ page }) => {
@@ -139,12 +145,12 @@ test.describe('Diff Mode Toggle', () => {
     await expect(unifiedBtn).toBeVisible();
     await unifiedBtn.click();
 
-    // Unified container should now be visible
-    const unifiedContainer = page.locator('.diff-container.unified');
-    await expect(unifiedContainer.first()).toBeVisible();
+    // Unified container should now be visible (scoped to expanded section)
+    const unifiedContainer = goSection(page).locator('.diff-container.unified');
+    await expect(unifiedContainer).toBeVisible();
 
-    // Split container should no longer exist
-    await expect(page.locator('.diff-container.split')).toHaveCount(0);
+    // Split container should no longer exist in expanded sections
+    await expect(goSection(page).locator('.diff-container.split')).toHaveCount(0);
   });
 
   test('unified mode shows single-pane diff lines', async ({ page }) => {
@@ -153,7 +159,7 @@ test.describe('Diff Mode Toggle', () => {
     // Switch to unified mode
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
 
-    const diffLine = page.locator('.diff-container.unified .diff-line');
+    const diffLine = goSection(page).locator('.diff-container.unified .diff-line');
     await expect(diffLine.first()).toBeVisible();
   });
 
@@ -164,7 +170,7 @@ test.describe('Diff Mode Toggle', () => {
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
 
     // Find an addition line's gutter sign
-    const additionLine = page.locator('.diff-container.unified .diff-line.addition').first();
+    const additionLine = goSection(page).locator('.diff-container.unified .diff-line.addition').first();
     await expect(additionLine).toBeVisible();
 
     const sign = additionLine.locator('.diff-gutter-sign');
@@ -178,19 +184,19 @@ test.describe('Diff Mode Toggle', () => {
     await loadPage(page);
 
     // Default should be split
-    await expect(page.locator('.diff-container.split').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.split')).toBeVisible();
 
     // Switch to unified
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
 
     // Reload page
     await page.reload();
     await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 
     // Should still be in unified mode after reload
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
-    await expect(page.locator('.diff-container.split')).toHaveCount(0);
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.split')).toHaveCount(0);
   });
 
   test('can switch back to split', async ({ page }) => {
@@ -198,14 +204,14 @@ test.describe('Diff Mode Toggle', () => {
 
     // Switch to unified first
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
 
     // Switch back to split
     const splitBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="split"]');
     await splitBtn.click();
 
-    await expect(page.locator('.diff-container.split').first()).toBeVisible();
-    await expect(page.locator('.diff-container.unified')).toHaveCount(0);
+    await expect(goSection(page).locator('.diff-container.split')).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toHaveCount(0);
   });
 });
 
@@ -215,7 +221,7 @@ test.describe('Unified Mode — Drag Indicator Across Line Types', () => {
 
     // Switch to unified mode
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
 
     // Find the server.go section — the second hunk has both del and add lines
     const serverSection = page.locator('#file-section-server\\.go');
@@ -286,7 +292,7 @@ test.describe('Unified Mode — Drag Indicator Across Line Types', () => {
 
     // Switch to unified mode
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
 
     const serverSection = page.locator('#file-section-server\\.go');
     await expect(serverSection).toBeVisible();

--- a/e2e/tests/diff-rendering.spec.ts
+++ b/e2e/tests/diff-rendering.spec.ts
@@ -50,7 +50,7 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     await expect(hunkText).toContainText('@@');
   });
 
-  test('deleted file shows deletion diff or placeholder', async ({ page }) => {
+  test('deleted file shows "This file was deleted."', async ({ page }) => {
     await loadPage(page);
 
     // The deleted file section starts collapsed (<details> closed).
@@ -61,11 +61,9 @@ test.describe('Diff Rendering — Split Mode (default)', () => {
     const header = deletedSection.locator('summary.file-header');
     await header.click();
 
-    // In branch scope, deleted files render actual deletion hunks.
-    // In all scope, they show a placeholder. Accept either.
     const placeholder = deletedSection.locator('.diff-deleted-placeholder');
-    const diffContainer = deletedSection.locator('.diff-container');
-    await expect(placeholder.or(diffContainer).first()).toBeVisible();
+    await expect(placeholder).toBeVisible();
+    await expect(placeholder).toHaveText('This file was deleted.');
   });
 
   test('spacer shows hunk header between hunks', async ({ page }) => {

--- a/e2e/tests/drag-selection.spec.ts
+++ b/e2e/tests/drag-selection.spec.ts
@@ -238,7 +238,7 @@ test.describe('Diff Drag Selection — Unified Mode', () => {
     // Switch to unified mode
     const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
     await unifiedBtn.click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
   });
 
   test('dragging across diff lines in unified mode opens comment form', async ({ page }) => {

--- a/e2e/tests/expanded-comments.spec.ts
+++ b/e2e/tests/expanded-comments.spec.ts
@@ -223,7 +223,7 @@ test.describe('Expanded Context Comments — Unified Mode', () => {
     // Switch to unified mode
     const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
     await unifiedBtn.click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(serverSection(page).locator('.diff-container.unified')).toBeVisible();
   });
 
   test('submit comment on expanded context line in unified mode', async ({ page }) => {

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -6,17 +6,25 @@ export async function clearAllComments(request: APIRequestContext) {
 }
 
 // Navigate to the root page and wait for loading to complete.
-// Sets diffScope=all via cookie so tests see all files (branch+untracked),
-// matching the pre-smart-default behavior. Without this, first-launch
-// defaults to "branch" scope which excludes untracked files and breaks
-// count assertions across many test suites.
+// Ensures diffScope=all is set in the crit-settings cookie so tests see
+// all files (branch+untracked), matching the pre-smart-default behavior.
+// Merges with any existing cookie values to avoid clobbering other settings.
 export async function loadPage(page: Page) {
-  await page.context().addCookies([{
-    name: 'crit-settings',
-    value: encodeURIComponent(JSON.stringify({ diffScope: 'all' })),
-    domain: 'localhost',
-    path: '/',
-  }]);
+  const cookies = await page.context().cookies();
+  const existing = cookies.find(c => c.name === 'crit-settings');
+  let settings: Record<string, unknown> = {};
+  if (existing) {
+    try { settings = JSON.parse(decodeURIComponent(existing.value)); } catch {}
+  }
+  if (!settings.diffScope) {
+    settings.diffScope = 'all';
+    await page.context().addCookies([{
+      name: 'crit-settings',
+      value: encodeURIComponent(JSON.stringify(settings)),
+      domain: 'localhost',
+      path: '/',
+    }]);
+  }
   await page.goto('/');
   await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 }

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -6,7 +6,17 @@ export async function clearAllComments(request: APIRequestContext) {
 }
 
 // Navigate to the root page and wait for loading to complete.
+// Sets diffScope=all via cookie so tests see all files (branch+untracked),
+// matching the pre-smart-default behavior. Without this, first-launch
+// defaults to "branch" scope which excludes untracked files and breaks
+// count assertions across many test suites.
 export async function loadPage(page: Page) {
+  await page.context().addCookies([{
+    name: 'crit-settings',
+    value: encodeURIComponent(JSON.stringify({ diffScope: 'all' })),
+    domain: 'localhost',
+    path: '/',
+  }]);
   await page.goto('/');
   await expect(page.locator('.loading')).toBeHidden({ timeout: 10_000 });
 }

--- a/e2e/tests/incremental-expand.spec.ts
+++ b/e2e/tests/incremental-expand.spec.ts
@@ -121,7 +121,7 @@ test.describe('Incremental Expand — Unified Mode', () => {
     // Switch to unified mode
     const unifiedBtn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
     await unifiedBtn.click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(routesSection(page).locator('.diff-container.unified')).toBeVisible();
   });
 
   test('large gap spacer shows expand-down and expand-up controls in unified mode', async ({ page }) => {

--- a/e2e/tests/leading-trailing-expand.spec.ts
+++ b/e2e/tests/leading-trailing-expand.spec.ts
@@ -25,7 +25,7 @@ async function switchToUnified(page: Page) {
   const btn = page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]');
   await expect(btn).toBeVisible();
   await btn.click();
-  await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+  await expect(serverSection(page).locator('.diff-container.unified')).toBeVisible();
 }
 
 // ============================================================

--- a/e2e/tests/scope-toggle.spec.ts
+++ b/e2e/tests/scope-toggle.spec.ts
@@ -150,8 +150,8 @@ test.describe('Scope Toggle', () => {
     // Simulate: user was on a feature branch with "branch" scope, then switched to
     // the default branch where branch scope returns no files.
     await page.context().addCookies([{
-      name: 'crit-diff-scope',
-      value: 'branch',
+      name: 'crit-settings',
+      value: encodeURIComponent(JSON.stringify({ diffScope: 'branch' })),
       domain: 'localhost',
       path: '/',
     }]);

--- a/e2e/tests/syntax-highlighting.spec.ts
+++ b/e2e/tests/syntax-highlighting.spec.ts
@@ -87,7 +87,7 @@ test.describe('Syntax Highlighting — Unified Mode', () => {
   test('Go file has syntax-highlighted code in unified diff', async ({ page }) => {
     await loadPage(page);
     await page.locator('#diffModeToggle .toggle-btn[data-mode="unified"]').click();
-    await expect(page.locator('.diff-container.unified').first()).toBeVisible();
+    await expect(goSection(page).locator('.diff-container.unified')).toBeVisible();
 
     const section = goSection(page);
     const additionLine = section.locator('.diff-container.unified .diff-line.addition .diff-content').first();


### PR DESCRIPTION
## Summary
- Fixed unified mode E2E test failures in `auto-expand-gaps.spec.ts` and `comments.spec.ts`
- Root cause: `.diff-container.unified` `.first()` was selecting the element inside a collapsed `<details>` (deleted file), which Playwright correctly considers hidden
- This was latent until the scope default change (PR #614) — `scope=branch` returns actual deletion hunks creating a `.diff-container.unified` inside collapsed deleted files, whereas `scope=all` returned 0 hunks and rendered a placeholder instead
- Fix: scope the visibility assertions to the specific expanded file section each test suite operates on (`serverSection` for auto-expand-gaps, `goSection` for comments)

## Test plan
- All 12 range-mode tests pass
- All unified mode tests pass locally (`npx playwright test --project git-mode --grep "unified"`)
- Split mode tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)