### PR TITLE
fix: preserve j/k focus across hover and comment form re-renders

### DIFF
--- a/e2e/tests/comment-nav.spec.ts
+++ b/e2e/tests/comment-nav.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearAllComments, loadPage, addComment, switchToDocumentView, clearFocus } from './helpers';
+import { clearAllComments, loadPage, addComment, switchToDocumentView, clearFocus, focusKbNavElement } from './helpers';
 
 // ============================================================
 // Comment Navigation — ] / [ shortcuts and prev/next buttons
@@ -200,7 +200,7 @@ test.describe('Comment Navigation — disabled in textarea', () => {
     // Open a new comment form on a line block
     const section = page.locator('.file-section').filter({ hasText: 'plan.md' });
     const lineBlock = section.locator('.line-block.kb-nav').first();
-    await lineBlock.hover();
+    await focusKbNavElement(page, lineBlock);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');
@@ -221,7 +221,7 @@ test.describe('Comment Navigation — disabled in textarea', () => {
     // Open a new comment form on a line block
     const section = page.locator('.file-section').filter({ hasText: 'plan.md' });
     const lineBlock = section.locator('.line-block.kb-nav').first();
-    await lineBlock.hover();
+    await focusKbNavElement(page, lineBlock);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');

--- a/e2e/tests/drag-selection.spec.ts
+++ b/e2e/tests/drag-selection.spec.ts
@@ -81,7 +81,7 @@ test.describe('Line Highlight Cleared — Markdown Git Mode', () => {
     await switchToDocumentView(page);
   });
 
-  test('drag-select then submit clears all selected/focused classes', async ({ page }) => {
+  test('drag-select then submit clears selected class and keeps keyboard focus', async ({ page }) => {
     const section = mdSection(page);
     const gutters = section.locator('.line-comment-gutter');
     const firstGutter = gutters.nth(0);
@@ -100,12 +100,11 @@ test.describe('Line Highlight Cleared — Markdown Git Mode', () => {
     await page.locator('.comment-form .btn-primary').click();
     await expect(page.locator('.comment-card')).toBeVisible();
 
-    // No line blocks should have .selected or .focused
     await expect(section.locator('.line-block.selected')).toHaveCount(0);
-    await expect(section.locator('.line-block.focused')).toHaveCount(0);
+    await expect(section.locator('.line-block.focused')).toHaveCount(1);
   });
 
-  test('drag-select then cancel clears all selected/focused classes', async ({ page }) => {
+  test('drag-select then cancel clears selected class and keeps keyboard focus', async ({ page }) => {
     const section = mdSection(page);
     const gutters = section.locator('.line-comment-gutter');
     const firstGutter = gutters.nth(0);
@@ -122,12 +121,11 @@ test.describe('Line Highlight Cleared — Markdown Git Mode', () => {
     await page.locator('.comment-form button', { hasText: 'Cancel' }).click();
     await expect(form).toBeHidden();
 
-    // No line blocks should have .selected or .focused
     await expect(section.locator('.line-block.selected')).toHaveCount(0);
-    await expect(section.locator('.line-block.focused')).toHaveCount(0);
+    await expect(section.locator('.line-block.focused')).toHaveCount(1);
   });
 
-  test('single-line click then submit clears all selected/focused classes', async ({ page }) => {
+  test('single-line click then submit clears selected class and keeps keyboard focus', async ({ page }) => {
     const section = mdSection(page);
     const lineBlock = section.locator('.line-block').first();
     await lineBlock.hover();
@@ -144,9 +142,8 @@ test.describe('Line Highlight Cleared — Markdown Git Mode', () => {
     await page.locator('.comment-form .btn-primary').click();
     await expect(page.locator('.comment-card')).toBeVisible();
 
-    // No line blocks should have .selected or .focused
     await expect(section.locator('.line-block.selected')).toHaveCount(0);
-    await expect(section.locator('.line-block.focused')).toHaveCount(0);
+    await expect(section.locator('.line-block.focused')).toHaveCount(1);
   });
 });
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -75,6 +75,23 @@ export async function clearFocus(page: Page) {
   await page.locator('body').click({ position: { x: 0, y: 0 } });
 }
 
+export async function focusKbNavByJ(page: Page, presses: number) {
+  for (let i = 0; i < presses; i++) {
+    await page.keyboard.press('j');
+  }
+}
+
+async function kbNavIndex(page: Page, locator: ReturnType<Page['locator']>) {
+  return locator.evaluate(el => Array.from(document.querySelectorAll('.kb-nav')).indexOf(el));
+}
+
+export async function focusKbNavElement(page: Page, locator: ReturnType<Page['locator']>) {
+  await clearFocus(page);
+  const index = await kbNavIndex(page, locator);
+  expect(index).toBeGreaterThanOrEqual(0);
+  await focusKbNavByJ(page, index + 1);
+}
+
 // Add a comment via API and return the created comment object.
 export async function addComment(request: APIRequestContext, path: string, line: number, body: string) {
   const resp = await request.post(`/api/file/comments?path=${encodeURIComponent(path)}`, {

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -1,6 +1,29 @@
 import { test, expect } from '@playwright/test';
 import { clearAllComments, loadPage, mdSection, goSection, clearFocus, switchToDocumentView } from './helpers';
 
+async function focusKbNavByJ(page: import('@playwright/test').Page, presses: number) {
+  for (let i = 0; i < presses; i++) {
+    await page.keyboard.press('j');
+  }
+}
+
+async function kbNavIndex(page: import('@playwright/test').Page, locator: import('@playwright/test').Locator) {
+  return locator.evaluate(el => Array.from(document.querySelectorAll('.kb-nav')).indexOf(el));
+}
+
+async function focusKbNavElement(page: import('@playwright/test').Page, locator: import('@playwright/test').Locator) {
+  await clearFocus(page);
+  const index = await kbNavIndex(page, locator);
+  expect(index).toBeGreaterThanOrEqual(0);
+  await focusKbNavByJ(page, index + 1);
+}
+
+async function focusMarkdownBlockWithStartLine(page: import('@playwright/test').Page, startLine: string) {
+  const block = mdSection(page).locator(`.line-block.kb-nav[data-start-line="${startLine}"]`);
+  await expect(block).toBeAttached();
+  await focusKbNavElement(page, block);
+}
+
 // ============================================================
 // j/k Navigation on Diff Blocks (Split Mode)
 // ============================================================
@@ -66,9 +89,8 @@ test.describe('Keyboard Navigation — Diff Split Mode', () => {
     const diffRows = page.locator('.diff-split-row.kb-nav');
     await expect(diffRows.first()).toBeAttached();
 
-    // Hover a diff-split-row to set focusedElement, then press j to focus it
-    await diffRows.first().hover();
-    await page.keyboard.press('j');
+    // Focus the first row, then advance one row with j
+    await focusKbNavByJ(page, 2);
 
     const currentRow = page.locator('.diff-split-row.kb-nav.focused');
     await expect(currentRow).toHaveCount(1);
@@ -90,6 +112,85 @@ test.describe('Keyboard Navigation — Diff Split Mode', () => {
 
     // Should have moved forward by exactly 1
     expect(nextIndex).toBe(currentIndex + 1);
+  });
+
+  test('j/k stays continuous when mouse is stationary over the document', async ({ page }) => {
+    const allNav = page.locator('.kb-nav');
+    const count = await allNav.count();
+    expect(count).toBeGreaterThan(15);
+
+    // Rest the pointer over the document while navigating purely with j/k.
+    const box = await allNav.nth(8).boundingBox();
+    expect(box).toBeTruthy();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+
+    let prevIndex = -1;
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('j');
+      const focused = page.locator('.kb-nav.focused');
+      await expect(focused).toHaveCount(1);
+      const index = await focused.evaluate(el => {
+        return Array.from(document.querySelectorAll('.kb-nav')).indexOf(el);
+      });
+      expect(index).toBeGreaterThanOrEqual(prevIndex);
+      prevIndex = index;
+    }
+  });
+
+  test('j/k resumes after canceling comment form with Escape', async ({ page }) => {
+    const targetIdx = 15;
+    await focusKbNavByJ(page, targetIdx + 1);
+
+    const beforeCancel = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(beforeCancel).toBe(targetIdx);
+
+    await page.keyboard.press('c');
+    await expect(page.locator('.comment-form')).toBeVisible();
+    await page.locator('.comment-form textarea').press('Escape');
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+
+    // Focus should still be on the same line after cancel (not reset to top).
+    const afterEscape = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(afterEscape).toBe(targetIdx);
+
+    await page.keyboard.press('j');
+    const afterJ = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(afterJ).toBe(targetIdx + 1);
+  });
+
+  test('j/k resumes after submitting a new comment', async ({ page }) => {
+    const targetIdx = 15;
+    await focusKbNavByJ(page, targetIdx + 1);
+
+    const beforeSubmit = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(beforeSubmit).toBe(targetIdx);
+
+    await page.keyboard.press('c');
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('resume focus after submit');
+    await page.locator('.comment-form .btn-primary').click();
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+    await expect(page.locator('.comment-card').filter({ hasText: 'resume focus after submit' })).toBeVisible();
+
+    const afterSubmit = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(afterSubmit).toBe(targetIdx);
+
+    await page.keyboard.press('j');
+    const afterJ = await page.locator('.kb-nav.focused').evaluate(el =>
+      Array.from(document.querySelectorAll('.kb-nav')).indexOf(el)
+    );
+    expect(afterJ).toBe(targetIdx + 1);
   });
 
   test('k from first element stays at first element', async ({ page }) => {
@@ -131,10 +232,9 @@ test.describe('Keyboard Navigation — Markdown Document View', () => {
     const count = await lineBlocks.count();
     expect(count).toBeGreaterThan(2);
 
-    // Hover the first markdown line-block to set focusedElement, then press j to focus it
+    // Focus the first markdown line-block, then advance one block with j
     const firstBlock = lineBlocks.first();
-    await firstBlock.hover();
-    await page.keyboard.press('j');
+    await focusKbNavElement(page, firstBlock);
 
     await expect(page.locator('.line-block.kb-nav.focused')).toHaveCount(1);
     const firstFocusedText = await page.locator('.line-block.kb-nav.focused').textContent();
@@ -162,12 +262,9 @@ test.describe('Keyboard Comment Shortcuts — Diff', () => {
   });
 
   test('c opens comment form on focused diff block', async ({ page }) => {
-    // Hover a diff row to set focusedElement via mouseenter
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
 
-    // Press c to open comment form (uses focusedElement directly)
+    // Press c to open comment form (uses keyboard-focused element)
     await page.keyboard.press('c');
 
     const form = page.locator('.comment-form');
@@ -180,6 +277,7 @@ test.describe('Keyboard Comment Shortcuts — Diff', () => {
     // Use the UI to create a comment on server.go, then test editing via keyboard
     const section = goSection(page);
     const additionSide = section.locator('.diff-split-side.addition').first();
+    const commentedRow = additionSide.locator('xpath=ancestor::*[contains(@class,"diff-split-row") and contains(@class,"kb-nav")][1]');
     await additionSide.hover();
     const commentBtn = additionSide.locator('.diff-comment-btn');
     await commentBtn.click();
@@ -191,12 +289,7 @@ test.describe('Keyboard Comment Shortcuts — Diff', () => {
     // Comment card should appear
     await expect(section.locator('.comment-card')).toBeVisible();
 
-    // Hover over the addition side with the comment to set focusedElement via mouseenter
-    const commentedSide = section.locator('.diff-split-side.has-comment').first();
-    await expect(commentedSide).toBeVisible();
-    await commentedSide.hover();
-
-    // Press e to edit — the hover set focusedElement to the row's nav element
+    // Submit restores keyboard focus to the commented line
     await page.keyboard.press('e');
 
     const editTextarea = page.locator('.comment-form textarea');
@@ -208,6 +301,7 @@ test.describe('Keyboard Comment Shortcuts — Diff', () => {
     // Use the UI to create a comment on server.go
     const section = goSection(page);
     const additionSide = section.locator('.diff-split-side.addition').first();
+    const commentedRow = additionSide.locator('xpath=ancestor::*[contains(@class,"diff-split-row") and contains(@class,"kb-nav")][1]');
     await additionSide.hover();
     const commentBtn = additionSide.locator('.diff-comment-btn');
     await commentBtn.click();
@@ -220,12 +314,7 @@ test.describe('Keyboard Comment Shortcuts — Diff', () => {
     const commentCard = section.locator('.comment-card');
     await expect(commentCard).toBeVisible();
 
-    // Hover over the addition side with the comment to set focusedElement via mouseenter
-    const commentedSide = section.locator('.diff-split-side.has-comment').first();
-    await expect(commentedSide).toBeVisible();
-    await commentedSide.hover();
-
-    // Press d to delete — the hover set focusedElement to the row's nav element
+    // Submit restores keyboard focus to the commented line
     await page.keyboard.press('d');
 
     // Comment should be removed
@@ -243,13 +332,8 @@ test.describe('Keyboard Comment Shortcuts — Markdown', () => {
     await switchToDocumentView(page);
     await clearFocus(page);
 
-    // Hover a markdown line-block to set focusedElement via mouseenter
-    const section = mdSection(page);
-    const lineBlock = section.locator('.line-block.kb-nav').first();
-    await expect(lineBlock).toBeAttached();
-    await lineBlock.hover();
+    await focusKbNavElement(page, mdSection(page).locator('.line-block.kb-nav').first());
 
-    // c uses focusedElement directly (set by hover), no j-key needed
     await page.keyboard.press('c');
 
     const form = page.locator('.comment-form');
@@ -268,13 +352,8 @@ test.describe('Keyboard Comment Shortcuts — Markdown', () => {
     await switchToDocumentView(page);
     await clearFocus(page);
 
-    // Hover the line-block covering line 1 to set focusedElement via mouseenter
-    const section = mdSection(page);
-    const lineBlock = section.locator('.line-block.kb-nav[data-start-line="1"]');
-    await expect(lineBlock).toBeAttached();
-    await lineBlock.hover();
+    await focusMarkdownBlockWithStartLine(page, '1');
 
-    // e uses focusedElement directly (set by hover), no j-key needed
     await page.keyboard.press('e');
 
     const textarea = page.locator('.comment-form textarea');
@@ -296,12 +375,8 @@ test.describe('Keyboard Comment Shortcuts — Markdown', () => {
     const section = mdSection(page);
     await expect(section.locator('.comment-card')).toBeVisible();
 
-    // Hover the line-block covering line 1 to set focusedElement via mouseenter
-    const lineBlock = section.locator('.line-block.kb-nav[data-start-line="1"]');
-    await expect(lineBlock).toBeAttached();
-    await lineBlock.hover();
+    await focusMarkdownBlockWithStartLine(page, '1');
 
-    // d uses focusedElement directly (set by hover), no j-key needed
     await page.keyboard.press('d');
 
     await expect(section.locator('.comment-card')).toHaveCount(0);
@@ -377,10 +452,7 @@ test.describe('Keyboard Escape Behavior', () => {
   });
 
   test('Escape closes open comment form', async ({ page }) => {
-    // Hover a diff row to set focusedElement, then open comment form
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const form = page.locator('.comment-form');
@@ -403,9 +475,7 @@ test.describe('Keyboard Escape Behavior', () => {
   });
 
   test('Escape on non-empty comment form prompts for confirmation', async ({ page }) => {
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');
@@ -431,9 +501,7 @@ test.describe('Keyboard Escape Behavior', () => {
   });
 
   test('Cancel button on non-empty comment form discards immediately (no confirm)', async ({ page }) => {
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');
@@ -449,9 +517,7 @@ test.describe('Keyboard Escape Behavior', () => {
   });
 
   test('Escape on empty comment form closes silently (no confirm)', async ({ page }) => {
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');
@@ -483,9 +549,8 @@ test.describe('Keyboard Visual Line Mode — Markdown', () => {
     const lineBlocks = section.locator('.line-block.kb-nav');
     await expect(lineBlocks.first()).toBeAttached();
 
-    // Focus the first line-block
-    await lineBlocks.first().hover();
-    await page.keyboard.press('j');
+    // Focus the first line-block with j/k
+    await focusKbNavElement(page, lineBlocks.first());
     const firstFocused = page.locator('.line-block.kb-nav.focused');
     await expect(firstFocused).toHaveCount(1);
     const anchorStart = parseInt((await firstFocused.getAttribute('data-start-line'))!);
@@ -529,8 +594,7 @@ test.describe('Keyboard Visual Line Mode — Markdown', () => {
   test('Escape clears visual selection and keeps focus on current block', async ({ page }) => {
     const section = mdSection(page);
     const lineBlocks = section.locator('.line-block.kb-nav');
-    await lineBlocks.first().hover();
-    await page.keyboard.press('j');
+    await focusKbNavElement(page, lineBlocks.first());
     await page.keyboard.press('Shift+V');
     await page.keyboard.press('j');
     await page.keyboard.press('j');
@@ -554,8 +618,7 @@ test.describe('Keyboard Visual Line Mode — Markdown', () => {
   test('V again exits visual mode (toggle)', async ({ page }) => {
     const section = mdSection(page);
     const lineBlocks = section.locator('.line-block.kb-nav');
-    await lineBlocks.first().hover();
-    await page.keyboard.press('j');
+    await focusKbNavElement(page, lineBlocks.first());
     await page.keyboard.press('Shift+V');
     await expect(section.locator('.line-block.selected').first()).toBeAttached();
 
@@ -575,10 +638,7 @@ test.describe('Shortcuts Disabled When Typing', () => {
   });
 
   test('j types into textarea instead of navigating when textarea is focused', async ({ page }) => {
-    // Hover a diff row to set focusedElement, then open comment form
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');
@@ -594,10 +654,7 @@ test.describe('Shortcuts Disabled When Typing', () => {
   });
 
   test('other shortcuts (?, t) do not fire when textarea is focused', async ({ page }) => {
-    // Hover a diff row to set focusedElement, then open comment form
-    const diffRow = page.locator('.diff-split-row.kb-nav').first();
-    await expect(diffRow).toBeAttached();
-    await diffRow.hover();
+    await focusKbNavByJ(page, 1);
     await page.keyboard.press('c');
 
     const textarea = page.locator('.comment-form textarea');

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -1,22 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { clearAllComments, loadPage, mdSection, goSection, clearFocus, switchToDocumentView } from './helpers';
-
-async function focusKbNavByJ(page: import('@playwright/test').Page, presses: number) {
-  for (let i = 0; i < presses; i++) {
-    await page.keyboard.press('j');
-  }
-}
-
-async function kbNavIndex(page: import('@playwright/test').Page, locator: import('@playwright/test').Locator) {
-  return locator.evaluate(el => Array.from(document.querySelectorAll('.kb-nav')).indexOf(el));
-}
-
-async function focusKbNavElement(page: import('@playwright/test').Page, locator: import('@playwright/test').Locator) {
-  await clearFocus(page);
-  const index = await kbNavIndex(page, locator);
-  expect(index).toBeGreaterThanOrEqual(0);
-  await focusKbNavByJ(page, index + 1);
-}
+import {
+  clearAllComments, loadPage, mdSection, goSection, clearFocus, switchToDocumentView,
+  focusKbNavByJ, focusKbNavElement,
+} from './helpers';
 
 async function focusMarkdownBlockWithStartLine(page: import('@playwright/test').Page, startLine: string) {
   const block = mdSection(page).locator(`.line-block.kb-nav[data-start-line="${startLine}"]`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -496,6 +496,8 @@
   let focusedFilePath = null;
   let focusedElement = null; // currently focused navigable element
   let navElements = []; // cached .kb-nav list, rebuilt on render
+  // Stable j/k position across re-renders (DOM refs and block indices alone are not enough).
+  let keyboardFocusTarget = null; // { filePath, blockIndex?, diffLineNum?, diffSide?, startLine?, endLine? }
   // Vim-style visual line mode (entered with V).
   // { kind: 'markdown'|'diff', filePath, anchorStartLine, anchorEndLine, anchorSide }
   let visualMode = null;
@@ -1599,6 +1601,167 @@
   function rebuildNavList() {
     navElements = Array.from(document.querySelectorAll('.kb-nav'));
     buildChangeGroups();
+    restoreKeyboardFocus();
+  }
+
+  function rememberKeyboardFocusTarget(target) {
+    if (!target || !target.filePath) return;
+    keyboardFocusTarget = target;
+  }
+
+  function rememberKeyboardFocusFromForm(formObj) {
+    if (!formObj || !formObj.filePath || formObj.scope === 'file') return;
+    const target = { filePath: formObj.filePath };
+    if (formObj.afterBlockIndex !== null && formObj.afterBlockIndex !== undefined) {
+      target.blockIndex = String(formObj.afterBlockIndex);
+    }
+    if (formObj.startLine) target.startLine = String(formObj.startLine);
+    if (formObj.endLine) target.endLine = String(formObj.endLine);
+    if (formObj.afterBlockIndex === null && formObj.startLine) {
+      target.diffLineNum = String(formObj.startLine);
+      target.diffSide = formObj.side || '';
+    }
+    rememberKeyboardFocusTarget(target);
+  }
+
+  function navFocusTargetFromElement(el) {
+    if (!el) return null;
+    const fp = el.dataset.filePath || el.dataset.diffFilePath;
+    if (!fp) return null;
+    const target = { filePath: fp };
+    if (el.dataset.blockIndex !== undefined) {
+      target.blockIndex = el.dataset.blockIndex;
+      if (el.dataset.startLine) target.startLine = el.dataset.startLine;
+      if (el.dataset.endLine) target.endLine = el.dataset.endLine;
+      return target;
+    }
+    if (el.classList.contains('diff-split-row')) {
+      const rightSide = el.querySelector('.diff-split-side.right:not(.empty)[data-diff-line-num], .diff-split-side.addition[data-diff-line-num]');
+      const leftSide = el.querySelector('.diff-split-side.left[data-diff-line-num], .diff-split-side.deletion[data-diff-line-num]');
+      const sideEl = rightSide || leftSide;
+      if (sideEl) {
+        target.diffLineNum = sideEl.dataset.diffLineNum;
+        target.diffSide = sideEl.dataset.diffSide || '';
+      }
+      return target;
+    }
+    if (el.dataset.diffLineNum) {
+      target.diffLineNum = el.dataset.diffLineNum;
+      target.diffSide = el.dataset.diffSide || '';
+    }
+    return target;
+  }
+
+  function rememberKeyboardFocusFromNav(el) {
+    const target = navFocusTargetFromElement(el);
+    rememberKeyboardFocusTarget(target);
+  }
+
+  function clearKeyboardFocusTarget() {
+    keyboardFocusTarget = null;
+  }
+
+  function getKeyboardFocusTarget() {
+    if (keyboardFocusTarget) return keyboardFocusTarget;
+    if (!focusedFilePath && !focusedElement) return null;
+    const fp = focusedFilePath || (focusedElement && (focusedElement.dataset.filePath || focusedElement.dataset.diffFilePath));
+    if (!fp) return null;
+    const target = { filePath: fp };
+    if (focusedBlockIndex !== null && focusedBlockIndex !== undefined && !isNaN(focusedBlockIndex)) {
+      target.blockIndex = String(focusedBlockIndex);
+    } else if (focusedElement) {
+      const fromEl = navFocusTargetFromElement(focusedElement);
+      if (fromEl) return fromEl;
+    }
+    return target;
+  }
+
+  function findNavElementForFocusTarget(target) {
+    for (let i = 0; i < navElements.length; i++) {
+      const n = navElements[i];
+      if (target.blockIndex !== undefined && n.dataset.filePath === target.filePath && n.dataset.blockIndex === target.blockIndex) {
+        return n;
+      }
+      if (target.startLine && n.dataset.filePath === target.filePath &&
+          n.dataset.startLine === target.startLine &&
+          (n.dataset.endLine || target.startLine) === (target.endLine || target.startLine)) {
+        return n;
+      }
+    }
+    if (!target.diffLineNum) return null;
+    const side = target.diffSide || '';
+    for (let i = 0; i < navElements.length; i++) {
+      const n = navElements[i];
+      if (n.dataset.diffFilePath !== target.filePath) continue;
+      if (n.dataset.diffLineNum === target.diffLineNum &&
+          (!side || (n.dataset.diffSide || '') === side || n.classList.contains('diff-split-row'))) {
+        return n;
+      }
+      if (n.classList.contains('diff-split-row')) {
+        const sides = n.querySelectorAll('.diff-split-side[data-diff-line-num]');
+        for (let si = 0; si < sides.length; si++) {
+          const sideEl = sides[si];
+          if (sideEl.dataset.diffLineNum === target.diffLineNum &&
+              (sideEl.dataset.diffSide || '') === side) {
+            return n;
+          }
+        }
+      } else if (n.classList.contains('diff-line') &&
+          n.dataset.diffLineNum === target.diffLineNum &&
+          (n.dataset.diffSide || '') === side) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  function getFocusedCommentLocation() {
+    const target = getKeyboardFocusTarget();
+    if (target) {
+      return {
+        filePath: target.filePath,
+        blockIndex: target.blockIndex !== undefined ? parseInt(target.blockIndex) : undefined,
+        lineNum: target.diffLineNum ? parseInt(target.diffLineNum) :
+          (target.startLine ? parseInt(target.startLine) : undefined),
+        side: target.diffSide || '',
+      };
+    }
+    if (!focusedElement) return null;
+    const filePath = focusedElement.dataset.filePath || focusedElement.dataset.diffFilePath;
+    if (!filePath) return null;
+    if (focusedElement.dataset.blockIndex !== undefined) {
+      return {
+        filePath: filePath,
+        blockIndex: parseInt(focusedElement.dataset.blockIndex),
+        lineNum: focusedElement.dataset.startLine ? parseInt(focusedElement.dataset.startLine) : undefined,
+        side: '',
+      };
+    }
+    if (focusedElement.dataset.diffLineNum) {
+      return {
+        filePath: filePath,
+        lineNum: parseInt(focusedElement.dataset.diffLineNum),
+        side: focusedElement.dataset.diffSide || '',
+      };
+    }
+    return null;
+  }
+
+  function restoreKeyboardFocus() {
+    const target = getKeyboardFocusTarget();
+    if (!target) return;
+    const match = findNavElementForFocusTarget(target);
+    if (!match) return;
+    document.querySelectorAll('.kb-nav.focused').forEach(function(el) { el.classList.remove('focused'); });
+    focusedElement = match;
+    match.classList.add('focused');
+    if (match.dataset.filePath) {
+      focusedFilePath = match.dataset.filePath;
+      focusedBlockIndex = parseInt(match.dataset.blockIndex);
+    } else if (match.dataset.diffFilePath) {
+      focusedFilePath = match.dataset.diffFilePath;
+      focusedBlockIndex = null;
+    }
   }
 
   function buildChangeGroups() {
@@ -2064,14 +2227,6 @@
     el.classList.toggle('form-selected', hasForm && !inSelection);
 
     if (blockIndex !== undefined) {
-      (function(fp, idx, elem) {
-        elem.addEventListener('mouseenter', function() {
-          focusedFilePath = fp;
-          focusedBlockIndex = idx;
-          focusedElement = elem;
-        });
-      })(filePath, blockIndex, el);
-
       if (focusedFilePath === filePath && focusedBlockIndex === blockIndex) {
         el.classList.add('focused');
       }
@@ -2534,11 +2689,6 @@
       nav.dataset.diffLineNum = lineNum;
       nav.dataset.diffSide = side || '';
     }
-    el.addEventListener('mouseenter', function() {
-      focusedElement = nav;
-      focusedFilePath = filePath;
-      focusedBlockIndex = null;
-    });
   }
 
   // Creates a dedicated comment gutter column element with a + button.
@@ -4015,6 +4165,7 @@
   }
 
   function openForm(newForm) {
+    rememberKeyboardFocusFromForm(newForm);
     const fk = formKey(newForm);
     const existing = activeForms.find(function(f) { return f.formKey === fk; });
     if (existing) {
@@ -4695,6 +4846,7 @@
 
   async function submitComment(body, formObj) {
     if (!body.trim() || !formObj) return null;
+    rememberKeyboardFocusFromForm(formObj);
     clearDraft(formObj);
     let created;
     const filePath = formObj.filePath;
@@ -4750,9 +4902,6 @@
         selectionStart = null;
         selectionEnd = null;
       }
-      focusedFilePath = null;
-      focusedBlockIndex = null;
-      focusedElement = null;
     }
     renderFileByPath(filePath);
     updateTreeCommentBadges();
@@ -4780,6 +4929,7 @@
 
   function cancelComment(formObj) {
     if (!formObj) return;
+    rememberKeyboardFocusFromForm(formObj);
     clearDraft(formObj);
     removeForm(formObj.formKey);
     if (getFormsForFile(formObj.filePath).length === 0) {
@@ -4788,9 +4938,6 @@
         selectionStart = null;
         selectionEnd = null;
       }
-      focusedFilePath = null;
-      focusedBlockIndex = null;
-      focusedElement = null;
     }
     renderFileByPath(formObj.filePath);
   }
@@ -8182,10 +8329,11 @@
         if (focusedElement.dataset.filePath) {
           focusedFilePath = focusedElement.dataset.filePath;
           focusedBlockIndex = parseInt(focusedElement.dataset.blockIndex);
-        } else if (focusedElement.dataset.diffFilePath) {
+        } else         if (focusedElement.dataset.diffFilePath) {
           focusedFilePath = focusedElement.dataset.diffFilePath;
           focusedBlockIndex = null;
         }
+        rememberKeyboardFocusFromNav(focusedElement);
         if (visualMode) extendVisualSelection();
         break;
       }
@@ -8241,37 +8389,33 @@
           openForm({ filePath: fp, afterBlockIndex: bi, startLine: block.startLine, endLine: block.endLine, editingId: null });
         }
         // Diff line
-        else if (focusedElement.dataset.diffFilePath && focusedElement.dataset.diffLineNum) {
-          const dfp = focusedElement.dataset.diffFilePath;
-          const lineNum = parseInt(focusedElement.dataset.diffLineNum);
-          const side = focusedElement.dataset.diffSide || '';
-          openForm({ filePath: dfp, afterBlockIndex: null, startLine: lineNum, endLine: lineNum, editingId: null, side: side || undefined });
+        else {
+          const loc = getFocusedCommentLocation();
+          if (!loc || loc.lineNum === undefined) return;
+          openForm({ filePath: loc.filePath, afterBlockIndex: null, startLine: loc.lineNum, endLine: loc.lineNum, editingId: null, side: loc.side || undefined });
         }
         break;
       }
       case 'e':
       case 'd': {
         e.preventDefault();
-        if (!focusedElement) return;
-        const fp = focusedElement.dataset.filePath || focusedElement.dataset.diffFilePath;
-        if (!fp) return;
-        const file = getFileByPath(fp);
+        const loc = getFocusedCommentLocation();
+        if (!loc) return;
+        const file = getFileByPath(loc.filePath);
         if (!file || !file.comments || file.comments.length === 0) return;
         // Find comments for the focused line
         let comment = null;
-        if (focusedElement.dataset.blockIndex !== undefined) {
-          const block = file.lineBlocks[parseInt(focusedElement.dataset.blockIndex)];
+        if (loc.blockIndex !== undefined && !isNaN(loc.blockIndex)) {
+          const block = file.lineBlocks[loc.blockIndex];
           if (block) {
             comment = file.comments.find(function(c) { return c.end_line >= block.startLine && c.end_line <= block.endLine; });
           }
-        } else if (focusedElement.dataset.diffLineNum) {
-          const ln = parseInt(focusedElement.dataset.diffLineNum);
-          const sd = focusedElement.dataset.diffSide || '';
-          comment = file.comments.find(function(c) { return c.end_line === ln && (c.side || '') === sd; });
+        } else if (loc.lineNum !== undefined) {
+          comment = file.comments.find(function(c) { return c.end_line === loc.lineNum && (c.side || '') === loc.side; });
         }
         if (!comment) return;
-        if (e.key === 'e') editComment(comment, fp);
-        else deleteComment(comment.id, fp);
+        if (e.key === 'e') editComment(comment, loc.filePath);
+        else deleteComment(comment.id, loc.filePath);
         break;
       }
       case 'F': {
@@ -8367,6 +8511,7 @@
           focusedBlockIndex = null;
           focusedFilePath = null;
           focusedElement = null;
+          clearKeyboardFocusTarget();
         }
         break;
       }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -834,6 +834,8 @@ body {
   display: flex;
 }
 
+.line-block:hover { background: var(--crit-brand-subtle); }
+
 .line-block.has-comment {
   background: var(--crit-comment-range-bg);
 }
@@ -847,6 +849,7 @@ body {
   background: var(--crit-line-focus-bg);
   box-shadow: inset 2px 0 0 var(--crit-brand);
 }
+.line-block.focused .line-gutter { background: var(--crit-line-focus-bg); }
 
 /* Visual line mode: recolor the focused block's left accent so it's clearly
    distinct from the default j/k cursor, signalling that j/k now extends the


### PR DESCRIPTION
## Summary
- Stop syncing keyboard focus from mouse hover on diff lines and markdown blocks, so a stationary cursor no longer steals j/k navigation when the document scrolls at viewport edges (#636).
- Persist keyboard focus across comment form open/cancel/submit re-renders so j/k resumes on the same line instead of resetting to the top.
- Add CSS `:hover` highlight for line blocks (matching crit-web) while keeping `.focused` for keyboard selection.

## Review
- [x] Code review: passed
- [x] Parity audit: passed (aligns local CLI with existing crit-web hover/focus split)

## Test plan
- [x] `go test -race ./...`
- [x] `npx playwright test tests/keyboard.spec.ts --project=git-mode` (30 passed)
- [x] New regressions: stationary-mouse j/k continuity, j/k after Escape cancel, j/k after comment submit

Closes #636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)