### PR TITLE
perf: delegate diff comment-button mousedown to fix large-diff UI freeze

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2769,17 +2769,10 @@
     btn.dataset.lineNum = lineNum;
     btn.dataset.side = side || '';
     if (visualIdx !== undefined) btn.dataset.visualIdx = visualIdx;
-    btn.addEventListener('mousedown', function(e) {
-      e.preventDefault();
-      e.stopPropagation();
-      const fp = this.dataset.filePath;
-      const ln = parseInt(this.dataset.lineNum);
-      const s = this.dataset.side || '';
-      const vi = this.dataset.visualIdx !== undefined ? parseInt(this.dataset.visualIdx) : undefined;
-      beginDiffCommentDrag(fp, ln, s, vi);
-      document.addEventListener('mousemove', handleDiffDragMove);
-      document.addEventListener('mouseup', handleDiffDragEnd);
-    });
+    // Mouse drag-init is delegated once on the diff container
+    // (attachDiffMouseHandler) rather than attached per-button. A large diff
+    // can contain thousands of these buttons, and one mousedown listener per
+    // button stalled the main thread for several seconds on render (#657).
     col.appendChild(btn);
     return col;
   }
@@ -2824,6 +2817,27 @@
       beginDiffCommentDrag(fp, ln, s, vi);
       document.addEventListener('pointermove', handleDiffDragMove);
       document.addEventListener('pointerup', handleDiffDragEnd);
+    });
+  }
+
+  // Desktop mouse path: delegate a single mousedown on the diff container
+  // instead of attaching one listener per .diff-comment-btn. On a large diff
+  // the per-button approach wired up thousands of listeners and stalled the
+  // main thread for several seconds on render (#657). One delegated handler is
+  // O(1) regardless of diff size. Mirrors attachDiffTouchHandler above.
+  function attachDiffMouseHandler(container) {
+    container.addEventListener('mousedown', function(e) {
+      const btn = e.target.closest('.diff-comment-btn');
+      if (!btn || !container.contains(btn)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const fp = btn.dataset.filePath;
+      const ln = parseInt(btn.dataset.lineNum);
+      const s = btn.dataset.side || '';
+      const vi = btn.dataset.visualIdx !== undefined ? parseInt(btn.dataset.visualIdx) : undefined;
+      beginDiffCommentDrag(fp, ln, s, vi);
+      document.addEventListener('mousemove', handleDiffDragMove);
+      document.addEventListener('mouseup', handleDiffDragEnd);
     });
   }
 
@@ -3320,6 +3334,7 @@
     const container = document.createElement('div');
     container.className = 'diff-container unified';
     attachDiffTouchHandler(container);
+    attachDiffMouseHandler(container);
 
     expandHunksForComments(file);
 
@@ -3449,6 +3464,7 @@
     const container = document.createElement('div');
     container.className = 'diff-container split';
     attachDiffTouchHandler(container);
+    attachDiffMouseHandler(container);
 
     expandHunksForComments(file);
 


### PR DESCRIPTION
## Summary
- A large diff (e.g. selecting a base branch that diverged months ago — the reporter hit a 565-file / ~54k-line diff) rendered thousands of `+` comment buttons, each with its own `mousedown` listener (~9,900 of them). Wiring them up froze the tab for several seconds on render.
- Replace the per-button listener in `makeDiffCommentGutter` with a single delegated `mousedown` on the diff container (`attachDiffMouseHandler`), wired into both `renderDiffUnified` and `renderDiffSplit`. Mirrors the existing `attachDiffTouchHandler` (the touch path was already delegated).
- One listener per container instead of one per line — O(1) regardless of diff size. Drag behavior is unchanged.

This is one of three directions identified in #657 (the others — deferring the eager-render batch and a large-diff warning — are larger and left as follow-ups).

## Review
- [x] Code review: passed (fresh frontend-expert review, no findings)
- [x] Intent audit: clean
- [x] Parity audit: N/A — crit-web has no diff-comment-btn git-diff view

## Test plan
- 68 mouse-path E2E (desktop-chrome, drag-selection, select-to-comment, comments) pass
- 6 touch-path E2E (mobile-tap-to-comment, mobile-add-comment-affordance) pass

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)