### PR TITLE
fix: align line numbers with rendered markdown text

### DIFF
--- a/e2e/tests/line-number-alignment.singlefile.spec.ts
+++ b/e2e/tests/line-number-alignment.singlefile.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loadPage } from './helpers';
+
+// Regression for #631: in document view the gutter line-number must line up
+// with the first line of the rendered text for headings AND paragraphs. The
+// bug was that heading/paragraph top margins pushed the text down inside the
+// flex row while the number stayed pinned at the row top. We assert the
+// vertical delta between the number's top and the first rendered text line's
+// top stays small. A correctly-aligned block sits ~0-3px off (ascender gap);
+// the regression produced 7-9px. 4px is a comfortable, non-flaky threshold.
+const MAX_DELTA = 4;
+
+// Measure |top(.line-num) - top(first text line of .line-content)| for the
+// .line-block whose rendered content matches `selector`.
+async function topDelta(page: Page, selector: string): Promise<number> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) throw new Error(`no element for ${sel}`);
+    const block = el.closest('.line-block');
+    if (!block) throw new Error(`no .line-block ancestor for ${sel}`);
+    const num = block.querySelector('.line-num');
+    const content = block.querySelector('.line-content');
+    if (!num || !content) throw new Error(`missing gutter/content for ${sel}`);
+
+    // Range over the first non-whitespace text node gives the true top of the
+    // first visual text line, independent of element box/margin.
+    const walker = document.createTreeWalker(content, NodeFilter.SHOW_TEXT, {
+      acceptNode(n) {
+        return n.nodeValue && n.nodeValue.trim().length
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT;
+      },
+    });
+    const textNode = walker.nextNode();
+    if (!textNode) throw new Error(`no text node for ${sel}`);
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 1);
+
+    const textTop = range.getBoundingClientRect().top;
+    const numTop = (num as HTMLElement).getBoundingClientRect().top;
+    return Math.abs(textTop - numTop);
+  }, selector);
+}
+
+test.describe('Line number alignment — Single File Mode (#631)', () => {
+  test('h1 line number aligns with its heading text', async ({ page }) => {
+    await loadPage(page);
+    await expect(page.locator('h1#authentication-plan')).toBeVisible();
+    await expect(async () => {
+      expect(await topDelta(page, 'h1#authentication-plan')).toBeLessThanOrEqual(MAX_DELTA);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test('h2 line number aligns with its heading text', async ({ page }) => {
+    await loadPage(page);
+    await expect(page.locator('h2#overview')).toBeVisible();
+    await expect(async () => {
+      expect(await topDelta(page, 'h2#overview')).toBeLessThanOrEqual(MAX_DELTA);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test('paragraph line number aligns with its text', async ({ page }) => {
+    await loadPage(page);
+    // The paragraph under "Overview" — a top-level <p> in its own line-block.
+    const para = page.locator('.line-content > p', {
+      hasText: 'adding API key authentication',
+    });
+    await expect(para).toBeVisible();
+    await expect(async () => {
+      const delta = await page.evaluate(() => {
+        const ps = Array.from(document.querySelectorAll('.line-content > p'));
+        const p = ps.find((n) => n.textContent && n.textContent.includes('adding API key authentication'));
+        if (!p) throw new Error('paragraph not found');
+        const block = p.closest('.line-block')!;
+        const num = block.querySelector('.line-num') as HTMLElement;
+        const walker = document.createTreeWalker(p, NodeFilter.SHOW_TEXT, {
+          acceptNode(n) {
+            return n.nodeValue && n.nodeValue.trim().length
+              ? NodeFilter.FILTER_ACCEPT
+              : NodeFilter.FILTER_REJECT;
+          },
+        });
+        const tn = walker.nextNode()!;
+        const range = document.createRange();
+        range.setStart(tn, 0);
+        range.setEnd(tn, 1);
+        return Math.abs(range.getBoundingClientRect().top - num.getBoundingClientRect().top);
+      });
+      expect(delta).toBeLessThanOrEqual(MAX_DELTA);
+    }).toPass({ timeout: 5000 });
+  });
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1021,6 +1021,13 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 
 /* ===== Markdown Styles ===== */
+/* Heading/paragraph top spacing lives on the .line-block row (see the
+   .line-block:has(...) rules below), NOT as margin-top on the heading itself.
+   A margin-top here would push the rendered text down inside the flex row
+   while the gutter line-number stays pinned at the row top (align-items:
+   flex-start), misaligning the number with its text (#631). Putting the
+   spacing on the row moves number and text down together, keeping them
+   aligned while preserving the breathing room above the block. */
 .line-content h1,
 .line-content h2,
 .line-content h3,
@@ -1029,14 +1036,25 @@ body.dragging { user-select: none; cursor: grabbing; }
   color: var(--crit-editor-fg);
   font-weight: 600;
   line-height: 1.3;
-  margin-top: 8px;
+  margin-top: 0;
 }
 .line-content h6 {
   font-weight: 600;
   line-height: 1.3;
-  margin-top: 8px;
+  margin-top: 0;
   font-size: 0.9rem;
   color: var(--crit-editor-fg-muted);
+}
+
+/* Re-express the removed top spacing as row padding so the gutter number and
+   the heading text share the same top edge (#631). */
+.line-block:has(> .line-content > h1),
+.line-block:has(> .line-content > h2),
+.line-block:has(> .line-content > h3),
+.line-block:has(> .line-content > h4),
+.line-block:has(> .line-content > h5),
+.line-block:has(> .line-content > h6) {
+  padding-top: 8px;
 }
 
 .line-content h1 { font-size: 1.8rem; padding-bottom: 8px; border-bottom: 1px solid var(--crit-border); margin-bottom: 4px; }
@@ -1079,6 +1097,16 @@ body.dragging { user-select: none; cursor: grabbing; }
 
 .line-content p {
   margin: 4px 0;
+}
+/* For a top-level paragraph (the block's own content element) move the top
+   spacing onto the row so the gutter number lines up with the first text line
+   (#631); keep the bottom margin for rhythm. Nested paragraphs (in lists,
+   blockquotes) keep the descendant margin above and are unaffected. */
+.line-content > p {
+  margin-top: 0;
+}
+.line-block:has(> .line-content > p) {
+  padding-top: 4px;
 }
 
 .line-content a {


### PR DESCRIPTION
## Summary
- In the markdown document view, the line numbers in the left gutter were vertically misaligned with the headings and paragraphs they label — headings sat ~8px below their number, paragraphs ~4px. Root cause: the gutter pins the number to the top of the flex row (`align-items: flex-start`), but heading/paragraph `margin-top` pushed the rendered text down *inside* the row, so the number floated above its text.
- Moves that top spacing off the content's `margin-top` and onto the `.line-block` row as `padding-top` (via `:has()`), so the gutter number and the text shift down together and stay level. Code lines, lists, blockquotes, and tables are unaffected.
- Ported identically to crit-web (`assets/css/app.css`) — same review surface (see tomasz-tomczyk/crit-web).

## Review
- [x] Visual verification: number-to-text delta dropped from 7-9px (broken) to 0-3px (built the binary, measured h1/h2/paragraph tops)
- [x] Parity audit: the crit-web change is semantically identical

## Test plan
- Added `e2e/tests/line-number-alignment.singlefile.spec.ts` asserting the gutter number top is within 4px of the first rendered text line for an h1, h2, and a paragraph. Verified it **fails** on the pre-fix CSS and **passes** with the fix.

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)