### PR TITLE
fix: accept @-prefixed file paths from agent file pickers

### DIFF
--- a/cmd/crit/at_args.go
+++ b/cmd/crit/at_args.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// resolveAtPrefixedArgs normalizes file references that agent file pickers
+// insert with a leading "@". Claude Code's "@" autocomplete (and similar
+// pickers) produce `crit @path/to/file.md`, but the literal "@path/to/file.md"
+// is not a real file, so review-mode detection and daemon keying break — the
+// daemon spawns, fails session init on the bogus path, and the client can't
+// connect (issue #656).
+//
+// For each argument beginning with "@", if the "@"-prefixed literal does not
+// exist on disk but the stripped path does, the stripped path is used.
+// Arguments that don't start with "@" (flags, URLs, plain paths) are returned
+// unchanged, and a file genuinely named "@foo" is preserved because the
+// literal-exists check runs first.
+func resolveAtPrefixedArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, arg := range args {
+		out[i] = arg
+		if len(arg) < 2 || !strings.HasPrefix(arg, "@") {
+			continue
+		}
+		if _, err := os.Stat(arg); err == nil {
+			continue // a real file literally named "@..."
+		}
+		stripped := arg[1:]
+		if _, err := os.Stat(stripped); err == nil {
+			out[i] = stripped
+		}
+	}
+	return out
+}

--- a/cmd/crit/at_args_test.go
+++ b/cmd/crit/at_args_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestResolveAtPrefixedArgs covers the "@file" form that agent file pickers
+// (e.g. Claude Code's "@" autocomplete) insert. See issue #656.
+func TestResolveAtPrefixedArgs(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "myfile.md")
+	if err := os.WriteFile(real, []byte("# hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "nope.md")
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"strips @ when stripped path exists", []string{"@" + real}, []string{real}},
+		{"strips @ for a directory target", []string{"@" + subdir}, []string{subdir}},
+		{"leaves plain path untouched", []string{real}, []string{real}},
+		{"leaves @ untouched when stripped path missing", []string{"@" + missing}, []string{"@" + missing}},
+		{"bare @ untouched", []string{"@"}, []string{"@"}},
+		{"flags untouched, only path normalized", []string{"--no-open", "@" + real}, []string{"--no-open", real}},
+		{"multiple @ paths", []string{"@" + real, "@" + missing}, []string{real, "@" + missing}},
+		{"nil", nil, []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveAtPrefixedArgs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("resolveAtPrefixedArgs(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveAtPrefixedArgs_RealAtFile verifies that a file genuinely named
+// "@foo" is preserved rather than stripped (the literal-exists check wins).
+func TestResolveAtPrefixedArgs_RealAtFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("@literal.md", []byte("# hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveAtPrefixedArgs([]string{"@literal.md"})
+	want := []string{"@literal.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolveAtPrefixedArgs = %q, want %q (real @-named file must be preserved)", got, want)
+	}
+}

--- a/cmd/crit/main.go
+++ b/cmd/crit/main.go
@@ -29,7 +29,7 @@ func main() {
 		handler(os.Args[2:])
 		return
 	}
-	args := os.Args[1:]
+	args := resolveAtPrefixedArgs(os.Args[1:])
 	if live.LooksLikeLiveArgs(args) {
 		runLive(args)
 		return


### PR DESCRIPTION
## Summary
- Claude Code's `@` file-picker autocomplete inserts `crit @myfile.md`, but the literal `@myfile.md` isn't a real file — the daemon spawned, failed session init on the bogus path, and the client couldn't connect (`connection reset by peer`). Meanwhile `crit myfile.md` worked fine.
- New `resolveAtPrefixedArgs` (`cmd/crit/at_args.go`) normalizes the default dispatch path: for each `@`-prefixed arg, strip the `@` when the literal doesn't exist on disk but the stripped path does. Files genuinely named `@foo` are preserved (literal-exists check wins); flags, URLs, `.html` preview targets, and plain paths pass through untouched.
- Wired into `main.go` before live/preview/review detection, so all three modes accept the `@file` form.

## Review
- [x] Code review: passed (fresh go-expert — "clean, ship it")
- [x] Intent audit: CLEAN (independent auditor)
- [x] Parity audit: N/A — CLI arg parsing only, no review-page files

## Test plan
- Table-driven unit tests cover: strip-when-exists (file + directory), plain-path passthrough, missing stripped target, bare `@`, flag interleaving, multiple `@` args, nil input, and a real file literally named `@foo` (preserved).
- Manually verified against a compiled binary: `crit @myfile.md` now starts the daemon cleanly, identical to `crit myfile.md`; pre-fix it failed with `connection reset by peer`.
- `go test -race ./cmd/crit/` and `golangci-lint` clean.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)