### PR TITLE
fix: sort files to match GitHub PR order

### DIFF
--- a/frontend/__tests__/crit-shared.test.js
+++ b/frontend/__tests__/crit-shared.test.js
@@ -10,6 +10,13 @@ const fn = new Function('window', 'document', src + '\nreturn window;');
 fn(sandbox.window, sandbox.document);
 const shared = sandbox.window.crit.shared;
 
+test('pathCompare matches GitHub PR byte order (foo.go before foo_test.go)', () => {
+  assert.ok(shared.pathCompare('foo.go', 'foo_test.go') < 0);
+  assert.ok(shared.pathCompare('foo_test.go', 'foo.go') > 0);
+  assert.equal(shared.pathCompare('pkg/foo.go', 'pkg/foo_test.go'), -49);
+  assert.equal(shared.pathCompare('a/b', 'a/b'), 0);
+});
+
 test('escapeHTML escapes <, >, &, ", and single quotes', () => {
   assert.equal(shared.escapeHTML('<a href="x">&</a>'),
     '&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -509,8 +509,10 @@
   // is loaded before app.js via index.html script order, so we reference it
   // directly without a local fallback.
   const authorColorIndex = window.crit.commentCardHelpers.authorColorIndex;
+  const pathCompare = window.crit.shared.pathCompare;
 
-  // Sort comparator: directories before files at each depth, then alphabetical.
+  // Sort comparator: directories before files at each depth, then path order
+  // matching GitHub PR diffs (ASCII byte compare, not localeCompare).
   // In files mode the user's CLI argument order is meaningful, so preserve it
   // (Array.prototype.sort is stable, so returning 0 keeps original order).
   function fileSortComparator(a, b) {
@@ -518,10 +520,10 @@
     const pa = a.path.split('/'), pb = b.path.split('/');
     const min = Math.min(pa.length, pb.length);
     for (let i = 0; i < min - 1; i++) {
-      if (pa[i] !== pb[i]) return pa[i].localeCompare(pb[i]);
+      if (pa[i] !== pb[i]) return pathCompare(pa[i], pb[i]);
     }
     if (pa.length !== pb.length) return pb.length - pa.length;
-    return pa[pa.length - 1].localeCompare(pb[pa.length - 1]);
+    return pathCompare(pa[pa.length - 1], pb[pa.length - 1]);
   }
 
   // Fetch and build file objects from the API for a list of file infos.
@@ -1418,7 +1420,7 @@
     // Render files. In files mode preserve user-provided CLI order.
     const sortedFiles = session.mode === 'files'
       ? node.files.slice()
-      : node.files.slice().sort(function(a, b) { return a.path.localeCompare(b.path); });
+      : node.files.slice().sort(function(a, b) { return pathCompare(a.path, b.path); });
     for (let fi = 0; fi < sortedFiles.length; fi++) {
       const f = sortedFiles[fi];
       const fileName = f.path.split('/').pop();

--- a/frontend/crit-shared.js
+++ b/frontend/crit-shared.js
@@ -747,8 +747,20 @@
     }
   }
 
+  // pathCompare — byte-order string compare matching Go sort.Strings and GitHub
+  // PR file order. localeCompare puts '_' before '.' (foo_test.go before foo.go).
+  function pathCompare(a, b) {
+    const min = Math.min(a.length, b.length);
+    for (let i = 0; i < min; i++) {
+      const diff = a.charCodeAt(i) - b.charCodeAt(i);
+      if (diff !== 0) return diff;
+    }
+    return a.length - b.length;
+  }
+
   window.crit = window.crit || {};
   window.crit.shared = {
+    pathCompare,
     escapeHTML,
     fetchJSON,
     getCookie,


### PR DESCRIPTION
## Summary
- Add `pathCompare` (ASCII byte order, matching Go `sort.Strings`) to `crit-shared.js`
- Use it in `fileSortComparator` and the file-tree sidebar instead of `localeCompare`
- `localeCompare` put `_` before `.`, so `foo_test.go` appeared before `foo.go`; GitHub does the opposite

## Test plan
- [x] `node --test frontend/__tests__/crit-shared.test.js` (pathCompare test)
- [x] `go test ./...`
- [ ] Manual: open a Go PR review — `server.go` should appear before `server_test.go`

Closes #635

Made with [Cursor](https://cursor.com)