### PR TITLE
docs: document make test-diff seed harness and integration tests in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,22 +38,59 @@ make e2e-report                                       # View HTML report
 
 **If your change touches the frontend, include E2E tests.** See the test organization table in `CLAUDE.md` and the existing specs in `e2e/tests/` for conventions and helpers.
 
-## Visual Diff Testing
+## Local Testing & Seed Fixtures
 
-`make test-diff` runs a manual visual test that simulates a full multi-round review:
-
-1. Starts Crit on a fixture markdown file
-2. Seeds 4 review comments via the API
-3. Pauses so you can inspect the comments in the browser
-4. Swaps in a v2 version of the file (simulating agent edits)
-5. Marks 3 of the 4 comments as resolved, signals round-complete
-6. Opens the diff view with resolved/open comments visible
-
-Use this when working on diff rendering, round-to-round state, or the resolved comment UI — areas where automated assertions are hard to write but visual correctness matters.
+`make test-diff` is a manual, visual seed harness for the review UI. It builds `crit`, spins up several local server instances — each seeding a different representative review scenario — prints their localhost URLs, and then blocks so you can open the tabs and eyeball the result. It is **not** an automated assertion suite; it exists for the parts of the review UI where visual correctness matters and automated assertions are awkward to write.
 
 ```bash
-make test-diff          # runs on port 3001
+make test-diff          # builds crit, seeds the scenarios, runs from port 3001 up
 ```
+
+Each instance binds a consecutive port starting at the one you pass (default `3001`) and covers a distinct scenario:
+
+| # | Port | Scenario |
+| --- | --- | --- |
+| 1 | `3001` | Multi-round markdown review — resolved comments, threaded replies, deletion markers, inter-round diff |
+| 2 | `3002` | Code diff — word-level diff, folded-line comments in spacer gaps, orphaned comments on a removed file |
+| 3 | `3003` | Carry-forward (file mode) — comment positioning across a v1 → v2 content change |
+| 4 | `3004` | Carry-forward (git mode) — same carry-forward exercise in a git context |
+| 5 | `3005` | Range mode (`--range A..B`) — SHA-pinned diff, focus-picker round-trip |
+| 6 | `3006` | Stacked PR — layer / full-stack diff-scope toggle and the push gate |
+
+The harness seeds comments, swaps in v2 content to simulate agent edits, and signals round-complete, then prints what to look for at each URL. Use it when working on diff rendering, round-to-round state, the resolved-comment UI, carry-forward, range mode, or the stacked-PR toggle.
+
+**Treat these scenarios as living seed fixtures.** When you add or change a review-UI feature, add a new seeded scenario (or extend an existing one) in `test/test-diff.sh` so a reviewer can spin it up and eyeball your change locally. A new scenario typically means starting another server instance on the next port and seeding the comments/content that exercise the feature.
+
+## Integration Tests
+
+These exercise crit against its real collaborators — `crit-web` and GitHub. They are heavier than the unit suite and live behind build tags so `go test ./...` stays fast and hermetic. Extend them when you touch the surfaces they cover.
+
+### crit ↔ crit-web share roundtrip
+
+`make e2e-share` runs the share roundtrip in `share_integration_test.go` (build tag `integration`): share a review, fetch web-authored comments, re-share without duplicates, unpublish. It needs a local `crit-web` checkout at `../crit-web` (or `CRIT_WEB_DIR`) and PostgreSQL running locally.
+
+```bash
+make e2e-share                                   # build crit, start crit-web on :4001, run all TestShareSync*, tear down
+./scripts/e2e-share.sh --serve                   # start crit-web for manual inspection (logs review URLs)
+./scripts/e2e-share.sh -run TestShareSyncFullLifecycle   # one case
+```
+
+When you change the share payload, comment sync, or any crit-web interaction, **add a `TestShareSync*` case** so the new behavior is covered, and use `--serve` to inspect the result on the web. See `scripts/AGENTS.md` for prerequisites, the full case list, and the seed helpers (`critShareCmd`, `seedComment`, `logReview`, etc.).
+
+### crit ↔ GitHub PR roundtrip
+
+`make e2e-roundtrip` runs the live GitHub PR roundtrip in `roundtrip_integration_test.go` (build tag `e2e_github`): each scenario opens a real sandbox PR, drives `crit pull` / `crit push` through one state transition, and asserts on both local review-file and live PR state. It needs `gh` authenticated and `CRIT_ROUNDTRIP_REPO=<owner>/crit-roundtrip-sandbox` exported. Scenarios are slow (~10–25s each) and rate-limited, which is why they stay out of CI.
+
+```bash
+make e2e-roundtrip                                              # all scenarios
+./scripts/e2e-roundtrip.sh -run TestRoundtrip_PushIsIdempotent -v   # one
+```
+
+When you change `crit pull` / `crit push`, GitHub comment-bucket logic, or reply posting, **add a `TestRoundtrip_<Name>` scenario** for the new state transition. If a scenario is currently `t.Skip`'d against a known bug and your change fixes it, remove the skip and run it. See `test/roundtrip/README.md` for one-time setup and authoring notes.
+
+### Leave a seed behind
+
+When you ship a review-UI feature, leave a seeded scenario in `test/test-diff.sh`; when you ship share or GitHub-sync behavior, leave an integration test case. The next contributor — and you, three months from now — should be able to spin up your feature and verify it without reverse-engineering it first.
 
 ## Linting
 


### PR DESCRIPTION
## Summary

Documents the local testing story in `CONTRIBUTING.md` so contributors know how to verify review-UI changes and how to extend the test suites.

- **Local Testing & Seed Fixtures** — rewrites the old "Visual Diff Testing" section to match the current `make test-diff` harness, which now spins up six local server instances (markdown multi-round, word-level code diff, file/git carry-forward, range mode, stacked-PR toggle) at consecutive ports. Frames the scenarios as living seed fixtures and asks contributors to add a new seeded scenario in `test/test-diff.sh` whenever they add or change a review-UI feature.
- **Integration Tests** — new section covering the two cross-system suites:
  - `make e2e-share` — crit ↔ crit-web share roundtrip (`integration` build tag, `share_integration_test.go`); add `TestShareSync*` cases for share-payload/comment-sync changes; needs `../crit-web` + Postgres; `--serve` to inspect on the web.
  - `make e2e-roundtrip` — crit ↔ GitHub PR roundtrip (`e2e_github` build tag, `roundtrip_integration_test.go`); add `TestRoundtrip_<Name>` scenarios; needs `gh` + `CRIT_ROUNDTRIP_REPO`.
- Closing nudge to leave behind a seed and/or integration test case when shipping a feature.

Points to the authoritative `scripts/AGENTS.md` and `test/roundtrip/README.md` rather than duplicating their detail.

Docs-only change. Pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)