### PR TITLE
feat: add crit comments command to list unresolved review comments

### DIFF
--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -23,6 +23,7 @@ var commandDispatch = map[string]func([]string){
 	"pull":      runPull,
 	"push":      runPush,
 	"comment":   runComment,
+	"comments":  runComments,
 	"review":    runReview,
 	"live":      runLive,
 	"preview":   runPreview,
@@ -57,6 +58,7 @@ Comments:
   crit comment --reply-to <id> <body>        Reply to a comment
   crit comment --json                        Bulk add comments from JSON on stdin
   crit comment --clear                       Remove all comments
+  crit comments [--json] [--all] [review]    List unresolved comments (review-level first)
 
 Sharing:
   crit share <file> [file...]                Share files to crit-web, print URL

--- a/cmd/crit/cli_handlers.go
+++ b/cmd/crit/cli_handlers.go
@@ -20,6 +20,7 @@ func runConfig(args []string)    { clicmd.Exit(config.RunConfig(args)) }
 func runPull(args []string)      { clicmd.Exit(github.RunPull(args)) }
 func runPush(args []string)      { clicmd.Exit(github.RunPush(args)) }
 func runComment(args []string)   { clicmd.Exit(comment.RunComment(args)) }
+func runComments(args []string)  { clicmd.Exit(comment.RunComments(args)) }
 func runReview(args []string)    { clicmd.Exit(session.RunReview(args)) }
 func runPlan(args []string)      { clicmd.Exit(session.RunPlan(args)) }
 func runStop(args []string)      { clicmd.Exit(session.RunStop(args)) }

--- a/internal/comment/list.go
+++ b/internal/comment/list.go
@@ -1,0 +1,183 @@
+package comment
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ListedComment is a flattened comment for CLI output.
+type ListedComment struct {
+	Scope     string  `json:"scope"`
+	ID        string  `json:"id"`
+	Path      *string `json:"path"`
+	StartLine *int    `json:"start_line"`
+	EndLine   *int    `json:"end_line"`
+	Body      string  `json:"body"`
+	Quote     *string `json:"quote,omitempty"`
+	Anchor    *string `json:"anchor,omitempty"`
+	Drifted   bool    `json:"drifted,omitempty"`
+	Replies   []Reply `json:"replies,omitempty"`
+}
+
+func isUnresolved(c Comment) bool {
+	return !c.Resolved
+}
+
+func commentScope(c Comment) string {
+	if c.Scope == "review" {
+		return "review"
+	}
+	if c.Scope == "file" {
+		return "file"
+	}
+	return "line"
+}
+
+func listCommentsFromCritJSON(cj CritJSON, unresolvedOnly bool) []ListedComment {
+	var out []ListedComment
+
+	for _, c := range cj.ReviewComments {
+		if unresolvedOnly && !isUnresolved(c) {
+			continue
+		}
+		out = append(out, toListedComment("review", "", c))
+	}
+
+	paths := make([]string, 0, len(cj.Files))
+	for path := range cj.Files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		var fileLevel, lineLevel []Comment
+		for _, c := range cj.Files[path].Comments {
+			if unresolvedOnly && !isUnresolved(c) {
+				continue
+			}
+			if commentScope(c) == "file" {
+				fileLevel = append(fileLevel, c)
+			} else {
+				lineLevel = append(lineLevel, c)
+			}
+		}
+		sort.Slice(lineLevel, func(i, j int) bool {
+			return lineLevel[i].StartLine < lineLevel[j].StartLine
+		})
+		for _, c := range fileLevel {
+			out = append(out, toListedComment("file", path, c))
+		}
+		for _, c := range lineLevel {
+			out = append(out, toListedComment("line", path, c))
+		}
+	}
+	return out
+}
+
+func toListedComment(scope, path string, c Comment) ListedComment {
+	lc := ListedComment{
+		Scope:   scope,
+		ID:      c.ID,
+		Body:    c.Body,
+		Drifted: c.Drifted,
+		Replies: c.Replies,
+	}
+	if path != "" {
+		lc.Path = &path
+	}
+	if scope == "line" {
+		start, end := c.StartLine, c.EndLine
+		if end == 0 {
+			end = start
+		}
+		lc.StartLine = &start
+		lc.EndLine = &end
+	}
+	if c.Quote != "" {
+		q := c.Quote
+		lc.Quote = &q
+	}
+	if c.Anchor != "" {
+		a := c.Anchor
+		lc.Anchor = &a
+	}
+	return lc
+}
+
+func formatCommentsText(entries []ListedComment, unresolvedOnly bool) string {
+	n := len(entries)
+	if n == 0 {
+		if unresolvedOnly {
+			return "No unresolved comments."
+		}
+		return "No comments."
+	}
+	var b strings.Builder
+	if unresolvedOnly {
+		fmt.Fprintf(&b, "%d unresolved comment%s:\n", n, plural(n))
+	} else {
+		fmt.Fprintf(&b, "%d comment%s:\n", n, plural(n))
+	}
+	for _, e := range entries {
+		b.WriteByte('\n')
+		b.WriteString(formatCommentHeader(e))
+		if e.Quote != nil && *e.Quote != "" {
+			b.WriteByte('\n')
+			b.WriteString(indentLines(2, "quote:  "+*e.Quote))
+		}
+		if e.Anchor != nil && *e.Anchor != "" {
+			b.WriteByte('\n')
+			b.WriteString(indentLines(2, "anchor: "+*e.Anchor))
+		}
+		b.WriteByte('\n')
+		b.WriteString(indentLines(2, "body:   "+e.Body))
+		if len(e.Replies) > 0 {
+			b.WriteString("\n  replies:")
+			for _, r := range e.Replies {
+				author := r.Author
+				if author == "" {
+					author = "?"
+				}
+				b.WriteByte('\n')
+				b.WriteString(indentLines(4, fmt.Sprintf("- [%s] %s: %s", r.ID, author, r.Body)))
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatCommentHeader(e ListedComment) string {
+	header := fmt.Sprintf("[%s] %s", e.ID, e.Scope)
+	if e.Path != nil {
+		header += " " + *e.Path + formatLineLoc(e.StartLine, e.EndLine)
+	}
+	if e.Drifted {
+		header += " (drifted)"
+	}
+	return header
+}
+
+func formatLineLoc(start, end *int) string {
+	if start == nil {
+		return ""
+	}
+	if end == nil || *end == *start {
+		return fmt.Sprintf(":%d", *start)
+	}
+	return fmt.Sprintf(":%d-%d", *start, *end)
+}
+
+func indentLines(spaces int, s string) string {
+	pad := strings.Repeat(" ", spaces)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = pad + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func encodeCommentsJSON(entries []ListedComment) ([]byte, error) {
+	return json.MarshalIndent(entries, "", "  ")
+}

--- a/internal/comment/list_cli.go
+++ b/internal/comment/list_cli.go
@@ -1,0 +1,139 @@
+package comment
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+	"github.com/tomasz-tomczyk/crit/internal/review"
+	"github.com/tomasz-tomczyk/crit/internal/session"
+)
+
+type commentsListFlags struct {
+	outputDir    string
+	plan         string
+	jsonOutput   bool
+	all          bool
+	explicitPath string
+}
+
+func parseCommentsListFlags(args []string) (commentsListFlags, error) {
+	var f commentsListFlags
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--plan":
+			val, err := clicmd.RequireFlagValue(args, i, "--plan")
+			if err != nil {
+				return f, err
+			}
+			f.plan = val
+			i++
+		case "--output", "-o":
+			val, err := clicmd.RequireFlagValue(args, i, arg)
+			if err != nil {
+				return f, err
+			}
+			f.outputDir = val
+			i++
+		case "--json":
+			f.jsonOutput = true
+		case "--all":
+			f.all = true
+		default:
+			if len(arg) > 0 && arg[0] == '-' {
+				return f, fmt.Errorf("unknown flag: %s", arg)
+			}
+			if f.explicitPath != "" {
+				return f, fmt.Errorf("unexpected extra argument: %s", arg)
+			}
+			f.explicitPath = arg
+		}
+	}
+	return f, nil
+}
+
+func resolveCommentsListFlags(f *commentsListFlags) error {
+	if f.plan != "" {
+		if f.outputDir != "" {
+			return fmt.Errorf("--plan and --output cannot be used together")
+		}
+		if f.explicitPath != "" {
+			return fmt.Errorf("--plan and an explicit review path cannot be used together")
+		}
+		var err error
+		f.outputDir, err = session.PlanStorageDir(session.Slugify(f.plan))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resolveCommentsCritPath(f commentsListFlags) (string, error) {
+	if f.explicitPath != "" {
+		return resolveExplicitReviewPath(f.explicitPath)
+	}
+	return review.ResolveReviewPath(f.outputDir)
+}
+
+func resolveExplicitReviewPath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		if _, err := os.Stat(filepath.Join(path, "review.json")); err == nil {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return "", err
+			}
+			return abs, nil
+		}
+		return review.ResolveReviewPath(path)
+	}
+	if filepath.Base(path) == "review.json" {
+		abs, err := filepath.Abs(filepath.Dir(path))
+		if err != nil {
+			return "", err
+		}
+		return abs, nil
+	}
+	return "", fmt.Errorf("expected review.json or .crit directory, got %q", path)
+}
+
+// RunComments lists comments from the current or specified review file.
+func RunComments(args []string) error {
+	f, err := parseCommentsListFlags(args)
+	if err != nil {
+		return err
+	}
+	if err := resolveCommentsListFlags(&f); err != nil {
+		return err
+	}
+
+	critPath, err := resolveCommentsCritPath(f)
+	if err != nil {
+		return err
+	}
+
+	cj, err := loadCritJSON(critPath)
+	if err != nil {
+		return err
+	}
+
+	unresolvedOnly := !f.all
+	entries := listCommentsFromCritJSON(cj, unresolvedOnly)
+	if f.jsonOutput {
+		data, err := encodeCommentsJSON(entries)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Println(formatCommentsText(entries, unresolvedOnly))
+	return nil
+}

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -1,0 +1,193 @@
+package comment
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestReview(t *testing.T, dir string, cj CritJSON) string {
+	t.Helper()
+	critPath := filepath.Join(dir, ".crit")
+	if err := os.MkdirAll(critPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveCritJSON(critPath, cj); err != nil {
+		t.Fatal(err)
+	}
+	return critPath
+}
+
+func TestListCommentsFromCritJSON_OrderAndFilter(t *testing.T) {
+	cj := CritJSON{
+		ReviewComments: []Comment{
+			{ID: "r_1", Body: "review note", Scope: "review", Resolved: false},
+			{ID: "r_2", Body: "resolved review", Scope: "review", Resolved: true},
+		},
+		Files: map[string]CritJSONFile{
+			"b.go": {
+				Comments: []Comment{
+					{ID: "c_line", Body: "line", StartLine: 20, EndLine: 20},
+					{ID: "c_file", Body: "file", Scope: "file"},
+					{ID: "c_done", Body: "done", StartLine: 5, Resolved: true},
+				},
+			},
+			"a.go": {
+				Comments: []Comment{
+					{ID: "c_a", Body: "earlier line", StartLine: 1},
+				},
+			},
+		},
+	}
+
+	entries := listCommentsFromCritJSON(cj, true)
+	wantIDs := []string{"r_1", "c_a", "c_file", "c_line"}
+	if len(entries) != len(wantIDs) {
+		t.Fatalf("got %d entries, want %d: %+v", len(entries), len(wantIDs), entries)
+	}
+	for i, id := range wantIDs {
+		if entries[i].ID != id {
+			t.Errorf("entry %d: got id %q, want %q", i, entries[i].ID, id)
+		}
+	}
+	if entries[0].Scope != "review" {
+		t.Errorf("first entry scope = %q, want review", entries[0].Scope)
+	}
+	if entries[2].Scope != "file" {
+		t.Errorf("third entry scope = %q, want file", entries[2].Scope)
+	}
+}
+
+func TestListCommentsFromCritJSON_AllIncludesResolved(t *testing.T) {
+	cj := CritJSON{
+		ReviewComments: []Comment{
+			{ID: "r_1", Body: "open", Scope: "review"},
+			{ID: "r_2", Body: "closed", Scope: "review", Resolved: true},
+		},
+	}
+	unresolved := listCommentsFromCritJSON(cj, true)
+	if len(unresolved) != 1 {
+		t.Fatalf("unresolved: got %d, want 1", len(unresolved))
+	}
+	all := listCommentsFromCritJSON(cj, false)
+	if len(all) != 2 {
+		t.Fatalf("all: got %d, want 2", len(all))
+	}
+}
+
+func TestFormatCommentsText_Empty(t *testing.T) {
+	if got := formatCommentsText(nil, true); got != "No unresolved comments." {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFormatCommentsText_WithReplies(t *testing.T) {
+	path := "main.go"
+	start, end := 10, 12
+	quote := "selected text"
+	entries := []ListedComment{{
+		Scope: "line", ID: "c_1", Path: &path,
+		StartLine: &start, EndLine: &end, Body: "fix this",
+		Quote: &quote, Drifted: true,
+		Replies: []Reply{{ID: "rp_1", Author: "Bot", Body: "on it"}},
+	}}
+	out := formatCommentsText(entries, true)
+	if !strings.Contains(out, "[c_1] line main.go:10-12 (drifted)") {
+		t.Errorf("missing header: %s", out)
+	}
+	if !strings.Contains(out, "quote:  selected text") {
+		t.Errorf("missing quote: %s", out)
+	}
+	if !strings.Contains(out, "[rp_1] Bot: on it") {
+		t.Errorf("missing reply: %s", out)
+	}
+}
+
+func TestRunComments_JSONOutput(t *testing.T) {
+	tmp := t.TempDir()
+	writeTestReview(t, tmp, CritJSON{
+		ReviewComments: []Comment{{ID: "r_1", Body: "note", Scope: "review"}},
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := RunComments([]string{"--output", tmp, "--json"})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	var entries []ListedComment
+	if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+		t.Fatalf("json: %v\n%s", err, buf.String())
+	}
+	if len(entries) != 1 || entries[0].ID != "r_1" {
+		t.Fatalf("got %+v", entries)
+	}
+}
+
+func TestRunComments_ExplicitReviewJSONPath(t *testing.T) {
+	tmp := t.TempDir()
+	critPath := writeTestReview(t, tmp, CritJSON{
+		Files: map[string]CritJSONFile{
+			"x.go": {Comments: []Comment{{ID: "c_1", Body: "hello", StartLine: 1}}},
+		},
+	})
+	reviewJSON := filepath.Join(critPath, "review.json")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := RunComments([]string{reviewJSON})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	if !strings.Contains(buf.String(), "[c_1]") {
+		t.Errorf("output missing comment: %s", buf.String())
+	}
+}
+
+func TestRunComments_PlanAndOutputConflict(t *testing.T) {
+	err := RunComments([]string{"--plan", "x", "--output", "/tmp", "--json"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveExplicitReviewPath(t *testing.T) {
+	tmp := t.TempDir()
+	critPath := filepath.Join(tmp, ".crit")
+	if err := os.MkdirAll(critPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(critPath, "review.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveExplicitReviewPath(critPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != critPath {
+		t.Errorf("got %q, want %q", got, critPath)
+	}
+
+	got, err = resolveExplicitReviewPath(filepath.Join(critPath, "review.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != critPath {
+		t.Errorf("review.json path: got %q, want %q", got, critPath)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `crit comments` to list unresolved review comments for agents (closes #674)
- Reuses the same review resolution as `crit comment` (`--output`, `--plan`, daemon registry)
- Review-level comments first, then per-file (file-level before line-level, lines by `start_line`)
- Supports `--json`, `--all`, and optional explicit `review.json` path

## Test plan
- [x] `go test ./internal/comment/... ./cmd/crit/...`
- [x] Manual smoke: `crit comments --output <dir>` text + JSON output

## Follow-ups
- #675 — inline unresolved comments in finish stdout
- #676 — document `crit comments` in agent SKILL.md files

Made with [Cursor](https://cursor.com)