### PR TITLE
feat: show file renames without content changes like GitHub

### DIFF
--- a/cmd/crit/frontend/app.js
+++ b/cmd/crit/frontend/app.js
@@ -557,6 +557,7 @@
     const lazyFiles = lazy.map(function(fi) {
       return {
         path: fi.path,
+        oldPath: fi.old_path || '',
         status: fi.status,
         fileType: fi.file_type,
         content: '',
@@ -629,6 +630,7 @@
 
     const f = {
       path: fi.path,
+      oldPath: fi.old_path || '',
       status: fi.status,
       fileType: fi.file_type,
       content: fileRes.content || '',
@@ -638,7 +640,8 @@
       lineBlocks: null,
       previousLineBlocks: null,
       tocItems: [],
-      collapsed: fi.status === 'deleted' || fi.generated === true,
+      collapsed: fi.status === 'deleted' || fi.generated === true ||
+        (fi.status === 'renamed' && !fi.additions && !fi.deletions),
       viewMode: (session.mode === 'git') ? 'diff' : 'document',
       additions: fi.additions || 0,
       deletions: fi.deletions || 0,
@@ -1954,12 +1957,14 @@
 
         loadSingleFile({
           path: file.path,
+          old_path: file.oldPath,
           status: file.status,
           file_type: file.fileType,
           additions: file.additions,
           deletions: file.deletions,
         }, diffScope).then(function(loaded) {
           // Copy loaded data into the existing file object
+          file.oldPath = loaded.oldPath;
           file.content = loaded.content;
           file.previousContent = loaded.previousContent;
           file.comments = loaded.comments;
@@ -2006,15 +2011,21 @@
     if (file.status === 'untracked') badgeLabel = 'New';
     if (file.status === 'added') badgeLabel = 'New File';
     if (file.status === 'removed') badgeLabel = 'Removed';
+    if (file.status === 'renamed') badgeLabel = 'Renamed';
 
     // In single-file file mode, hide the file header (filename is shown in the header bar)
     const singleFileMode = session.mode !== 'git' && files.length === 1;
     if (singleFileMode) header.style.display = 'none';
 
+    const renameHeader = file.status === 'renamed' && file.oldPath
+      ? '<span class="rename-paths"><span class="rename-old">' + escapeHtml(file.oldPath) + '</span>' +
+        '<span class="rename-arrow"> → </span><span class="rename-new">' + escapeHtml(file.path) + '</span></span>'
+      : '<span class="dir">' + escapeHtml(dirPath) + '</span><span class="filename">' + escapeHtml(fileName) + '</span>';
+
     header.innerHTML =
       '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
       '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-editor-fg-muted)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
-      '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span><span class="filename">' + escapeHtml(fileName) + '</span>' +
+      '<span class="file-header-name">' + renameHeader +
         '<button type="button" class="file-header-copy-path" aria-label="Copy file path">' + ICON_COPY_PATH + '</button>' +
       '</span>' +
       (showBadge ? '<span class="file-header-badge ' + escapeHtml(file.status) + '">' + escapeHtml(badgeLabel) + '</span>' : '') +
@@ -2161,6 +2172,11 @@
       deleted.className = 'diff-deleted-placeholder';
       deleted.textContent = 'This file was deleted.';
       body.appendChild(deleted);
+    } else if (file.status === 'renamed' && (!file.diffHunks || file.diffHunks.length === 0)) {
+      const renamed = document.createElement('div');
+      renamed.className = 'diff-deleted-placeholder rename-placeholder';
+      renamed.textContent = 'File renamed without changes.';
+      body.appendChild(renamed);
     } else if (showDiff && file.diffTooLarge && !file.diffLoaded) {
       let diffLineCount = 0;
       if (file.diffHunks) {

--- a/cmd/crit/frontend/style.css
+++ b/cmd/crit/frontend/style.css
@@ -4477,6 +4477,13 @@ body.sidebar-resizing * {
   color: var(--crit-editor-fg-muted);
   font-size: 14px;
 }
+.file-header-name .rename-paths {
+  font-family: var(--crit-font-mono, ui-monospace, monospace);
+  font-size: 13px;
+}
+.file-header-name .rename-arrow {
+  color: var(--crit-editor-fg-muted);
+}
 .orphaned-placeholder {
   font-style: italic;
   color: var(--crit-editor-fg-muted);

--- a/cmd/crit/git.go
+++ b/cmd/crit/git.go
@@ -16,8 +16,9 @@ import (
 
 // FileChange represents a single file change detected by git.
 type FileChange struct {
-	Path   string // relative to repo root
-	Status string // "added", "modified", "deleted", "renamed", "untracked"
+	Path    string // relative to repo root (new path for renames)
+	OldPath string // previous path when Status is "renamed"
+	Status  string // "added", "modified", "deleted", "renamed", "untracked"
 }
 
 // DiffHunk represents a single hunk in a unified diff.
@@ -810,8 +811,8 @@ func remoteBranchTipsSapling(repoRoot, defaultBranch string) ([]BranchEntry, err
 }
 
 // ChangedFilesBetweenSHAs returns the files changed in the range baseSHA..headSHA.
-// Renames are reported with status "renamed" and the new path; the old path is
-// not surfaced (matches existing parseNameStatus behavior).
+// Renames are reported with status "renamed", OldPath set to the previous path,
+// and Path set to the new path.
 // Untracked working-tree files are NOT included — this is a pure git-history range.
 func ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileChange, error) {
 	cmd := exec.Command("git", "diff", "--name-status", "-M", baseSHA+".."+headSHA)
@@ -826,10 +827,13 @@ func ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileChange, error)
 }
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range
-// baseSHA..headSHA. Returns nil hunks when there is no diff.
+// baseSHA..headSHA. Pass oldPath when status is "renamed" so git pairs the
+// rename instead of treating the new path as a full-file add.
+// Returns nil hunks when there is no diff.
 // When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
-func FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
-	cmd := exec.Command("git", append(diffBaseArgs(ignoreWhitespace), baseSHA+".."+headSHA, "--", path)...)
+func FileDiffBetweenSHAs(path, oldPath, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	pathArgs := diffPathArgs(oldPath, path)
+	cmd := exec.Command("git", append(diffBaseArgs(ignoreWhitespace), append([]string{baseSHA + ".." + headSHA, "--"}, pathArgs...)...)...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -1006,10 +1010,13 @@ func parseNameStatus(output string) []FileChange {
 		}
 		status := parts[0]
 		path := parts[1]
-		// For renames (R100\told\tnew), use the new path
+		// For renames (R100\told\tnew), keep both paths
 		if strings.HasPrefix(status, "R") && len(parts) >= 3 {
-			path = parts[2]
-			changes = append(changes, FileChange{Path: path, Status: "renamed"})
+			changes = append(changes, FileChange{
+				Path:    parts[2],
+				OldPath: parts[1],
+				Status:  "renamed",
+			})
 			continue
 		}
 		switch status {
@@ -1088,41 +1095,32 @@ func diffBaseArgs(ignoreWhitespace bool) []string {
 	return args
 }
 
+// diffPathArgs returns git diff path arguments for a file, pairing old+new
+// paths for renames so git reports rename-only diffs instead of full adds.
+func diffPathArgs(oldPath, path string) []string {
+	if oldPath != "" {
+		return []string{oldPath, path}
+	}
+	return []string{path}
+}
+
 // fileDiffUnified returns the parsed diff hunks for a file against a base ref.
 // If baseRef is empty, diffs against HEAD. The dir parameter sets the working directory.
 // When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
+// For renames, use diffHunksForFile which passes old+new paths via fileDiffUnifiedCtx.
 func fileDiffUnified(path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
-	ref := baseRef
-	if ref == "" {
-		ref = "HEAD"
-	}
-	args := append(diffBaseArgs(ignoreWhitespace), ref, "--", path)
-	cmd := exec.Command("git", args...)
-	cmd.Env = stripExternalDiffEnv()
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		// Exit code 1 means diff found changes (normal), check for actual errors
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			// git diff exits 1 when there are differences
-		} else {
-			return nil, fmt.Errorf("git diff failed: %w", err)
-		}
-	}
-	return ParseUnifiedDiff(string(out)), nil
+	return fileDiffUnifiedCtx(context.Background(), path, "", baseRef, dir, ignoreWhitespace)
 }
 
 // fileDiffUnifiedCtx is like fileDiffUnified but accepts a context for timeout control.
 // When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
-func fileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+func fileDiffUnifiedCtx(ctx context.Context, path, oldPath, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	ref := baseRef
 	if ref == "" {
 		ref = "HEAD"
 	}
-	args := append(diffBaseArgs(ignoreWhitespace), ref, "--", path)
+	pathArgs := diffPathArgs(oldPath, path)
+	args := append(diffBaseArgs(ignoreWhitespace), append([]string{ref, "--"}, pathArgs...)...)
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
@@ -1208,7 +1206,12 @@ func DiffNumstatDir(baseRef, dir string) (map[string]NumstatEntry, error) {
 		if err1 != nil || err2 != nil {
 			adds, dels = 0, 0
 		}
-		stats[path] = NumstatEntry{Additions: adds, Deletions: dels}
+		entry := NumstatEntry{Additions: adds, Deletions: dels}
+		stats[path] = entry
+		// Rename lines look like "old.go => new.go" — index by new path too.
+		if i := strings.Index(path, " => "); i >= 0 {
+			stats[path[i+4:]] = entry
+		}
 	}
 	return stats, nil
 }

--- a/cmd/crit/git_test.go
+++ b/cmd/crit/git_test.go
@@ -24,7 +24,7 @@ func TestParseNameStatus(t *testing.T) {
 	if changes[2].Path != "old.go" || changes[2].Status != "deleted" {
 		t.Errorf("changes[2] = %+v", changes[2])
 	}
-	if changes[3].Path != "new_name.go" || changes[3].Status != "renamed" {
+	if changes[3].Path != "new_name.go" || changes[3].OldPath != "old_name.go" || changes[3].Status != "renamed" {
 		t.Errorf("changes[3] = %+v", changes[3])
 	}
 }

--- a/cmd/crit/git_vcs.go
+++ b/cmd/crit/git_vcs.go
@@ -48,7 +48,7 @@ func (g *GitVCS) FileDiffUnified(path, baseRef, dir string, ignoreWhitespace boo
 }
 
 func (g *GitVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
-	return fileDiffUnifiedCtx(ctx, path, baseRef, dir, ignoreWhitespace)
+	return fileDiffUnifiedCtx(ctx, path, "", baseRef, dir, ignoreWhitespace)
 }
 
 func (g *GitVCS) FileDiffScoped(path, scope, baseRef, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
@@ -109,8 +109,8 @@ func (g *GitVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileCh
 }
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range baseSHA..headSHA.
-func (g *GitVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
-	return FileDiffBetweenSHAs(path, baseSHA, headSHA, dir, ignoreWhitespace)
+func (g *GitVCS) FileDiffBetweenSHAs(path, oldPath, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+	return FileDiffBetweenSHAs(path, oldPath, baseSHA, headSHA, dir, ignoreWhitespace)
 }
 
 // ReadFileAtSHA returns the bytes of path at the given SHA.

--- a/cmd/crit/git_vcs_test.go
+++ b/cmd/crit/git_vcs_test.go
@@ -104,8 +104,16 @@ func TestChangedFilesBetweenSHAs_Rename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].Path != "new.go" || got[0].Status != "renamed" {
-		t.Fatalf("got %+v, want [{new.go renamed}]", got)
+	if len(got) != 1 || got[0].Path != "new.go" || got[0].OldPath != "old.go" || got[0].Status != "renamed" {
+		t.Fatalf("got %+v, want [{Path:new.go OldPath:old.go renamed}]", got)
+	}
+
+	hunks, err := FileDiffBetweenSHAs("new.go", "old.go", base, head, dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hunks) != 0 {
+		t.Fatalf("rename-only diff: got %d hunks, want 0", len(hunks))
 	}
 }
 
@@ -152,7 +160,7 @@ func TestFileDiffBetweenSHAs_HappyPath(t *testing.T) {
 	commitAt(t, dir, "a.txt", "line1\nline2\nline3\n", "modify a")
 	head := gitT(t, dir, "rev-parse", "HEAD")
 
-	hunks, err := FileDiffBetweenSHAs("a.txt", base, head, dir, false)
+	hunks, err := FileDiffBetweenSHAs("a.txt", "", base, head, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +173,7 @@ func TestFileDiffBetweenSHAs_IdenticalSHAs(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "a.txt", "line1\n", "add a")
 	sha := gitT(t, dir, "rev-parse", "HEAD")
-	hunks, err := FileDiffBetweenSHAs("a.txt", sha, sha, dir, false)
+	hunks, err := FileDiffBetweenSHAs("a.txt", "", sha, sha, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +186,7 @@ func TestFileDiffBetweenSHAs_MissingPath(t *testing.T) {
 	dir := initTestRepo(t)
 	base := gitT(t, dir, "rev-parse", "HEAD")
 	head := commitAt(t, dir, "a.txt", "x", "add a")
-	hunks, err := FileDiffBetweenSHAs("does-not-exist.txt", base, head, dir, false)
+	hunks, err := FileDiffBetweenSHAs("does-not-exist.txt", "", base, head, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/crit/jj.go
+++ b/cmd/crit/jj.go
@@ -345,7 +345,7 @@ func (j *JJVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]FileCha
 	return parseJJDiffSummary(out), nil
 }
 
-func (j *JJVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+func (j *JJVCS) FileDiffBetweenSHAs(path, _ string, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	base, err := resolveJJRevisionToCommitID(dir, baseSHA)
 	if err != nil {
 		return nil, err

--- a/cmd/crit/jj_detect_test.go
+++ b/cmd/crit/jj_detect_test.go
@@ -181,7 +181,7 @@ func (*fakeJJVCSForFetch) FileContentAtRef(string, string, string) (string, erro
 func (*fakeJJVCSForFetch) ChangedFilesBetweenSHAs(string, string, string) ([]FileChange, error) {
 	return nil, nil
 }
-func (*fakeJJVCSForFetch) FileDiffBetweenSHAs(string, string, string, string, bool) ([]DiffHunk, error) {
+func (*fakeJJVCSForFetch) FileDiffBetweenSHAs(string, string, string, string, string, bool) ([]DiffHunk, error) {
 	return nil, nil
 }
 func (*fakeJJVCSForFetch) ReadFileAtSHA(string, string, string) ([]byte, error) {

--- a/cmd/crit/jj_methods_test.go
+++ b/cmd/crit/jj_methods_test.go
@@ -378,7 +378,7 @@ func TestJJVCS_ChangedFilesAndDiffBetweenSHAs(t *testing.T) {
 	}
 	assertFileChangesEqual(t, changes, []FileChange{{Path: "between.txt", Status: "added"}})
 
-	hunks, err := j.FileDiffBetweenSHAs("between.txt", mainSHA, headSHA, dir, false)
+	hunks, err := j.FileDiffBetweenSHAs("between.txt", "", mainSHA, headSHA, dir, false)
 	if err != nil {
 		t.Fatalf("FileDiffBetweenSHAs: %v", err)
 	}

--- a/cmd/crit/jj_parse.go
+++ b/cmd/crit/jj_parse.go
@@ -31,31 +31,38 @@ func parseJJDiffSummary(output string) []FileChange {
 			continue
 		}
 		path := line[2:]
+		var oldPath string
 		if status == "renamed" {
-			path = parseJJRenameTarget(path)
+			oldPath, path = parseJJRenamePaths(path)
 		}
 		if path == "" {
 			continue
 		}
-		changes = append(changes, FileChange{Path: path, Status: status})
+		changes = append(changes, FileChange{Path: path, OldPath: oldPath, Status: status})
 	}
 	return changes
 }
 
-// parseJJRenameTarget extracts the destination from JJ's compact rename syntax.
-// Examples: `{old.txt => new.txt}` -> `new.txt`, `src/{old.go => new.go}` -> `src/new.go`.
-func parseJJRenameTarget(path string) string {
+// parseJJRenamePaths extracts old and new paths from JJ's compact rename syntax.
+// Examples: `{old.txt => new.txt}` -> `old.txt`, `new.txt`;
+// `src/{old.go => new.go}` -> `src/old.go`, `src/new.go`.
+func parseJJRenamePaths(path string) (oldPath, newPath string) {
 	path = strings.TrimSpace(path)
 	idx := strings.LastIndex(path, " => ")
 	if idx < 0 {
-		return strings.Trim(path, "{}")
+		return "", strings.Trim(path, "{}")
 	}
 
 	leftBrace := strings.LastIndex(path[:idx], "{")
 	rightRel := strings.Index(path[idx+4:], "}")
 	if leftBrace >= 0 && rightRel >= 0 {
 		rightBrace := idx + 4 + rightRel
-		return path[:leftBrace] + path[idx+4:rightBrace] + path[rightBrace+1:]
+		oldPart := path[leftBrace+1 : idx]
+		newPath = path[:leftBrace] + path[idx+4:rightBrace] + path[rightBrace+1:]
+		oldPath = path[:leftBrace] + oldPart + path[rightBrace+1:]
+		return oldPath, newPath
 	}
-	return strings.Trim(strings.TrimSpace(path[idx+4:]), "{}")
+	oldPath = strings.Trim(strings.TrimSpace(path[:idx]), "{}")
+	newPath = strings.Trim(strings.TrimSpace(path[idx+4:]), "{}")
+	return oldPath, newPath
 }

--- a/cmd/crit/jj_parse_more_test.go
+++ b/cmd/crit/jj_parse_more_test.go
@@ -13,12 +13,12 @@ func TestParseJJDiffSummary_EdgeCases(t *testing.T) {
 		{
 			name:  "nested rename braces",
 			input: "R src/a/{b/old.go => c/new.go}",
-			want:  []FileChange{{Path: "src/a/c/new.go", Status: "renamed"}},
+			want:  []FileChange{{Path: "src/a/c/new.go", OldPath: "src/a/b/old.go", Status: "renamed"}},
 		},
 		{
 			name:  "rename with trailing newline",
 			input: "R {old.txt => new.txt}\n",
-			want:  []FileChange{{Path: "new.txt", Status: "renamed"}},
+			want:  []FileChange{{Path: "new.txt", OldPath: "old.txt", Status: "renamed"}},
 		},
 		{
 			name:  "copy status ignored",
@@ -34,7 +34,7 @@ func TestParseJJDiffSummary_EdgeCases(t *testing.T) {
 		{
 			name:  "path with spaces inside braces",
 			input: "R src/{old name.txt => new name.txt}",
-			want:  []FileChange{{Path: "src/new name.txt", Status: "renamed"}},
+			want:  []FileChange{{Path: "src/new name.txt", OldPath: "src/old name.txt", Status: "renamed"}},
 		},
 		{
 			name:  "crlf only",

--- a/cmd/crit/jj_parse_test.go
+++ b/cmd/crit/jj_parse_test.go
@@ -12,15 +12,15 @@ func TestParseJJDiffSummary(t *testing.T) {
 		{name: "modified", input: "M src/main.go", want: []FileChange{{Path: "src/main.go", Status: "modified"}}},
 		{name: "added", input: "A new file.txt", want: []FileChange{{Path: "new file.txt", Status: "added"}}},
 		{name: "deleted", input: "D old.go", want: []FileChange{{Path: "old.go", Status: "deleted"}}},
-		{name: "rename whole path", input: "R {old.txt => new.txt}", want: []FileChange{{Path: "new.txt", Status: "renamed"}}},
-		{name: "rename shared prefix", input: "R src/{old.go => new.go}", want: []FileChange{{Path: "src/new.go", Status: "renamed"}}},
+		{name: "rename whole path", input: "R {old.txt => new.txt}", want: []FileChange{{Path: "new.txt", OldPath: "old.txt", Status: "renamed"}}},
+		{name: "rename shared prefix", input: "R src/{old.go => new.go}", want: []FileChange{{Path: "src/new.go", OldPath: "src/old.go", Status: "renamed"}}},
 		{
 			name:  "mixed",
 			input: "M app.go\r\nA docs/plan.md\nR {a.txt => b.txt}\nD gone.txt",
 			want: []FileChange{
 				{Path: "app.go", Status: "modified"},
 				{Path: "docs/plan.md", Status: "added"},
-				{Path: "b.txt", Status: "renamed"},
+				{Path: "b.txt", OldPath: "a.txt", Status: "renamed"},
 				{Path: "gone.txt", Status: "deleted"},
 			},
 		},

--- a/cmd/crit/sapling.go
+++ b/cmd/crit/sapling.go
@@ -341,7 +341,7 @@ func (s *SaplingVCS) ChangedFilesBetweenSHAs(baseSHA, headSHA, dir string) ([]Fi
 
 // FileDiffBetweenSHAs returns parsed diff hunks for path in the range baseSHA..headSHA.
 // When ignoreWhitespace is true, whitespace-only changes collapse to context ("-w").
-func (s *SaplingVCS) FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
+func (s *SaplingVCS) FileDiffBetweenSHAs(path, _ string, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error) {
 	args := []string{"diff"}
 	if ignoreWhitespace {
 		args = append(args, "-w")

--- a/cmd/crit/session.go
+++ b/cmd/crit/session.go
@@ -182,13 +182,14 @@ type SSEEvent struct {
 
 // FileEntry holds the state for a single file in a review session.
 type FileEntry struct {
-	Path     string    `json:"path"`      // relative (e.g., "auth/middleware.go")
-	AbsPath  string    `json:"-"`         // absolute on disk
-	Status   string    `json:"status"`    // "added", "modified", "deleted", "untracked"
-	FileType string    `json:"file_type"` // "markdown" or "code"
-	Content  string    `json:"-"`         // current file content
-	FileHash string    `json:"-"`         // sha256 hash of content
-	Comments []Comment `json:"-"`         // this file's comments
+	Path     string    `json:"path"`               // relative (e.g., "auth/middleware.go")
+	AbsPath  string    `json:"-"`                  // absolute on disk
+	Status   string    `json:"status"`             // "added", "modified", "deleted", "renamed", "untracked"
+	OldPath  string    `json:"old_path,omitempty"` // previous path when renamed
+	FileType string    `json:"file_type"`          // "markdown" or "code"
+	Content  string    `json:"-"`                  // current file content
+	FileHash string    `json:"-"`                  // sha256 hash of content
+	Comments []Comment `json:"-"`                  // this file's comments
 
 	// Diff hunks for code files (from git diff)
 	DiffHunks []DiffHunk `json:"-"`
@@ -252,21 +253,27 @@ func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string, vcs VCS) error {
 
 // loadDiff computes diff hunks via the VCS interface or git package-level fallback.
 func (fe *FileEntry) loadDiff(ctx context.Context, repoRoot, baseRef string, vcs VCS) {
-	if vcs != nil {
-		hunks, err := vcs.FileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot, false)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fe.Path, err)
-		} else {
-			fe.DiffHunks = hunks
-		}
-		return
-	}
-	hunks, err := fileDiffUnifiedCtx(ctx, fe.Path, baseRef, repoRoot, false)
+	hunks, err := diffHunksForFileCtx(ctx, fe.Path, fe.OldPath, fe.Status, baseRef, repoRoot, false, vcs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fe.Path, err)
+		fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fe.Path, err)
 	} else {
 		fe.DiffHunks = hunks
 	}
+}
+
+// diffHunksForFile returns diff hunks for a file, pairing old+new paths for renames.
+func diffHunksForFile(path, oldPath, status, baseRef, repoRoot string, ignoreWhitespace bool, vcs VCS) ([]DiffHunk, error) {
+	return diffHunksForFileCtx(context.Background(), path, oldPath, status, baseRef, repoRoot, ignoreWhitespace, vcs)
+}
+
+func diffHunksForFileCtx(ctx context.Context, path, oldPath, status, baseRef, repoRoot string, ignoreWhitespace bool, vcs VCS) ([]DiffHunk, error) {
+	if status == "renamed" && oldPath != "" {
+		return fileDiffUnifiedCtx(ctx, path, oldPath, baseRef, repoRoot, ignoreWhitespace)
+	}
+	if vcs != nil {
+		return vcs.FileDiffUnifiedCtx(ctx, path, baseRef, repoRoot, ignoreWhitespace)
+	}
+	return fileDiffUnifiedCtx(ctx, path, "", baseRef, repoRoot, ignoreWhitespace)
 }
 
 // Session is the top-level state manager for a multi-file review.
@@ -476,18 +483,9 @@ func populateEagerFile(fe *FileEntry, fc FileChange, baseRef, root string, vcs V
 
 // populateEagerFileDiff computes diff hunks for an eager-loaded file.
 func populateEagerFileDiff(fe *FileEntry, fc FileChange, baseRef, root string, vcs VCS) {
-	if vcs != nil {
-		hunks, err := vcs.FileDiffUnified(fc.Path, baseRef, root, false)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fc.Path, err)
-		} else {
-			fe.DiffHunks = hunks
-		}
-		return
-	}
-	hunks, err := fileDiffUnified(fc.Path, baseRef, root, false)
+	hunks, err := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, baseRef, root, false, vcs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: git diff failed for %s: %v\n", fc.Path, err)
+		fmt.Fprintf(os.Stderr, "Warning: diff failed for %s: %v\n", fc.Path, err)
 	} else {
 		fe.DiffHunks = hunks
 	}
@@ -584,6 +582,7 @@ func newGitSession(vcs VCS, ignorePatterns []string, requireChanges bool) (*Sess
 		absPath := filepath.Join(root, fc.Path)
 		fe := &FileEntry{
 			Path:      fc.Path,
+			OldPath:   fc.OldPath,
 			AbsPath:   absPath,
 			Status:    fc.Status,
 			FileType:  detectFileType(fc.Path),
@@ -2453,16 +2452,19 @@ func (s *Session) GetFileSnapshotFromDisk(path string) (map[string]any, bool) {
 // deleted files (where whitespace-ignore changes nothing) and the markdown
 // branch, it returns the cached hunks unchanged. On any recompute error it logs
 // a warning and falls back to the cached hunks — the request never fails.
-func whitespaceIgnoredHunks(cached []DiffHunk, status string, ignoreWhitespace bool, path, baseRef, repoRoot string, vcs VCS) []DiffHunk {
-	if !ignoreWhitespace || vcs == nil {
+func whitespaceIgnoredHunks(cached []DiffHunk, status, oldPath string, ignoreWhitespace bool, path, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+	if !ignoreWhitespace {
 		return cached
 	}
 	if status == "added" || status == "untracked" || status == "deleted" {
 		return cached
 	}
+	if vcs == nil && (status != "renamed" || oldPath == "") {
+		return cached
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	hunks, err := vcs.FileDiffUnifiedCtx(ctx, path, baseRef, repoRoot, true)
+	hunks, err := diffHunksForFileCtx(ctx, path, oldPath, status, baseRef, repoRoot, true, vcs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: whitespace-ignored diff failed for %s: %v\n", path, err)
 		return cached
@@ -2492,8 +2494,9 @@ func (s *Session) GetFileDiffSnapshot(path string, ignoreWhitespace bool) (map[s
 	if f.FileType == "code" || s.Mode == "git" {
 		hunks := f.DiffHunks
 		status := f.Status
+		oldPath := f.OldPath
 		s.mu.RUnlock()
-		hunks = whitespaceIgnoredHunks(hunks, status, ignoreWhitespace, path, baseRef, repoRoot, vcs)
+		hunks = whitespaceIgnoredHunks(hunks, status, oldPath, ignoreWhitespace, path, baseRef, repoRoot, vcs)
 		if hunks == nil {
 			hunks = []DiffHunk{}
 		}
@@ -2536,6 +2539,7 @@ type SessionInfo struct {
 // SessionFileInfo is a summary of a file for the session API response.
 type SessionFileInfo struct {
 	Path         string `json:"path"`
+	OldPath      string `json:"old_path,omitempty"`
 	Status       string `json:"status"`
 	FileType     string `json:"file_type"`
 	CommentCount int    `json:"comment_count"`
@@ -2593,6 +2597,7 @@ func (s *Session) GetSessionInfo() SessionInfo {
 		}
 		fi := SessionFileInfo{
 			Path:         f.Path,
+			OldPath:      f.OldPath,
 			Status:       f.Status,
 			FileType:     f.FileType,
 			CommentCount: visibleCount,

--- a/cmd/crit/session_focus.go
+++ b/cmd/crit/session_focus.go
@@ -400,6 +400,7 @@ func (s *Session) buildFilesForFocus(f Focus, vcs VCS, repoRoot string) ([]*File
 	for _, fc := range changes {
 		fe := &FileEntry{
 			Path:     fc.Path,
+			OldPath:  fc.OldPath,
 			AbsPath:  filepath.Join(repoRoot, fc.Path),
 			Status:   fc.Status,
 			FileType: detectFileType(fc.Path),
@@ -414,7 +415,7 @@ func (s *Session) buildFilesForFocus(f Focus, vcs VCS, repoRoot string) ([]*File
 			fe.FileHash = fileHash(data)
 		}
 		if fc.Status != "added" && fc.Status != "untracked" {
-			hunks, _ := vcs.FileDiffBetweenSHAs(fc.Path, f.DiffBaseSHA(), f.HeadSHA, repoRoot, false)
+			hunks, _ := vcs.FileDiffBetweenSHAs(fc.Path, fc.OldPath, f.DiffBaseSHA(), f.HeadSHA, repoRoot, false)
 			fe.DiffHunks = hunks
 		} else {
 			fe.DiffHunks = FileDiffUnifiedNewFile(fe.Content)
@@ -461,6 +462,7 @@ func (s *Session) buildFilesForWorkingTree(vcs VCS, repoRoot string) ([]*FileEnt
 	for _, fc := range changes {
 		fe := &FileEntry{
 			Path:     fc.Path,
+			OldPath:  fc.OldPath,
 			AbsPath:  filepath.Join(repoRoot, fc.Path),
 			Status:   fc.Status,
 			FileType: detectFileType(fc.Path),
@@ -629,7 +631,7 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 		return nil
 	}
 	if base, head, ok := splitCommitRange(commit); ok {
-		h, err := vcs.FileDiffBetweenSHAs(fc.Path, base, head, repoRoot, false)
+		h, err := vcs.FileDiffBetweenSHAs(fc.Path, fc.OldPath, base, head, repoRoot, false)
 		if err == nil {
 			return h
 		}
@@ -646,6 +648,13 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 		absPath := filepath.Join(repoRoot, fc.Path)
 		if data, err := os.ReadFile(absPath); err == nil {
 			return FileDiffUnifiedNewFile(string(data))
+		}
+		return nil
+	}
+	if fc.Status == "renamed" && fc.OldPath != "" {
+		h, err := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, baseRef, repoRoot, false, vcs)
+		if err == nil {
+			return h
 		}
 		return nil
 	}
@@ -728,6 +737,7 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 	for _, fc := range changes {
 		fi := SessionFileInfo{
 			Path:         fc.Path,
+			OldPath:      fc.OldPath,
 			Status:       fc.Status,
 			FileType:     detectFileType(fc.Path),
 			CommentCount: snap.commentCounts[fc.Path],
@@ -823,7 +833,7 @@ func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoR
 		return nil
 	}
 	if base, head, ok := splitCommitRange(commit); ok {
-		h, err := vcs.FileDiffBetweenSHAs(path, base, head, repoRoot, ignoreWhitespace)
+		h, err := vcs.FileDiffBetweenSHAs(path, "", base, head, repoRoot, ignoreWhitespace)
 		if err == nil {
 			return h
 		}

--- a/cmd/crit/vcs.go
+++ b/cmd/crit/vcs.go
@@ -103,7 +103,7 @@ type VCS interface {
 	// FileDiffBetweenSHAs returns parsed diff hunks for path in the range
 	// baseSHA..headSHA. Returns nil hunks when there is no diff for that path.
 	// When ignoreWhitespace is true, whitespace-only changes collapse to context.
-	FileDiffBetweenSHAs(path, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
+	FileDiffBetweenSHAs(path, oldPath, baseSHA, headSHA, dir string, ignoreWhitespace bool) ([]DiffHunk, error)
 
 	// ReadFileAtSHA returns the bytes of path at the given SHA. Returns
 	// (nil, nil) when the file does not exist at that SHA. Errors are

--- a/cmd/crit/whitespace_diff_test.go
+++ b/cmd/crit/whitespace_diff_test.go
@@ -145,7 +145,7 @@ func TestWhitespaceIgnoredHunks_ShortCircuits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := whitespaceIgnoredHunks(sentinel, tt.status, tt.ignoreWS, "code.go", "HEAD", t.TempDir(), tt.vcs)
+			got := whitespaceIgnoredHunks(sentinel, tt.status, "", tt.ignoreWS, "code.go", "HEAD", t.TempDir(), tt.vcs)
 			cachedBack := len(got) == 1 && got[0].Header == sentinel[0].Header
 			if cachedBack != tt.wantCachedBack {
 				t.Errorf("got %v (cachedBack=%v), want cachedBack=%v", got, cachedBack, tt.wantCachedBack)
@@ -162,7 +162,7 @@ func TestWhitespaceIgnoredHunks_ShortCircuits(t *testing.T) {
 		gitT(t, dir, "commit", "-m", "add code.go")
 		writeFile(t, filepath.Join(dir, "code.go"), "func main() {\n\treturn\n}\n")
 
-		got := whitespaceIgnoredHunks(sentinel, "modified", true, "code.go", "HEAD", dir, &GitVCS{})
+		got := whitespaceIgnoredHunks(sentinel, "modified", "", true, "code.go", "HEAD", dir, &GitVCS{})
 		if len(got) != 0 {
 			t.Errorf("recompute: got %d hunks, want 0 (whitespace-only change collapses)", len(got))
 		}


### PR DESCRIPTION
## Summary
- Preserve `old_path` from git rename detection (`R100`) and pass both paths to `git diff` so pure renames no longer render as full-file adds
- Show `old → new` in the file header and "File renamed without changes." when there are no diff hunks (GitHub parity)
- Fix rename numstat lookup (`old => new` lines) so lazy file stats show 0/+0 instead of inflated addition counts

## Review
- [x] Code review: passed (focused diff review, tests + golangci-lint green)
- [x] Parity audit: N/A (crit CLI only; crit-web unchanged)

## Test plan
- [x] `go test ./cmd/crit/...`
- [x] `golangci-lint run ./cmd/crit/...`
- [x] Pre-commit hook (gofmt, eslint, stylelint)
- [ ] Manual: `git mv` a file on a feature branch and confirm crit shows rename placeholder instead of full content


Made with [Cursor](https://cursor.com)