### PR TITLE
fix: align and keyboard-enable the commit picker "All commits" row

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -990,7 +990,7 @@
       } else {
         commitDropdownEl.style.display = 'none';
         selectedCommits.clear();
-        diffCommit = '';
+        recomputeDiffCommit();
       }
     }
 
@@ -6663,7 +6663,7 @@
 
         // Clear commit filter on round-complete
         selectedCommits.clear();
-        diffCommit = '';
+        recomputeDiffCommit();
 
         // Re-fetch everything on file-changed (round complete)
         const sessionRes = await fetch('/api/session?scope=' + enc(diffScope)).then(r => r.json());
@@ -7326,6 +7326,18 @@
     if (diffCommit !== prevDiffCommit) reloadForScope();
   });
 
+  // The "All commits" row (data-commit="") has no focusable child — unlike the
+  // dynamic commit rows, whose checkbox is keyboard-operable — so it carries
+  // role="button" tabindex="0". Route Enter/Space through the same click path
+  // so clearing the selection is keyboard-reachable.
+  document.getElementById('commitDropdownMenu').addEventListener('keydown', function(e) {
+    if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;
+    const item = e.target.closest('.commit-picker-item[data-commit=""]');
+    if (!item) return;
+    e.preventDefault();
+    item.click();
+  });
+
   // ===== Scope Toggle (All / Branch / Staged / Unstaged) =====
   document.getElementById('scopeToggle').addEventListener('click', async function(e) {
     const btn = e.target.closest('.toggle-btn');
@@ -7336,7 +7348,7 @@
     setSetting('diffScope', scope);
     if (scope !== 'all' && scope !== 'branch') {
       selectedCommits.clear();
-      diffCommit = '';
+      recomputeDiffCommit();
       commitDropdownEl.style.display = 'none';
     } else {
       fetchCommits();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -132,7 +132,7 @@
         <svg class="commit-picker-chevron" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2.5 3.75 5 6.25 7.5 3.75"/></svg>
       </button>
       <div class="commit-picker-menu" id="commitDropdownMenu">
-        <div class="commit-picker-item active" data-commit="">All commits</div>
+        <div class="commit-picker-item active" data-commit="" role="button" tabindex="0"><span class="commit-picker-item-check-spacer" aria-hidden="true"></span>All commits</div>
         <div class="commit-picker-separator"></div>
         <div class="commit-picker-list" id="commitDropdownList"></div>
       </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4148,6 +4148,14 @@ body.sidebar-resizing * {
   cursor: pointer;
   align-self: center;
 }
+/* Non-interactive spacer that mirrors the checkbox footprint so the "All
+   commits" row's text aligns with the SHA column of the checkbox-prefixed
+   commit rows. Hidden from AT (aria-hidden) since "All commits" is not itself
+   a selectable commit. Width matches .commit-picker-item-check exactly. */
+.commit-picker-item-check-spacer {
+  width: 13px;
+  flex-shrink: 0;
+}
 /* Commits that fall between two checked commits: included in the diff range
    but not themselves checked. Left accent bar + muted hint make this honest. */
 .commit-picker-item.in-range {

--- a/session.go
+++ b/session.go
@@ -2448,7 +2448,6 @@ func (s *Session) GetFileSnapshotFromDisk(path string) (map[string]any, bool) {
 	}, true
 }
 
-// GetFileDiffSnapshot returns diff data for the /api/file/diff endpoint.
 // whitespaceIgnoredHunks recomputes a fresh whitespace-ignored diff for a
 // normal modified file when ignoreWhitespace is requested. For added/untracked/
 // deleted files (where whitespace-ignore changes nothing) and the markdown
@@ -2471,6 +2470,7 @@ func whitespaceIgnoredHunks(cached []DiffHunk, status string, ignoreWhitespace b
 	return hunks
 }
 
+// GetFileDiffSnapshot returns diff data for the /api/file/diff endpoint.
 func (s *Session) GetFileDiffSnapshot(path string, ignoreWhitespace bool) (map[string]any, bool) {
 	s.mu.RLock()
 	f := s.fileByPathLocked(path)


### PR DESCRIPTION
## Summary
Pre-release audit polish for the multi-commit commit picker (changes in the v0.16.0 release window), all scoped to crit's git-mode picker plus one Go doc comment.

- **Alignment** — the static "All commits" row had no checkbox, so its text started ~21px left of every checkboxed commit row's SHA column. Add a 13px non-interactive spacer so the columns line up.
- **Keyboard reach** — make the "All commits" row operable via keyboard (`role="button"`, `tabindex="0"`, Enter/Space → existing clear path). The new per-row checkboxes had left this the one selection action a keyboard user couldn't reach.
- **DRY** — replace three hand-rolled `diffCommit = ''` resets with the existing `recomputeDiffCommit()` so the derived param has a single source of truth (behavior identical for an empty Set).
- **Docs** — relocate a detached doc comment in `session.go`: the `GetFileDiffSnapshot` summary had been left above `whitespaceIgnoredHunks`; move it back so each function is documented correctly.

No crit-web parity impact — the commit picker is a git-mode-only local affordance with no crit-web counterpart.

## Review
- [x] Code review: passed (release-audit fix + independent post-fix review)
- [x] Parity audit: N/A (crit-only; confirmed no shared review-page chrome touched)

## Test plan
- gofmt / golangci-lint clean; go test (race) green
- commit-selection.spec.ts e2e: 19/19 passing
- Verified the "All commits" clear path works via mouse and keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)