### PR TITLE
fix: inject crit-agent into all preview HTML pages

### DIFF
--- a/cmd/crit/frontend/live-mode.js
+++ b/cmd/crit/frontend/live-mode.js
@@ -246,7 +246,7 @@
         '<div class="crit-live-iframe-pane-inner">' +
         '<div class="crit-live-iframe-frame" id="critLiveFrame">' +
         // No `sandbox` attribute by design — see spec security section.
-        '<iframe id="critLiveIframe" title="Live target" referrerpolicy="no-referrer" allow="*"></iframe>' +
+        '<iframe id="critLiveIframe" title="Live target" referrerpolicy="no-referrer"></iframe>' +
         '<div class="crit-live-iframe-resizer" id="critLiveResizer" role="separator" aria-orientation="vertical" aria-label="Resize live viewport" tabindex="0"></div>' +
         '</div>' +
         '</div>';

--- a/cmd/crit/preview.go
+++ b/cmd/crit/preview.go
@@ -143,7 +143,21 @@ func (s *Server) handlePreviewContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Multi-page previews (e.g. static sites with chapter/*.html) must get
+	// the same crit-agent injection as the root page — otherwise in-iframe
+	// navigation leaves Pin mode enabled in the chrome but the new document
+	// has no agent listening for clicks.
+	if isPreviewHTMLPath(resolved) {
+		s.servePreviewHTML(w, resolved)
+		return
+	}
+
 	http.ServeFile(w, r, resolved)
+}
+
+func isPreviewHTMLPath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".html" || ext == ".htm"
 }
 
 // servePreviewHTML reads the HTML file and injects agent scripts before </body>.

--- a/cmd/crit/preview_test.go
+++ b/cmd/crit/preview_test.go
@@ -216,6 +216,30 @@ func TestHandlePreviewContent_InjectsAgent(t *testing.T) {
 	}
 }
 
+func TestHandlePreviewContent_InjectsAgentOnSiblingHTML(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html><body>home</body></html>"), 0644)
+	chDir := filepath.Join(dir, "chapters")
+	os.Mkdir(chDir, 0755)
+	os.WriteFile(filepath.Join(chDir, "01-intro.html"), []byte("<html><body>chapter</body></html>"), 0644)
+	s, _ := newPreviewTestServer(t, dir)
+
+	req := httptest.NewRequest("GET", "/preview-content/chapters/01-intro.html", nil)
+	w := httptest.NewRecorder()
+	s.handlePreviewContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "chapter") {
+		t.Error("response missing chapter content")
+	}
+	if !strings.Contains(body, "crit-agent.js") {
+		t.Error("agent script not injected into sibling HTML")
+	}
+}
+
 func TestHandlePreviewContent_ServesSiblingAssets(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html></html>"), 0644)


### PR DESCRIPTION
## Summary
- Route sibling `.html`/`.htm` files under `/preview-content/` through `servePreviewHTML` so the crit-agent bundle loads on every page, not just the root
- Fixes Pin mode appearing enabled but clicks doing nothing after in-iframe navigation in multi-page static previews (e.g. chapter links)
- Remove invalid `allow="*"` on the preview iframe (harmless browser console warning)

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit CLI preview only)

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [x] Added `TestHandlePreviewContent_InjectsAgentOnSiblingHTML`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)