### PR TITLE
refactor: remove dead alias and fix stale comments from release audit

### DIFF
--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -179,6 +179,9 @@ func resolveFocusFromPR(prSpec string, scope DiffScope, remoteFiles bool, v vcs.
 	// the merge-base so the diff matches GitHub regardless of rebase state.
 	baseSHA := info.BaseRefOid
 	if v != nil {
+		// Best-effort: in --remote mode the base/head objects may not be local
+		// (EnsureSHAFetched was skipped above), so merge-base can fail. We then
+		// fall back to BaseRefOid — a two-dot diff (the case #659 fixed locally).
 		if mb, err := v.MergeBaseOf(info.BaseRefOid, info.HeadRefOid, repoRoot); err == nil && mb != "" {
 			baseSHA = mb
 		}

--- a/internal/session/export.go
+++ b/internal/session/export.go
@@ -11,7 +11,6 @@ const MaxAttachmentBytes = maxAttachmentBytes
 type DeleteResult = deleteResult
 
 const (
-	DeleteResultDeleted   = deleteResultDeleted
 	DeleteResultNotFound  = deleteResultNotFound
 	DeleteResultForbidden = deleteResultForbidden
 )

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -445,7 +445,7 @@ func (s *Session) buildFilesForFocus(f Focus, v vcs.VCS, repoRoot string) ([]*Fi
 }
 
 // buildFilesForWorkingTree rebuilds the file list from the VCS for the
-// working-tree focus. Mirrors the eager-load loop in NewSessionFromVCS but
+// working-tree focus. Mirrors the eager-load loop in NewGitSession but
 // does not mutate session state directly.
 func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileEntry, string, error) {
 	if v == nil {

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -246,7 +246,7 @@ func MergeBase(base string) (string, error) {
 func MergeBaseOf(a, b, dir string) (string, error) {
 	out, err := runGit(context.Background(), dir, "merge-base", a, b)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git merge-base: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/web/app.js
+++ b/web/app.js
@@ -2913,8 +2913,8 @@
 
   function handleDiffDragEnd() {
     // Remove both mouse and pointer listeners — desktop attaches mouse
-    // listeners via the .diff-comment-btn mousedown handler, touch
-    // attaches pointer listeners via attachDiffTouchHandler. Cleaning
+    // listeners via the delegated mousedown handler on the diff container,
+    // touch attaches pointer listeners via attachDiffTouchHandler. Cleaning
     // both is safe (removeEventListener is a no-op if not attached).
     document.removeEventListener('mousemove', handleDiffDragMove);
     document.removeEventListener('mouseup', handleDiffDragEnd);


### PR DESCRIPTION
## Summary
Post-release-audit cleanup (`v0.16.2..main`), all findings validated by independent agents:

- **Delete dead exported alias** `DeleteResultDeleted` (`internal/session`) — referenced nowhere; leftover from the #655 layout refactor.
- **Wrap `git MergeBaseOf` error** for consistency with the sapling/jj impls and the adjacent `MergeBase` (behavior unchanged — the sole call site ignores the error).
- **Fix stale doc comment** referencing renamed `NewSessionFromVCS` (now `NewGitSession`).
- **Document the `--remote` merge-base best-effort fallback** in `internal/focus` (comment only — notes the #659 two-dot fallback when objects aren't local).
- **Fix stale `handleDiffDragEnd` comment** wording (`web/app.js`) — the mousedown listener is delegated on the container now, not the button (#665).

## Review
- [x] Code review: passed (fresh post-fix review)
- [x] Parity audit: N/A (no shared review-page behavior changed; companion crit-web parity fix in tomasz-tomczyk/crit-web#271)

## Test plan
- `go vet ./...` — clean
- `go build ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test ./...` — pass (pre-commit hook ran full gate: gofmt, golangci-lint, tests, eslint, stylelint, CSS vars — passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)