### PR TITLE
fix(pr): diff PRs from the merge-base, not the base-branch tip

### DIFF
--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -172,12 +172,24 @@ func resolveFocusFromPR(prSpec string, scope DiffScope, remoteFiles bool, v vcs.
 		return nil, fmt.Errorf("--scope=full-stack requires a resolvable default branch tip; got none for %q (detached HEAD or no remote?)", defaultBranch)
 	}
 
+	// GitHub renders a PR as base...head (three-dot, from the merge-base).
+	// Using info.BaseRefOid directly would diff base..head (two-dot), folding
+	// in any commits that landed on the base branch since this branch diverged
+	// — surfacing files that aren't part of the PR. Pin the layer diff base to
+	// the merge-base so the diff matches GitHub regardless of rebase state.
+	baseSHA := info.BaseRefOid
+	if v != nil {
+		if mb, err := v.MergeBaseOf(info.BaseRefOid, info.HeadRefOid, repoRoot); err == nil && mb != "" {
+			baseSHA = mb
+		}
+	}
+
 	return &Focus{
 		Kind:        FocusRange,
 		PRNumber:    info.Number,
 		PRURL:       info.URL,
 		Label:       fmt.Sprintf("PR #%d: %s", info.Number, info.Title),
-		BaseSHA:     info.BaseRefOid,
+		BaseSHA:     baseSHA,
 		HeadSHA:     info.HeadRefOid,
 		DefaultSHA:  defaultSHA,
 		ForkURL:     forkURL,

--- a/internal/focus/focus_pr_mergebase_test.go
+++ b/internal/focus/focus_pr_mergebase_test.go
@@ -1,0 +1,62 @@
+package focus
+
+import (
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
+)
+
+// TestResolveFocusFromPR_UsesMergeBaseNotBaseTip is the regression guard for the
+// reported bug: `crit --pr` on a branch that isn't rebased onto its base must
+// diff from the merge-base (matching GitHub's base...head), not from the base
+// branch tip (which folds in unrelated base-branch drift as spurious changes).
+func TestResolveFocusFromPR_UsesMergeBaseNotBaseTip(t *testing.T) {
+	vcs.ClearGitEnvForTest(t) // robust under git hooks that export GIT_DIR
+
+	prevFetch := FetchPRByNumberHook
+	prevStack := IsStackedPRHook
+	t.Cleanup(func() {
+		FetchPRByNumberHook = prevFetch
+		IsStackedPRHook = prevStack
+	})
+
+	// Drifted repo: the base branch advances past the PR's fork point.
+	//   main:    C0 ── C1(forkpoint) ── M1(drift, base tip)
+	//                     └── F1(PR head)
+	dir := vcs.InitTestRepo(t)
+	forkpoint := vcs.CommitAtForTest(t, dir, "base.txt", "base\n", "forkpoint")
+	vcs.GitRun(t, dir, "checkout", "-b", "feature")
+	prHead := vcs.CommitAtForTest(t, dir, "feature.txt", "feat\n", "pr work")
+	vcs.GitRun(t, dir, "checkout", "main")
+	baseTip := vcs.CommitAtForTest(t, dir, "drift.txt", "drift\n", "base branch drift")
+
+	FetchPRByNumberHook = func(int) (PRResolveInfo, error) {
+		return PRResolveInfo{
+			Number:      7,
+			Title:       "drifted PR",
+			URL:         "https://github.com/o/r/pull/7",
+			BaseRefName: "main",
+			HeadRefName: "feature",
+			BaseRefOid:  baseTip, // GitHub reports the base branch TIP
+			HeadRefOid:  prHead,
+		}, nil
+	}
+	IsStackedPRHook = func(PRResolveInfo, vcs.VCS) bool { return false }
+
+	// remoteFiles=true skips EnsureSHAFetched; all objects already exist locally,
+	// so the merge-base is computed against the real repo.
+	f, err := ResolveFocus("7", "", "", true, &vcs.GitVCS{}, dir)
+	if err != nil {
+		t.Fatalf("ResolveFocus: %v", err)
+	}
+	if f == nil {
+		t.Fatal("ResolveFocus returned nil focus")
+	}
+	if f.BaseSHA != forkpoint {
+		t.Errorf("Focus.BaseSHA = %s, want merge-base %s; base tip %s would reintroduce the bug",
+			f.BaseSHA, forkpoint, baseTip)
+	}
+	if f.HeadSHA != prHead {
+		t.Errorf("Focus.HeadSHA = %s, want %s", f.HeadSHA, prHead)
+	}
+}

--- a/internal/vcs/fetch_sha_test.go
+++ b/internal/vcs/fetch_sha_test.go
@@ -20,13 +20,14 @@ func (f *fakeFetchVCS) HasObject(_, _ string) bool {
 	}
 	return false
 }
-func (f *fakeFetchVCS) RepoRoot() (string, error)        { return "", nil }
-func (f *fakeFetchVCS) CurrentBranch() string            { return "main" }
-func (f *fakeFetchVCS) DefaultBranch() string            { return "main" }
-func (f *fakeFetchVCS) SetDefaultBranchOverride(string)  {}
-func (f *fakeFetchVCS) GetDefaultBranchOverride() string { return "" }
-func (f *fakeFetchVCS) DefaultBaseRef() string           { return "main" }
-func (f *fakeFetchVCS) MergeBase(string) (string, error) { return "", nil }
+func (f *fakeFetchVCS) RepoRoot() (string, error)                  { return "", nil }
+func (f *fakeFetchVCS) CurrentBranch() string                      { return "main" }
+func (f *fakeFetchVCS) DefaultBranch() string                      { return "main" }
+func (f *fakeFetchVCS) SetDefaultBranchOverride(string)            {}
+func (f *fakeFetchVCS) GetDefaultBranchOverride() string           { return "" }
+func (f *fakeFetchVCS) DefaultBaseRef() string                     { return "main" }
+func (f *fakeFetchVCS) MergeBase(string) (string, error)           { return "", nil }
+func (f *fakeFetchVCS) MergeBaseOf(_, _, _ string) (string, error) { return "", nil }
 func (f *fakeFetchVCS) ChangedFilesOnDefaultInDir(string) ([]FileChange, error) {
 	return nil, nil
 }

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -240,6 +240,17 @@ func MergeBase(base string) (string, error) {
 	return "", fmt.Errorf("merge-base failed: %w", err)
 }
 
+// MergeBaseOf returns the merge base of two arbitrary commits, run in dir.
+// Neither side is pinned to HEAD (unlike MergeBase), so it can compute a PR's
+// base as merge-base(base, head).
+func MergeBaseOf(a, b, dir string) (string, error) {
+	out, err := runGit(context.Background(), dir, "merge-base", a, b)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // fileContentAtRef returns the content of a file at the given git ref.
 // Returns empty string on any error (file doesn't exist at ref, not a git repo, etc.).
 func FileContentAtRef(path, ref, dir string) string {

--- a/internal/vcs/git_vcs.go
+++ b/internal/vcs/git_vcs.go
@@ -25,6 +25,8 @@ func (g *GitVCS) GetDefaultBranchOverride() string { return getDefaultBranchOver
 
 func (g *GitVCS) MergeBase(ref string) (string, error) { return MergeBase(ref) }
 
+func (g *GitVCS) MergeBaseOf(a, b, dir string) (string, error) { return MergeBaseOf(a, b, dir) }
+
 func (g *GitVCS) DefaultBaseRef() string { return DefaultBaseRef() }
 
 func (g *GitVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {

--- a/internal/vcs/jj.go
+++ b/internal/vcs/jj.go
@@ -134,6 +134,13 @@ func (j *JJVCS) MergeBase(ref string) (string, error) {
 	return JJMergeBase("", "@", base)
 }
 
+// MergeBaseOf returns the merge-base of two arbitrary revisions (neither pinned
+// to @). Delegates to JJMergeBase, which resolves both sides and intersects
+// their ancestor sets — symmetric, so argument order does not matter.
+func (j *JJVCS) MergeBaseOf(a, b, dir string) (string, error) {
+	return JJMergeBase(dir, a, b)
+}
+
 func (j *JJVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
 	out, err := JJCommandInDir(dir, "diff", "--summary", "-r", "@")
 	if err != nil {

--- a/internal/vcs/jj_detect_test.go
+++ b/internal/vcs/jj_detect_test.go
@@ -98,15 +98,16 @@ func TestEnsureSHAFetchedJJ_PureJJErrorMessages(t *testing.T) {
 // returns zero values to satisfy the interface without doing any real work.
 type fakeJJVCSForFetch struct{}
 
-func (*fakeJJVCSForFetch) Name() string                     { return "jj" }
-func (*fakeJJVCSForFetch) HasObject(string, string) bool    { return false }
-func (*fakeJJVCSForFetch) RepoRoot() (string, error)        { return "", nil }
-func (*fakeJJVCSForFetch) CurrentBranch() string            { return "" }
-func (*fakeJJVCSForFetch) DefaultBranch() string            { return "" }
-func (*fakeJJVCSForFetch) SetDefaultBranchOverride(string)  {}
-func (*fakeJJVCSForFetch) GetDefaultBranchOverride() string { return "" }
-func (*fakeJJVCSForFetch) DefaultBaseRef() string           { return "" }
-func (*fakeJJVCSForFetch) MergeBase(string) (string, error) { return "", nil }
+func (*fakeJJVCSForFetch) Name() string                               { return "jj" }
+func (*fakeJJVCSForFetch) HasObject(string, string) bool              { return false }
+func (*fakeJJVCSForFetch) RepoRoot() (string, error)                  { return "", nil }
+func (*fakeJJVCSForFetch) CurrentBranch() string                      { return "" }
+func (*fakeJJVCSForFetch) DefaultBranch() string                      { return "" }
+func (*fakeJJVCSForFetch) SetDefaultBranchOverride(string)            {}
+func (*fakeJJVCSForFetch) GetDefaultBranchOverride() string           { return "" }
+func (*fakeJJVCSForFetch) DefaultBaseRef() string                     { return "" }
+func (*fakeJJVCSForFetch) MergeBase(string) (string, error)           { return "", nil }
+func (*fakeJJVCSForFetch) MergeBaseOf(_, _, _ string) (string, error) { return "", nil }
 func (*fakeJJVCSForFetch) ChangedFilesOnDefaultInDir(string) ([]FileChange, error) {
 	return nil, nil
 }

--- a/internal/vcs/mergebaseof_test.go
+++ b/internal/vcs/mergebaseof_test.go
@@ -1,0 +1,119 @@
+package vcs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildDriftedGitRepo creates a repo where the base branch has advanced past the
+// point the PR branch forked from:
+//
+//	main:    C0 ── C1(forkpoint) ── M1(drift, base tip)
+//	                  └── F1(PR head)
+//
+// It returns (repoDir, forkpoint=C1, baseTip=M1, prHead=F1).
+func buildDriftedGitRepo(t *testing.T) (dir, forkpoint, baseTip, prHead string) {
+	t.Helper()
+	dir = InitTestRepo(t) // C0 on main
+	forkpoint = CommitAtForTest(t, dir, "base.txt", "base\n", "forkpoint")
+	GitRun(t, dir, "checkout", "-b", "feature")
+	prHead = CommitAtForTest(t, dir, "feature.txt", "feat\n", "pr work")
+	GitRun(t, dir, "checkout", "main")
+	baseTip = CommitAtForTest(t, dir, "drift.txt", "drift\n", "base branch drift")
+	return dir, forkpoint, baseTip, prHead
+}
+
+// TestMergeBaseOf_Git pins the two-arg merge-base: neither side is HEAD, and it
+// returns the fork point, not the (drifted) base tip. This is the git path of
+// the `crit --pr` fix.
+func TestMergeBaseOf_Git(t *testing.T) {
+	ClearGitEnvForTest(t) // robust under git hooks that export GIT_DIR
+	dir, forkpoint, baseTip, prHead := buildDriftedGitRepo(t)
+
+	mb, err := MergeBaseOf(baseTip, prHead, dir)
+	if err != nil {
+		t.Fatalf("MergeBaseOf: %v", err)
+	}
+	if mb != forkpoint {
+		t.Errorf("MergeBaseOf(baseTip, prHead) = %s, want forkpoint %s (got base tip %s?)",
+			mb, forkpoint, baseTip)
+	}
+
+	// Symmetric: argument order must not matter.
+	mbSwapped, err := MergeBaseOf(prHead, baseTip, dir)
+	if err != nil {
+		t.Fatalf("MergeBaseOf (swapped): %v", err)
+	}
+	if mbSwapped != forkpoint {
+		t.Errorf("MergeBaseOf(prHead, baseTip) = %s, want forkpoint %s", mbSwapped, forkpoint)
+	}
+}
+
+// TestJJVCS_MergeBaseOf covers the two-arg merge-base where neither side is @:
+// two siblings off main must resolve to their common ancestor (the fork point),
+// not the divergent base-branch tip. This is the jj path of the `crit --pr` fix.
+func TestJJVCS_MergeBaseOf(t *testing.T) {
+	dir := initTestJJRepoWithLocalMain(t)
+	j := &JJVCS{}
+
+	forkpoint := runJJ(t, dir, "log", "-r", "bookmarks(exact:\"main\")", "--no-graph", "-T", "commit_id")
+
+	// PR head: a child of main.
+	runJJ(t, dir, "new", "main", "-m", "pr work")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prHead := runJJ(t, dir, "log", "-r", "@", "--no-graph", "-T", "commit_id")
+
+	// Base drift: a second child of main, diverging from the PR.
+	runJJ(t, dir, "new", "main", "-m", "base drift")
+	if err := os.WriteFile(filepath.Join(dir, "drift.txt"), []byte("drift\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseTip := runJJ(t, dir, "log", "-r", "@", "--no-graph", "-T", "commit_id")
+
+	mb, err := j.MergeBaseOf(baseTip, prHead, dir)
+	if err != nil {
+		t.Fatalf("MergeBaseOf: %v", err)
+	}
+	if mb != forkpoint {
+		t.Errorf("MergeBaseOf(baseTip, prHead) = %q, want forkpoint %q (got base tip %q?)",
+			mb, forkpoint, baseTip)
+	}
+}
+
+// TestSaplingVCS_MergeBaseOf is the sapling path of the `crit --pr` fix: two
+// siblings off the seed must resolve to their common ancestor, not the drifted
+// base tip. ancestor() is symmetric, so order does not matter.
+func TestSaplingVCS_MergeBaseOf(t *testing.T) {
+	dir := initTestSaplingRepo(t)
+	s := &SaplingVCS{}
+
+	forkpoint := strings.TrimSpace(runSL(t, dir, "log", "-r", ".", "-T", "{node}"))
+
+	// PR head: a child of the seed.
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runSL(t, dir, "commit", "-A", "-m", "pr work")
+	prHead := strings.TrimSpace(runSL(t, dir, "log", "-r", ".", "-T", "{node}"))
+
+	// Base drift: move the working parent back to the seed and branch off again.
+	runSL(t, dir, "goto", forkpoint)
+	if err := os.WriteFile(filepath.Join(dir, "drift.txt"), []byte("drift\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runSL(t, dir, "commit", "-A", "-m", "base drift")
+	baseTip := strings.TrimSpace(runSL(t, dir, "log", "-r", ".", "-T", "{node}"))
+
+	mb, err := s.MergeBaseOf(baseTip, prHead, dir)
+	if err != nil {
+		t.Fatalf("MergeBaseOf: %v", err)
+	}
+	if strings.TrimSpace(mb) != forkpoint {
+		t.Errorf("MergeBaseOf(baseTip, prHead) = %q, want forkpoint %q (got base tip %q?)",
+			strings.TrimSpace(mb), forkpoint, baseTip)
+	}
+}

--- a/internal/vcs/sapling.go
+++ b/internal/vcs/sapling.go
@@ -97,6 +97,17 @@ func (s *SaplingVCS) MergeBase(ref string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// MergeBaseOf returns the common ancestor of two arbitrary revisions (neither
+// pinned to the working copy). ancestor() is symmetric, so order is irrelevant.
+func (s *SaplingVCS) MergeBaseOf(a, b, dir string) (string, error) {
+	revset := fmt.Sprintf("ancestor(%s, %s)", a, b)
+	out, err := SLCommandInDir(dir, "log", "-r", revset, "-T", "{node}")
+	if err != nil {
+		return "", fmt.Errorf("sl ancestor: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // ChangedFilesOnDefaultInDir returns changed files when on the default branch.
 func (s *SaplingVCS) ChangedFilesOnDefaultInDir(dir string) ([]FileChange, error) {
 	out, err := SLCommandInDir(dir, "status")

--- a/internal/vcs/test_git.go
+++ b/internal/vcs/test_git.go
@@ -42,6 +42,28 @@ func IsCommitish(s string) bool {
 	return isCommitish(s)
 }
 
+// ClearGitEnvForTest unsets git's repo-location environment variables for the
+// duration of the test, restoring them on cleanup. Git hooks (e.g. pre-commit)
+// export GIT_DIR / GIT_WORK_TREE, which take precedence over a command's working
+// directory — so a production git-in-dir call would resolve the hook's repo
+// instead of the temp repo under test. Tests that exercise such calls against a
+// temp repo must call this to stay deterministic when run from inside a hook.
+func ClearGitEnvForTest(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_CEILING_DIRECTORIES", "GIT_NAMESPACE",
+	} {
+		if v, ok := os.LookupEnv(k); ok {
+			k, v := k, v
+			if err := os.Unsetenv(k); err != nil {
+				t.Fatalf("unset %s: %v", k, err)
+			}
+			t.Cleanup(func() { os.Setenv(k, v) })
+		}
+	}
+}
+
 func writeFileForTest(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -33,6 +33,13 @@ type VCS interface {
 	// MergeBase returns the merge-base commit between HEAD and the given ref.
 	MergeBase(ref string) (string, error)
 
+	// MergeBaseOf returns the merge-base (best common ancestor) of two
+	// arbitrary revisions, computed in dir. Unlike MergeBase, neither side is
+	// pinned to the working-tree head — used to derive a PR's diff base as
+	// merge-base(base, head) so the layer diff matches GitHub's three-dot PR
+	// diff regardless of whether the branch is rebased.
+	MergeBaseOf(a, b, dir string) (string, error)
+
 	// DefaultBaseRef returns the best ref to use as the diff base for the
 	// auto-detected default branch. For git, prefers `origin/<branch>` when
 	// the remote-tracking ref exists locally, since the local default branch


### PR DESCRIPTION
`crit --pr <n>` used the base branch's tip (info.BaseRefOid) as the diff base, producing a two-dot base..head diff. When the PR branch isn't rebased onto its base, that folds in commits landed on the base branch since the fork point - surfacing files that aren't part of the PR. GitHub renders a PR as the three-dot base...head diff (from the merge-base), so crit's layer view diverged from GitHub. The effect is most visible under jj, but the bug is backend-agnostic.