### PR TITLE
fix(test): stabilize TestBindProxyServer_PortIsAPIPlusOne

### DIFF
--- a/cmd/crit/proxy_test.go
+++ b/cmd/crit/proxy_test.go
@@ -598,22 +598,31 @@ func TestProxyErrorHandler_Returns502JSON(t *testing.T) {
 }
 
 func TestBindProxyServer_PortIsAPIPlusOne(t *testing.T) {
-	ln0, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	apiPort := ln0.Addr().(*net.TCPAddr).Port
-	ln0.Close()
+	const maxAttempts = 20
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		apiLn, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		apiPort := apiLn.Addr().(*net.TCPAddr).Port
 
-	ln, srv, err := bindProxyServer("http://127.0.0.1:19997", apiPort)
-	if err != nil {
-		t.Fatalf("bindProxyServer: %v", err)
+		ln, srv, err := bindProxyServer("http://127.0.0.1:19997", apiPort)
+		if err != nil {
+			apiLn.Close()
+			if attempt < maxAttempts-1 && strings.Contains(err.Error(), "already in use") {
+				continue
+			}
+			t.Fatalf("bindProxyServer: %v", err)
+		}
+		defer ln.Close()
+		apiLn.Close()
+		_ = srv
+		if ln.Addr().(*net.TCPAddr).Port != apiPort+1 {
+			t.Errorf("proxy port = %d, want %d", ln.Addr().(*net.TCPAddr).Port, apiPort+1)
+		}
+		return
 	}
-	defer ln.Close()
-	_ = srv
-	if ln.Addr().(*net.TCPAddr).Port != apiPort+1 {
-		t.Errorf("proxy port = %d, want %d", ln.Addr().(*net.TCPAddr).Port, apiPort+1)
-	}
+	t.Fatalf("could not bind proxy after %d attempts", maxAttempts)
 }
 
 func TestProxyModifyResponse_MidBodyReadFailureReturns502(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix flaky `TestBindProxyServer_PortIsAPIPlusOne` that intermittently failed in CI with `proxy port N already in use`
- Keep the API port listener open until `bindProxyServer` succeeds, and retry with a new port pair when `apiPort+1` is still held (e.g. TIME_WAIT from earlier `httptest` servers in the same package run)

Closes #642

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (test-only, crit-only)

## Test plan
- [x] `go test ./cmd/crit/ -run TestBindProxyServer_PortIsAPIPlusOne -count=50`
- [x] `go test ./cmd/crit/` (full package, pre-commit hook)


Made with [Cursor](https://cursor.com)