### PR TITLE
feat: add "ignore whitespace" diff setting

### DIFF
--- a/e2e/tests/whitespace.spec.ts
+++ b/e2e/tests/whitespace.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { clearAllComments, loadPage } from './helpers';
 
 // Git-mode only: the "Ignore whitespace" toggle controls whether code diffs
@@ -7,6 +7,18 @@ import { clearAllComments, loadPage } from './helpers';
 // persists (checked + cookie) across a reload. We deliberately avoid asserting
 // on diff *content* — the fixed fixture has no reliable whitespace-only hunk,
 // so a content assertion would be flaky.
+//
+// The toggle uses the `.comments-panel-switch` pattern: a visually-hidden
+// <input opacity:0> behind a styled <span> track. Playwright's `.check()`
+// hit-test lands on the track, not the input, so we click the wrapping
+// <label> (exactly how a real user flips it) instead of checking the input.
+
+// Clicks the switch label wrapping #ignoreWhitespaceToggle (toggles the input).
+function switchLabel(page: Page) {
+  return page.locator('label.comments-panel-switch', {
+    has: page.locator('#ignoreWhitespaceToggle'),
+  });
+}
 
 test.describe('Ignore whitespace', () => {
   test.beforeEach(async ({ request }) => {
@@ -35,7 +47,7 @@ test.describe('Ignore whitespace', () => {
     const diffRequest = page.waitForRequest(
       (req) => req.url().includes('/api/file/diff') && req.url().includes('w=1'),
     );
-    await toggle.check();
+    await switchLabel(page).click();
     await diffRequest;
 
     await expect(toggle).toBeChecked();
@@ -45,16 +57,14 @@ test.describe('Ignore whitespace', () => {
     await loadPage(page);
     await page.click('#settingsToggle');
 
-    const toggle = page.locator('#ignoreWhitespaceToggle');
-    await toggle.check();
-    await expect(toggle).toBeChecked();
+    await switchLabel(page).click();
+    await expect(page.locator('#ignoreWhitespaceToggle')).toBeChecked();
 
     // Reload and re-open settings.
     await loadPage(page);
     await page.click('#settingsToggle');
 
-    const toggleAfter = page.locator('#ignoreWhitespaceToggle');
-    await expect(toggleAfter).toBeChecked();
+    await expect(page.locator('#ignoreWhitespaceToggle')).toBeChecked();
 
     // Setting persisted in the consolidated crit-settings cookie (not localStorage).
     const stored = await page.evaluate(() => {

--- a/e2e/tests/whitespace.spec.ts
+++ b/e2e/tests/whitespace.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage } from './helpers';
+
+// Git-mode only: the "Ignore whitespace" toggle controls whether code diffs
+// are re-fetched with `&w=1` (server collapses whitespace-only changes). We
+// verify the toggle renders, fires a `&w=1` diff request when enabled, and
+// persists (checked + cookie) across a reload. We deliberately avoid asserting
+// on diff *content* — the fixed fixture has no reliable whitespace-only hunk,
+// so a content assertion would be flaky.
+
+test.describe('Ignore whitespace', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('settings panel shows Ignore whitespace toggle in git mode', async ({ page }) => {
+    await loadPage(page);
+    await page.click('#settingsToggle');
+    const pane = page.locator('.settings-pane[data-pane="settings"]');
+    await expect(
+      pane.locator('.settings-display-label').filter({ hasText: 'Ignore whitespace' }),
+    ).toBeVisible();
+    await expect(pane.locator('#ignoreWhitespaceToggle')).toBeAttached();
+  });
+
+  test('enabling the toggle fires a diff fetch with &w=1', async ({ page }) => {
+    await loadPage(page);
+    await page.click('#settingsToggle');
+
+    const toggle = page.locator('#ignoreWhitespaceToggle');
+    await expect(toggle).not.toBeChecked();
+
+    // Toggling triggers reloadForScope(), which re-fetches every code diff.
+    // Those fetches must carry &w=1 now that the setting is on.
+    const diffRequest = page.waitForRequest(
+      (req) => req.url().includes('/api/file/diff') && req.url().includes('w=1'),
+    );
+    await toggle.check();
+    await diffRequest;
+
+    await expect(toggle).toBeChecked();
+  });
+
+  test('toggle persists (checked + cookie) across reload', async ({ page }) => {
+    await loadPage(page);
+    await page.click('#settingsToggle');
+
+    const toggle = page.locator('#ignoreWhitespaceToggle');
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+
+    // Reload and re-open settings.
+    await loadPage(page);
+    await page.click('#settingsToggle');
+
+    const toggleAfter = page.locator('#ignoreWhitespaceToggle');
+    await expect(toggleAfter).toBeChecked();
+
+    // Setting persisted in the consolidated crit-settings cookie (not localStorage).
+    const stored = await page.evaluate(() => {
+      const match = document.cookie.match(/(?:^|;\s*)crit-settings=([^;]+)/);
+      if (!match) return null;
+      try {
+        return JSON.parse(decodeURIComponent(match[1])).ignoreWhitespace;
+      } catch {
+        return null;
+      }
+    });
+    expect(stored).toBe(true);
+  });
+});

--- a/frontend/__tests__/crit-settings-panes.test.js
+++ b/frontend/__tests__/crit-settings-panes.test.js
@@ -241,6 +241,74 @@ test('renderSettingsTab: opts.show overrides defaults', () => {
   assert.doesNotMatch(pane.innerHTML, /Configuration/);
 });
 
+test('renderSettingsTab: ignore-whitespace toggle omitted by default (no hook / show off)', () => {
+  const sp = loadShared();
+  const pane = makePane();
+  sp.renderSettingsTab(pane, {
+    mode: 'code-review',
+    cfg: {},
+    hooks: { applyTheme: () => {}, applyWidth: () => {}, getHideResolved: () => false, setHideResolved: () => {} },
+  });
+  // Defaults: ignoreWhitespace is off, so the row never renders even though
+  // the hide-resolved row does.
+  assert.match(pane.innerHTML, /id="hideResolvedToggle"/);
+  assert.doesNotMatch(pane.innerHTML, /id="ignoreWhitespaceToggle"/);
+});
+
+test('renderSettingsTab: ignore-whitespace toggle renders when show.ignoreWhitespace + hook provided', () => {
+  const sp = loadShared();
+  const pane = makePane();
+  sp.renderSettingsTab(pane, {
+    mode: 'code-review',
+    cfg: {},
+    show: { ignoreWhitespace: true },
+    hooks: {
+      applyTheme: () => {},
+      applyWidth: () => {},
+      getHideResolved: () => false,
+      setHideResolved: () => {},
+      getIgnoreWhitespace: () => false,
+      setIgnoreWhitespace: () => {},
+      onIgnoreWhitespaceChange: () => {},
+    },
+  });
+  assert.match(pane.innerHTML, /id="ignoreWhitespaceToggle"/);
+  assert.match(pane.innerHTML, /Ignore whitespace/);
+  // Unchecked when getIgnoreWhitespace returns false.
+  assert.doesNotMatch(pane.innerHTML, /id="ignoreWhitespaceToggle"[^>]*checked/);
+});
+
+test('renderSettingsTab: ignore-whitespace toggle omitted when show on but hook absent', () => {
+  const sp = loadShared();
+  const pane = makePane();
+  sp.renderSettingsTab(pane, {
+    mode: 'code-review',
+    cfg: {},
+    show: { ignoreWhitespace: true },
+    hooks: { applyTheme: () => {}, getHideResolved: () => false, setHideResolved: () => {} },
+  });
+  // Same guard as hide-resolved: needs BOTH show flag and the getter hook.
+  assert.doesNotMatch(pane.innerHTML, /id="ignoreWhitespaceToggle"/);
+});
+
+test('renderSettingsTab: pre-checks ignore-whitespace when getIgnoreWhitespace returns true', () => {
+  const sp = loadShared();
+  const pane = makePane();
+  sp.renderSettingsTab(pane, {
+    mode: 'code-review',
+    cfg: {},
+    show: { ignoreWhitespace: true },
+    hooks: {
+      applyTheme: () => {},
+      getHideResolved: () => false,
+      setHideResolved: () => {},
+      getIgnoreWhitespace: () => true,
+      setIgnoreWhitespace: () => {},
+    },
+  });
+  assert.match(pane.innerHTML, /id="ignoreWhitespaceToggle"[^>]*checked/);
+});
+
 test('renderShortcutsPane / renderAboutPane still exposed', () => {
   const sp = loadShared();
   assert.equal(typeof sp.renderShortcutsPane, 'function');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -397,6 +397,12 @@
   }
   let diffScope = getSetting('diffScope', null); // null = no preference saved yet
 
+  // Whether code diffs are fetched with whitespace ignored (appends `&w=1` to
+  // /api/file/diff). Persisted via the consolidated `crit-settings` cookie (not
+  // localStorage) so it survives random-port restarts. Only meaningful in git
+  // mode — the settings toggle is gated to git mode in renderSettingsPane().
+  let ignoreWhitespace = !!getSetting('ignoreWhitespace', false);
+
   // Single source of truth for hide-resolved state. Persisted via the
   // consolidated `crit-settings` cookie (not localStorage) so the setting
   // survives random-port server restarts — localStorage is scoped per origin
@@ -599,6 +605,9 @@
     }
     if (diffCommit) {
       diffUrl += '&commit=' + enc(diffCommit);
+    }
+    if (ignoreWhitespace) {
+      diffUrl += '&w=1';
     }
     const [fileRes, commentsRes, diffRes] = await Promise.all([
       fetch('/api/file?path=' + enc(fi.path)).then(function(r) { return r.ok ? r.json() : { content: '' }; }).catch(function() { return { content: '' }; }),
@@ -7675,19 +7684,30 @@
     const pane = document.getElementById('settingsPane');
     const shared = window.crit && window.crit.settingsPanes;
     if (shared && shared.renderSettingsTab) {
+      const isGit = session.mode === 'git';
+      const hooks = {
+        applyTheme: window.applyTheme,
+        applyWidth: applyWidth,
+        getHideResolved: isHideResolved,
+        setHideResolved: setHideResolved,
+        onHideResolvedChange: function () { renderAllFiles(); },
+        hasActivePendingUpdates: hasActivePendingUpdates,
+        announceCopy: announceCopy,
+        escape: escapeHtml,
+      };
+      // Ignore-whitespace only applies to code diffs (git mode). Providing the
+      // hooks + show flag only in git mode keeps the toggle out of file/preview
+      // review, where there are no git diffs to recompute.
+      if (isGit) {
+        hooks.getIgnoreWhitespace = function () { return ignoreWhitespace; };
+        hooks.setIgnoreWhitespace = function (v) { ignoreWhitespace = !!v; setSetting('ignoreWhitespace', ignoreWhitespace); };
+        hooks.onIgnoreWhitespaceChange = function () { reloadForScope(); };
+      }
       shared.renderSettingsTab(pane, {
         mode: 'code-review',
         cfg: cfg,
-        hooks: {
-          applyTheme: window.applyTheme,
-          applyWidth: applyWidth,
-          getHideResolved: isHideResolved,
-          setHideResolved: setHideResolved,
-          onHideResolvedChange: function () { renderAllFiles(); },
-          hasActivePendingUpdates: hasActivePendingUpdates,
-          announceCopy: announceCopy,
-          escape: escapeHtml,
-        },
+        show: isGit ? { ignoreWhitespace: true } : undefined,
+        hooks: hooks,
       });
       return;
     }

--- a/frontend/crit-settings-panes.js
+++ b/frontend/crit-settings-panes.js
@@ -13,13 +13,18 @@
 //   renderSettingsTab(pane, opts)
 //     opts.mode    : 'code-review' | 'live'
 //     opts.cfg     : /api/config response or {}
-//     opts.show    : { width, hideResolved, update, account, agent,
-//                       integration, share } — booleans, defaulted from mode
+//     opts.show    : { width, hideResolved, ignoreWhitespace, update, account,
+//                       agent, integration, share } — booleans, defaulted from
+//                       mode. ignoreWhitespace defaults off; the caller enables
+//                       it only when code diffs exist (git mode).
 //     opts.hooks   : {
 //                      applyTheme(choice),                   // required
 //                      applyWidth(choice),                   // required if show.width
 //                      getHideResolved(), setHideResolved(v),// required if show.hideResolved
 //                      onHideResolvedChange(),               // optional, called after toggle
+//                      getIgnoreWhitespace(),                // required if show.ignoreWhitespace
+//                      setIgnoreWhitespace(v),               // required if show.ignoreWhitespace
+//                      onIgnoreWhitespaceChange(),           // optional, called after toggle (reloads diffs)
 //                      hasActivePendingUpdates(),            // optional, default false
 //                      announceCopy(),                       // optional
 //                    }
@@ -163,6 +168,7 @@
       return {
         width: false,         // width pill is file-mode only
         hideResolved: true,
+        ignoreWhitespace: false, // code-diff only; enabled per-call in git mode
         update: true,
         account: true,
         agent: true,
@@ -174,6 +180,7 @@
     return {
       width: true,
       hideResolved: true,
+      ignoreWhitespace: false, // code-diff only; enabled per-call in git mode
       update: true,
       account: true,
       agent: true,
@@ -264,6 +271,18 @@
       html += '<span class="settings-display-label">Hide resolved comments</span>';
       html += '<label class="comments-panel-switch">';
       html += '<input type="checkbox" id="hideResolvedToggle" aria-label="Hide resolved comments"' + (hideResolved ? ' checked' : '') + '>';
+      html += '<span class="comments-panel-switch-track"><span class="comments-panel-switch-thumb"></span></span>';
+      html += '</label>';
+      html += '</div>';
+    }
+
+    // Ignore whitespace row (code diffs / git mode only)
+    if (show.ignoreWhitespace && hooks.getIgnoreWhitespace) {
+      var ignoreWhitespace = !!hooks.getIgnoreWhitespace();
+      html += '<div class="settings-display-row">';
+      html += '<span class="settings-display-label">Ignore whitespace</span>';
+      html += '<label class="comments-panel-switch">';
+      html += '<input type="checkbox" id="ignoreWhitespaceToggle" aria-label="Ignore whitespace changes in diffs"' + (ignoreWhitespace ? ' checked' : '') + '>';
       html += '<span class="comments-panel-switch-track"><span class="comments-panel-switch-thumb"></span></span>';
       html += '</label>';
       html += '</div>';
@@ -479,6 +498,16 @@
         hrToggle.addEventListener('change', function () {
           if (hooks.setHideResolved) hooks.setHideResolved(hrToggle.checked);
           if (hooks.onHideResolvedChange) hooks.onHideResolvedChange();
+        });
+      }
+    }
+
+    if (show.ignoreWhitespace && hooks.getIgnoreWhitespace) {
+      var iwToggle = pane.querySelector('#ignoreWhitespaceToggle');
+      if (iwToggle) {
+        iwToggle.addEventListener('change', function () {
+          if (hooks.setIgnoreWhitespace) hooks.setIgnoreWhitespace(iwToggle.checked);
+          if (hooks.onIgnoreWhitespaceChange) hooks.onIgnoreWhitespaceChange();
         });
       }
     }

--- a/git.go
+++ b/git.go
@@ -325,20 +325,22 @@ func changedFilesBranch(baseRef string) ([]FileChange, error) {
 // FileDiffScoped returns parsed diff hunks for a file using a scope-appropriate git diff command.
 // Supported scopes: "branch", "staged", "unstaged". Any other value delegates to fileDiffUnified.
 // The dir parameter sets the working directory for git commands (use repo root for correct path resolution).
-func FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	base := diffBaseArgs(ignoreWhitespace)
 	var cmd *exec.Cmd
 	switch scope {
 	case "branch":
 		if baseRef == "" {
 			return nil, nil
 		}
-		cmd = exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", baseRef+"..HEAD", "--", path)
+		cmd = exec.Command("git", append(base, baseRef+"..HEAD", "--", path)...)
 	case "staged":
-		cmd = exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", "--cached", "--", path)
+		cmd = exec.Command("git", append(base, "--cached", "--", path)...)
 	case "unstaged":
-		cmd = exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", "--", path)
+		cmd = exec.Command("git", append(base, "--", path)...)
 	default:
-		return fileDiffUnified(path, baseRef, dir)
+		return fileDiffUnified(path, baseRef, dir, ignoreWhitespace)
 	}
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
@@ -425,8 +427,9 @@ func ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
 // FileDiffForCommit returns parsed diff hunks for a file in a single commit.
 // The dir parameter sets the working directory for the git command.
 // For the initial (root) commit, sha^ is undefined so we diff against the empty tree.
-func FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	cmd := exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", sha+"^.."+sha, "--", path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	cmd := exec.Command("git", append(diffBaseArgs(ignoreWhitespace), sha+"^.."+sha, "--", path)...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -440,7 +443,7 @@ func FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
 		case errors.As(err, &exitErr) && exitErr.ExitCode() == 128:
 			// sha^ failed (root commit) — diff against the empty tree
 			emptyTree := "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-			cmd2 := exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", emptyTree+".."+sha, "--", path)
+			cmd2 := exec.Command("git", append(diffBaseArgs(ignoreWhitespace), emptyTree+".."+sha, "--", path)...)
 			cmd2.Env = stripExternalDiffEnv()
 			if dir != "" {
 				cmd2.Dir = dir
@@ -799,10 +802,9 @@ func ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileChange, error)
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range
 // baseSHA..headSHA. Returns nil hunks when there is no diff.
-func FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error) {
-	cmd := exec.Command("git", "-c", "diff.external=", "diff",
-		"--no-color", "--no-ext-diff",
-		baseSHA+".."+headSHA, "--", path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	cmd := exec.Command("git", append(diffBaseArgs(ignoreWhitespace), baseSHA+".."+headSHA, "--", path)...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -1051,15 +1053,26 @@ func dedup(changes []FileChange) []FileChange {
 	return result
 }
 
+// diffBaseArgs returns the leading git diff arguments. When ignoreWhitespace
+// is true, "-w" is inserted right after "--no-ext-diff" (GitHub's ?w=1 parity).
+func diffBaseArgs(ignoreWhitespace bool) []string {
+	args := []string{"-c", "diff.external=", "diff", "--no-color", "--no-ext-diff"}
+	if ignoreWhitespace {
+		args = append(args, "-w")
+	}
+	return args
+}
+
 // fileDiffUnified returns the parsed diff hunks for a file against a base ref.
 // If baseRef is empty, diffs against HEAD. The dir parameter sets the working directory.
-func fileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
-	var cmd *exec.Cmd
-	if baseRef == "" {
-		cmd = exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", "HEAD", "--", path)
-	} else {
-		cmd = exec.Command("git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", baseRef, "--", path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func fileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	ref := baseRef
+	if ref == "" {
+		ref = "HEAD"
 	}
+	args := append(diffBaseArgs(ignoreWhitespace), ref, "--", path)
+	cmd := exec.Command("git", args...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -1078,13 +1091,14 @@ func fileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
 }
 
 // fileDiffUnifiedCtx is like fileDiffUnified but accepts a context for timeout control.
-func fileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
-	var cmd *exec.Cmd
-	if baseRef == "" {
-		cmd = exec.CommandContext(ctx, "git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", "HEAD", "--", path)
-	} else {
-		cmd = exec.CommandContext(ctx, "git", "-c", "diff.external=", "diff", "--no-color", "--no-ext-diff", baseRef, "--", path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func fileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	ref := baseRef
+	if ref == "" {
+		ref = "HEAD"
 	}
+	args := append(diffBaseArgs(ignoreWhitespace), ref, "--", path)
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir

--- a/git_test.go
+++ b/git_test.go
@@ -273,7 +273,7 @@ func TestFileDiffUnified_RealRepo(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n\nNew content\n")
 	gitT(t, dir, "add", "README.md")
 
-	hunks, err := fileDiffUnified("README.md", "HEAD", "")
+	hunks, err := fileDiffUnified("README.md", "HEAD", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +789,7 @@ func TestFileDiffScoped_Branch(t *testing.T) {
 	gitT(t, dir, "add", "README.md")
 	gitT(t, dir, "commit", "-m", "modify readme")
 
-	hunks, err := FileDiffScoped("README.md", "branch", baseRef, dir)
+	hunks, err := FileDiffScoped("README.md", "branch", baseRef, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -808,7 +808,7 @@ func TestFileDiffScoped_Staged(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Staged content\n")
 	gitT(t, dir, "add", "README.md")
 
-	hunks, err := FileDiffScoped("README.md", "staged", "", dir)
+	hunks, err := FileDiffScoped("README.md", "staged", "", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -826,7 +826,7 @@ func TestFileDiffScoped_Unstaged(t *testing.T) {
 	// Modify without staging
 	writeFile(t, filepath.Join(dir, "README.md"), "# Unstaged content\n")
 
-	hunks, err := FileDiffScoped("README.md", "unstaged", "", dir)
+	hunks, err := FileDiffScoped("README.md", "unstaged", "", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,7 +845,7 @@ func TestFileDiffScoped_Default(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Default scope\n")
 	gitT(t, dir, "add", "README.md")
 
-	hunks, err := FileDiffScoped("README.md", "", "HEAD", dir)
+	hunks, err := FileDiffScoped("README.md", "", "HEAD", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -860,7 +860,7 @@ func TestFileDiffScoped_BranchEmptyBaseRef(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	hunks, err := FileDiffScoped("README.md", "branch", "", dir)
+	hunks, err := FileDiffScoped("README.md", "branch", "", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -890,17 +890,17 @@ func TestFileDiffScoped_DifferentHunksPerScope(t *testing.T) {
 	// Make an unstaged change on top
 	writeFile(t, filepath.Join(dir, "README.md"), "# Branch change\n\nStaged line\nUnstaged line\n")
 
-	branchHunks, err := FileDiffScoped("README.md", "branch", baseRef, dir)
+	branchHunks, err := FileDiffScoped("README.md", "branch", baseRef, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	stagedHunks, err := FileDiffScoped("README.md", "staged", "", dir)
+	stagedHunks, err := FileDiffScoped("README.md", "staged", "", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	unstagedHunks, err := FileDiffScoped("README.md", "unstaged", "", dir)
+	unstagedHunks, err := FileDiffScoped("README.md", "unstaged", "", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1039,7 +1039,7 @@ func TestFileDiff_SuppressBlankEmpty(t *testing.T) {
 
 	writeFile(t, filepath.Join(dir, "code.go"), modified)
 
-	hunks, err := fileDiffUnified("code.go", "HEAD", dir)
+	hunks, err := fileDiffUnified("code.go", "HEAD", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1369,7 +1369,7 @@ func TestFileDiffForCommit(t *testing.T) {
 	// Get HEAD SHA
 	sha := gitT(t, dir, "rev-parse", "HEAD")
 
-	hunks, err := FileDiffForCommit("code.go", sha, dir)
+	hunks, err := FileDiffForCommit("code.go", sha, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1603,7 +1603,7 @@ func TestFileDiffForCommit_RootCommit(t *testing.T) {
 	// Get the initial (root) commit SHA.
 	sha := gitT(t, dir, "rev-parse", "HEAD")
 
-	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	hunks, err := FileDiffForCommit("README.md", sha, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffForCommit on root commit: %v", err)
 	}
@@ -1619,7 +1619,7 @@ func TestFileDiffForCommit_NormalCommit(t *testing.T) {
 	gitT(t, dir, "commit", "-m", "update readme")
 	sha := gitT(t, dir, "rev-parse", "HEAD")
 
-	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	hunks, err := FileDiffForCommit("README.md", sha, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffForCommit: %v", err)
 	}
@@ -1636,7 +1636,7 @@ func TestFileDiffForCommit_FileNotInCommit(t *testing.T) {
 	sha := gitT(t, dir, "rev-parse", "HEAD")
 
 	// README.md was not changed in this commit.
-	hunks, err := FileDiffForCommit("README.md", sha, dir)
+	hunks, err := FileDiffForCommit("README.md", sha, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffForCommit: %v", err)
 	}

--- a/git_vcs.go
+++ b/git_vcs.go
@@ -43,20 +43,20 @@ func (g *GitVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
 	return ChangedFilesForCommit(sha, dir)
 }
 
-func (g *GitVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
-	return fileDiffUnified(path, baseRef, dir)
+func (g *GitVCS) FileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return fileDiffUnified(path, baseRef, dir, ignoreWhitespace)
 }
 
-func (g *GitVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
-	return fileDiffUnifiedCtx(ctx, path, baseRef, dir)
+func (g *GitVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return fileDiffUnifiedCtx(ctx, path, baseRef, dir, ignoreWhitespace)
 }
 
-func (g *GitVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
-	return FileDiffScoped(path, scope, baseRef, dir)
+func (g *GitVCS) FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return FileDiffScoped(path, scope, baseRef, dir, ignoreWhitespace)
 }
 
-func (g *GitVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	return FileDiffForCommit(path, sha, dir)
+func (g *GitVCS) FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return FileDiffForCommit(path, sha, dir, ignoreWhitespace)
 }
 
 func (g *GitVCS) FileDiffUnifiedNewFile(path string) ([]DiffHunk, error) {
@@ -109,8 +109,8 @@ func (g *GitVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileCh
 }
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range baseSHA..headSHA.
-func (g *GitVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error) {
-	return FileDiffBetweenSHAs(path, baseSHA, headSHA, dir)
+func (g *GitVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return FileDiffBetweenSHAs(path, baseSHA, headSHA, dir, ignoreWhitespace)
 }
 
 // ReadFileAtSHA returns the bytes of path at the given SHA.

--- a/git_vcs_test.go
+++ b/git_vcs_test.go
@@ -152,7 +152,7 @@ func TestFileDiffBetweenSHAs_HappyPath(t *testing.T) {
 	commitAt(t, dir, "a.txt", "line1\nline2\nline3\n", "modify a")
 	head := gitT(t, dir, "rev-parse", "HEAD")
 
-	hunks, err := FileDiffBetweenSHAs("a.txt", base, head, dir)
+	hunks, err := FileDiffBetweenSHAs("a.txt", base, head, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestFileDiffBetweenSHAs_IdenticalSHAs(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "line1\n", "add a")
 	sha := gitT(t, dir, "rev-parse", "HEAD")
-	hunks, err := FileDiffBetweenSHAs("a.txt", sha, sha, dir)
+	hunks, err := FileDiffBetweenSHAs("a.txt", sha, sha, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestFileDiffBetweenSHAs_MissingPath(t *testing.T) {
 	dir := initTestRepo(t)
 	base := gitT(t, dir, "rev-parse", "HEAD")
 	head := commitAt(t, dir, "a.txt", "x", "add a")
-	hunks, err := FileDiffBetweenSHAs("does-not-exist.txt", base, head, dir)
+	hunks, err := FileDiffBetweenSHAs("does-not-exist.txt", base, head, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/jj.go
+++ b/jj.go
@@ -178,12 +178,12 @@ func (j *JJVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {
 	return parseJJDiffSummary(out), nil
 }
 
-func (j *JJVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
-	return j.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir)
+func (j *JJVCS) FileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return j.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir, ignoreWhitespace)
 }
 
-func (j *JJVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
-	args := []string{"diff", "--git"}
+func (j *JJVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	args := jjDiffArgs(ignoreWhitespace)
 	if strings.TrimSpace(baseRef) == "" {
 		args = append(args, "-r", "@")
 	} else {
@@ -201,23 +201,34 @@ func (j *JJVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir strin
 	return ParseUnifiedDiff(out), nil
 }
 
-func (j *JJVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+func (j *JJVCS) FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	if scope == "branch" {
-		return j.FileDiffUnified(path, baseRef, dir)
+		return j.FileDiffUnified(path, baseRef, dir, ignoreWhitespace)
 	}
 	return nil, nil
 }
 
-func (j *JJVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
+func (j *JJVCS) FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	rev, err := resolveJJRevisionToCommitID(dir, sha)
 	if err != nil {
 		return nil, err
 	}
-	out, err := jjCommandInDir(dir, "diff", "--git", "-r", jjCommitRevset(rev), "--", path)
+	args := append(jjDiffArgs(ignoreWhitespace), "-r", jjCommitRevset(rev), "--", path)
+	out, err := jjCommandInDir(dir, args...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUnifiedDiff(out), nil
+}
+
+// jjDiffArgs returns the leading jj diff arguments. When ignoreWhitespace is
+// true, "--ignore-all-space" is inserted right after "--git".
+func jjDiffArgs(ignoreWhitespace bool) []string {
+	args := []string{"diff", "--git"}
+	if ignoreWhitespace {
+		args = append(args, "--ignore-all-space")
+	}
+	return args
 }
 
 func (j *JJVCS) FileDiffUnifiedNewFile(path string) ([]DiffHunk, error) {
@@ -334,7 +345,7 @@ func (j *JJVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileCha
 	return parseJJDiffSummary(out), nil
 }
 
-func (j *JJVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error) {
+func (j *JJVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	base, err := resolveJJRevisionToCommitID(dir, baseSHA)
 	if err != nil {
 		return nil, err
@@ -343,7 +354,8 @@ func (j *JJVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffH
 	if err != nil {
 		return nil, err
 	}
-	out, err := jjCommandInDir(dir, "diff", "--git", "--from", jjCommitRevset(base), "--to", jjCommitRevset(head), "--", path)
+	args := append(jjDiffArgs(ignoreWhitespace), "--from", jjCommitRevset(base), "--to", jjCommitRevset(head), "--", path)
+	out, err := jjCommandInDir(dir, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/jj_detect_test.go
+++ b/jj_detect_test.go
@@ -151,16 +151,16 @@ func (*fakeJJVCSForFetch) ChangedFilesScoped(string, string) ([]FileChange, erro
 func (*fakeJJVCSForFetch) ChangedFilesForCommit(string, string) ([]FileChange, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffUnified(string, string, string) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffUnified(string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffUnifiedCtx(context.Context, string, string, string) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffUnifiedCtx(context.Context, string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffScoped(string, string, string, string) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffScoped(string, string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffForCommit(string, string, string) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffForCommit(string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
 func (*fakeJJVCSForFetch) FileDiffUnifiedNewFile(string) ([]DiffHunk, error) { return nil, nil }
@@ -181,7 +181,7 @@ func (*fakeJJVCSForFetch) FileContentAtRef(string, string, string) (string, erro
 func (*fakeJJVCSForFetch) ChangedFilesBetweenSHAs(string, string, string) ([]FileChange, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffBetweenSHAs(string, string, string, string) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffBetweenSHAs(string, string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
 func (*fakeJJVCSForFetch) ReadFileAtSHA(string, string, string) ([]byte, error) {

--- a/jj_methods_test.go
+++ b/jj_methods_test.go
@@ -123,13 +123,13 @@ func TestJJVCS_FileDiffScoped(t *testing.T) {
 	withCwd(t, dir)
 
 	// Non-branch scopes return (nil, nil).
-	hunks, err := j.FileDiffScoped("app.txt", "staged", base, dir)
+	hunks, err := j.FileDiffScoped("app.txt", "staged", base, dir, false)
 	if err != nil || hunks != nil {
 		t.Errorf("FileDiffScoped(staged) = (%v, %v), want (nil, nil)", hunks, err)
 	}
 
 	// "branch" delegates and produces hunks.
-	hunks, err = j.FileDiffScoped("app.txt", "branch", base, dir)
+	hunks, err = j.FileDiffScoped("app.txt", "branch", base, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffScoped(branch): %v", err)
 	}
@@ -155,7 +155,7 @@ func TestJJVCS_FileDiffForCommit_AndChangedFilesForCommit(t *testing.T) {
 	}
 	assertFileChangesEqual(t, changes, []FileChange{{Path: "feature.txt", Status: "added"}})
 
-	hunks, err := j.FileDiffForCommit("feature.txt", commitSHA, dir)
+	hunks, err := j.FileDiffForCommit("feature.txt", commitSHA, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffForCommit: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestJJVCS_FileDiffForCommit_AndChangedFilesForCommit(t *testing.T) {
 	}
 
 	// Unknown sha errors on resolve.
-	if _, err := j.FileDiffForCommit("feature.txt", "deadbeefdeadbeef", dir); err == nil {
+	if _, err := j.FileDiffForCommit("feature.txt", "deadbeefdeadbeef", dir, false); err == nil {
 		t.Error("FileDiffForCommit on unknown sha should error")
 	}
 	if _, err := j.ChangedFilesForCommit("deadbeefdeadbeef", dir); err == nil {
@@ -183,7 +183,7 @@ func TestJJVCS_FileDiffUnifiedCtx_Cancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before invoking — jj subprocess exits with cancellation error.
 
-	_, err := j.FileDiffUnifiedCtx(ctx, "app.txt", base, dir)
+	_, err := j.FileDiffUnifiedCtx(ctx, "app.txt", base, dir, false)
 	if err == nil {
 		t.Fatal("FileDiffUnifiedCtx with cancelled ctx should error")
 	}
@@ -202,7 +202,7 @@ func TestJJVCS_FileDiffUnifiedCtx_DeadlineExceeded(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
-	_, err := j.FileDiffUnifiedCtx(ctx, "app.txt", base, dir)
+	_, err := j.FileDiffUnifiedCtx(ctx, "app.txt", base, dir, false)
 	if err == nil {
 		t.Fatal("FileDiffUnifiedCtx with expired deadline should error")
 	}
@@ -378,7 +378,7 @@ func TestJJVCS_ChangedFilesAndDiffBetweenSHAs(t *testing.T) {
 	}
 	assertFileChangesEqual(t, changes, []FileChange{{Path: "between.txt", Status: "added"}})
 
-	hunks, err := j.FileDiffBetweenSHAs("between.txt", mainSHA, headSHA, dir)
+	hunks, err := j.FileDiffBetweenSHAs("between.txt", mainSHA, headSHA, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffBetweenSHAs: %v", err)
 	}

--- a/jj_test.go
+++ b/jj_test.go
@@ -127,7 +127,7 @@ func TestJJVCS_ChangedFilesAndDiffFromBase(t *testing.T) {
 		{Path: "new.txt", Status: "added"},
 	})
 
-	hunks, err := j.FileDiffUnified("app.txt", base, dir)
+	hunks, err := j.FileDiffUnified("app.txt", base, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sapling.go
+++ b/sapling.go
@@ -135,13 +135,15 @@ func (s *SaplingVCS) ChangedFilesForCommit(sha, dir string) ([]FileChange, error
 }
 
 // FileDiffUnified returns parsed diff hunks for a file against a base ref.
-func (s *SaplingVCS) FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error) {
-	return s.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func (s *SaplingVCS) FileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return s.FileDiffUnifiedCtx(context.Background(), path, baseRef, dir, ignoreWhitespace)
 }
 
 // FileDiffUnifiedCtx is like FileDiffUnified but accepts a context for cancellation.
-func (s *SaplingVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error) {
-	args := buildDiffArgs(baseRef, path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func (s *SaplingVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	args := buildDiffArgs(baseRef, path, ignoreWhitespace)
 	cmd := exec.CommandContext(ctx, "sl", args...)
 	if dir != "" {
 		cmd.Dir = dir
@@ -159,17 +161,24 @@ func (s *SaplingVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir 
 
 // FileDiffScoped returns diff hunks for a file using a scope-appropriate diff.
 // Sapling has no staging area, so "staged" and "unstaged" return nil.
-func (s *SaplingVCS) FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error) {
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func (s *SaplingVCS) FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	if scope == "branch" {
-		return s.FileDiffUnified(path, baseRef, dir)
+		return s.FileDiffUnified(path, baseRef, dir, ignoreWhitespace)
 	}
 	return nil, nil
 }
 
 // FileDiffForCommit returns diff hunks for a file in a single commit.
 // Uses --change which handles initial commits (no parent) correctly.
-func (s *SaplingVCS) FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error) {
-	cmd := exec.Command("sl", "diff", "--change", sha, path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func (s *SaplingVCS) FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	args := []string{"diff"}
+	if ignoreWhitespace {
+		args = append(args, "-w")
+	}
+	args = append(args, "--change", sha, path)
+	cmd := exec.Command("sl", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -331,8 +340,14 @@ func (s *SaplingVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]Fi
 }
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range baseSHA..headSHA.
-func (s *SaplingVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error) {
-	cmd := exec.Command("sl", "diff", "--rev", baseSHA, "--rev", headSHA, path)
+// When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+func (s *SaplingVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	args := []string{"diff"}
+	if ignoreWhitespace {
+		args = append(args, "-w")
+	}
+	args = append(args, "--rev", baseSHA, "--rev", headSHA, path)
+	cmd := exec.Command("sl", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -400,9 +415,13 @@ func slCommandInDir(dir string, args ...string) (string, error) {
 	return string(out), nil
 }
 
-// buildDiffArgs constructs arguments for sl diff.
-func buildDiffArgs(baseRef, path string) []string {
+// buildDiffArgs constructs arguments for sl diff. When ignoreWhitespace is
+// true, "-w" is inserted right after "diff" (hg-compatible whitespace flag).
+func buildDiffArgs(baseRef, path string, ignoreWhitespace bool) []string {
 	args := []string{"diff"}
+	if ignoreWhitespace {
+		args = append(args, "-w")
+	}
 	if baseRef != "" {
 		args = append(args, "-r", baseRef)
 	}

--- a/sapling_diff_args_test.go
+++ b/sapling_diff_args_test.go
@@ -19,7 +19,7 @@ func TestBuildDiffArgs(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := buildDiffArgs(c.baseRef, c.path)
+			got := buildDiffArgs(c.baseRef, c.path, false)
 			if !reflect.DeepEqual(got, c.want) {
 				t.Errorf("buildDiffArgs(%q, %q) = %v, want %v", c.baseRef, c.path, got, c.want)
 			}

--- a/server.go
+++ b/server.go
@@ -1208,12 +1208,15 @@ func serveFileAtRound(w http.ResponseWriter, r *http.Request, session *Session, 
 
 // handleFileDiff returns diff hunks for a file.
 // For code files: git diff hunks. For markdown files: inter-round LCS diff.
-// GET /api/file/diff?path=server.go[&round=N]
+// GET /api/file/diff?path=server.go[&round=N][&w=1]
 //
 // In files mode, ?round=N returns the diff between round N's snapshot and
 // round (N-1)'s snapshot. R1 is the baseline and has no previous content,
 // so the response carries empty hunks. In git/range mode, the round
 // parameter is ignored.
+//
+// ?w=1 recomputes the code diff with whitespace ignored (GitHub's ?w=1 parity);
+// the markdown round diff always renders raw.
 func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1231,7 +1234,8 @@ func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
 
 	scope := r.URL.Query().Get("scope")
 	commit := r.URL.Query().Get("commit")
-	snapshot, ok := s.session.Load().GetFileDiffSnapshotScoped(path, scope, commit)
+	ignoreWS := r.URL.Query().Get("w") == "1"
+	snapshot, ok := s.session.Load().GetFileDiffSnapshotScoped(path, scope, commit, ignoreWS)
 	if !ok {
 		http.Error(w, "File not found", http.StatusNotFound)
 		return

--- a/session.go
+++ b/session.go
@@ -253,7 +253,7 @@ func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string, vcs VCS) error {
 // loadDiff computes diff hunks via the VCS interface or git package-level fallback.
 func (fe *FileEntry) loadDiff(ctx context.Context, repoRoot, baseRef string, vcs VCS) {
 	if vcs != nil {
-		hunks, err := vcs.FileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot)
+		hunks, err := vcs.FileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fe.Path, err)
 		} else {
@@ -261,7 +261,7 @@ func (fe *FileEntry) loadDiff(ctx context.Context, repoRoot, baseRef string, vcs
 		}
 		return
 	}
-	hunks, err := fileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot)
+	hunks, err := fileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fe.Path, err)
 	} else {
@@ -477,7 +477,7 @@ func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string, vcs V
 // populateEagerFileDiff computes diff hunks for an eager-loaded file.
 func populateEagerFileDiff(fe *FileEntry, fc FileChange, baseRef, root string, vcs VCS) {
 	if vcs != nil {
-		hunks, err := vcs.FileDiffUnified(fc.Path, baseRef, root)
+		hunks, err := vcs.FileDiffUnified(fc.Path, baseRef, root, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fc.Path, err)
 		} else {
@@ -485,7 +485,7 @@ func populateEagerFileDiff(fe *FileEntry, fc FileChange, baseRef, root string, v
 		}
 		return
 	}
-	hunks, err := fileDiffUnified(fc.Path, baseRef, root)
+	hunks, err := fileDiffUnified(fc.Path, baseRef, root, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fc.Path, err)
 	} else {
@@ -723,7 +723,7 @@ func NewSessionFromFiles(paths []string, ignorePatterns []string) (*Session, err
 		}
 
 		if vcs != nil {
-			hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, root)
+			hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, root, false)
 			if diffErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", relPath, diffErr)
 			} else {
@@ -1698,7 +1698,7 @@ func (s *Session) EnsureFileEntry(path string) bool {
 	if status == "added" || status == "untracked" {
 		fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
 	} else if status != "deleted" && vcs != nil {
-		if hunks, err := vcs.FileDiffUnified(path, baseRef, repoRoot); err == nil {
+		if hunks, err := vcs.FileDiffUnified(path, baseRef, repoRoot, false); err == nil {
 			fe.DiffHunks = hunks
 		}
 	}
@@ -2063,7 +2063,7 @@ func (s *Session) ChangeBaseBranch(branch string) error { //nolint:gocyclo // in
 			}
 		}
 		if fc.Status != "added" && fc.Status != "untracked" {
-			if hunks, diffErr := vcs.FileDiffUnified(fc.Path, mb, repoRoot); diffErr == nil {
+			if hunks, diffErr := vcs.FileDiffUnified(fc.Path, mb, repoRoot, false); diffErr == nil {
 				fe.DiffHunks = hunks
 			}
 		} else {
@@ -2449,7 +2449,29 @@ func (s *Session) GetFileSnapshotFromDisk(path string) (map[string]any, bool) {
 }
 
 // GetFileDiffSnapshot returns diff data for the /api/file/diff endpoint.
-func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
+// whitespaceIgnoredHunks recomputes a fresh whitespace-ignored diff for a
+// normal modified file when ignoreWhitespace is requested. For added/untracked/
+// deleted files (where whitespace-ignore changes nothing) and the markdown
+// branch, it returns the cached hunks unchanged. On any recompute error it logs
+// a warning and falls back to the cached hunks — the request never fails.
+func whitespaceIgnoredHunks(cached []DiffHunk, status string, ignoreWhitespace bool, path, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+	if !ignoreWhitespace || vcs == nil {
+		return cached
+	}
+	if status == "added" || status == "untracked" || status == "deleted" {
+		return cached
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	hunks, err := vcs.FileDiffUnifiedCtx(ctx, path, baseRef, repoRoot, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: whitespace-ignored diff failed for %s: %v\n", path, err)
+		return cached
+	}
+	return hunks
+}
+
+func (s *Session) GetFileDiffSnapshot(path string, ignoreWhitespace bool) (map[string]any, bool) {
 	s.mu.RLock()
 	f := s.fileByPathLocked(path)
 	if f == nil {
@@ -2469,7 +2491,9 @@ func (s *Session) GetFileDiffSnapshot(path string) (map[string]any, bool) {
 	s.mu.RLock()
 	if f.FileType == "code" || s.Mode == "git" {
 		hunks := f.DiffHunks
+		status := f.Status
 		s.mu.RUnlock()
+		hunks = whitespaceIgnoredHunks(hunks, status, ignoreWhitespace, path, baseRef, repoRoot, vcs)
 		if hunks == nil {
 			hunks = []DiffHunk{}
 		}

--- a/session_focus.go
+++ b/session_focus.go
@@ -414,7 +414,7 @@ func (s *Session) buildFilesForFocus(f Focus, vcs VCS, repoRoot string) ([]*File
 			fe.FileHash = fileHash(data)
 		}
 		if fc.Status != "added" && fc.Status != "untracked" {
-			hunks, _ := vcs.FileDiffBetweenSHAs(fc.Path, f.DiffBaseSHA(), f.HeadSHA, repoRoot)
+			hunks, _ := vcs.FileDiffBetweenSHAs(fc.Path, f.DiffBaseSHA(), f.HeadSHA, repoRoot, false)
 			fe.DiffHunks = hunks
 		} else {
 			fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
@@ -629,7 +629,7 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 		return nil
 	}
 	if commit != "" {
-		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot)
+		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot, false)
 		if err == nil {
 			return h
 		}
@@ -642,7 +642,7 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 		}
 		return nil
 	}
-	h, err := vcs.FileDiffScoped(fc.Path, scope, baseRef, repoRoot)
+	h, err := vcs.FileDiffScoped(fc.Path, scope, baseRef, repoRoot, false)
 	if err == nil {
 		return h
 	}
@@ -802,7 +802,7 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 	return status, content, baseRef, repoRoot
 }
 
-func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot string, vcs VCS, ignoreWhitespace bool) []DiffHunk {
 	// Pure content-based diffs don't need VCS.
 	if status == "untracked" && (scope == "unstaged" || scope == "all" || scope == "") {
 		return FileDiffUnifiedNewFile(content)
@@ -814,13 +814,13 @@ func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoR
 		return nil
 	}
 	if commit != "" {
-		h, err := vcs.FileDiffForCommit(path, commit, repoRoot)
+		h, err := vcs.FileDiffForCommit(path, commit, repoRoot, ignoreWhitespace)
 		if err == nil {
 			return h
 		}
 		return nil
 	}
-	h, err := vcs.FileDiffScoped(path, scope, baseRef, repoRoot)
+	h, err := vcs.FileDiffScoped(path, scope, baseRef, repoRoot, ignoreWhitespace)
 	if err == nil {
 		return h
 	}
@@ -830,9 +830,10 @@ func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoR
 // GetFileDiffSnapshotScoped returns diff data for a file filtered by scope.
 // When scope is "" or in file mode (scopes only apply to git), delegates to GetFileDiffSnapshot.
 // When commit is non-empty, returns the diff for that single commit.
-func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string) (map[string]any, bool) {
+// When ignoreWhitespace is true, whitespace-only changes collapse to context (code diffs only).
+func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string, ignoreWhitespace bool) (map[string]any, bool) {
 	if commit == "" && (scope == "" || scope == "all" || s.Mode == "files" || s.Mode == "plan") {
-		return s.GetFileDiffSnapshot(path)
+		return s.GetFileDiffSnapshot(path, ignoreWhitespace)
 	}
 
 	status, content, baseRef, repoRoot := s.loadScopedFileState(path, scope)
@@ -841,7 +842,7 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string) (map[str
 	vcs := s.VCS
 	s.mu.RUnlock()
 
-	hunks := computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot, vcs)
+	hunks := computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot, vcs, ignoreWhitespace)
 	if hunks == nil {
 		hunks = []DiffHunk{}
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -871,7 +871,7 @@ func TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope(t *testing.T) {
 	s.Files[1].Status = "added"
 	s.Files[1].Content = "package main\n\nfunc main() {}\n"
 
-	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "")
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "", false)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -895,7 +895,7 @@ func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
 	s.Files[1].Status = "untracked"
 	s.Files[1].Content = "package main\n\nfunc main() {}\n"
 
-	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "")
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "", false)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -1623,7 +1623,7 @@ func TestFileDiffUnified_ColorConfigDoesNotBreakParsing(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "README.md"), "# Modified\n\nNew content\n")
 
 	// fileDiffUnified uses --no-color, so it should parse correctly despite the config
-	hunks, err := fileDiffUnified("README.md", "HEAD", dir)
+	hunks, err := fileDiffUnified("README.md", "HEAD", dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2461,7 +2461,7 @@ func TestGetFileDiffSnapshotScoped_RuntimeFile(t *testing.T) {
 
 	// When the file status can't be determined from git (no git repo),
 	// we still get a valid response (empty hunks, not a 404).
-	result, ok := s.GetFileDiffSnapshotScoped("newfile.py", "unstaged", "")
+	result, ok := s.GetFileDiffSnapshotScoped("newfile.py", "unstaged", "", false)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -3059,7 +3059,7 @@ func TestGetFileSnapshotLazy(t *testing.T) {
 	}
 
 	// GetFileDiffSnapshot should also work for the now-loaded file
-	diffSnap, ok := s.GetFileDiffSnapshot("snap.go")
+	diffSnap, ok := s.GetFileDiffSnapshot("snap.go", false)
 	if !ok {
 		t.Fatal("expected diff snapshot to be found")
 	}
@@ -4950,14 +4950,14 @@ func TestFilterDeletedReviewComments_SomeDeleted(t *testing.T) {
 // --- computeScopedDiffHunks tests ---
 
 func TestComputeScopedDiffHunks_UntrackedFile(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "untracked", "package main\n", "", "", nil)
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "untracked", "package main\n", "", "", nil, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for untracked file")
 	}
 }
 
 func TestComputeScopedDiffHunks_AddedFileAllScope(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "all", "", "added", "package main\n", "", "", nil)
+	hunks := computeScopedDiffHunks("test.go", "all", "", "added", "package main\n", "", "", nil, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for added file with all scope")
 	}
@@ -4965,7 +4965,7 @@ func TestComputeScopedDiffHunks_AddedFileAllScope(t *testing.T) {
 
 func TestComputeScopedDiffHunks_AddedFileUnstagedScope(t *testing.T) {
 	// scope=unstaged + status=added => does not use FileDiffUnifiedNewFile
-	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "added", "package main\n", "", "", nil)
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "added", "package main\n", "", "", nil, false)
 	// No VCS to fall back on, should return nil.
 	if hunks != nil {
 		t.Error("expected nil hunks for added file with unstaged scope and no VCS")
@@ -4973,7 +4973,7 @@ func TestComputeScopedDiffHunks_AddedFileUnstagedScope(t *testing.T) {
 }
 
 func TestComputeScopedDiffHunks_NilVCS(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "branch", "", "modified", "package main\n", "main", "/tmp", nil)
+	hunks := computeScopedDiffHunks("test.go", "branch", "", "modified", "package main\n", "main", "/tmp", nil, false)
 	if hunks != nil {
 		t.Error("expected nil hunks with no VCS")
 	}

--- a/vcs.go
+++ b/vcs.go
@@ -52,16 +52,20 @@ type VCS interface {
 	ChangedFilesForCommit(sha, dir string) ([]FileChange, error)
 
 	// FileDiffUnified returns parsed diff hunks for a file against a base ref.
-	FileDiffUnified(path, baseRef, dir string) ([]DiffHunk, error)
+	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
+	FileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// FileDiffUnifiedCtx is like FileDiffUnified but accepts a context for timeout control.
-	FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string) ([]DiffHunk, error)
+	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
+	FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// FileDiffScoped returns diff hunks for a file using a scope-appropriate diff command.
-	FileDiffScoped(path, scope, baseRef, dir string) ([]DiffHunk, error)
+	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
+	FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// FileDiffForCommit returns diff hunks for a file in a single commit.
-	FileDiffForCommit(path, sha, dir string) ([]DiffHunk, error)
+	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
+	FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// FileDiffUnifiedNewFile returns diff hunks showing an entire file as added.
 	FileDiffUnifiedNewFile(path string) ([]DiffHunk, error)
@@ -98,7 +102,8 @@ type VCS interface {
 
 	// FileDiffBetweenSHAs returns parsed diff hunks for path in the range
 	// baseSHA..headSHA. Returns nil hunks when there is no diff for that path.
-	FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string) ([]DiffHunk, error)
+	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
+	FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// ReadFileAtSHA returns the bytes of path at the given SHA. Returns
 	// (nil, nil) when the file does not exist at that SHA. Errors are

--- a/watch.go
+++ b/watch.go
@@ -45,7 +45,7 @@ func (s *Session) RefreshDiffs() {
 		if snap.status == "added" || snap.status == "untracked" {
 			hunks = FileDiffUnifiedNewFile(snap.content)
 		} else if vcs != nil {
-			h, err := vcs.FileDiffUnified(snap.path, baseRef, repoRoot)
+			h, err := vcs.FileDiffUnified(snap.path, baseRef, repoRoot, false)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", snap.path, err)
 			} else {
@@ -543,7 +543,7 @@ func (s *Session) buildFileEntry(absPath, repoRoot, baseRef string, vcs VCS) *Fi
 	}
 
 	if vcs != nil {
-		hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, repoRoot)
+		hunks, diffErr := vcs.FileDiffUnified(relPath, baseRef, repoRoot, false)
 		if diffErr == nil {
 			fe.DiffHunks = hunks
 		}

--- a/watch_refresh_test.go
+++ b/watch_refresh_test.go
@@ -48,7 +48,7 @@ func (f *fakeWatchVCS) ChangedFilesFromBaseInDir(_, _ string) ([]FileChange, err
 	return out, nil
 }
 
-func (f *fakeWatchVCS) FileDiffUnified(path, _, _ string) ([]DiffHunk, error) {
+func (f *fakeWatchVCS) FileDiffUnified(path, _, _ string, _ bool) ([]DiffHunk, error) {
 	atomic.AddInt32(&f.diffCalls, 1)
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/whitespace_diff_test.go
+++ b/whitespace_diff_test.go
@@ -122,6 +122,53 @@ func TestHandleFileDiff_IgnoreWhitespace(t *testing.T) {
 	}
 }
 
+// TestWhitespaceIgnoredHunks_ShortCircuits verifies that whitespaceIgnoredHunks
+// returns the cached hunks untouched for every case where a whitespace-ignored
+// recompute can't change the result (flag off, all-added/untracked/deleted
+// files, or no VCS), and only recomputes for a normal modified file.
+func TestWhitespaceIgnoredHunks_ShortCircuits(t *testing.T) {
+	sentinel := []DiffHunk{{Header: "@@ sentinel @@"}}
+
+	tests := []struct {
+		name           string
+		status         string
+		ignoreWS       bool
+		vcs            VCS
+		wantCachedBack bool // true => must return the cached slice unchanged
+	}{
+		{name: "flag off", status: "modified", ignoreWS: false, vcs: &GitVCS{}, wantCachedBack: true},
+		{name: "added file", status: "added", ignoreWS: true, vcs: &GitVCS{}, wantCachedBack: true},
+		{name: "untracked file", status: "untracked", ignoreWS: true, vcs: &GitVCS{}, wantCachedBack: true},
+		{name: "deleted file", status: "deleted", ignoreWS: true, vcs: &GitVCS{}, wantCachedBack: true},
+		{name: "no vcs", status: "modified", ignoreWS: true, vcs: nil, wantCachedBack: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := whitespaceIgnoredHunks(sentinel, tt.status, tt.ignoreWS, "code.go", "HEAD", t.TempDir(), tt.vcs)
+			cachedBack := len(got) == 1 && got[0].Header == sentinel[0].Header
+			if cachedBack != tt.wantCachedBack {
+				t.Errorf("got %v (cachedBack=%v), want cachedBack=%v", got, cachedBack, tt.wantCachedBack)
+			}
+		})
+	}
+
+	// Modified file with a real repo and a whitespace-only working-tree change:
+	// the recompute path runs and collapses the diff to no hunks (≠ cached).
+	t.Run("modified recomputes and collapses", func(t *testing.T) {
+		dir := initTestRepo(t)
+		writeFile(t, filepath.Join(dir, "code.go"), "func main() {\nreturn\n}\n")
+		gitT(t, dir, "add", "code.go")
+		gitT(t, dir, "commit", "-m", "add code.go")
+		writeFile(t, filepath.Join(dir, "code.go"), "func main() {\n\treturn\n}\n")
+
+		got := whitespaceIgnoredHunks(sentinel, "modified", true, "code.go", "HEAD", dir, &GitVCS{})
+		if len(got) != 0 {
+			t.Errorf("recompute: got %d hunks, want 0 (whitespace-only change collapses)", len(got))
+		}
+	})
+}
+
 // fileDiffHunks issues a GET to the given URL against the diff handler and
 // returns the parsed hunks.
 func fileDiffHunks(t *testing.T, s *Server, url string) []DiffHunk {

--- a/whitespace_diff_test.go
+++ b/whitespace_diff_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// TestFileDiffUnified_IgnoreWhitespace verifies that a file whose only change
+// is leading-whitespace/indentation produces hunks with the flag off and
+// collapses to no hunks with the flag on (GitHub's ?w=1 / git diff -w parity).
+func TestFileDiffUnified_IgnoreWhitespace(t *testing.T) {
+	tests := []struct {
+		name             string
+		original         string
+		modified         string
+		wantHunksRaw     bool
+		wantHunksIgnoreW bool
+	}{
+		{
+			name:             "leading indentation only",
+			original:         "func main() {\nreturn\n}\n",
+			modified:         "func main() {\n\treturn\n}\n",
+			wantHunksRaw:     true,
+			wantHunksIgnoreW: false,
+		},
+		{
+			name:             "real change survives ignore-whitespace",
+			original:         "func main() {\nreturn\n}\n",
+			modified:         "func main() {\n\treturn 42\n}\n",
+			wantHunksRaw:     true,
+			wantHunksIgnoreW: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := initTestRepo(t)
+			writeFile(t, filepath.Join(dir, "code.go"), tt.original)
+			gitT(t, dir, "add", "code.go")
+			gitT(t, dir, "commit", "-m", "add code.go")
+
+			// Re-indent / edit in the working tree (uncommitted change vs HEAD).
+			writeFile(t, filepath.Join(dir, "code.go"), tt.modified)
+
+			rawHunks, err := fileDiffUnified("code.go", "HEAD", dir, false)
+			if err != nil {
+				t.Fatalf("fileDiffUnified(raw): %v", err)
+			}
+			if got := len(rawHunks) > 0; got != tt.wantHunksRaw {
+				t.Errorf("raw diff: got hunks=%v, want %v (hunks=%v)", got, tt.wantHunksRaw, rawHunks)
+			}
+
+			wHunks, err := fileDiffUnified("code.go", "HEAD", dir, true)
+			if err != nil {
+				t.Fatalf("fileDiffUnified(ignore-ws): %v", err)
+			}
+			if got := len(wHunks) > 0; got != tt.wantHunksIgnoreW {
+				t.Errorf("ignore-ws diff: got hunks=%v, want %v (hunks=%v)", got, tt.wantHunksIgnoreW, wHunks)
+			}
+		})
+	}
+}
+
+// TestHandleFileDiff_IgnoreWhitespace verifies that GET /api/file/diff?w=1
+// returns the whitespace-ignored hunks for a code file while the default
+// (no ?w) path returns the raw cached diff.
+func TestHandleFileDiff_IgnoreWhitespace(t *testing.T) {
+	dir := initTestRepo(t)
+	// Commit a baseline, then re-indent in the working tree.
+	writeFile(t, filepath.Join(dir, "code.go"), "func main() {\nreturn\n}\n")
+	gitT(t, dir, "add", "code.go")
+	gitT(t, dir, "commit", "-m", "add code.go")
+	writeFile(t, filepath.Join(dir, "code.go"), "func main() {\n\treturn\n}\n")
+
+	// Cached (raw) diff, as the eager loader would have computed it.
+	cached, err := fileDiffUnified("code.go", "HEAD", dir, false)
+	if err != nil {
+		t.Fatalf("fileDiffUnified(raw): %v", err)
+	}
+	if len(cached) == 0 {
+		t.Fatal("expected non-empty raw diff for re-indented file")
+	}
+
+	session := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		BaseRef:  "HEAD",
+		VCS:      &GitVCS{},
+
+		subscribers:   make(map[chan SSEEvent]struct{}),
+		roundComplete: make(chan struct{}, 1),
+		Files: []*FileEntry{
+			{
+				Path:      "code.go",
+				AbsPath:   filepath.Join(dir, "code.go"),
+				Status:    "modified",
+				FileType:  "code",
+				DiffHunks: cached,
+				Comments:  []Comment{},
+			},
+		},
+	}
+
+	s, err := NewServer(session, frontendFS, "", false, "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default path: returns the raw cached hunks.
+	rawResp := fileDiffHunks(t, s, "/api/file/diff?path=code.go")
+	if len(rawResp) != len(cached) {
+		t.Errorf("default path: got %d hunks, want cached %d", len(rawResp), len(cached))
+	}
+
+	// ?w=1 path: whitespace-only change collapses to no hunks.
+	wResp := fileDiffHunks(t, s, "/api/file/diff?path=code.go&w=1")
+	if len(wResp) != 0 {
+		t.Errorf("?w=1 path: got %d hunks, want 0 (whitespace-only change)", len(wResp))
+	}
+}
+
+// fileDiffHunks issues a GET to the given URL against the diff handler and
+// returns the parsed hunks.
+func fileDiffHunks(t *testing.T, s *Server, url string) []DiffHunk {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	s.handleFileDiff(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: status %d, body %s", url, rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Hunks []DiffHunk `json:"hunks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp.Hunks
+}


### PR DESCRIPTION
## Summary
- Adds a GitHub-style **"Ignore whitespace"** toggle to the review settings (Display group), persisted in the `crit-settings` cookie. Shown in git mode only (where code diffs appear).
- When enabled, code-file diffs are recomputed with whitespace ignored, so whitespace-only changes and pure re-indentation collapse to context (like GitHub's `?w=1`).
- Backend: an `ignoreWhitespace` flag is threaded through the VCS diff interface and its three backends — git `-w`, sapling `-w`, jj `--ignore-all-space` — and surfaced on `GET /api/file/diff?...&w=1`. Recompute is **on-demand**: the cached default diff stays whitespace-sensitive, and recompute falls back to the cache on error (the endpoint never fails).
- Frontend: settings toggle wired through the existing `getSetting`/`setSetting` cookie helpers; `&w=1` appended to diff fetches; re-render via the existing `reloadForScope()` path.

## Scope
- **crit only** — crit-web intentionally not changed (deliberate decision, not parity drift).
- **Code diffs only** — markdown inter-round diffs are unaffected.
- No keyboard shortcut (by design).

## Review
- [x] Code review: passed — two fresh-eyes expert agents (Go + frontend), 0 blockers, 0 warnings
- [x] Parity audit: N/A (single repo by design)

## Test plan
- `go test -race ./...` green; new `whitespace_diff_test.go` covers the whitespace-only-collapse case (raw vs `-w`) at both the VCS and `/api/file/diff` endpoint levels
- JS unit test for the settings-pane toggle (render + wiring + git-mode gating)
- git-mode Playwright spec (`e2e/tests/whitespace.spec.ts`): toggle persists across reload and a diff request fires with `&w=1`
- gofmt / golangci-lint / eslint / stylelint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)