### PR TITLE
fix: use raw bind address for internal HTTP calls to avoid IPv6 mismatch

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -70,7 +70,7 @@ func (e sessionEntry) displayHost() string {
 	return hostForDisplay(e.Host)
 }
 
-// baseURL returns the HTTP base URL for connecting to this daemon.
+// baseURL returns the user-facing HTTP base URL (browser, stderr).
 func (e sessionEntry) baseURL() string {
 	return fmt.Sprintf("http://%s:%d", e.displayHost(), e.Port)
 }

--- a/daemon.go
+++ b/daemon.go
@@ -75,6 +75,16 @@ func (e sessionEntry) baseURL() string {
 	return fmt.Sprintf("http://%s:%d", e.displayHost(), e.Port)
 }
 
+// connURL returns the HTTP base URL for internal connectivity (health checks, API calls).
+// Uses the raw bind address to avoid DNS resolution mismatches (e.g. localhost → [::1]).
+func (e sessionEntry) connURL() string {
+	host := e.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s:%d", host, e.Port)
+}
+
 // hostForDisplay maps a listen host to a user-facing hostname.
 func hostForDisplay(host string) string {
 	if host == "" || host == "127.0.0.1" {
@@ -348,7 +358,7 @@ func isDaemonAlive(s sessionEntry) bool {
 	}
 	// HTTP health probe — ensures the port belongs to our daemon, not a reused PID.
 	// We validate the response body to guard against a non-crit process on the same port.
-	resp, err := aliveClient.Get(s.baseURL() + "/api/health")
+	resp, err := aliveClient.Get(s.connURL() + "/api/health")
 	if err != nil {
 		return false
 	}
@@ -369,7 +379,7 @@ func isDaemonAlive(s sessionEntry) bool {
 // Uses a pointer to distinguish "field missing" (older daemon) from "false".
 // When the field is missing, assumes a browser is connected (safe default).
 func daemonHasBrowser(s sessionEntry) bool {
-	resp, err := browserClient.Get(s.baseURL() + "/api/health")
+	resp, err := browserClient.Get(s.connURL() + "/api/health")
 	if err != nil {
 		return true // can't reach daemon, assume browser exists
 	}

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -115,6 +115,25 @@ func TestSessionEntry_BaseURL(t *testing.T) {
 	}
 }
 
+func TestSessionEntry_ConnURL(t *testing.T) {
+	tests := []struct {
+		host string
+		port int
+		want string
+	}{
+		{"", 3000, "http://127.0.0.1:3000"},
+		{"127.0.0.1", 4567, "http://127.0.0.1:4567"},
+		{"0.0.0.0", 8080, "http://0.0.0.0:8080"},
+		{"192.168.1.10", 3000, "http://192.168.1.10:3000"},
+	}
+	for _, tt := range tests {
+		e := sessionEntry{Host: tt.host, Port: tt.port}
+		if got := e.connURL(); got != tt.want {
+			t.Errorf("connURL(host=%q, port=%d) = %q, want %q", tt.host, tt.port, got, tt.want)
+		}
+	}
+}
+
 func TestSessionFileRoundTrip(t *testing.T) {
 	home := t.TempDir()
 	setHome(t, home)

--- a/focus_cli.go
+++ b/focus_cli.go
@@ -305,7 +305,11 @@ func probeDaemonFocusReal() *Focus {
 // (nil on any error). Factored out so probeDaemonFocusReal can iterate over
 // every matching daemon without ballooning its complexity.
 func fetchSessionFocus(client *http.Client, host string, port int) *Focus {
-	resp, err := client.Get(fmt.Sprintf("http://%s:%d/api/session", hostForDisplay(host), port))
+	connHost := host
+	if connHost == "" {
+		connHost = "127.0.0.1"
+	}
+	resp, err := client.Get(fmt.Sprintf("http://%s:%d/api/session", connHost, port))
 	if err != nil {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -2256,7 +2256,11 @@ func runCodexPlanHook() {
 // On connection errors (e.g. "connection refused"), the daemon log is consulted
 // to surface the actual init failure instead of the misleading network error.
 func waitForDaemonReady(client *http.Client, host string, port int, sessionKey string) (statusCode int, body []byte, err error) {
-	base := fmt.Sprintf("http://%s:%d", hostForDisplay(host), port)
+	connHost := host
+	if connHost == "" {
+		connHost = "127.0.0.1"
+	}
+	base := fmt.Sprintf("http://%s:%d", connHost, port)
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		resp, reqErr := client.Get(base + "/api/session")
@@ -2292,7 +2296,7 @@ func runReviewClientRaw(entry sessionEntry, sessionKey string) (approved bool, p
 	}
 
 	resp, err := client.Post(
-		entry.baseURL()+"/api/review-cycle",
+		entry.connURL()+"/api/review-cycle",
 		"application/json",
 		nil,
 	)
@@ -2468,7 +2472,7 @@ func runReviewClient(entry sessionEntry, sessionKey string) (approved bool) {
 	}
 
 	resp, err := client.Post(
-		entry.baseURL()+"/api/review-cycle",
+		entry.connURL()+"/api/review-cycle",
 		"application/json",
 		nil,
 	)


### PR DESCRIPTION
## Problem

On systems where Go 1.26+ resolves `localhost` to `[::1]` (IPv6) — notably WSL2 with IPv6 enabled — the daemon fails to start. The parent process health-checks the daemon via `http://localhost:PORT/api/health`, which Go dials as `[::1]:PORT`, but the server binds to `127.0.0.1` (IPv4 only). The connection is refused and the client gives up.

## Root cause

`baseURL()` calls `displayHost()`, which maps `127.0.0.1` → `localhost` for user-friendly output. That same `baseURL()` was used for **both** user-facing URLs (log messages, browser opens) and internal Go HTTP calls (health checks, review-cycle requests). When Go resolves `localhost` to `::1`, all internal connectivity breaks.

## Fix

Separate the display concern from the connectivity concern.

**New `connURL()` method** on `sessionEntry` — uses the raw `Host` field (defaulting to `127.0.0.1`) so the Go dialler always targets the actual listener, regardless of how the OS resolves `localhost`.

**`baseURL()` unchanged** — still returns `http://localhost:PORT` for the default binding; used only where a human or browser sees the URL.

**Swapped call sites:**
- `isDaemonAlive` / `daemonHasBrowser` → `connURL()`
- `runReviewClient` / `runReviewClientRaw` (POST `/api/review-cycle`) → `connURL()`
- `waitForDaemonReady` / `fetchSessionFocus` — inline construction now uses raw host instead of `hostForDisplay()`

Log messages and `openBrowser` calls are untouched; they still show `http://localhost:PORT`.