### PR TITLE
fix: skip --share-url confirm prompt when stdin is not a TTY

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	qrterminal "github.com/mdp/qrterminal/v3"
+	"golang.org/x/term"
 )
 
 //go:embed frontend/*.html frontend/*.css frontend/*.js frontend/*.png frontend/*.svg frontend/*.ico frontend/*.webmanifest
@@ -291,7 +292,12 @@ func runShare(args []string) {
 		}
 		cfg.ShareConsented = true
 	}
-	if flagURL {
+	// Confirm sharing to a custom URL — but only in genuine interactive
+	// sessions. In non-interactive contexts (CI, the integration suite,
+	// scripted/agent usage) there is no TTY, so the prompt would read EOF,
+	// abort, and the share would never persist its result to the review file.
+	// Auto-proceed there; keep the confirm for real terminals.
+	if flagURL && term.IsTerminal(int(os.Stdin.Fd())) {
 		if !promptShareURLConfirm(os.Stderr, os.Stdin, sf.svcURL) {
 			return
 		}


### PR DESCRIPTION
## Summary
- Non-interactive `crit share --share-url <url>` was broken: the interactive confirm prompt added in #601 unconditionally read `os.Stdin`. In non-interactive contexts (CI, the share integration suite, scripted/agent usage) there is no TTY, so the prompt read EOF, the share aborted, and `share_org` / `share_visibility` / `share_url` were never persisted to the review file.
- Gate the confirm on `term.IsTerminal(int(os.Stdin.Fd()))` at the call site: auto-proceed when non-interactive, keep the confirm for genuine terminal sessions.
- The pure `promptShareURLConfirm` helper is unchanged, so its unit tests still exercise the interactive prompt path.

This was the pre-existing "`--share-url` TTY gate" behavior that kept `make e2e-share` red on `TestShareSyncOrgPersistence`.

## Review
- [x] Code review (go-expert): clean, no blockers
- [x] Intent audit: clean — diff matches stated intent
- [x] Parity audit: N/A — Go-only CLI confirm path, no review-page surface

## Test plan
- `TestShareSyncOrgPersistence` now passes (was failing pre-fix with empty share fields)
- Full `make e2e-share` suite green
- `go test -race ./...` green; `golangci-lint` 0 issues; `gofmt` clean
- Existing `promptShareURLConfirm` unit tests still pass (interactive path unaffected)

Closes CRI-89 — https://linear.app/crit-md/issue/CRI-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)