### PR TITLE
fix: keep default-branch review visible after agent commits

### DIFF
--- a/internal/session/round_complete_main_test.go
+++ b/internal/session/round_complete_main_test.go
@@ -1,0 +1,42 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
+)
+
+func TestRoundCompleteOnMainAfterCommit_KeepsFiles(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "foo.go"), "package main\n")
+	oldWd, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldWd) })
+
+	sess, err := NewGitSession(&vcs.GitVCS{}, nil)
+	if err != nil {
+		t.Fatalf("NewGitSession: %v", err)
+	}
+	if len(sess.Files) == 0 {
+		t.Fatal("expected files from unstaged change on main")
+	}
+	if sess.BaseRef == "" {
+		t.Fatal("expected BaseRef pinned to session-start HEAD on main")
+	}
+
+	gitT(t, dir, "add", "foo.go")
+	gitT(t, dir, "commit", "-m", "agent commit")
+
+	sess.handleRoundCompleteGit()
+
+	if len(sess.Files) == 0 {
+		t.Fatal("after round-complete on committed main, expected files to remain visible")
+	}
+
+	info := sess.GetSessionInfoScoped("all", "")
+	if len(info.Files) == 0 {
+		t.Fatalf("GetSessionInfoScoped(all) returned no files after commit on main")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -548,6 +548,34 @@ func DetectVCSChanges(vc vcs.VCS, root string, ignorePatterns []string) (branch,
 	return branch, baseRef, resolvedBase, changes, nil
 }
 
+// resolveSessionStartBaseRef pins BaseRef to HEAD when reviewing on the default
+// branch. Without this, committing during a multi-round review clears the file
+// list on round-complete because ChangedFilesOnDefaultInDir only diffs the
+// working tree against the current HEAD.
+func resolveSessionStartBaseRef(v vcs.VCS, branch, resolvedBase, baseRef, repoRoot string) (string, error) {
+	if baseRef != "" || branch != resolvedBase {
+		return baseRef, nil
+	}
+	if v == nil || v.Name() != "git" {
+		return baseRef, nil
+	}
+	sha, err := vcs.HeadSHAInDir(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving session start HEAD: %w", err)
+	}
+	return sha, nil
+}
+
+// changedFilesForSession returns changed files for git-mode refresh. When
+// BaseRef is set (feature-branch merge-base or default-branch session start),
+// diffs from that ref to the working tree; otherwise falls back to working-tree-only.
+func changedFilesForSession(v vcs.VCS, baseRef, repoRoot string) ([]vcs.FileChange, error) {
+	if baseRef != "" {
+		return v.ChangedFilesFromBaseInDir(baseRef, repoRoot)
+	}
+	return v.ChangedFilesOnDefaultInDir(repoRoot)
+}
+
 // NewGitSession creates a session by auto-detecting changed files using the given VCS backend.
 // This is the VCS-agnostic equivalent of NewSessionFromGit.
 func NewGitSession(v vcs.VCS, ignorePatterns []string) (*Session, error) {
@@ -582,6 +610,11 @@ func newGitSession(v vcs.VCS, ignorePatterns []string, requireChanges bool) (*Se
 		}
 		err = nil
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	baseRef, err = resolveSessionStartBaseRef(v, branch, resolvedBase, baseRef, root)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -576,6 +576,26 @@ func changedFilesForSession(v vcs.VCS, baseRef, repoRoot string) ([]vcs.FileChan
 	return v.ChangedFilesOnDefaultInDir(repoRoot)
 }
 
+// baseRefForWorkingTreeDiscovery returns the diff base for rebuilding the
+// working-tree file list. On a feature branch this is always the merge-base
+// with the default branch (not the session's current BaseRef, which may still
+// hold a range-focus SHA). On the default branch it uses the session-pinned
+// start HEAD when set.
+func (s *Session) baseRefForWorkingTreeDiscovery(v vcs.VCS) (string, error) {
+	s.mu.RLock()
+	sessionBase := s.BaseRef
+	branch := s.Branch
+	s.mu.RUnlock()
+
+	if branch != v.DefaultBranch() {
+		return v.MergeBase(v.DefaultBaseRef())
+	}
+	if sessionBase != "" {
+		return sessionBase, nil
+	}
+	return "", nil
+}
+
 // NewGitSession creates a session by auto-detecting changed files using the given VCS backend.
 // This is the VCS-agnostic equivalent of NewSessionFromGit.
 func NewGitSession(v vcs.VCS, ignorePatterns []string) (*Session, error) {

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -458,20 +458,11 @@ func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileE
 	}
 	s.mu.RLock()
 	ignorePatterns := s.IgnorePatterns
-	branch := s.Branch
+	baseRef := s.BaseRef
 	s.mu.RUnlock()
-	defaultBranch := v.DefaultBranch()
-	baseRef := ""
-	if branch != defaultBranch {
-		baseRef, _ = v.MergeBase(defaultBranch)
-	}
 	var changes []vcs.FileChange
 	var err error
-	if branch == defaultBranch {
-		changes, err = v.ChangedFilesOnDefaultInDir(repoRoot)
-	} else {
-		changes, err = v.ChangedFilesFromBaseInDir(baseRef, repoRoot)
-	}
+	changes, err = changedFilesForSession(v, baseRef, repoRoot)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -458,11 +458,12 @@ func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileE
 	}
 	s.mu.RLock()
 	ignorePatterns := s.IgnorePatterns
-	baseRef := s.BaseRef
 	s.mu.RUnlock()
-	var changes []vcs.FileChange
-	var err error
-	changes, err = changedFilesForSession(v, baseRef, repoRoot)
+	baseRef, err := s.baseRefForWorkingTreeDiscovery(v)
+	if err != nil {
+		return nil, "", err
+	}
+	changes, err := changedFilesForSession(v, baseRef, repoRoot)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/session/watch.go
+++ b/internal/session/watch.go
@@ -91,11 +91,7 @@ func (s *Session) RefreshFileList() {
 
 	var changes []vcs.FileChange
 	var err error
-	if vc.CurrentBranch() == vc.DefaultBranch() {
-		changes, err = vc.ChangedFilesOnDefaultInDir(repoRoot)
-	} else {
-		changes, err = vc.ChangedFilesFromBaseInDir(baseRef, repoRoot)
-	}
+	changes, err = changedFilesForSession(vc, baseRef, repoRoot)
 	if err != nil {
 		return
 	}

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -572,6 +572,15 @@ func changedFilesFromBaseInDir(baseRef, dir string) ([]FileChange, error) {
 	return dedup(changes), nil
 }
 
+// HeadSHAInDir returns the full SHA of HEAD in dir.
+func HeadSHAInDir(dir string) (string, error) {
+	out, err := RunGitInDir(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD failed: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // RunGitInDir runs `git <args...>` in dir and returns the stdout. Mirrors the
 // existing inline exec.Command pattern used elsewhere in git.go.
 func RunGitInDir(dir string, args ...string) (string, error) {


### PR DESCRIPTION
## Summary

- Pin `BaseRef` to HEAD at session start when reviewing on the default branch (`main`)
- Use that pinned ref for `RefreshFileList` and working-tree focus rebuilds instead of `git diff HEAD` only
- Fixes empty Round 2 UI when an agent commits unstaged changes during a multi-round review on `main`

## Problem

On `main`, crit only tracked working-tree changes (`git diff HEAD`). After the agent committed in Round 1, round-complete re-queried git and got an empty file list — the review disappeared in Round 2.

Feature branches were unaffected because they already diff from merge-base.

## Test plan

- [x] `go test ./...`
- [x] New regression test: `TestRoundCompleteOnMainAfterCommit_KeepsFiles`
- [ ] Manual: `crit` on `main` with unstaged changes → agent commits → Round 2 still shows files


Made with [Cursor](https://cursor.com)