### PR TITLE
chore: bump Nix flake version to v0.16.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      version = "0.16.1";
+      version = "0.16.2";
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in rec {


### PR DESCRIPTION
Release prep: bump flake.nix version to v0.16.2 before tagging.


Made with [Cursor](https://cursor.com)