### PR TITLE
fix: finish button shows Approve after switching commits with pending comment

### DIFF
--- a/test/e2e/tests/approve-button-commit-scope.spec.ts
+++ b/test/e2e/tests/approve-button-commit-scope.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, addComment } from './helpers';
+
+// Regression: switching commit scope hid out-of-scope unresolved comments from the
+// finish button label — it showed "Approve" while hidden_unresolved > 0.
+test.describe('Approve Button Text — commit scope', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('shows Finish Review when unresolved comment is outside selected commit', async ({ page, request }) => {
+    // config.yaml is untracked — visible on "All commits" but not when a single commit is selected.
+    await addComment(request, 'config.yaml', 1, 'Fix config');
+
+    await loadPage(page);
+    await expect(page.locator('#finishBtn')).toHaveText('Finish Review');
+
+    await page.click('#commitDropdownBtn');
+    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const responsePromise = page.waitForResponse(r =>
+      r.url().includes('/api/session') && r.status() === 200
+    );
+    await commitItem.click();
+    await responsePromise;
+
+    await expect(page.locator('#finishBtn')).toHaveText('Finish Review');
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6245,7 +6245,8 @@
     window.crit.shared.updateCommentCountIndicator({ totalCount: total, openCount: unresolved });
     renderCommentsPanel();
     if (uiState === 'reviewing') {
-      document.getElementById('finishBtn').textContent = unresolved === 0 ? 'Approve' : 'Finish Review';
+      const openTotal = unresolved + hiddenUnresolved;
+      document.getElementById('finishBtn').textContent = openTotal === 0 ? 'Approve' : 'Finish Review';
     }
   }
 


### PR DESCRIPTION
## Summary

When reviewing individual commits, leaving a comment on one commit and switching to another caused the finish button to show **Approve** even though an unresolved comment still existed outside the current commit scope.

`updateCommentCount()` only counted comments on loaded files. The API already exposes out-of-scope unresolved comments via `hidden_unresolved` (used by `setUIState`), but that count was not included when updating the button after `reloadForScope()`.

## Fix

Include `hiddenUnresolved` in the finish-button label logic inside `updateCommentCount()`, matching `setUIState('reviewing')`.

## Test plan

- [x] New e2e: comment on untracked file, select single commit → button stays "Finish Review"
- [x] Existing approve-button e2e tests pass
- [x] Pre-commit (go test, eslint, stylelint) passes


Made with [Cursor](https://cursor.com)