### PR TITLE
fix: thread oldPath through scoped commit-range rename diffs

### DIFF
--- a/cmd/crit/session_focus.go
+++ b/cmd/crit/session_focus.go
@@ -799,35 +799,52 @@ func (s *Session) loadScopedFileState(path, scope, commit string) (status, conte
 			content = f.Content
 			s.mu.RUnlock()
 		}
-		return status, content, oldPath, baseRef, repoRoot
+		if commit == "" {
+			return status, content, oldPath, baseRef, repoRoot
+		}
 	}
 
 	if repoRoot == "" {
 		return status, content, oldPath, baseRef, repoRoot
 	}
-	absPath := filepath.Join(repoRoot, path)
-	if data, err := os.ReadFile(absPath); err == nil {
-		content = string(data)
-		if vcs != nil {
-			var changes []FileChange
-			var err error
-			if base, head, ok := splitCommitRange(commit); ok {
-				changes, err = vcs.ChangedFilesBetweenSHAs(base, head, repoRoot)
-			} else if commit != "" {
-				changes, err = vcs.ChangedFilesForCommit(commit, repoRoot)
-			} else {
-				changes, err = vcs.ChangedFilesScoped(scope, baseRef)
-			}
-			if err == nil {
-				for _, fc := range changes {
-					if fc.Path == path {
-						status = fc.Status
-						oldPath = fc.OldPath
-						break
-					}
+
+	lookupScopedStatus := func() {
+		if vcs == nil {
+			return
+		}
+		var changes []FileChange
+		var err error
+		if base, head, ok := splitCommitRange(commit); ok {
+			changes, err = vcs.ChangedFilesBetweenSHAs(base, head, repoRoot)
+		} else if commit != "" {
+			changes, err = vcs.ChangedFilesForCommit(commit, repoRoot)
+		} else {
+			changes, err = vcs.ChangedFilesScoped(scope, baseRef)
+		}
+		if err == nil {
+			for _, fc := range changes {
+				if fc.Path == path {
+					status = fc.Status
+					oldPath = fc.OldPath
+					break
 				}
 			}
 		}
+	}
+
+	if commit != "" {
+		lookupScopedStatus()
+		return status, content, oldPath, baseRef, repoRoot
+	}
+
+	if f != nil {
+		return status, content, oldPath, baseRef, repoRoot
+	}
+
+	absPath := filepath.Join(repoRoot, path)
+	if data, err := os.ReadFile(absPath); err == nil {
+		content = string(data)
+		lookupScopedStatus()
 	}
 	return status, content, oldPath, baseRef, repoRoot
 }

--- a/cmd/crit/session_focus.go
+++ b/cmd/crit/session_focus.go
@@ -626,19 +626,19 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	}
 }
 
-func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS) []DiffHunk {
+func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS, ignoreWhitespace bool) []DiffHunk {
 	if vcs == nil {
 		return nil
 	}
 	if base, head, ok := splitCommitRange(commit); ok {
-		h, err := vcs.FileDiffBetweenSHAs(fc.Path, fc.OldPath, base, head, repoRoot, false)
+		h, err := vcs.FileDiffBetweenSHAs(fc.Path, fc.OldPath, base, head, repoRoot, ignoreWhitespace)
 		if err == nil {
 			return h
 		}
 		return nil
 	}
 	if commit != "" {
-		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot, false)
+		h, err := vcs.FileDiffForCommit(fc.Path, commit, repoRoot, ignoreWhitespace)
 		if err == nil {
 			return h
 		}
@@ -652,13 +652,13 @@ func scopedHunks(fc FileChange, scope, commit, baseRef, repoRoot string, vcs VCS
 		return nil
 	}
 	if fc.Status == "renamed" && fc.OldPath != "" {
-		h, err := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, baseRef, repoRoot, false, vcs)
+		h, err := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, baseRef, repoRoot, ignoreWhitespace, vcs)
 		if err == nil {
 			return h
 		}
 		return nil
 	}
-	h, err := vcs.FileDiffScoped(fc.Path, scope, baseRef, repoRoot, false)
+	h, err := vcs.FileDiffScoped(fc.Path, scope, baseRef, repoRoot, ignoreWhitespace)
 	if err == nil {
 		return h
 	}
@@ -751,7 +751,7 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 			continue
 		}
 
-		hunks := scopedHunks(fc, scope, commit, snap.baseRef, snap.repoRoot, snap.vcs)
+		hunks := scopedHunks(fc, scope, commit, snap.baseRef, snap.repoRoot, snap.vcs, false)
 		fi.Additions, fi.Deletions = countHunkStats(hunks)
 		info.Files = append(info.Files, fi)
 	}
@@ -781,7 +781,7 @@ func (snap *scopedSessionSnapshot) hiddenUnresolved(scopeFiles []SessionFileInfo
 }
 
 // loadScopedFileState reads file state from the session or disk for scoped diff queries.
-func (s *Session) loadScopedFileState(path, scope string) (status, content, baseRef, repoRoot string) {
+func (s *Session) loadScopedFileState(path, scope, commit string) (status, content, oldPath, baseRef, repoRoot string) {
 	s.mu.RLock()
 	f := s.fileByPathLocked(path)
 	baseRef = s.BaseRef
@@ -789,6 +789,7 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 	vcs := s.VCS
 	if f != nil {
 		status = f.Status
+		oldPath = f.OldPath
 	}
 	s.mu.RUnlock()
 
@@ -798,30 +799,40 @@ func (s *Session) loadScopedFileState(path, scope string) (status, content, base
 			content = f.Content
 			s.mu.RUnlock()
 		}
-		return status, content, baseRef, repoRoot
+		return status, content, oldPath, baseRef, repoRoot
 	}
 
 	if repoRoot == "" {
-		return status, content, baseRef, repoRoot
+		return status, content, oldPath, baseRef, repoRoot
 	}
 	absPath := filepath.Join(repoRoot, path)
 	if data, err := os.ReadFile(absPath); err == nil {
 		content = string(data)
 		if vcs != nil {
-			if changes, err := vcs.ChangedFilesScoped(scope, baseRef); err == nil {
+			var changes []FileChange
+			var err error
+			if base, head, ok := splitCommitRange(commit); ok {
+				changes, err = vcs.ChangedFilesBetweenSHAs(base, head, repoRoot)
+			} else if commit != "" {
+				changes, err = vcs.ChangedFilesForCommit(commit, repoRoot)
+			} else {
+				changes, err = vcs.ChangedFilesScoped(scope, baseRef)
+			}
+			if err == nil {
 				for _, fc := range changes {
 					if fc.Path == path {
 						status = fc.Status
+						oldPath = fc.OldPath
 						break
 					}
 				}
 			}
 		}
 	}
-	return status, content, baseRef, repoRoot
+	return status, content, oldPath, baseRef, repoRoot
 }
 
-func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot string, vcs VCS, ignoreWhitespace bool) []DiffHunk {
+func computeScopedDiffHunks(path, scope, commit, status, oldPath, content, baseRef, repoRoot string, vcs VCS, ignoreWhitespace bool) []DiffHunk {
 	// Pure content-based diffs don't need VCS.
 	if status == "untracked" && (scope == "unstaged" || scope == "all" || scope == "") {
 		return FileDiffUnifiedNewFile(content)
@@ -829,28 +840,7 @@ func computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoR
 	if status == "added" && scope != "unstaged" {
 		return FileDiffUnifiedNewFile(content)
 	}
-	if vcs == nil {
-		return nil
-	}
-	if base, head, ok := splitCommitRange(commit); ok {
-		h, err := vcs.FileDiffBetweenSHAs(path, "", base, head, repoRoot, ignoreWhitespace)
-		if err == nil {
-			return h
-		}
-		return nil
-	}
-	if commit != "" {
-		h, err := vcs.FileDiffForCommit(path, commit, repoRoot, ignoreWhitespace)
-		if err == nil {
-			return h
-		}
-		return nil
-	}
-	h, err := vcs.FileDiffScoped(path, scope, baseRef, repoRoot, ignoreWhitespace)
-	if err == nil {
-		return h
-	}
-	return nil
+	return scopedHunks(FileChange{Path: path, OldPath: oldPath, Status: status}, scope, commit, baseRef, repoRoot, vcs, ignoreWhitespace)
 }
 
 // GetFileDiffSnapshotScoped returns diff data for a file filtered by scope.
@@ -862,13 +852,13 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string, ignoreWh
 		return s.GetFileDiffSnapshot(path, ignoreWhitespace)
 	}
 
-	status, content, baseRef, repoRoot := s.loadScopedFileState(path, scope)
+	status, content, oldPath, baseRef, repoRoot := s.loadScopedFileState(path, scope, commit)
 
 	s.mu.RLock()
 	vcs := s.VCS
 	s.mu.RUnlock()
 
-	hunks := computeScopedDiffHunks(path, scope, commit, status, content, baseRef, repoRoot, vcs, ignoreWhitespace)
+	hunks := computeScopedDiffHunks(path, scope, commit, status, oldPath, content, baseRef, repoRoot, vcs, ignoreWhitespace)
 	if hunks == nil {
 		hunks = []DiffHunk{}
 	}

--- a/cmd/crit/session_test.go
+++ b/cmd/crit/session_test.go
@@ -5031,6 +5031,43 @@ func TestGetFileDiffSnapshotScoped_CommitRangeRename(t *testing.T) {
 	}
 }
 
+func TestGetFileDiffSnapshotScoped_CommitRangeRename_PreloadedFile(t *testing.T) {
+	dir := initTestRepo(t)
+	commitAt(t, dir, "old.go", "package x\n", "add old")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "mv", "old.go", "new.go")
+	gitT(t, dir, "commit", "-m", "rename")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// Session file preloaded without OldPath (common merge-base working-tree path).
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{{
+			Path:    "new.go",
+			Status:  "modified",
+			Content: "package x\n",
+		}},
+	}
+
+	result, ok := s.GetFileDiffSnapshotScoped("new.go", "branch", base+".."+head, false)
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+	hunks, _ := result["hunks"].([]DiffHunk)
+	if len(hunks) != 0 {
+		t.Fatalf("preloaded file without OldPath: got %d hunks, want 0 for rename-only", len(hunks))
+	}
+}
+
 // --- scopedHunks tests ---
 
 func TestScopedHunks_NilVCS(t *testing.T) {

--- a/cmd/crit/session_test.go
+++ b/cmd/crit/session_test.go
@@ -4950,14 +4950,14 @@ func TestFilterDeletedReviewComments_SomeDeleted(t *testing.T) {
 // --- computeScopedDiffHunks tests ---
 
 func TestComputeScopedDiffHunks_UntrackedFile(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "untracked", "package main\n", "", "", nil, false)
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "untracked", "", "package main\n", "", "", nil, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for untracked file")
 	}
 }
 
 func TestComputeScopedDiffHunks_AddedFileAllScope(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "all", "", "added", "package main\n", "", "", nil, false)
+	hunks := computeScopedDiffHunks("test.go", "all", "", "added", "", "package main\n", "", "", nil, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for added file with all scope")
 	}
@@ -4965,7 +4965,7 @@ func TestComputeScopedDiffHunks_AddedFileAllScope(t *testing.T) {
 
 func TestComputeScopedDiffHunks_AddedFileUnstagedScope(t *testing.T) {
 	// scope=unstaged + status=added => does not use FileDiffUnifiedNewFile
-	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "added", "package main\n", "", "", nil, false)
+	hunks := computeScopedDiffHunks("test.go", "unstaged", "", "added", "", "package main\n", "", "", nil, false)
 	// No VCS to fall back on, should return nil.
 	if hunks != nil {
 		t.Error("expected nil hunks for added file with unstaged scope and no VCS")
@@ -4973,9 +4973,61 @@ func TestComputeScopedDiffHunks_AddedFileUnstagedScope(t *testing.T) {
 }
 
 func TestComputeScopedDiffHunks_NilVCS(t *testing.T) {
-	hunks := computeScopedDiffHunks("test.go", "branch", "", "modified", "package main\n", "main", "/tmp", nil, false)
+	hunks := computeScopedDiffHunks("test.go", "branch", "", "modified", "", "package main\n", "main", "/tmp", nil, false)
 	if hunks != nil {
 		t.Error("expected nil hunks with no VCS")
+	}
+}
+
+func TestComputeScopedDiffHunks_CommitRangeRename(t *testing.T) {
+	dir := initTestRepo(t)
+	commitAt(t, dir, "old.go", "package x\n", "add old")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "mv", "old.go", "new.go")
+	gitT(t, dir, "commit", "-m", "rename")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+	commit := base + ".." + head
+
+	hunks := computeScopedDiffHunks("new.go", "branch", commit, "renamed", "old.go", "package x\n", "", dir, &GitVCS{}, false)
+	if len(hunks) != 0 {
+		t.Fatalf("rename-only diff with oldPath: got %d hunks, want 0", len(hunks))
+	}
+	// Without oldPath git treats the new path as an added file.
+	wrong := computeScopedDiffHunks("new.go", "branch", commit, "renamed", "", "package x\n", "", dir, &GitVCS{}, false)
+	if len(wrong) == 0 {
+		t.Fatal("without oldPath, expected spurious add hunks for rename")
+	}
+}
+
+func TestGetFileDiffSnapshotScoped_CommitRangeRename(t *testing.T) {
+	dir := initTestRepo(t)
+	commitAt(t, dir, "old.go", "package x\n", "add old")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "mv", "old.go", "new.go")
+	gitT(t, dir, "commit", "-m", "rename")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     "main",
+		VCS:         &GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files:       []*FileEntry{},
+	}
+
+	result, ok := s.GetFileDiffSnapshotScoped("new.go", "branch", base+".."+head, false)
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+	hunks, _ := result["hunks"].([]DiffHunk)
+	if len(hunks) != 0 {
+		t.Fatalf("rename-only diff: got %d hunks, want 0", len(hunks))
 	}
 }
 
@@ -4983,7 +5035,7 @@ func TestComputeScopedDiffHunks_NilVCS(t *testing.T) {
 
 func TestScopedHunks_NilVCS(t *testing.T) {
 	fc := FileChange{Path: "test.go", Status: "modified"}
-	hunks := scopedHunks(fc, "branch", "", "main", "/tmp", nil)
+	hunks := scopedHunks(fc, "branch", "", "main", "/tmp", nil, false)
 	if hunks != nil {
 		t.Error("expected nil hunks with nil VCS")
 	}
@@ -4999,7 +5051,7 @@ func TestScopedHunks_AddedFile(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	fc := FileChange{Path: "new.go", Status: "added"}
-	hunks := scopedHunks(fc, "branch", "", "main", dir, &GitVCS{})
+	hunks := scopedHunks(fc, "branch", "", "main", dir, &GitVCS{}, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for added file showing full content")
 	}
@@ -5014,7 +5066,7 @@ func TestScopedHunks_UntrackedFile(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	fc := FileChange{Path: "untracked.go", Status: "untracked"}
-	hunks := scopedHunks(fc, "all", "", "", dir, &GitVCS{})
+	hunks := scopedHunks(fc, "all", "", "", dir, &GitVCS{}, false)
 	if len(hunks) == 0 {
 		t.Error("expected hunks for untracked file")
 	}


### PR DESCRIPTION
## Summary
- Fix GetFileDiffSnapshotScoped showing spurious full-file adds for rename-only commits in commit ranges
- Thread OldPath through loadScopedFileState; resolve from VCS even for preloaded session files
- Delegate VCS diff work to scopedHunks with ignoreWhitespace support

## Review
- [x] Code review: passed (after preloaded-file fix)
- [x] Parity audit: N/A (Go backend only)

## Test plan
- [x] go vet, golangci-lint, go test ./...
- [x] TestComputeScopedDiffHunks_CommitRangeRename
- [x] TestGetFileDiffSnapshotScoped_CommitRangeRename + PreloadedFile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)