### PR TITLE
chore: bump Nix flake version to v0.16.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      version = "0.16.2";
+      version = "0.16.3";
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in rec {


### PR DESCRIPTION
Version bump for the v0.16.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)