### PR TITLE
feat: multi-commit selection in commit picker

### DIFF
--- a/commit_range_test.go
+++ b/commit_range_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSplitCommitRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		commit   string
+		wantBase string
+		wantHead string
+		wantOK   bool
+	}{
+		{"single sha", "abc123", "", "", false},
+		{"empty", "", "", "", false},
+		{"valid range", "abc123..def456", "abc123", "def456", true},
+		{"full hex shas", "0a1b2c3d4e5f60718293a4b5c6d7e8f901234567..76543210fedcba98765432100123456789abcdef", "0a1b2c3d4e5f60718293a4b5c6d7e8f901234567", "76543210fedcba98765432100123456789abcdef", true},
+		{"option injection base", "--foo..def456", "", "", false},
+		{"option injection head", "abc123..--bar", "", "", false},
+		{"empty base", "..def456", "", "", false},
+		{"empty head", "abc123..", "", "", false},
+		{"both empty", "..", "", "", false},
+		{"non-hex base", "zzzz..def456", "", "", false},
+		{"non-hex head", "abc123..gggg", "", "", false},
+		{"too short base", "ab..def456", "", "", false},
+		{"path-like ref", "main..feature", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, head, ok := splitCommitRange(tt.commit)
+			if base != tt.wantBase || head != tt.wantHead || ok != tt.wantOK {
+				t.Errorf("splitCommitRange(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.commit, base, head, ok, tt.wantBase, tt.wantHead, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsCommitish(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"abc1", true},
+		{"0123456789abcdefABCDEF0123456789abcdef01", true},
+		{"abc", false},   // too short (<4)
+		{"", false},      // empty
+		{"--foo", false}, // option injection
+		{"main", false},  // non-hex
+		{"abc123def456abc123def456abc123def456abc12", false}, // 41 chars, too long
+	}
+	for _, tt := range tests {
+		if got := isCommitish(tt.in); got != tt.want {
+			t.Errorf("isCommitish(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestGetSessionInfoScoped_CommitRange builds a feature branch with three
+// commits over a base and asserts that scoping by a commit RANGE
+// (C1sha..C3sha) returns the union of files changed across those commits,
+// matching ChangedFilesBetweenSHAs, while a single-commit param still returns
+// only that commit's files.
+func TestGetSessionInfoScoped_CommitRange(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+
+	c1 := commitAt(t, dir, "a.txt", "a1\n", "C1: add a")
+	c2 := commitAt(t, dir, "b.txt", "b1\n", "C2: add b")
+	c3 := commitAt(t, dir, "c.txt", "c1\n", "C3: add c")
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		BaseRef:  base,
+		Branch:   "main",
+		VCS:      &GitVCS{},
+	}
+
+	// Range C1..C3 should return the union of files touched by C2 and C3
+	// (a.txt was introduced by C1 itself, so it's part of the C1 tree, not the
+	// diff from C1). Assert against ChangedFilesBetweenSHAs as the source of truth.
+	wantChanges, err := ChangedFilesBetweenSHAs(c1, c3, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPaths := pathsOf(wantChanges)
+
+	rangeInfo := s.GetSessionInfoScoped("", c1+".."+c3)
+	gotPaths := filePaths(rangeInfo.Files)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Errorf("range C1..C3 files = %v, want %v", gotPaths, wantPaths)
+	}
+
+	// A single commit (C2) should return only C2's files.
+	singleInfo := s.GetSessionInfoScoped("", c2)
+	singleWant, err := ChangedFilesForCommit(c2, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := filePaths(singleInfo.Files), pathsOf(singleWant); !reflect.DeepEqual(got, want) {
+		t.Errorf("single commit C2 files = %v, want %v", got, want)
+	}
+	if want := []string{"b.txt"}; !reflect.DeepEqual(filePaths(singleInfo.Files), want) {
+		t.Errorf("single commit C2 files = %v, want %v", filePaths(singleInfo.Files), want)
+	}
+}
+
+func pathsOf(changes []FileChange) []string {
+	out := make([]string, len(changes))
+	for i, c := range changes {
+		out[i] = c.Path
+	}
+	sort.Strings(out)
+	return out
+}
+
+func filePaths(files []SessionFileInfo) []string {
+	out := make([]string, len(files))
+	for i, f := range files {
+		out[i] = f.Path
+	}
+	sort.Strings(out)
+	return out
+}

--- a/e2e/tests/commit-selection.spec.ts
+++ b/e2e/tests/commit-selection.spec.ts
@@ -59,8 +59,8 @@ test.describe('Commit Selection', () => {
     await commitItem.click();
     await responsePromise;
 
-    // Dropdown should close after selection
-    await expect(page.locator('#commitDropdown')).not.toHaveClass(/open/);
+    // Multi-select: the dropdown STAYS OPEN after selecting a commit
+    await expect(page.locator('#commitDropdown')).toHaveClass(/open/);
 
     // Label should update to show the selected commit
     await expect(page.locator('#commitDropdownLabel')).not.toHaveText('All commits');
@@ -82,9 +82,10 @@ test.describe('Commit Selection', () => {
     const firstResponsePromise = page.waitForResponse(r => r.url().includes('/api/session'));
     await commitItem.click();
     await firstResponsePromise;
+    await expect(page.locator('#commitDropdownLabel')).not.toHaveText('All commits');
 
-    // Now open again and select "All commits"
-    await openCommitPicker(page);
+    // The dropdown stays open after multi-select; click "All commits" directly
+    // WITHOUT re-opening (re-opening would toggle it closed).
     const allItem = page.locator('.commit-picker-item[data-commit=""]');
     const responsePromise = page.waitForResponse(r =>
       r.url().includes('/api/session') && r.status() === 200
@@ -193,12 +194,152 @@ test.describe('Commit Selection', () => {
     await commitItem.click();
     await responsePromise;
 
-    // Open dropdown again to inspect state
-    await openCommitPicker(page);
-
+    // Dropdown stays open after selection — inspect state directly without
+    // re-opening (re-opening would toggle it closed).
     // "All commits" should no longer be active
     await expect(page.locator('.commit-picker-item[data-commit=""]')).not.toHaveClass(/active/);
     // The selected commit should be active
     await expect(page.locator('#commitDropdownList .commit-picker-item.active')).toHaveCount(1);
+  });
+
+  // ===== Multi-select behavior =====
+
+  test('checking two commits shows "2 commits" label and sends a range param', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    await expect(commits).toHaveCount(2);
+
+    // Select the first commit (single — full SHA param).
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(0).click();
+    await firstResponse;
+    await expect(page.locator('#commitDropdownLabel')).not.toHaveText('All commits');
+
+    // Selecting the second commit derives a git range — the commit param
+    // must contain "..".
+    const rangeRequest = page.waitForRequest(
+      r => r.url().includes('/api/session') && /[?&]commit=[^&]*\.\.[^&]*/.test(r.url())
+    );
+    await commits.nth(1).click();
+    await rangeRequest;
+
+    await expect(page.locator('#commitDropdownLabel')).toHaveText('2 commits');
+  });
+
+  test('both checkboxes are checked when two commits selected', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    await expect(commits).toHaveCount(2);
+
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(0).click();
+    await firstResponse;
+
+    const secondResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(1).click();
+    await secondResponse;
+
+    await expect(
+      page.locator('#commitDropdownList .commit-picker-item input.commit-picker-item-check:checked')
+    ).toHaveCount(2);
+    await expect(page.locator('#commitDropdownList .commit-picker-item.active')).toHaveCount(2);
+  });
+
+  test('unchecking returns toward fewer commits', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    await expect(commits).toHaveCount(2);
+
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(0).click();
+    await firstResponse;
+
+    const secondResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(1).click();
+    await secondResponse;
+    await expect(page.locator('#commitDropdownLabel')).toHaveText('2 commits');
+
+    // Uncheck the second commit — back down to a single-commit selection.
+    const uncheckResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(1).click();
+    await uncheckResponse;
+
+    // One commit remains, so label is a single-commit label (not "All commits"
+    // and not "2 commits").
+    await expect(page.locator('#commitDropdownLabel')).not.toHaveText('All commits');
+    await expect(page.locator('#commitDropdownLabel')).not.toHaveText('2 commits');
+    await expect(
+      page.locator('#commitDropdownList .commit-picker-item input.commit-picker-item-check:checked')
+    ).toHaveCount(1);
+  });
+
+  test('"All commits" row clears a multi-selection', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    await expect(commits).toHaveCount(2);
+
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(0).click();
+    await firstResponse;
+
+    const secondResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(1).click();
+    await secondResponse;
+    await expect(page.locator('#commitDropdownLabel')).toHaveText('2 commits');
+
+    // Click "All commits" — clears the entire selection.
+    const clearResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await page.locator('.commit-picker-item[data-commit=""]').click();
+    await clearResponse;
+
+    await expect(page.locator('#commitDropdownLabel')).toHaveText('All commits');
+    await expect(page.locator('#commitDropdownList .commit-picker-item.active')).toHaveCount(0);
+    await expect(
+      page.locator('#commitDropdownList .commit-picker-item input.commit-picker-item-check:checked')
+    ).toHaveCount(0);
+  });
+
+  test('dropdown stays open across multiple selections', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    await expect(commits).toHaveCount(2);
+
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(0).click();
+    await firstResponse;
+
+    const secondResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await commits.nth(1).click();
+    await secondResponse;
+
+    await expect(page.locator('#commitDropdown')).toHaveClass(/open/);
+  });
+
+  test('commit checkboxes are accessible and toggle selection on click', async ({ page }) => {
+    await openCommitPicker(page);
+
+    const checks = page.locator('#commitDropdownList .commit-picker-item input.commit-picker-item-check');
+    await expect(checks).toHaveCount(2);
+
+    // Every checkbox exposes an accessible name for keyboard/AT users.
+    const count = await checks.count();
+    for (let i = 0; i < count; i++) {
+      await expect(checks.nth(i)).toHaveAttribute('aria-label', /^Select commit /);
+    }
+
+    // Clicking the input itself toggles the selection (drives the active row),
+    // with no double-toggle.
+    const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
+    await checks.first().click();
+    await firstResponse;
+    await expect(page.locator('#commitDropdownList .commit-picker-item.active')).toHaveCount(1);
+    await expect(
+      page.locator('#commitDropdownList .commit-picker-item input.commit-picker-item-check:checked')
+    ).toHaveCount(1);
   });
 });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -415,7 +415,15 @@
     document.body.classList.toggle('hide-resolved', hideResolvedState);
   }
 
+  // diffCommit is the DERIVED backend param string (kept so the existing
+  // &commit= append sites and the reloadForScope key work unchanged):
+  //   0 selected      -> ''                  (all commits)
+  //   exactly 1       -> '<full sha>'         (single-commit path)
+  //   2+ selected     -> '<baseSHA>..<headSHA>' (git range)
+  // selectedCommits holds the user-checked full SHAs; diffCommit is recomputed
+  // from it via recomputeDiffCommit() whenever the selection changes.
   let diffCommit = '';
+  const selectedCommits = new Set();
   let commitList = [];
   let diffActive = false; // rendered diff view toggle for file mode
 
@@ -981,6 +989,7 @@
         fetchCommits();
       } else {
         commitDropdownEl.style.display = 'none';
+        selectedCommits.clear();
         diffCommit = '';
       }
     }
@@ -6653,6 +6662,7 @@
         }
 
         // Clear commit filter on round-complete
+        selectedCommits.clear();
         diffCommit = '';
 
         // Re-fetch everything on file-changed (round complete)
@@ -7156,12 +7166,17 @@
       commitList = await res.json();
       if (!commitList || commitList.length < 2) {
         commitDropdownEl.style.display = 'none';
-        diffCommit = '';
+        selectedCommits.clear();
+        recomputeDiffCommit();
         return;
       }
-      if (diffCommit && !commitList.some(function(c) { return c.sha === diffCommit; })) {
-        diffCommit = '';
-      }
+      // Drop any selected SHA that's no longer present in the new commit list,
+      // then recompute the derived backend param.
+      const present = new Set(commitList.map(function(c) { return c.sha; }));
+      selectedCommits.forEach(function(sha) {
+        if (!present.has(sha)) selectedCommits.delete(sha);
+      });
+      recomputeDiffCommit();
       commitDropdownEl.style.display = '';
       renderCommitPicker();
     } catch {
@@ -7169,26 +7184,93 @@
     }
   }
 
+  // Recompute the derived diffCommit backend param from selectedCommits.
+  // commitList is newest-first, so the smallest index is the newest (head)
+  // and the largest index is the oldest. For a 2+ range the base is the
+  // PARENT of the oldest selected commit (commitList[oldestIdx + 1].sha) or
+  // session.base_ref when the oldest selected commit is the first commit.
+  // Emits FULL 40-char SHAs (the backend validates hex 4-40): commitList SHAs
+  // come from /api/commits, and session.base_ref is a merge-base SHA — both are
+  // guaranteed present and hex whenever the picker is interactive, because
+  // GetCommits returns nil (→ commitList empty → picker hidden) when base_ref
+  // is unset. The empty-base guard below is belt-and-suspenders for that
+  // invariant: never emit a malformed "..<head>" range that would silently
+  // fall back to the full unscoped diff on the backend.
+  function recomputeDiffCommit() {
+    if (selectedCommits.size === 0) {
+      diffCommit = '';
+      return;
+    }
+    if (selectedCommits.size === 1) {
+      diffCommit = selectedCommits.values().next().value;
+      return;
+    }
+    let newestIdx = Infinity;
+    let oldestIdx = -1;
+    commitList.forEach(function(c, i) {
+      if (selectedCommits.has(c.sha)) {
+        if (i < newestIdx) newestIdx = i;
+        if (i > oldestIdx) oldestIdx = i;
+      }
+    });
+    const head = commitList[newestIdx].sha;
+    const base = commitList[oldestIdx + 1]
+      ? commitList[oldestIdx + 1].sha
+      : (session.base_ref || '');
+    // Defensive: if base is somehow unavailable, fall back to the newest
+    // selected commit alone rather than a broken range.
+    diffCommit = base ? base + '..' + head : head;
+  }
+
   function renderCommitPicker() {
     const list = document.getElementById('commitDropdownList');
     const allItem = document.querySelector('.commit-picker-item[data-commit=""]');
     const label = document.getElementById('commitDropdownLabel');
 
-    if (diffCommit) {
-      if (allItem) allItem.classList.remove('active');
-      const sel = commitList.find(function(c) { return c.sha === diffCommit; });
-      if (sel && label) label.textContent = sel.short_sha + ' ' + (sel.message.length > 30 ? sel.message.slice(0, 30) + '\u2026' : sel.message);
-    } else {
-      if (allItem) allItem.classList.add('active');
-      if (label) label.textContent = 'All commits';
+    // Compute the contiguous in-range span [newestIdx, oldestIdx] so commits
+    // between two checked commits show an "in range" indicator even when not
+    // themselves checked (the diff includes them).
+    let newestIdx = Infinity;
+    let oldestIdx = -1;
+    if (selectedCommits.size >= 2) {
+      commitList.forEach(function(c, i) {
+        if (selectedCommits.has(c.sha)) {
+          if (i < newestIdx) newestIdx = i;
+          if (i > oldestIdx) oldestIdx = i;
+        }
+      });
     }
 
-    list.innerHTML = commitList.map(function(c) {
-      const active = c.sha === diffCommit ? ' active' : '';
+    // "All commits" is active when nothing is checked.
+    if (selectedCommits.size === 0) {
+      if (allItem) allItem.classList.add('active');
+      if (label) label.textContent = 'All commits';
+    } else {
+      if (allItem) allItem.classList.remove('active');
+      if (selectedCommits.size === 1) {
+        const sel = commitList.find(function(c) { return selectedCommits.has(c.sha); });
+        if (sel && label) label.textContent = sel.short_sha + ' ' + (sel.message.length > 30 ? sel.message.slice(0, 30) + '\u2026' : sel.message);
+      } else if (label) {
+        // The diff spans the whole contiguous range, so count commits in the
+        // span (oldestIdx - newestIdx + 1) \u2014 not just the checked ones \u2014 so the
+        // label stays honest when in-between commits are included.
+        const spanCount = oldestIdx - newestIdx + 1;
+        label.textContent = spanCount + ' commits';
+      }
+    }
+
+    list.innerHTML = commitList.map(function(c, i) {
+      const checked = selectedCommits.has(c.sha);
+      const inRange = !checked && i > newestIdx && i < oldestIdx;
+      const cls = 'commit-picker-item' + (checked ? ' active' : '') + (inRange ? ' in-range' : '');
       const time = c.date ? '<span class="commit-picker-item-time">' + relativeTime(c.date) + '</span>' : '';
-      return '<div class="commit-picker-item' + active + '" data-commit="' + c.sha + '">'
+      const rangeHint = inRange ? '<span class="commit-picker-item-range">in range</span>' : '';
+      return '<div class="' + cls + '" data-commit="' + c.sha + '">'
+        + '<input type="checkbox" class="commit-picker-item-check"' + (checked ? ' checked' : '')
+        + ' aria-label="Select commit ' + escapeHtml(c.short_sha) + '">'
         + '<span class="commit-picker-item-sha">' + escapeHtml(c.short_sha) + '</span>'
         + '<span class="commit-picker-item-msg">' + escapeHtml(c.message.length > 40 ? c.message.slice(0, 40) + '\u2026' : c.message) + '</span>'
+        + rangeHint
         + time
         + '</div>';
     }).join('');
@@ -7214,19 +7296,34 @@
     }
   });
 
-  // Item selection (delegate from dropdown menu)
+  // Item selection (delegate from dropdown menu). Multi-select: clicking a row
+  // toggles its checkbox and keeps the dropdown OPEN. Clicking the checkbox
+  // directly is handled by the same path (we drive the Set, not the input's
+  // own checked state) so there's no double-toggle. The "All commits" row
+  // (data-commit="") clears the entire selection.
   document.getElementById('commitDropdownMenu').addEventListener('click', function(e) {
     const item = e.target.closest('.commit-picker-item');
     if (!item) return;
+    // renderCommitPicker() below replaces #commitDropdownList's innerHTML,
+    // orphaning the clicked node. Without this, the click bubbles to the
+    // document outside-click handler, where commitDropdownEl.contains(e.target)
+    // is false for the now-detached node and the dropdown closes — defeating
+    // multi-select stay-open. Stop propagation so the menu owns this click.
+    e.stopPropagation();
     const sha = item.dataset.commit;
-    if (sha === diffCommit) {
-      commitDropdownEl.classList.remove('open');
-      return;
+    const prevDiffCommit = diffCommit;
+    if (sha === '') {
+      selectedCommits.clear();
+    } else if (selectedCommits.has(sha)) {
+      selectedCommits.delete(sha);
+    } else {
+      selectedCommits.add(sha);
     }
-    diffCommit = sha;
+    recomputeDiffCommit();
     renderCommitPicker();
-    commitDropdownEl.classList.remove('open');
-    reloadForScope();
+    // Only reload if the derived range actually changed (e.g. checking a commit
+    // already inside the in-range span doesn't change the diff).
+    if (diffCommit !== prevDiffCommit) reloadForScope();
   });
 
   // ===== Scope Toggle (All / Branch / Staged / Unstaged) =====
@@ -7238,6 +7335,7 @@
     navCommentId = null;
     setSetting('diffScope', scope);
     if (scope !== 'all' && scope !== 'branch') {
+      selectedCommits.clear();
       diffCommit = '';
       commitDropdownEl.style.display = 'none';
     } else {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4111,6 +4111,29 @@ body.sidebar-resizing * {
   color: var(--crit-brand);
   font-weight: 600;
 }
+.commit-picker-item-check {
+  flex-shrink: 0;
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: var(--crit-brand);
+  cursor: pointer;
+  align-self: center;
+}
+/* Commits that fall between two checked commits: included in the diff range
+   but not themselves checked. Left accent bar + muted hint make this honest. */
+.commit-picker-item.in-range {
+  border-left: 2px solid var(--crit-brand);
+  padding-left: 6px;
+  color: var(--crit-editor-fg-muted);
+}
+.commit-picker-item-range {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--crit-brand);
+  flex-shrink: 0;
+}
 .commit-picker-item-sha {
   font-family: var(--crit-font-mono);
   font-size: 10px;

--- a/git.go
+++ b/git.go
@@ -410,6 +410,31 @@ func CommitLog(baseRef, headRef, dir string) ([]CommitInfo, error) {
 	return commits, nil
 }
 
+// commitishRe matches a safe git ref token: a hex string 4–40 chars long.
+// Restricting to hex rejects option-injection (a token starting with "-")
+// since base+".."+head is passed to git as a single argument.
+var commitishRe = regexp.MustCompile(`^[0-9a-fA-F]{4,40}$`)
+
+// isCommitish reports whether s is a safe ref token (hex SHA, 4–40 chars).
+func isCommitish(s string) bool {
+	return commitishRe.MatchString(s)
+}
+
+// splitCommitRange parses a commit query param of the form "<baseSHA>..<headSHA>".
+// Returns ok=false for a single-SHA (no "..") param, which keeps single-commit
+// behavior. Both parts must be valid commit-ish tokens; otherwise ok=false.
+func splitCommitRange(commit string) (base, head string, ok bool) {
+	i := strings.Index(commit, "..")
+	if i < 0 {
+		return "", "", false
+	}
+	base, head = commit[:i], commit[i+2:]
+	if !isCommitish(base) || !isCommitish(head) {
+		return "", "", false
+	}
+	return base, head, true
+}
+
 // ChangedFilesForCommit returns the files changed in a single commit.
 // The dir parameter sets the working directory for the git command.
 func ChangedFilesForCommit(sha, dir string) ([]FileChange, error) {

--- a/session_focus.go
+++ b/session_focus.go
@@ -628,6 +628,13 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 	if vcs == nil {
 		return nil
 	}
+	if base, head, ok := splitCommitRange(commit); ok {
+		h, err := vcs.FileDiffBetweenSHAs(fc.Path, base, head, repoRoot, false)
+		if err == nil {
+			return h
+		}
+		return nil
+	}
 	if commit != "" {
 		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot, false)
 		if err == nil {
@@ -704,7 +711,9 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 
 	var changes []FileChange
 	var err error
-	if commit != "" {
+	if base, head, ok := splitCommitRange(commit); ok {
+		changes, err = snap.vcs.ChangedFilesBetweenSHAs(base, head, snap.repoRoot)
+	} else if commit != "" {
 		changes, err = snap.vcs.ChangedFilesForCommit(commit, snap.repoRoot)
 	} else {
 		changes, err = snap.vcs.ChangedFilesScoped(scope, snap.baseRef)
@@ -811,6 +820,13 @@ func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoR
 		return FileDiffUnifiedNewFile(content)
 	}
 	if vcs == nil {
+		return nil
+	}
+	if base, head, ok := splitCommitRange(commit); ok {
+		h, err := vcs.FileDiffBetweenSHAs(path, base, head, repoRoot, ignoreWhitespace)
+		if err == nil {
+			return h
+		}
 		return nil
 	}
 	if commit != "" {


### PR DESCRIPTION
## Summary
- The commit picker is now **multi-select** via checkboxes. Selecting 2+ commits reviews the combined git range from the oldest selected commit's parent to the newest selected commit.
- In-between commits are included in the range (git two-dot semantics) and shown with an "in range" indicator so the spanned set is visible. The button label reports the span count, not just the checked count, so it stays honest.
- Single-commit selection and the "All commits" reset behave exactly as before.

## Implementation
- **Backend:** the existing `commit` query param now also accepts a `<baseSHA>..<headSHA>` range form, routed to the existing `*BetweenSHAs` VCS methods (already implemented for git/sapling/jj). Range parts are validated as hex commit-ish tokens (`^[0-9a-fA-F]{4,40}$`), rejecting git option-injection. The single-SHA form is untouched, preserving root-commit handling.
- **Frontend:** a `selectedCommits` Set drives a derived `diffCommit` param (0 → all, 1 → single sha, 2+ → range). The base for the oldest selected commit is its parent in the commit list, or the session's merge-base ref for the first commit. The dropdown stays open for multi-select; `stopPropagation` prevents the list re-render from tripping the outside-click close handler.

## Review
- [x] Code review: passed (fresh go-expert + frontend-expert + red-team pass)
- [x] Parity audit: N/A — crit-web has no commit picker

## Test plan
- Go: new `commit_range_test.go` (range parsing, hex/injection validation, range file-set == `ChangedFilesBetweenSHAs`, single-commit unchanged). Full `go test -race ./...` green.
- E2E: extended `commit-selection.spec.ts` for multi-select (range param, checked counts, stay-open, unchecking, clear-all, accessibility). 19/19 git-mode specs pass.
- gofmt clean, golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)