### PR TITLE
fix: align split diff rows positionally to preserve line number order

### DIFF
--- a/cmd/crit/frontend/__tests__/crit-diff-renderer.test.js
+++ b/cmd/crit/frontend/__tests__/crit-diff-renderer.test.js
@@ -216,3 +216,73 @@ test('wordDiff returns ranges for small changes', function() {
     assert.ok(Array.isArray(result.newRanges));
   }
 });
+
+// --- buildSplitChangeRows ---
+
+function lineNums(rows, side) {
+  return rows.map(function(r) {
+    if (side === 'old') return r.del ? r.del.OldNum : null;
+    return r.add ? r.add.NewNum : null;
+  });
+}
+
+function assertMonotonic(nums, label) {
+  var prev = null;
+  for (var i = 0; i < nums.length; i++) {
+    if (nums[i] == null) continue;
+    if (prev != null && nums[i] < prev) {
+      assert.fail(label + ' not monotonic: ' + JSON.stringify(nums));
+    }
+    prev = nums[i];
+  }
+}
+
+test('buildSplitChangeRows pairs del[i] with add[i] positionally', function() {
+  var dels = [
+    { Type: 'del', Content: 'old loop', OldNum: 268 },
+  ];
+  var adds = [
+    { Type: 'add', Content: 'g, gctx := errgroup.WithContext(ctx)', NewNum: 267 },
+    { Type: 'add', Content: 'g.Go(func() error {', NewNum: 268 },
+    { Type: 'add', Content: 'return g.Wait()', NewNum: 269 },
+  ];
+  var rows = diffRenderer.buildSplitChangeRows(dels, adds, function() { return null; });
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].del.OldNum, 268);
+  assert.equal(rows[0].add.NewNum, 267);
+  assert.equal(rows[1].del, null);
+  assert.equal(rows[1].add.NewNum, 268);
+  assert.equal(rows[2].add.NewNum, 269);
+  assertMonotonic(lineNums(rows, 'new'), 'new line numbers');
+});
+
+test('buildSplitChangeRows keeps old line numbers monotonic for multi-del runs', function() {
+  var dels = [
+    { Type: 'del', Content: 'a', OldNum: 267 },
+    { Type: 'del', Content: 'b', OldNum: 268 },
+    { Type: 'del', Content: 'c', OldNum: 269 },
+  ];
+  var adds = [
+    { Type: 'add', Content: 'a2', NewNum: 267 },
+    { Type: 'add', Content: 'b2', NewNum: 268 },
+  ];
+  var rows = diffRenderer.buildSplitChangeRows(dels, adds, function() { return null; });
+  assert.equal(rows.length, 3);
+  assert.deepEqual(lineNums(rows, 'old'), [267, 268, 269]);
+  assert.deepEqual(lineNums(rows, 'new'), [267, 268, null]);
+});
+
+test('buildSplitChangeRows handles dels-only and adds-only', function() {
+  assert.equal(diffRenderer.buildSplitChangeRows([], [], function() { return null; }).length, 0);
+  var delOnly = diffRenderer.buildSplitChangeRows(
+    [{ Type: 'del', Content: 'x', OldNum: 5 }], [], function() { return null; }
+  );
+  assert.equal(delOnly.length, 1);
+  assert.equal(delOnly[0].del.OldNum, 5);
+  assert.equal(delOnly[0].add, null);
+  var addOnly = diffRenderer.buildSplitChangeRows(
+    [], [{ Type: 'add', Content: 'y', NewNum: 3 }], function() { return null; }
+  );
+  assert.equal(addOnly.length, 1);
+  assert.equal(addOnly[0].add.NewNum, 3);
+});

--- a/cmd/crit/frontend/app.js
+++ b/cmd/crit/frontend/app.js
@@ -2686,6 +2686,7 @@
   const htmlToText = window.crit.diffRenderer.htmlToText;
   const applyWordDiffPair = window.crit.diffRenderer.applyWordDiffPair;
   const buildHunkWordDiffs = window.crit.diffRenderer.buildHunkWordDiffs;
+  const buildSplitChangeRows = window.crit.diffRenderer.buildSplitChangeRows;
 
 
   // ===== Diff Gutter Drag (multi-line comment selection) =====
@@ -3508,34 +3509,8 @@
           appendDiffForm(container, file.path, line.OldNum, 'old');
           appendDiffForm(container, file.path, line.NewNum, '');
         } else {
-          // Pair del/add lines by similarity for word diff (not positionally)
-          const delTexts = [];
-          for (let dt = 0; dt < seg.dels.length; dt++) delTexts.push(seg.dels[dt].Content);
-          const addTexts = [];
-          for (let at = 0; at < seg.adds.length; at++) addTexts.push(seg.adds[at].Content);
-          const pairs = bestWordDiffPairing(delTexts, addTexts);
-
-          // Build reverse mapping: addIdx → delIdx
-          const addToDel = {};
-          const pairedDels = {};
-          for (let p = 0; p < pairs.length; p++) {
-            addToDel[pairs[p][1]] = pairs[p][0];
-            pairedDels[pairs[p][0]] = true;
-          }
-
-          // Build rows: unpaired dels first, then adds in order (paired adds bring their del)
-          const splitRows = [];
-          for (let d = 0; d < seg.dels.length; d++) {
-            if (!pairedDels[d]) splitRows.push({ del: seg.dels[d], add: null, wd: null });
-          }
-          for (let a = 0; a < seg.adds.length; a++) {
-            if (addToDel[a] !== undefined) {
-              const pd = seg.dels[addToDel[a]];
-              splitRows.push({ del: pd, add: seg.adds[a], wd: wordDiff(pd.Content, seg.adds[a].Content) });
-            } else {
-              splitRows.push({ del: null, add: seg.adds[a], wd: null });
-            }
-          }
+          // Positional alignment (GitHub-style): del[i] beside add[i], surplus single-sided.
+          const splitRows = buildSplitChangeRows(seg.dels, seg.adds, wordDiff);
 
           for (let j = 0; j < splitRows.length; j++) {
             const sr = splitRows[j];

--- a/cmd/crit/frontend/crit-diff-renderer.js
+++ b/cmd/crit/frontend/crit-diff-renderer.js
@@ -257,6 +257,25 @@
     return wordDiffMap;
   }
 
+  // Build split-view rows for a del/add run using positional alignment (GitHub-style).
+  // Pairs del[i] with add[i]; surplus dels or adds become single-sided rows.
+  // wordDiffFn(oldContent, newContent) is called for each paired row only.
+  function buildSplitChangeRows(dels, adds, wordDiffFn) {
+    var rows = [];
+    var minLen = Math.min(dels.length, adds.length);
+    for (var i = 0; i < minLen; i++) {
+      var wd = wordDiffFn(dels[i].Content, adds[i].Content);
+      rows.push({ del: dels[i], add: adds[i], wd: wd });
+    }
+    for (var d = minLen; d < dels.length; d++) {
+      rows.push({ del: dels[d], add: null, wd: null });
+    }
+    for (var a = minLen; a < adds.length; a++) {
+      rows.push({ del: null, add: adds[a], wd: null });
+    }
+    return rows;
+  }
+
   var api = {
     lineSimilarity: lineSimilarity,
     bestWordDiffPairing: bestWordDiffPairing,
@@ -265,6 +284,7 @@
     htmlToText: htmlToText,
     applyWordDiffPair: applyWordDiffPair,
     buildHunkWordDiffs: buildHunkWordDiffs,
+    buildSplitChangeRows: buildSplitChangeRows,
   };
   if (typeof window !== 'undefined') {
     window.crit = window.crit || {};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "update-deps": "bun run copy-deps.js",
-    "test:frontend": "node cmd/crit/frontend/__tests__/markdown-patch.test.mjs && node cmd/crit/frontend/test-diff-render.mjs"
+    "test:frontend": "node cmd/crit/frontend/__tests__/markdown-patch.test.mjs && node cmd/crit/frontend/__tests__/crit-diff-renderer.test.js && node cmd/crit/frontend/test-diff-render.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.28.0",


### PR DESCRIPTION
## Summary
- Fix split diff view showing gutter line numbers out of file order (Fixes #646)
- Replace similarity-based del/add row reordering with GitHub-style positional alignment (`del[i]` beside `add[i]`, surplus lines single-sided)
- Extract `buildSplitChangeRows()` into `crit-diff-renderer.js` with regression tests; wire `crit-diff-renderer.test.js` into `npm run test:frontend`

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web has no split hunk renderer yet)

## Test plan
- [x] `npm run test:frontend` (25 diff-renderer + existing suites)
- [x] `go test -race -count=1 ./...`
- [x] Pre-commit hook (gofmt, golangci-lint, eslint, stylelint)


Made with [Cursor](https://cursor.com)