### PR TITLE
feat: show session summary on exit

### DIFF
--- a/e2e/tests/round-complete.filemode.spec.ts
+++ b/e2e/tests/round-complete.filemode.spec.ts
@@ -79,7 +79,8 @@ test.describe('Multi-Round — File Mode — Frontend', () => {
     const dialog = page.locator('#waitingDialog');
     await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
     await expect(page.locator('#waitingHeading')).toHaveText('Approved');
-    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
+    await expect(page.locator('#summaryReceipt')).toBeVisible();
+    await expect(page.locator('#summaryLine')).toContainText('Done reviewing');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/e2e/tests/round-complete.spec.ts
+++ b/e2e/tests/round-complete.spec.ts
@@ -276,7 +276,8 @@ test.describe('Multi-Round — Frontend', () => {
     const dialog = page.locator('#waitingDialog');
     await expect(dialog).toHaveClass(/approved/, { timeout: 10_000 });
     await expect(page.locator('#waitingHeading')).toHaveText('Approved');
-    await expect(page.locator('#waitingMessage')).toContainText('close this tab');
+    await expect(page.locator('#summaryReceipt')).toBeVisible();
+    await expect(page.locator('#summaryLine')).toContainText('Done reviewing');
   });
 
   test('round-complete SSE triggers UI refresh and exits waiting state', async ({ page, request }) => {

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -222,6 +222,34 @@
     return hours + 'h ' + minutes + 'm';
   }
 
+  // Wire up the summary receipt copy button (once).
+  var _summaryBtnWired = false;
+  function wireSummaryCopyBtn() {
+    if (_summaryBtnWired) return;
+    var btn = document.getElementById('summaryCopyBtn');
+    if (!btn) return;
+    _summaryBtnWired = true;
+    btn.addEventListener('click', function () {
+      var receipt = btn.closest('.summary-receipt');
+      var text = receipt ? receipt.getAttribute('data-copy-text') : '';
+      if (!text) return;
+      navigator.clipboard.writeText(text).then(function () {
+        btn.classList.add('copied');
+        receipt.classList.add('copied');
+        var iconCopy = btn.querySelector('.icon-copy');
+        var iconCheck = btn.querySelector('.icon-check');
+        if (iconCopy) iconCopy.style.display = 'none';
+        if (iconCheck) iconCheck.style.display = '';
+        setTimeout(function () {
+          btn.classList.remove('copied');
+          receipt.classList.remove('copied');
+          if (iconCopy) iconCopy.style.display = '';
+          if (iconCheck) iconCheck.style.display = 'none';
+        }, 1800);
+      });
+    });
+  }
+
   // ===== runFinishReview =====
   // Shared finish-review flow used by both code-review (app.js) and
   // live-mode (live-mode.js). POSTs /api/finish, parses
@@ -284,38 +312,41 @@
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';
       if (messageEl) {
         if (approved) {
-          var phrases = [
-            'Ship it!',
-            'Looks good to me!',
-            'Clean as a whistle.',
-            'Nothing to see here — all good.',
-            'Ready to roll.',
-            'Two thumbs up.',
-            'Stamp of approval.',
-            'Good to go!',
-            'Nailed it.',
-            'All clear, captain.',
+          var subtitles = [
+            'Nice work, you\'re all done',
+            'All wrapped up',
+            'Review complete',
+            'That\'s a wrap',
           ];
-          messageEl.textContent = phrases[Math.floor(Math.random() * phrases.length)];
+          messageEl.textContent = subtitles[Math.floor(Math.random() * subtitles.length)];
         } else {
           messageEl.textContent =
             "Agent notified. Copy the prompt below if it wasn't listening.";
         }
       }
 
-      var statsEl = document.getElementById('waitingStats');
-      if (statsEl) {
+      var receiptEl = document.getElementById('summaryReceipt');
+      var lineEl = document.getElementById('summaryLine');
+      if (receiptEl && lineEl) {
         if (approved && data.stats) {
-          var parts = [];
+          var statParts = [];
+          if (data.stats.files_reviewed) statParts.push(data.stats.files_reviewed + (data.stats.files_reviewed === 1 ? ' file' : ' files'));
+          if (data.stats.comments_submitted) statParts.push(data.stats.comments_submitted + (data.stats.comments_submitted === 1 ? ' comment' : ' comments'));
           var dur = data.stats.duration_seconds;
-          if (dur != null) parts.push(formatStatsDuration(dur));
-          if (data.stats.files_reviewed) parts.push(data.stats.files_reviewed + (data.stats.files_reviewed === 1 ? ' file' : ' files'));
-          if (data.stats.comments_submitted) parts.push(data.stats.comments_submitted + (data.stats.comments_submitted === 1 ? ' comment' : ' comments'));
-          statsEl.textContent = parts.length ? parts.join(' · ') : '';
-          statsEl.style.display = parts.length ? '' : 'none';
+          if (dur != null) statParts.push(formatStatsDuration(dur));
+          if (statParts.length) {
+            var plainText = 'Done reviewing — ' + statParts.join(' · ');
+            receiptEl.setAttribute('data-copy-text', plainText);
+            var html = 'Done reviewing <span class="sep">—</span> ';
+            html += statParts.join(' <span class="sep">·</span> ');
+            lineEl.innerHTML = html;
+            receiptEl.style.display = '';
+            wireSummaryCopyBtn();
+          } else {
+            receiptEl.style.display = 'none';
+          }
         } else {
-          statsEl.textContent = '';
-          statsEl.style.display = 'none';
+          receiptEl.style.display = 'none';
         }
       }
 

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -211,6 +211,17 @@
     return dismiss;
   }
 
+  // ===== formatStatsDuration =====
+  // Human-readable duration: "42s", "3m", "1h", "1h 15m".
+  function formatStatsDuration(seconds) {
+    if (seconds < 60) return seconds + 's';
+    var hours = Math.floor(seconds / 3600);
+    var minutes = Math.floor((seconds % 3600) / 60);
+    if (hours === 0) return minutes + 'm';
+    if (minutes === 0) return hours + 'h';
+    return hours + 'h ' + minutes + 'm';
+  }
+
   // ===== runFinishReview =====
   // Shared finish-review flow used by both code-review (app.js) and
   // live-mode (live-mode.js). POSTs /api/finish, parses
@@ -273,12 +284,38 @@
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';
       if (messageEl) {
         if (approved) {
-          messageEl.textContent =
-            'Your agent has been notified — no further action needed. ' +
-            'You can close this tab whenever you\'re ready.';
+          var phrases = [
+            'Ship it!',
+            'Looks good to me!',
+            'Clean as a whistle.',
+            'Nothing to see here — all good.',
+            'Ready to roll.',
+            'Two thumbs up.',
+            'Stamp of approval.',
+            'Good to go!',
+            'Nailed it.',
+            'All clear, captain.',
+          ];
+          messageEl.textContent = phrases[Math.floor(Math.random() * phrases.length)];
         } else {
           messageEl.textContent =
             "Agent notified. Copy the prompt below if it wasn't listening.";
+        }
+      }
+
+      var statsEl = document.getElementById('waitingStats');
+      if (statsEl) {
+        if (approved && data.stats) {
+          var parts = [];
+          var dur = data.stats.duration_seconds;
+          if (dur != null) parts.push(formatStatsDuration(dur));
+          if (data.stats.files_reviewed) parts.push(data.stats.files_reviewed + (data.stats.files_reviewed === 1 ? ' file' : ' files'));
+          if (data.stats.comments_submitted) parts.push(data.stats.comments_submitted + (data.stats.comments_submitted === 1 ? ' comment' : ' comments'));
+          statsEl.textContent = parts.length ? parts.join(' · ') : '';
+          statsEl.style.display = parts.length ? '' : 'none';
+        } else {
+          statsEl.textContent = '';
+          statsEl.style.display = 'none';
         }
       }
 

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -248,6 +248,25 @@
     });
   }
 
+  var CONFETTI_COLORS = ['#56d364', '#85aaf8', '#ff8c6b', '#e8c555', '#d285f8'];
+  function spawnConfetti(container) {
+    if (!container) return;
+    container.style.position = 'relative';
+    container.style.overflow = 'hidden';
+    for (var i = 0; i < 14; i++) {
+      var dot = document.createElement('span');
+      dot.className = 'confetti-dot';
+      var size = 4 + Math.random() * 5;
+      dot.style.width = size + 'px';
+      dot.style.height = size + 'px';
+      dot.style.left = (8 + Math.random() * 84) + '%';
+      dot.style.top = (10 + Math.random() * 30) + '%';
+      dot.style.background = CONFETTI_COLORS[i % CONFETTI_COLORS.length];
+      dot.style.setProperty('--confetti-delay', (Math.random() * 0.5) + 's');
+      container.appendChild(dot);
+    }
+  }
+
   // ===== runFinishReview =====
   // Shared finish-review flow used by both code-review (app.js) and
   // live-mode (live-mode.js). POSTs /api/finish, parses
@@ -301,10 +320,12 @@
 
       if (dialog) {
         dialog.classList.remove('approved');
+        dialog.querySelectorAll('.confetti-dot').forEach(function (d) { d.remove(); });
         if (approved) {
           // Force reflow so the CSS animation restarts when the class is re-added.
           void dialog.offsetWidth;
           dialog.classList.add('approved');
+          spawnConfetti(dialog.querySelector('.waiting-header'));
         }
       }
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -310,13 +310,9 @@
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';
       if (messageEl) {
         if (approved) {
-          var subtitles = [
-            'Nice work, you\'re all done',
-            'All wrapped up',
-            'Review complete',
-          ];
-          messageEl.textContent = subtitles[Math.floor(Math.random() * subtitles.length)];
+          messageEl.style.display = 'none';
         } else {
+          messageEl.style.display = '';
           messageEl.textContent =
             "Agent notified. Copy the prompt below if it wasn't listening.";
         }

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -262,7 +262,7 @@
       dot.style.left = (8 + Math.random() * 84) + '%';
       dot.style.top = (10 + Math.random() * 30) + '%';
       dot.style.background = CONFETTI_COLORS[i % CONFETTI_COLORS.length];
-      dot.style.setProperty('--confetti-delay', (Math.random() * 0.5) + 's');
+      dot.style.animationDelay = (Math.random() * 0.5) + 's';
       container.appendChild(dot);
     }
   }

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -235,14 +235,12 @@
       if (!text) return;
       navigator.clipboard.writeText(text).then(function () {
         btn.classList.add('copied');
-        receipt.classList.add('copied');
         var iconCopy = btn.querySelector('.icon-copy');
         var iconCheck = btn.querySelector('.icon-check');
         if (iconCopy) iconCopy.style.display = 'none';
         if (iconCheck) iconCheck.style.display = '';
         setTimeout(function () {
           btn.classList.remove('copied');
-          receipt.classList.remove('copied');
           if (iconCopy) iconCopy.style.display = '';
           if (iconCheck) iconCheck.style.display = 'none';
         }, 1800);
@@ -316,7 +314,6 @@
             'Nice work, you\'re all done',
             'All wrapped up',
             'Review complete',
-            'That\'s a wrap',
           ];
           messageEl.textContent = subtitles[Math.floor(Math.random() * subtitles.length)];
         } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -185,7 +185,13 @@
       </svg>
       <h3 id="waitingHeading">Review Complete</h3>
       <p id="waitingMessage"></p>
-      <p class="waiting-stats" id="waitingStats"></p>
+      <div class="summary-receipt" id="summaryReceipt" style="display:none">
+        <span class="summary-line" id="summaryLine"></span>
+        <button class="summary-copy-btn" id="summaryCopyBtn" aria-label="Copy summary to clipboard">
+          <svg class="icon-copy" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="8" height="8" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <svg class="icon-check" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><path d="M3 8.5L6.5 12L13 4"/></svg>
+        </button>
+      </div>
       <p class="waiting-edits" id="waitingEdits"></p>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -185,6 +185,7 @@
       </svg>
       <h3 id="waitingHeading">Review Complete</h3>
       <p id="waitingMessage"></p>
+      <p class="waiting-stats" id="waitingStats"></p>
       <p class="waiting-edits" id="waitingEdits"></p>
     </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2211,7 +2211,6 @@ textarea.drag-active {
   opacity: 0;
   pointer-events: none;
   animation: confetti-fall 1.6s var(--crit-ease) forwards;
-  animation-delay: var(--confetti-delay, 0s);
 }
 @keyframes confetti-fall {
   0%   { opacity: 0; transform: translateY(-16px) scale(0.5); }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2216,8 +2216,6 @@ textarea.drag-active {
   font-size: 14px;
   line-height: 1.5;
   color: var(--crit-fg-primary);
-  user-select: all;
-  -webkit-user-select: all;
   letter-spacing: -0.01em;
   white-space: nowrap;
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2202,17 +2202,32 @@ textarea.drag-active {
     animation: none;
   }
   .waiting-spinner .dot { animation: none; opacity: 0.6; }
+  .confetti-dot { animation: none !important; display: none; }
+}
+
+.confetti-dot {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0;
+  pointer-events: none;
+  animation: confetti-fall 1.6s var(--crit-ease) forwards;
+  animation-delay: var(--confetti-delay, 0s);
+}
+@keyframes confetti-fall {
+  0%   { opacity: 0; transform: translateY(-16px) scale(0.5); }
+  15%  { opacity: 0.8; }
+  100% { opacity: 0; transform: translateY(50px) scale(0.3); }
 }
 
 .waiting-dialog .summary-receipt {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   margin: 12px 0 0;
   cursor: text;
 }
 .waiting-dialog .summary-line {
-  flex: 1;
   font-size: 14px;
   line-height: 1.5;
   color: var(--crit-fg-primary);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2204,6 +2204,13 @@ textarea.drag-active {
   .waiting-spinner .dot { animation: none; opacity: 0.6; }
 }
 
+.waiting-dialog .waiting-stats {
+  font-size: 0.95rem;
+  color: var(--crit-editor-fg-secondary);
+  margin: 0.25rem 0 0;
+  letter-spacing: 0.01em;
+}
+
 .waiting-dialog .waiting-edits {
   font-size: 14px;
   font-weight: 600;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2213,8 +2213,7 @@ textarea.drag-active {
 }
 .waiting-dialog .summary-line {
   flex: 1;
-  font-family: var(--crit-font-mono);
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.5;
   color: var(--crit-fg-primary);
   user-select: all;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2208,20 +2208,8 @@ textarea.drag-active {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--crit-editor-bg-elevated);
-  border: 1px solid var(--crit-border);
-  border-radius: 10px;
-  padding: 10px 12px 10px 16px;
   margin: 12px 0 0;
   cursor: text;
-  transition: border-color var(--crit-dur-fast) ease, background var(--crit-dur-fast) ease;
-}
-.waiting-dialog .summary-receipt:hover {
-  border-color: var(--crit-fg-muted);
-}
-.waiting-dialog .summary-receipt.copied {
-  border-color: var(--crit-green);
-  background: var(--crit-green-subtle);
 }
 .waiting-dialog .summary-line {
   flex: 1;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2230,12 +2230,9 @@ textarea.drag-active {
 .waiting-dialog .summary-line {
   font-size: 14px;
   line-height: 1.5;
-  color: var(--crit-fg-primary);
+  color: var(--crit-editor-fg-secondary);
   letter-spacing: -0.01em;
   white-space: nowrap;
-}
-.waiting-dialog .summary-line .sep {
-  color: var(--crit-fg-muted);
 }
 .waiting-dialog .summary-copy-btn {
   flex-shrink: 0;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2108,7 +2108,7 @@ textarea.drag-active {
   background: var(--crit-bg-card);
   border: 1px solid var(--crit-border);
   border-radius: 12px;
-  max-width: 520px;
+  max-width: 480px;
   width: 90vw;
   box-shadow: var(--crit-shadow);
   overflow: hidden;
@@ -2204,11 +2204,66 @@ textarea.drag-active {
   .waiting-spinner .dot { animation: none; opacity: 0.6; }
 }
 
-.waiting-dialog .waiting-stats {
-  font-size: 0.95rem;
-  color: var(--crit-editor-fg-secondary);
-  margin: 0.25rem 0 0;
-  letter-spacing: 0.01em;
+.waiting-dialog .summary-receipt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--crit-editor-bg-elevated);
+  border: 1px solid var(--crit-border);
+  border-radius: 10px;
+  padding: 10px 12px 10px 16px;
+  margin: 12px 0 0;
+  cursor: text;
+  transition: border-color var(--crit-dur-fast) ease, background var(--crit-dur-fast) ease;
+}
+.waiting-dialog .summary-receipt:hover {
+  border-color: var(--crit-fg-muted);
+}
+.waiting-dialog .summary-receipt.copied {
+  border-color: var(--crit-green);
+  background: var(--crit-green-subtle);
+}
+.waiting-dialog .summary-line {
+  flex: 1;
+  font-family: var(--crit-font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--crit-fg-primary);
+  user-select: all;
+  -webkit-user-select: all;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.waiting-dialog .summary-line .sep {
+  color: var(--crit-fg-muted);
+}
+.waiting-dialog .summary-copy-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--crit-fg-muted);
+  cursor: pointer;
+  transition: background var(--crit-dur-fast) ease, color var(--crit-dur-fast) ease;
+}
+.waiting-dialog .summary-copy-btn:hover {
+  background: var(--crit-brand-subtle);
+  color: var(--crit-brand);
+}
+.waiting-dialog .summary-copy-btn:active {
+  transform: scale(0.92);
+}
+.waiting-dialog .summary-copy-btn.copied {
+  color: var(--crit-green);
+}
+.waiting-dialog .summary-copy-btn svg {
+  width: 16px;
+  height: 16px;
 }
 
 .waiting-dialog .waiting-edits {

--- a/main.go
+++ b/main.go
@@ -2406,6 +2406,11 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 	var result struct {
 		Approved    bool   `json:"approved"`
 		NextCommand string `json:"next_command"`
+		Stats       *struct {
+			Duration int `json:"duration_seconds"`
+			Files    int `json:"files_reviewed"`
+			Comments int `json:"comments_submitted"`
+		} `json:"stats"`
 	}
 	if json.Unmarshal(body, &result) == nil {
 		// Print the exact command for the next round so the agent can
@@ -2414,6 +2419,15 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 		// or may not end with one.
 		if !result.Approved && result.NextCommand != "" {
 			fmt.Fprintf(os.Stdout, "\nNext round: %s\n", result.NextCommand)
+		}
+		if result.Approved && result.Stats != nil {
+			s := result.Stats
+			if s.Files > 0 || s.Comments > 0 {
+				fmt.Fprintf(os.Stderr, "\n%s · %d %s · %d %s\n",
+					formatDuration(s.Duration),
+					s.Files, pluralize(s.Files, "file", "files"),
+					s.Comments, pluralize(s.Comments, "comment", "comments"))
+			}
 		}
 		return result.Approved
 	}

--- a/main.go
+++ b/main.go
@@ -2421,17 +2421,30 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 			fmt.Fprintf(os.Stdout, "\nNext round: %s\n", result.NextCommand)
 		}
 		if result.Approved && result.Stats != nil {
-			s := result.Stats
-			if s.Files > 0 || s.Comments > 0 {
-				fmt.Fprintf(os.Stderr, "\n%s · %d %s · %d %s\n",
-					formatDuration(s.Duration),
-					s.Files, pluralize(s.Files, "file", "files"),
-					s.Comments, pluralize(s.Comments, "comment", "comments"))
-			}
+			printSessionSummary(result.Stats)
 		}
 		return result.Approved
 	}
 	return false
+}
+
+func printSessionSummary(s *struct {
+	Duration int `json:"duration_seconds"`
+	Files    int `json:"files_reviewed"`
+	Comments int `json:"comments_submitted"`
+}) {
+	if s.Files == 0 && s.Comments == 0 {
+		return
+	}
+	var parts []string
+	if s.Files > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", s.Files, pluralize(s.Files, "file", "files")))
+	}
+	if s.Comments > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", s.Comments, pluralize(s.Comments, "comment", "comments")))
+	}
+	parts = append(parts, formatDuration(s.Duration))
+	fmt.Fprintf(os.Stderr, "\nDone reviewing — %s\n", strings.Join(parts, " · "))
 }
 
 // dirArgs returns the subset of paths that are directories.

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -1818,44 +1819,26 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	totalComments := sess.TotalCommentCount()
 	newComments := sess.NewCommentCount()
 	unresolvedComments := sess.UnresolvedCommentCount()
 	// In v4 the session identity is a folder (.../<key>/ or .../.crit/); the
 	// agent-facing review payload lives at <identity>/review.json. Surface the
 	// file path, not the folder, so `cat $review_file` works.
 	reviewFile := reviewPathsFor(sess.critJSONPath()).Review
-	prompt := ""
-	if totalComments > 0 && unresolvedComments > 0 {
-		if sess.Mode == "plan" {
-			// Plan mode: concise feedback for the hook workflow.
-			// Claude revises the plan text directly — no need for crit comment or review file instructions.
-			prompt = s.buildPlanFeedback(reviewFile)
-		} else {
-			prompt = fmt.Sprintf(
-				"Review comments are in %s — comments are grouped per file with start_line/end_line referencing the source. "+
-					"Each comment has a scope field: \"line\" for inline comments, \"file\" for file-level comments, or \"review\" for review-level comments. "+
-					"Review-level comments appear in the top-level review_comments array (not tied to any file). "+
-					"Read the file, address each unresolved comment in the relevant file and location. "+
-					"Before acting, check each comment's replies array — if you have already replied, the reviewer may be following up conversationally rather than requesting a new code change. "+
-					"For each comment, reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> \"<explanation>\"`. "+
-					"When done run: `%s`",
-				reviewFile, sess.ReinvokeCommand())
-		}
-	} else if totalComments > 0 && unresolvedComments == 0 {
-		prompt = "All comments are resolved — no changes needed, please proceed."
-	}
-
+	prompt := s.buildFinishPrompt(sess, reviewFile)
 	approved := unresolvedComments == 0
 	if !approved {
 		sess.setWaitingForAgent(true)
 	}
+
+	stats := s.buildSessionStats(sess)
 
 	writeJSON(w, map[string]any{
 		"status":      "finished",
 		"review_file": reviewFile,
 		"prompt":      prompt,
 		"approved":    approved,
+		"stats":       stats,
 	})
 
 	// Encode approved status into SSE event content as JSON so review-cycle
@@ -1863,6 +1846,7 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	eventData, _ := json.Marshal(map[string]any{
 		"prompt":   prompt,
 		"approved": approved,
+		"stats":    stats,
 	})
 	sess.notify(SSEEvent{
 		Type:    "finish",
@@ -1882,6 +1866,45 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 		s.statsRecorded = true
 	}
 
+}
+
+// buildSessionStats returns duration/files/comments for the current session,
+// or nil if the session start time was never recorded.
+func (s *Server) buildSessionStats(sess *Session) map[string]any {
+	if s.sessionStartedAt.IsZero() {
+		return nil
+	}
+	duration := int(math.Round(time.Since(s.sessionStartedAt).Seconds()))
+	files, comments := sessionActivity(sess, s.author)
+	return map[string]any{
+		"duration_seconds":   duration,
+		"files_reviewed":     files,
+		"comments_submitted": comments,
+	}
+}
+
+// buildFinishPrompt returns the agent-facing prompt string based on comment state.
+func (s *Server) buildFinishPrompt(sess *Session, reviewFile string) string {
+	totalComments := sess.TotalCommentCount()
+	unresolvedComments := sess.UnresolvedCommentCount()
+	if totalComments > 0 && unresolvedComments > 0 {
+		if sess.Mode == "plan" {
+			return s.buildPlanFeedback(reviewFile)
+		}
+		return fmt.Sprintf(
+			"Review comments are in %s — comments are grouped per file with start_line/end_line referencing the source. "+
+				"Each comment has a scope field: \"line\" for inline comments, \"file\" for file-level comments, or \"review\" for review-level comments. "+
+				"Review-level comments appear in the top-level review_comments array (not tied to any file). "+
+				"Read the file, address each unresolved comment in the relevant file and location. "+
+				"Before acting, check each comment's replies array — if you have already replied, the reviewer may be following up conversationally rather than requesting a new code change. "+
+				"For each comment, reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> \"<explanation>\"`. "+
+				"When done run: `%s`",
+			reviewFile, sess.ReinvokeCommand())
+	}
+	if totalComments > 0 && unresolvedComments == 0 {
+		return "All comments are resolved — no changes needed, please proceed."
+	}
+	return ""
 }
 
 // buildPlanFeedback formats review feedback for plan mode.
@@ -1971,8 +1994,9 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 				sess.SetAwaitingFirstReview(false)
 				// Parse the structured finish event data
 				var finishData struct {
-					Prompt   string `json:"prompt"`
-					Approved bool   `json:"approved"`
+					Prompt   string         `json:"prompt"`
+					Approved bool           `json:"approved"`
+					Stats    map[string]any `json:"stats"`
 				}
 				json.Unmarshal([]byte(event.Content), &finishData)
 				writeJSON(w, map[string]any{
@@ -1980,6 +2004,7 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 					"review_file":  reviewPathsFor(sess.critJSONPath()).Review,
 					"prompt":       finishData.Prompt,
 					"approved":     finishData.Approved,
+					"stats":        finishData.Stats,
 					"next_command": buildNextCommand(s.cliArgs),
 				})
 				return


### PR DESCRIPTION
## Summary
- Show a shareable receipt line in the approval modal: `Done reviewing — 12 files · 5 comments · 15m`
- Copy button with green flash feedback, centered layout, confetti burst on approval
- CLI prints the same summary to stderr on approved exit
- Stats flow through `/api/finish` → SSE → review-cycle relay

## Test plan
- Go tests pass (build, lint, test suite)
- Manual browser test: approval modal shows receipt line with copy button
- Copy button copies self-contained text to clipboard
- Confetti respects `prefers-reduced-motion`
- CLI output verified via daemon-mode finish flow

Closes CRI-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)