### PR TITLE
feat(live): forward upstream cookies for authenticated apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Two-level JSON config files, merged (project overrides global):
 - **Global**: `~/.crit.config.json` — user-wide defaults
 - **Project**: `.crit.config.json` in repo root — per-project overrides
 
-Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `disable_stats`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`.
+Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `disable_stats`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`, `live_cookie`, `live_cookie_file`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to the configured VCS user name if not set
@@ -147,6 +147,7 @@ Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`
 - `ignore_patterns` are unioned (global + project both apply); types: `*.ext`, `dir/`, `exact.file`, `path/*.ext`
 - `vcs` selects backend: `"git"` (default), `"sl"` (sapling), or `"jj"` (Jujutsu)
 - `auth_*` keys hold cached hosted-crit-web credentials (set by `crit auth`); treat as secrets
+- `live_cookie` / `live_cookie_file` forward session cookies to the upstream app in live mode (global or project; prefer gitignored `live_cookie_file` e.g. `.crit/live-cookies.txt`). CLI: `crit live --cookie`, `--cookie-file`
 - CLI flags override config file values
 </important>
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ crit http://localhost:3000        # review a running dev server
 crit landing.html                 # review a static HTML file
 ```
 
+### Live mode
+
+`crit live <url>` (or `crit <url>`) proxies a running dev server through Crit's review UI. Crit's iframe loads the app on a different origin/port than your browser tab, so **host-scoped session cookies are not shared automatically**. If the direct URL works but Crit shows a login page or hydration mismatch, forward the upstream cookies:
+
+```bash
+# one-off
+crit live http://localhost:4000/dashboard --cookie "_crit_key=..."
+
+# repeatable (Netscape jar or raw Cookie header lines)
+crit live http://localhost:4000/dashboard --cookie-file .crit/live-cookies.txt
+```
+
+**Getting cookies:** log in to the app in your browser, then copy the session cookie from DevTools (Application → Cookies) or export a cookie jar.
+
+**Config** (global or project `.crit.config.json`; project overrides global):
+
+```json
+{
+  "live_cookie_file": ".crit/live-cookies.txt"
+}
+```
+
+Relative paths resolve from the repo root. Prefer a gitignored file under `.crit/` over committing `live_cookie` inline. Run `crit live --help` for all flags.
+
 ```bash
 crit status                       # show review file path and daemon status
 crit stats                        # show lifetime review statistics
@@ -261,6 +285,8 @@ All keys are optional — omit any you don't need.
 | `no_update_check`      | bool     | `false`                    | Don't check for new versions on startup.                                                                                                                                                |
 | `no_integration_check` | bool     | `false`                    | Skip the integration config freshness check on startup.                                                                                                                                 |
 | `vcs`                  | string   | auto-detected              | Preferred VCS backend: `"git"`, `"sl"`, or `"jj"`. When set, crit uses this VCS instead of auto-detecting. Falls back to git if the configured VCS isn't available. Can also be set via `--vcs` CLI flag (flag takes precedence over config). |
+| `live_cookie`          | string   | `""`                       | Cookie header value forwarded to the upstream app in live mode (e.g. `"_crit_key=..."`). Global or project. Prefer `live_cookie_file` for secrets. |
+| `live_cookie_file`     | string   | `""`                       | Path to a file with upstream cookies for live mode (raw header lines or Netscape jar). Global or project; relative paths resolve from repo root. |
 
 ### Global-only config keys
 
@@ -288,6 +314,13 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | `--vcs`         |       | `vcs`                 | VCS backend (`git`, `sl`, or `jj`)     |
 | `--no-ignore`   |       |                       | Temporarily bypass all ignore patterns |
 | `--version`     | `-v`  |                       | Print version and exit                 |
+
+**Live mode only** (`crit live <url>` — see `crit live --help`):
+
+| Flag            | Equivalent config key | Description |
+| --------------- | --------------------- | ----------- |
+| `--cookie`      | `live_cookie`         | Upstream cookie value (repeatable) |
+| `--cookie-file` | `live_cookie_file`    | File with upstream cookies |
 
 ### Ignore patterns
 

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -52,6 +52,9 @@ type serverConfig struct {
 	// liveOrigin is the parsed --live-origin flag (live-mode daemon).
 	liveOrigin string
 
+	// liveCookie is the Cookie header value forwarded to the upstream app.
+	liveCookie string
+
 	// previewFile is the absolute path to an HTML file for preview mode.
 	previewFile string
 }
@@ -85,6 +88,9 @@ type serverFlagSet struct {
 	// liveOrigin is the parsed --live-origin flag (live-mode daemon).
 	liveOrigin string
 
+	// liveCookie is the parsed --live-cookie flag (live-mode daemon).
+	liveCookie string
+
 	// previewFile is the parsed --preview-file flag (preview-mode daemon).
 	previewFile string
 }
@@ -112,6 +118,7 @@ func parseServerFlags(args []string) serverFlagSet {
 	scopeSpec := fs.String("scope", "", "Diff scope when reviewing a PR: layer (default) or full-stack")
 	remoteFiles := fs.Bool("remote", false, "Read PR file content via GitHub API instead of local git (avoids `git fetch`; requires gh)")
 	liveOrigin := fs.String("live-origin", "", "")
+	liveCookie := fs.String("live-cookie", "", "")
 	previewFile := fs.String("preview-file", "", "")
 	fs.Usage = func() {
 		printHelp()
@@ -137,6 +144,7 @@ func parseServerFlags(args []string) serverFlagSet {
 		scopeSpec:   *scopeSpec,
 		remoteFiles: *remoteFiles,
 		liveOrigin:  *liveOrigin,
+		liveCookie:  *liveCookie,
 		previewFile: *previewFile,
 	}
 }
@@ -252,6 +260,7 @@ func resolveServerConfig(args []string) (*serverConfig, error) {
 		focus:              focus,
 		remoteFiles:        sf.remoteFiles,
 		liveOrigin:         sf.liveOrigin,
+		liveCookie:         sf.liveCookie,
 		previewFile:        sf.previewFile,
 	}, nil
 }
@@ -587,7 +596,7 @@ func runServe(args []string) {
 	var proxyLn net.Listener
 	var proxySrv *http.Server
 	if sc.liveOrigin != "" {
-		pl, ps, err := bindProxyServer(sc.liveOrigin, addr.Port)
+		pl, ps, err := bindProxyServer(sc.liveOrigin, addr.Port, sc.liveCookie)
 		if err != nil {
 			daemonFatal(pipe, "Error starting proxy server: %v", err)
 		}

--- a/cmd/crit/config.go
+++ b/cmd/crit/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	DisableStats       bool     `json:"disable_stats,omitempty"`
 	VCS                string   `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl", "jj"
 	ShareConsented     bool     `json:"share_consented,omitempty"`
+	LiveCookie         string   `json:"live_cookie,omitempty"`
+	LiveCookieFile     string   `json:"live_cookie_file,omitempty"`
 }
 
 // needsShareConsent reports whether the user must confirm before sharing.
@@ -203,12 +205,21 @@ func mergeConfigs(global, project Config, projectPresence configPresence) Config
 	if projectPresence.CleanupOnApprove {
 		merged.CleanupOnApprove = project.CleanupOnApprove
 	}
+	if project.LiveCookie != "" {
+		merged.LiveCookie = project.LiveCookie
+	}
+	if project.LiveCookieFile != "" {
+		merged.LiveCookieFile = project.LiveCookieFile
+	}
 	// Security: agent_cmd, auth_token, share_url, and proxy_auth are intentionally
 	// NOT merged from project config. They must remain global-only: agent_cmd to
 	// prevent untrusted repos from hijacking the agent command; auth_token and
 	// share_url to prevent a malicious repo's .crit.config.json from redirecting
 	// share requests (and the bearer token) to an attacker-controlled host;
 	// proxy_auth to prevent a repo from silently changing the transport mode.
+	// live_cookie/live_cookie_file DO merge from project config — common for local
+	// dev auth. Prefer live_cookie_file pointing at a gitignored path (e.g.
+	// .crit/live-cookies.txt) over committing live_cookie inline.
 	// Union ignore patterns
 	merged.IgnorePatterns = append(merged.IgnorePatterns, project.IgnorePatterns...)
 	return merged

--- a/cmd/crit/config_test.go
+++ b/cmd/crit/config_test.go
@@ -183,6 +183,15 @@ func TestBaseBranchConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("mergeConfigs: project live_cookie_file overrides global", func(t *testing.T) {
+		global := Config{LiveCookieFile: "~/.crit/global-cookies.txt"}
+		project := Config{LiveCookieFile: ".crit/live-cookies.txt"}
+		merged := mergeConfigs(global, project, configPresence{})
+		if merged.LiveCookieFile != ".crit/live-cookies.txt" {
+			t.Errorf("live_cookie_file = %q, want .crit/live-cookies.txt", merged.LiveCookieFile)
+		}
+	})
+
 	t.Run("LoadConfig: project base_branch wins over global", func(t *testing.T) {
 		homeDir := t.TempDir()
 		setHome(t, homeDir)

--- a/cmd/crit/config_test.go
+++ b/cmd/crit/config_test.go
@@ -192,6 +192,15 @@ func TestBaseBranchConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("mergeConfigs: project live_cookie overrides global", func(t *testing.T) {
+		global := Config{LiveCookie: "global=1"}
+		project := Config{LiveCookie: "project=1"}
+		merged := mergeConfigs(global, project, configPresence{})
+		if merged.LiveCookie != "project=1" {
+			t.Errorf("live_cookie = %q, want project=1", merged.LiveCookie)
+		}
+	})
+
 	t.Run("LoadConfig: project base_branch wins over global", func(t *testing.T) {
 		homeDir := t.TempDir()
 		setHome(t, homeDir)

--- a/cmd/crit/live.go
+++ b/cmd/crit/live.go
@@ -54,8 +54,19 @@ func detectFrameworks(body []byte) []string {
 
 var smokeClient = &http.Client{Timeout: 10 * time.Second}
 
-func runSmokeTest(origin string) smokeResult {
-	resp, err := smokeClient.Get(origin)
+func runSmokeTest(origin, cookies string) smokeResult {
+	req, err := http.NewRequest(http.MethodGet, origin, nil)
+	if err != nil {
+		return smokeResult{
+			kind:    smokeConnRefused,
+			fatal:   true,
+			message: fmt.Sprintf("is your dev server running at %s? (%v)", origin, err),
+		}
+	}
+	if cookies != "" {
+		req.Header.Set("Cookie", cookies)
+	}
+	resp, err := smokeClient.Do(req)
 	if err != nil {
 		return smokeResult{
 			kind:    smokeConnRefused,
@@ -139,8 +150,18 @@ func connectToLiveDaemon(key string) bool {
 	return true
 }
 
-// runLive is the entry point for `crit live <url>`.
-func runLive(args []string) {
+type liveCLIFlags struct {
+	port        int
+	host        string
+	noOpen      bool
+	quiet       bool
+	shareURL    string
+	cookieFlags stringSliceFlag
+	cookieFile  string
+	origin      string
+}
+
+func parseLiveCLIFlags(args []string) liveCLIFlags {
 	fs := flag.NewFlagSet("live", flag.ExitOnError)
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
@@ -149,6 +170,9 @@ func runLive(args []string) {
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
 	shareURL := fs.String("share-url", "", "Share service URL")
+	var cookieFlags stringSliceFlag
+	fs.Var(&cookieFlags, "cookie", "Cookie header value for upstream requests (repeatable)")
+	cookieFile := fs.String("cookie-file", "", "File with upstream cookies (raw header or Netscape jar)")
 	fs.Parse(args)
 
 	rawURL := ""
@@ -171,34 +195,57 @@ func runLive(args []string) {
 	// correct page (e.g. http://localhost:3333/live.html, not just /).
 	u.RawQuery = ""
 	u.Fragment = ""
-	origin := strings.TrimSuffix(u.String(), "/")
+	return liveCLIFlags{
+		port:        *port,
+		host:        *host,
+		noOpen:      *noOpen,
+		quiet:       *quiet,
+		shareURL:    *shareURL,
+		cookieFlags: cookieFlags,
+		cookieFile:  *cookieFile,
+		origin:      strings.TrimSuffix(u.String(), "/"),
+	}
+}
 
-	// 1. Smoke test.
-	checkLiveSmoke(origin)
+func buildLiveDaemonArgs(origin, liveCookies string, f liveCLIFlags, cfg Config, noOpenResolved bool) []string {
+	daemonArgs := []string{"--live-origin", origin}
+	if liveCookies != "" {
+		daemonArgs = append(daemonArgs, "--live-cookie", liveCookies)
+	}
+	return appendCommonDaemonFlags(daemonArgs, commonDaemonFlags{
+		port:     resolvePort(f.port, cfg.Port),
+		host:     resolveHost(f.host, cfg.Host),
+		noOpen:   noOpenResolved,
+		quiet:    f.quiet || cfg.Quiet,
+		shareURL: resolveShareURL(f.shareURL, cfg, ""),
+	})
+}
 
-	// 2. Session key + existing daemon check.
+// runLive is the entry point for `crit live <url>`.
+func runLive(args []string) {
+	f := parseLiveCLIFlags(args)
+
 	cwd, err := resolvedCWD()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	cfg := LoadConfig(cwd)
-	key := liveSessionKey(cwd, origin)
+	liveCookies, err := resolveLiveCookies(f.cookieFlags, f.cookieFile, cfg, cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	checkLiveSmoke(f.origin, liveCookies)
+
+	key := liveSessionKey(cwd, f.origin)
 	if connectToLiveDaemon(key) {
 		return
 	}
 
-	// 3. Spawn daemon via _serve. startDaemon prepends "_serve" itself.
-	noOpenResolved := *noOpen || cfg.NoOpen
-	daemonArgs := []string{"--live-origin", origin}
-	daemonArgs = appendCommonDaemonFlags(daemonArgs, commonDaemonFlags{
-		port:     resolvePort(*port, cfg.Port),
-		host:     resolveHost(*host, cfg.Host),
-		noOpen:   noOpenResolved,
-		quiet:    *quiet || cfg.Quiet,
-		shareURL: resolveShareURL(*shareURL, cfg, ""),
-	})
-	entry, err := startDaemon(key, daemonArgs)
+	noOpenResolved := f.noOpen || cfg.NoOpen
+	entry, err := startDaemon(key, buildLiveDaemonArgs(f.origin, liveCookies, f, cfg, noOpenResolved))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start live daemon: %v\n", err)
 		os.Exit(1)
@@ -210,17 +257,15 @@ func runLive(args []string) {
 
 	installDaemonSignalHandler(entry.PID)
 
-	// 4. Open browser.
 	if !noOpenResolved {
 		go openBrowser(entry.baseURL() + "/live")
 	}
 
-	// 5. Block until review complete.
 	runReviewClient(entry, key)
 }
 
-func checkLiveSmoke(origin string) {
-	result := runSmokeTest(origin)
+func checkLiveSmoke(origin, cookies string) {
+	result := runSmokeTest(origin, cookies)
 	switch result.kind {
 	case smokeConnRefused, smokeNonHTML:
 		fmt.Fprintf(os.Stderr, "Error: %s\n", result.message)

--- a/cmd/crit/live_cookie.go
+++ b/cmd/crit/live_cookie.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// stringSliceFlag collects repeated --cookie values.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, "; ") }
+
+func (s *stringSliceFlag) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+// resolveLiveCookies merges cookie values from CLI flags and config (global +
+// project). Precedence: inline flags and explicit --cookie-file override config
+// file paths, but all provided sources are merged (later duplicates are left to
+// the upstream). Relative cookie file paths resolve against configDir.
+func resolveLiveCookies(flagCookies []string, flagCookieFile string, cfg Config, configDir string) (string, error) {
+	var parts []string
+	parts = append(parts, flagCookies...)
+	if cfg.LiveCookie != "" {
+		parts = append(parts, cfg.LiveCookie)
+	}
+
+	filePath := flagCookieFile
+	if filePath == "" {
+		filePath = cfg.LiveCookieFile
+	}
+	if filePath != "" {
+		filePath = resolveCookieFilePath(filePath, configDir)
+		fromFile, err := readLiveCookieFile(filePath)
+		if err != nil {
+			return "", err
+		}
+		if fromFile != "" {
+			parts = append(parts, fromFile)
+		}
+	}
+
+	return joinCookieHeader(parts), nil
+}
+
+func resolveCookieFilePath(path, configDir string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	if configDir == "" {
+		return path
+	}
+	return filepath.Join(configDir, path)
+}
+
+func joinCookieHeader(parts []string) string {
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, "; ")
+}
+
+// readLiveCookieFile reads cookies from a file. Supports:
+//   - a raw Cookie header value (one line or multiple lines joined)
+//   - Netscape cookie jar lines (tab-separated); name/value columns are used
+//   - comment lines starting with # (ignored)
+func readLiveCookieFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading cookie file %q: %w", path, err)
+	}
+	var parts []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if name, value, ok := parseNetscapeCookieLine(line); ok {
+			parts = append(parts, name+"="+value)
+			continue
+		}
+		parts = append(parts, line)
+	}
+	return joinCookieHeader(parts), nil
+}
+
+func parseNetscapeCookieLine(line string) (name, value string, ok bool) {
+	fields := strings.Split(line, "\t")
+	if len(fields) != 7 {
+		return "", "", false
+	}
+	name = strings.TrimSpace(fields[5])
+	value = strings.TrimSpace(fields[6])
+	if name == "" {
+		return "", "", false
+	}
+	return name, value, true
+}

--- a/cmd/crit/live_cookie_test.go
+++ b/cmd/crit/live_cookie_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveLiveCookies_FlagsOnly(t *testing.T) {
+	got, err := resolveLiveCookies([]string{"session=abc", "other=def"}, "", Config{}, "")
+	if err != nil {
+		t.Fatalf("resolveLiveCookies: %v", err)
+	}
+	want := "session=abc; other=def"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveLiveCookies_ConfigAndFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cookies.txt")
+	if err := os.WriteFile(path, []byte("from_file=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{LiveCookie: "from_cfg=1", LiveCookieFile: path}
+	got, err := resolveLiveCookies([]string{"from_flag=1"}, "", cfg, dir)
+	if err != nil {
+		t.Fatalf("resolveLiveCookies: %v", err)
+	}
+	want := "from_flag=1; from_cfg=1; from_file=1"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveLiveCookies_FlagFileOverridesConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	flagPath := filepath.Join(dir, "flag.txt")
+	cfgPath := filepath.Join(dir, "cfg.txt")
+	if err := os.WriteFile(flagPath, []byte("flag_file=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("cfg_file=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveLiveCookies(nil, flagPath, Config{LiveCookieFile: cfgPath}, dir)
+	if err != nil {
+		t.Fatalf("resolveLiveCookies: %v", err)
+	}
+	want := "flag_file=1"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadLiveCookieFile_Netscape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jar.txt")
+	content := "# Netscape HTTP Cookie File\n" +
+		".example.com\tTRUE\t/\tFALSE\t0\tsession\tabc123\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readLiveCookieFile(path)
+	if err != nil {
+		t.Fatalf("readLiveCookieFile: %v", err)
+	}
+	if got != "session=abc123" {
+		t.Fatalf("got %q, want session=abc123", got)
+	}
+}
+
+func TestResolveLiveCookies_ProjectRelativeCookieFile(t *testing.T) {
+	dir := t.TempDir()
+	cookiePath := filepath.Join(dir, ".crit", "live-cookies.txt")
+	if err := os.MkdirAll(filepath.Dir(cookiePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cookiePath, []byte("session=from_project\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{LiveCookieFile: ".crit/live-cookies.txt"}
+	got, err := resolveLiveCookies(nil, "", cfg, dir)
+	if err != nil {
+		t.Fatalf("resolveLiveCookies: %v", err)
+	}
+	if got != "session=from_project" {
+		t.Fatalf("got %q, want session=from_project", got)
+	}
+}
+
+func TestParseServerFlags_LiveCookie(t *testing.T) {
+	f := parseServerFlags([]string{"--live-origin", "http://localhost:3000", "--live-cookie", "session=abc"})
+	if f.liveCookie != "session=abc" {
+		t.Fatalf("liveCookie = %q, want session=abc", f.liveCookie)
+	}
+}

--- a/cmd/crit/live_cookie_test.go
+++ b/cmd/crit/live_cookie_test.go
@@ -99,9 +99,10 @@ func TestParseServerFlags_LiveCookie(t *testing.T) {
 
 func TestResolveCookieFilePath(t *testing.T) {
 	t.Run("absolute unchanged", func(t *testing.T) {
-		got := resolveCookieFilePath("/etc/cookies.txt", "/repo")
-		if got != "/etc/cookies.txt" {
-			t.Fatalf("got %q", got)
+		abs := filepath.Join(t.TempDir(), "cookies.txt")
+		got := resolveCookieFilePath(abs, filepath.Join(t.TempDir(), "repo"))
+		if got != abs {
+			t.Fatalf("got %q, want %q", got, abs)
 		}
 	})
 	t.Run("relative joins config dir", func(t *testing.T) {

--- a/cmd/crit/live_cookie_test.go
+++ b/cmd/crit/live_cookie_test.go
@@ -96,3 +96,82 @@ func TestParseServerFlags_LiveCookie(t *testing.T) {
 		t.Fatalf("liveCookie = %q, want session=abc", f.liveCookie)
 	}
 }
+
+func TestResolveCookieFilePath(t *testing.T) {
+	t.Run("absolute unchanged", func(t *testing.T) {
+		got := resolveCookieFilePath("/etc/cookies.txt", "/repo")
+		if got != "/etc/cookies.txt" {
+			t.Fatalf("got %q", got)
+		}
+	})
+	t.Run("relative joins config dir", func(t *testing.T) {
+		got := resolveCookieFilePath(".crit/live-cookies.txt", "/repo")
+		want := filepath.Join("/repo", ".crit/live-cookies.txt")
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("empty config dir leaves relative", func(t *testing.T) {
+		got := resolveCookieFilePath("cookies.txt", "")
+		if got != "cookies.txt" {
+			t.Fatalf("got %q", got)
+		}
+	})
+}
+
+func TestJoinCookieHeader_SkipsEmptyParts(t *testing.T) {
+	got := joinCookieHeader([]string{" a=1 ", "", "  ", "b=2"})
+	if got != "a=1; b=2" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReadLiveCookieFile_Missing(t *testing.T) {
+	_, err := readLiveCookieFile(filepath.Join(t.TempDir(), "nope.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadLiveCookieFile_RawMultiLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cookies.txt")
+	if err := os.WriteFile(path, []byte("a=1\nb=2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readLiveCookieFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "a=1; b=2" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParseNetscapeCookieLine_Invalid(t *testing.T) {
+	if _, _, ok := parseNetscapeCookieLine("not-a-jar-line"); ok {
+		t.Fatal("expected false for non-netscape line")
+	}
+	if _, _, ok := parseNetscapeCookieLine("a\tb\tc\td\te\t\tvalue"); ok {
+		t.Fatal("expected false when cookie name empty")
+	}
+}
+
+func TestStringSliceFlag_SetAndString(t *testing.T) {
+	var f stringSliceFlag
+	if err := f.Set("a=1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Set("b=2"); err != nil {
+		t.Fatal(err)
+	}
+	if f.String() != "a=1; b=2" {
+		t.Fatalf("String() = %q", f.String())
+	}
+}
+
+func TestResolveLiveCookies_MissingFile(t *testing.T) {
+	_, err := resolveLiveCookies(nil, filepath.Join(t.TempDir(), "missing.txt"), Config{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/crit/live_test.go
+++ b/cmd/crit/live_test.go
@@ -153,7 +153,7 @@ func TestLooksLikeLiveArgs(t *testing.T) {
 }
 
 func TestSmokeTest_ConnectionRefused(t *testing.T) {
-	r := runSmokeTest("http://127.0.0.1:19999")
+	r := runSmokeTest("http://127.0.0.1:19999", "")
 	if r.kind != smokeConnRefused {
 		t.Errorf("kind = %v, want smokeConnRefused", r.kind)
 	}
@@ -167,7 +167,7 @@ func TestSmokeTest_Non2xx(t *testing.T) {
 		http.Error(w, "auth required", http.StatusUnauthorized)
 	}))
 	defer srv.Close()
-	r := runSmokeTest(srv.URL)
+	r := runSmokeTest(srv.URL, "")
 	if r.kind != smokeNon2xx {
 		t.Errorf("kind = %v, want smokeNon2xx", r.kind)
 	}
@@ -182,7 +182,7 @@ func TestSmokeTest_NonHTML(t *testing.T) {
 		fmt.Fprintln(w, `{"ok":true}`)
 	}))
 	defer srv.Close()
-	r := runSmokeTest(srv.URL)
+	r := runSmokeTest(srv.URL, "")
 	if r.kind != smokeNonHTML {
 		t.Errorf("kind = %v, want smokeNonHTML", r.kind)
 	}
@@ -197,7 +197,7 @@ func TestSmokeTest_MissingBodyTag(t *testing.T) {
 		fmt.Fprintln(w, "<html><head></head><!-- no closing body -->")
 	}))
 	defer srv.Close()
-	r := runSmokeTest(srv.URL)
+	r := runSmokeTest(srv.URL, "")
 	if r.kind != smokeMissingBody {
 		t.Errorf("kind = %v, want smokeMissingBody", r.kind)
 	}
@@ -212,7 +212,7 @@ func TestSmokeTest_OK(t *testing.T) {
 		fmt.Fprintln(w, "<html><body><p>hello</p></body></html>")
 	}))
 	defer srv.Close()
-	r := runSmokeTest(srv.URL)
+	r := runSmokeTest(srv.URL, "")
 	if r.kind != smokeOK {
 		t.Errorf("kind = %v, want smokeOK", r.kind)
 	}
@@ -228,7 +228,7 @@ func TestSmokeTest_CSPFrameAncestors_Informational(t *testing.T) {
 		fmt.Fprintln(w, "<html><body>app</body></html>")
 	}))
 	defer srv.Close()
-	r := runSmokeTest(srv.URL)
+	r := runSmokeTest(srv.URL, "")
 	if r.kind != smokeOK {
 		t.Errorf("kind = %v, want smokeOK (CSP stripped by proxy)", r.kind)
 	}
@@ -426,7 +426,7 @@ func TestCreateLiveSession_EmptyOriginIsFatal(t *testing.T) {
 }
 
 func TestRunLive_SmokeFailFatal(t *testing.T) {
-	result := runSmokeTest("http://127.0.0.1:19999")
+	result := runSmokeTest("http://127.0.0.1:19999", "")
 	if !result.fatal {
 		t.Error("conn refused must be fatal")
 	}

--- a/cmd/crit/live_test.go
+++ b/cmd/crit/live_test.go
@@ -435,6 +435,133 @@ func TestRunLive_SmokeFailFatal(t *testing.T) {
 	}
 }
 
+func TestParseLiveCLIFlags(t *testing.T) {
+	f := parseLiveCLIFlags([]string{
+		"-p", "8080",
+		"--host", "0.0.0.0",
+		"--no-open",
+		"-q",
+		"--share-url", "https://share.example",
+		"--cookie", "a=1",
+		"--cookie", "b=2",
+		"--cookie-file", "/tmp/jar.txt",
+		"https://example.com/app?q=1#frag",
+	})
+	if f.origin != "https://example.com/app" {
+		t.Fatalf("origin = %q", f.origin)
+	}
+	if f.port != 8080 || f.host != "0.0.0.0" || !f.noOpen || !f.quiet {
+		t.Fatalf("flags = %+v", f)
+	}
+	if f.shareURL != "https://share.example" || f.cookieFile != "/tmp/jar.txt" {
+		t.Fatalf("share/cookie file = %+v", f)
+	}
+	if len(f.cookieFlags) != 2 || f.cookieFlags[0] != "a=1" || f.cookieFlags[1] != "b=2" {
+		t.Fatalf("cookieFlags = %v", f.cookieFlags)
+	}
+}
+
+func TestBuildLiveDaemonArgs(t *testing.T) {
+	f := liveCLIFlags{port: 9000, host: "127.0.0.1", quiet: true}
+	cfg := Config{Port: 3000, Quiet: false}
+
+	withCookie := buildLiveDaemonArgs("http://localhost:3000/dashboard", "sess=abc", f, cfg, true)
+	if !containsArgPair(withCookie, "--live-origin", "http://localhost:3000/dashboard") {
+		t.Fatalf("missing live-origin: %v", withCookie)
+	}
+	if !containsArgPair(withCookie, "--live-cookie", "sess=abc") {
+		t.Fatalf("missing live-cookie: %v", withCookie)
+	}
+	if !containsArgPair(withCookie, "--port", "9000") {
+		t.Fatalf("missing port: %v", withCookie)
+	}
+	if !containsArgPair(withCookie, "--no-open", "") {
+		t.Fatalf("missing no-open: %v", withCookie)
+	}
+	if !containsArgPair(withCookie, "--quiet", "") {
+		t.Fatalf("missing quiet: %v", withCookie)
+	}
+
+	withoutCookie := buildLiveDaemonArgs("http://localhost:3000", "", f, cfg, false)
+	for i, a := range withoutCookie {
+		if a == "--live-cookie" {
+			t.Fatalf("unexpected --live-cookie at %d in %v", i, withoutCookie)
+		}
+	}
+}
+
+func containsArgPair(args []string, key, want string) bool {
+	for i := 0; i < len(args); i++ {
+		if args[i] != key {
+			continue
+		}
+		if want == "" {
+			return true
+		}
+		if i+1 < len(args) && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRunSmokeTest_WithCookies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Cookie") != "session=abc" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer srv.Close()
+
+	result := runSmokeTest(srv.URL, "session=abc")
+	if result.fatal {
+		t.Fatalf("unexpected fatal: %+v", result)
+	}
+	if result.kind != smokeOK {
+		t.Fatalf("kind = %v, want smokeOK", result.kind)
+	}
+}
+
+func TestRunSmokeTest_WithCookies_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	result := runSmokeTest(srv.URL, "wrong=1")
+	if result.kind != smokeNon2xx {
+		t.Fatalf("kind = %v, want smokeNon2xx", result.kind)
+	}
+	if result.fatal {
+		t.Fatal("non-2xx should warn, not fatal")
+	}
+}
+
+func TestCheckLiveSmoke_WarnsOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, "<html><body>nope</body></html>")
+	}))
+	defer srv.Close()
+
+	checkLiveSmoke(srv.URL, "")
+}
+
+func TestCheckLiveSmoke_NotesFrameworkAndCSP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'")
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, `<html><head></head><body id="__next">ok</body></html>`)
+	}))
+	defer srv.Close()
+
+	checkLiveSmoke(srv.URL, "")
+}
+
 func TestRunLive_OriginNormalisedToSchemeHost(t *testing.T) {
 	u, _ := url.Parse("https://myapp.test:4000/dashboard?q=1")
 	origin := u.Scheme + "://" + u.Host

--- a/cmd/crit/proxy.go
+++ b/cmd/crit/proxy.go
@@ -21,7 +21,7 @@ import (
 // upstreamOrigin is the target URL, optionally including a path prefix
 // (e.g. "http://localhost:3000" or "http://localhost:3333/live.html").
 // apiPort is the API server's port, used to construct the agent script URL.
-func newLiveProxy(upstreamOrigin string, apiPort int) (http.Handler, error) {
+func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (http.Handler, error) {
 	target, err := url.Parse(upstreamOrigin)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream origin %q: %w", upstreamOrigin, err)
@@ -48,6 +48,9 @@ func newLiveProxy(upstreamOrigin string, apiPort int) (http.Handler, error) {
 			req.Header.Del("Accept-Encoding")
 			req.Header.Del("If-None-Match")
 			req.Header.Del("If-Modified-Since")
+			if upstreamCookies != "" {
+				req.Header.Set("Cookie", upstreamCookies)
+			}
 			if req.Header.Get("Origin") != "" {
 				req.Header.Set("Origin", target.Scheme+"://"+target.Host)
 			}
@@ -347,13 +350,13 @@ func rewriteCookies(resp *http.Response) {
 // bindProxyServer creates a TCP listener on 127.0.0.1:(apiPort+1) and
 // returns (listener, *http.Server, error). The server is not yet started;
 // caller calls srv.Serve(ln).
-func bindProxyServer(upstreamOrigin string, apiPort int) (net.Listener, *http.Server, error) {
+func bindProxyServer(upstreamOrigin string, apiPort int, upstreamCookies string) (net.Listener, *http.Server, error) {
 	proxyPort := apiPort + 1
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
 	if err != nil {
 		return nil, nil, fmt.Errorf("proxy port %d already in use: %w", proxyPort, err)
 	}
-	handler, err := newLiveProxy(upstreamOrigin, apiPort)
+	handler, err := newLiveProxy(upstreamOrigin, apiPort, upstreamCookies)
 	if err != nil {
 		ln.Close()
 		return nil, nil, err

--- a/cmd/crit/proxy_test.go
+++ b/cmd/crit/proxy_test.go
@@ -23,7 +23,7 @@ func TestProxyDirector_StripsAcceptEncoding(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 
@@ -39,6 +39,31 @@ func TestProxyDirector_StripsAcceptEncoding(t *testing.T) {
 	}
 }
 
+func TestProxyDirector_InjectsConfiguredCookies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Cookie") != "session=abc" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "session=abc")
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+
+	resp, err := http.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d; configured cookie was not injected", resp.StatusCode)
+	}
+}
+
 func TestProxyDirector_PreservesCookieAndAuth(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Cookie") != "session=abc" || r.Header.Get("Authorization") != "Bearer tok" {
@@ -50,7 +75,7 @@ func TestProxyDirector_PreservesCookieAndAuth(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 
@@ -77,7 +102,7 @@ func TestProxyDirector_SetsUpstreamHost(t *testing.T) {
 	defer upstream.Close()
 	upstreamURL, _ := url.Parse(upstream.URL)
 
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 
@@ -99,7 +124,7 @@ func TestProxyModifyResponse_StripsSecurityHeaders(t *testing.T) {
 		fmt.Fprintln(w, "<html><body>app</body></html>")
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, _ := http.Get(ps.URL + "/")
@@ -123,7 +148,7 @@ func TestProxyModifyResponse_InjectsAgentBeforeBodyTag(t *testing.T) {
 		fmt.Fprintln(w, "<html><body><p>Hello</p></body></html>")
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 54321)
+	proxy, _ := newLiveProxy(upstream.URL, 54321, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -169,7 +194,7 @@ func TestProxyModifyResponse_InjectsAtLastBodyTag(t *testing.T) {
 		fmt.Fprintln(w, `<html><body><script>var s = "</body>";</script><p>Real content</p></body></html>`)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 54321)
+	proxy, _ := newLiveProxy(upstream.URL, 54321, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -204,7 +229,7 @@ func TestProxyModifyResponse_OversizedBodyPassesThrough(t *testing.T) {
 		w.Write(huge)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -223,7 +248,7 @@ func TestProxyModifyResponse_SkipsInjectionWhenNoBodyTag(t *testing.T) {
 		fmt.Fprintln(w, "<html><!-- no body tag -->")
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -250,7 +275,7 @@ func TestProxyModifyResponse_SameOriginRedirectRewritten(t *testing.T) {
 	}))
 	defer upstream.Close()
 	upURL, _ := url.Parse(upstream.URL)
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}}
@@ -272,7 +297,7 @@ func TestProxyModifyResponse_CrossOriginRedirect200Stub(t *testing.T) {
 		http.Redirect(w, r, "https://accounts.google.com/oauth", http.StatusFound)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}}
@@ -332,7 +357,7 @@ func TestProxyModifyResponse_CrossOriginRedirectStubEscaping(t *testing.T) {
 				w.WriteHeader(http.StatusFound)
 			}))
 			defer upstream.Close()
-			proxy, _ := newLiveProxy(upstream.URL, 9001)
+			proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 			client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			}}
@@ -366,7 +391,7 @@ func TestProxyModifyResponse_StripsCookieDomain(t *testing.T) {
 		fmt.Fprintln(w, "<html><body>ok</body></html>")
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, _ := http.Get(ps.URL + "/")
@@ -438,7 +463,7 @@ func TestProxyModifyResponse_RewritesCookieAttributes(t *testing.T) {
 				fmt.Fprintln(w, "<html><body>ok</body></html>")
 			}))
 			defer upstream.Close()
-			proxy, _ := newLiveProxy(upstream.URL, 9001)
+			proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 			ps := httptest.NewServer(proxy)
 			defer ps.Close()
 			resp, _ := http.Get(ps.URL + "/")
@@ -502,7 +527,7 @@ func TestProxyModifyResponse_SWShimInjectedInHTMLHead(t *testing.T) {
 		fmt.Fprintln(w, `<html><head><title>app</title></head><body><script>navigator.serviceWorker.register('/sw.js');</script></body></html>`)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -533,7 +558,7 @@ func TestProxyModifyResponse_JSResponsesPassThrough(t *testing.T) {
 		fmt.Fprint(w, js)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/app.js")
@@ -554,7 +579,7 @@ func TestProxyModifyResponse_NonHTMLPassedThrough(t *testing.T) {
 		fmt.Fprintln(w, `{"ok":true}`)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/api/data")
@@ -572,7 +597,7 @@ func TestProxyModifyResponse_NonHTMLPassedThrough(t *testing.T) {
 }
 
 func TestProxyErrorHandler_Returns502JSON(t *testing.T) {
-	proxy, _ := newLiveProxy("http://127.0.0.1:19998", 9001)
+	proxy, _ := newLiveProxy("http://127.0.0.1:19998", 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -606,7 +631,7 @@ func TestBindProxyServer_PortIsAPIPlusOne(t *testing.T) {
 		}
 		apiPort := apiLn.Addr().(*net.TCPAddr).Port
 
-		ln, srv, err := bindProxyServer("http://127.0.0.1:19997", apiPort)
+		ln, srv, err := bindProxyServer("http://127.0.0.1:19997", apiPort, "")
 		if err != nil {
 			apiLn.Close()
 			if attempt < maxAttempts-1 && strings.Contains(err.Error(), "already in use") {
@@ -645,7 +670,7 @@ func TestProxyModifyResponse_MidBodyReadFailureReturns502(t *testing.T) {
 		conn.Close()
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 
@@ -671,7 +696,7 @@ func TestProxyModifyResponse_HeadInsideHTMLComment(t *testing.T) {
 		fmt.Fprintln(w, `<!doctype html><!-- example: <head> --><html><head><title>x</title></head><body>hi</body></html>`)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -705,7 +730,7 @@ func TestProxyModifyResponse_BodyCloseInsideHTMLComment(t *testing.T) {
 		fmt.Fprintln(w, `<html><head></head><body><p>hi</p><!-- legacy </body> remnant --></body></html>`)
 	}))
 	defer upstream.Close()
-	proxy, _ := newLiveProxy(upstream.URL, 9001)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
 	resp, err := http.Get(ps.URL + "/")
@@ -749,7 +774,7 @@ func TestProxyModifyResponse_InjectsRouteAnnouncer(t *testing.T) {
 			}))
 			defer upstream.Close()
 
-			handler, err := newLiveProxy(upstream.URL, 4101)
+			handler, err := newLiveProxy(upstream.URL, 4101, "")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
## Summary

- Add `--cookie` and `--cookie-file` flags to `crit live` for forwarding upstream session cookies through the live proxy
- Add `live_cookie` and `live_cookie_file` config keys (global or project `.crit.config.json`; relative paths resolve from repo root)
- Inject configured cookies on every upstream proxy request and use them in the live smoke test

Closes #644

Follow-up: automatic browser session reuse via CDP tracked in #648.

## Review

- [x] Code review: passed (crit review round approved)
- [x] Parity audit: N/A (crit CLI only)

## Test plan

- [x] `go test ./cmd/crit/...`
- [x] Pre-commit hook (gofmt, golangci-lint, tests)
- [x] Manual smoke against local crit-web with `_crit_key` cookie forwarding


Made with [Cursor](https://cursor.com)