### PR TITLE
chore: make fresh worktrees and e2e work out of the box

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,6 +1,8 @@
 # Trust mise.toml before the worktree's shell auto-loads mise — otherwise
 # the shell entry triggers a mise parse error and aborts subsequent hooks.
-[pre-start]
+# Array-of-tables form ([[pre-start]]) — the deprecated [pre-start] table form
+# changes behavior in future worktrunk versions.
+[[pre-start]]
 mise-trust = "mise trust ."
 
 # Copy gitignored files (node_modules, caches, .env, etc.) from the primary

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+# crit's toolchain and environment come from mise (see mise.toml), not direnv.
+#
+# This file exists so the global worktrunk `direnv allow` pre-start hook
+# succeeds when a new worktree is created. direnv errors on a missing .envrc
+# ("`.envrc` file not found"), and because that hook runs first, its failure
+# aborts the rest of the pre-start pipeline — skipping `mise trust .` and the
+# `wt step copy-ignored` step, which leaves the worktree unable to run tests.
+#
+# dotenv_if_exists is a no-op when there's no .env file, so this never errors.
+dotenv_if_exists

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,31 +6,31 @@
     "": {
       "name": "crit-e2e",
       "devDependencies": {
-        "@axe-core/playwright": "^4.11.1",
-        "@playwright/test": "^1.50.0"
+        "@axe-core/playwright": "4.11.2",
+        "@playwright/test": "1.59.1"
       }
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
-      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.11.1"
+        "axe-core": "~4.11.3"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -40,9 +40,7 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -65,13 +63,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -84,9 +82,21 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
     "report": "npx playwright show-report"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.11.1",
-    "@playwright/test": "^1.50.0"
+    "@axe-core/playwright": "4.11.2",
+    "@playwright/test": "1.59.1"
   }
 }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -24,6 +24,14 @@ else
   (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" .)
 fi
 
+# Ensure the Chromium build matching this project's pinned @playwright/test is
+# installed. The browser cache (~/Library/Caches/ms-playwright on macOS) is
+# global and version-specific, so a machine that only has another project's
+# Playwright version (e.g. crit-web's) won't have the build crit needs and every
+# test fails with "Executable doesn't exist". Idempotent — skips the download
+# when the build is already cached, so it's a fast no-op in CI and on reruns.
+(cd "$SCRIPT_DIR" && npx playwright install chromium)
+
 # Kill any stale processes on our test ports before starting fresh
 for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT"; do
   e2e_kill_port "$port"


### PR DESCRIPTION
## Problem

A freshly created worktree was **completely broken** — no test suite could run:

1. The global worktrunk `pre-start = "direnv allow"` hook ran first and **failed** (`direnv: error .envrc file not found`), and since a failed `pre-start` aborts the pipeline, the project's `mise trust .` and `wt step copy-ignored` never ran → untrusted `mise.toml` → `mise exec` failed → **go test, frontend, and e2e all failed**.
2. `make e2e` assumed the Playwright browser was cached, but the `ms-playwright` cache is global and version-specific. crit pinned a different Playwright version than crit-web, so on a machine that ran the other repo's e2e, crit had no matching Chromium → every test failed instantly with *"Executable doesn't exist"*.

## Fix (all checked-in config / scripts)

- **`.envrc`**: add a minimal no-op-safe file (`dotenv_if_exists`) so `direnv allow` succeeds and the rest of the pre-start pipeline runs. crit's env still comes from mise.
- **`.config/wt.toml`**: use the `[[pre-start]]` array-of-tables form (the table form is deprecated in worktrunk).
- **`e2e/run.sh`**: run `npx playwright install chromium` (idempotent) before tests, matching what CI does, so the version-matched browser exists locally.
- **`e2e/package.json` + lockfile**: pin Playwright to **exactly 1.59.1** (and `@axe-core/playwright` 4.11.2) to match crit-web. Both repos now share one Chromium build (v1217) from the shared global cache. Exact (non-caret) pins so npm can't float crit to a newer version and reintroduce the mismatch.

CI needs no version edit: both workflows key the browser cache on the lockfile hash and run `npx playwright install chromium`, so they install the same build from the matching lockfiles.

## Verification

Zero-touch in a freshly created worktree: `go test ./...` ✅, `make test-frontend` ✅, e2e live/mobile/range/nogit/single/multi ✅.

> Note: ~25 **file-mode** e2e tests fail on macOS locally (a duplicate `plan.md` path-normalization issue) — this is **pre-existing on `main`** and independent of this PR (the diff touches no Go/frontend/fixture/test code). CI runs e2e on Ubuntu, where they pass. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)