### PR TITLE
chore: bump Nix flake version to v0.16.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      version = "0.16.3";
+      version = "0.16.4";
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in rec {


### PR DESCRIPTION
Release version bump for v0.16.4.


Made with [Cursor](https://cursor.com)