### PR TITLE
fix(windows): retry transient ENOENT during concurrent review reads

### DIFF
--- a/cmd/crit/atomic_windows.go
+++ b/cmd/crit/atomic_windows.go
@@ -26,7 +26,7 @@ func renameAtomic(src, dst string) error {
 		if err == nil {
 			return nil
 		}
-		if !isWindowsSharingViolation(err) {
+		if !isWindowsTransientIOErr(err) {
 			return err
 		}
 		time.Sleep(delay)
@@ -41,6 +41,9 @@ func renameAtomic(src, dst string) error {
 // While renameAtomic protects writers from short-lived readers, the inverse
 // race exists too: os.ReadFile fails with ERROR_SHARING_VIOLATION /
 // ERROR_LOCK_VIOLATION when a writer is mid-rename over the destination.
+// MoveFileEx with MOVEFILE_REPLACE_EXISTING can also briefly surface
+// ERROR_FILE_NOT_FOUND on the destination between delete-and-replace;
+// retry that the same way (see TestConcurrentSaveCritJSON_NoCorruption).
 // 10 attempts with 1→50ms backoff covers any realistic crit workload.
 func readFileShared(path string) ([]byte, error) {
 	const maxAttempts = 10
@@ -51,7 +54,7 @@ func readFileShared(path string) ([]byte, error) {
 	)
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		data, err = os.ReadFile(path)
-		if err == nil || !isWindowsSharingViolation(err) {
+		if err == nil || !isWindowsTransientIOErr(err) {
 			return data, err
 		}
 		time.Sleep(delay)
@@ -62,7 +65,12 @@ func readFileShared(path string) ([]byte, error) {
 	return data, err
 }
 
-func isWindowsSharingViolation(err error) bool {
+// isWindowsTransientIOErr reports Windows errors that can appear briefly
+// during concurrent rename/read of the same path and are worth retrying.
+func isWindowsTransientIOErr(err error) bool {
+	if os.IsNotExist(err) {
+		return true
+	}
 	var errno windows.Errno
 	if !errors.As(err, &errno) {
 		return false

--- a/cmd/crit/atomic_windows_test.go
+++ b/cmd/crit/atomic_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestIsWindowsTransientIOErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"not exist", os.ErrNotExist, true},
+		{"file not found", windows.Errno(windows.ERROR_FILE_NOT_FOUND), true},
+		{"sharing violation", windows.Errno(windows.ERROR_SHARING_VIOLATION), true},
+		{"lock violation", windows.Errno(windows.ERROR_LOCK_VIOLATION), true},
+		{"access denied", windows.Errno(windows.ERROR_ACCESS_DENIED), true},
+		{"other", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWindowsTransientIOErr(tc.err); got != tc.want {
+				t.Fatalf("isWindowsTransientIOErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Treat brief `ERROR_FILE_NOT_FOUND` / `os.ErrNotExist` as transient during Windows concurrent rename/read of `review.json`
- `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING` can momentarily leave the destination missing; `readFileShared` previously only retried sharing violations
- Add `atomic_windows_test.go` covering `isWindowsTransientIOErr` error classification

Fixes the `TestConcurrentSaveCritJSON_NoCorruption` flake seen on `unit-windows` in PR #647.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (Windows-only atomic I/O)

## Test plan
- [x] `gofmt`, `golangci-lint`, `go test -race -count=1 ./...`
- [x] `go test -race -count=20 -run TestConcurrentSaveCritJSON_NoCorruption` (local)
- [ ] `unit-windows` CI (validates fix on Windows runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)