### PR TITLE
fix: include full comment fields in finish output and improve copy prompt

### DIFF
--- a/internal/comment/list.go
+++ b/internal/comment/list.go
@@ -7,18 +7,13 @@ import (
 	"strings"
 )
 
-// ListedComment is a flattened comment for CLI output.
+// ListedComment is a comment flattened for CLI/finish output. It embeds Comment
+// so new review.json fields are included automatically; Scope and Path are the
+// only list-specific additions.
 type ListedComment struct {
-	Scope     string  `json:"scope"`
-	ID        string  `json:"id"`
-	Path      *string `json:"path"`
-	StartLine *int    `json:"start_line"`
-	EndLine   *int    `json:"end_line"`
-	Body      string  `json:"body"`
-	Quote     *string `json:"quote,omitempty"`
-	Anchor    *string `json:"anchor,omitempty"`
-	Drifted   bool    `json:"drifted,omitempty"`
-	Replies   []Reply `json:"replies,omitempty"`
+	Scope string  `json:"scope"`
+	Path  *string `json:"path,omitempty"`
+	Comment
 }
 
 func isUnresolved(c Comment) bool {
@@ -77,31 +72,12 @@ func listCommentsFromCritJSON(cj CritJSON, unresolvedOnly bool) []ListedComment 
 }
 
 func toListedComment(scope, path string, c Comment) ListedComment {
-	lc := ListedComment{
-		Scope:   scope,
-		ID:      c.ID,
-		Body:    c.Body,
-		Drifted: c.Drifted,
-		Replies: c.Replies,
-	}
+	lc := ListedComment{Scope: scope, Comment: c}
 	if path != "" {
 		lc.Path = &path
 	}
-	if scope == "line" {
-		start, end := c.StartLine, c.EndLine
-		if end == 0 {
-			end = start
-		}
-		lc.StartLine = &start
-		lc.EndLine = &end
-	}
-	if c.Quote != "" {
-		q := c.Quote
-		lc.Quote = &q
-	}
-	if c.Anchor != "" {
-		a := c.Anchor
-		lc.Anchor = &a
+	if scope == "line" && c.EndLine == 0 {
+		lc.EndLine = c.StartLine
 	}
 	return lc
 }
@@ -123,13 +99,27 @@ func formatCommentsText(entries []ListedComment, unresolvedOnly bool) string {
 	for _, e := range entries {
 		b.WriteByte('\n')
 		b.WriteString(formatCommentHeader(e))
-		if e.Quote != nil && *e.Quote != "" {
+		if e.PinNumber > 0 {
 			b.WriteByte('\n')
-			b.WriteString(indentLines(2, "quote:  "+*e.Quote))
+			fmt.Fprintf(&b, "  pin:    #%d", e.PinNumber)
 		}
-		if e.Anchor != nil && *e.Anchor != "" {
+		if e.Quote != "" {
 			b.WriteByte('\n')
-			b.WriteString(indentLines(2, "anchor: "+*e.Anchor))
+			b.WriteString(indentLines(2, "quote:  "+e.Quote))
+		}
+		if e.Anchor != "" {
+			b.WriteByte('\n')
+			b.WriteString(indentLines(2, "anchor: "+e.Anchor))
+		}
+		if e.DOMAnchor != nil {
+			if e.DOMAnchor.CSSSelector != "" {
+				b.WriteByte('\n')
+				b.WriteString(indentLines(2, "selector: "+e.DOMAnchor.CSSSelector))
+			}
+			if e.DOMAnchor.AccessibleName != "" {
+				b.WriteByte('\n')
+				b.WriteString(indentLines(2, "a11y:     "+e.DOMAnchor.AccessibleName))
+			}
 		}
 		b.WriteByte('\n')
 		b.WriteString(indentLines(2, "body:   "+e.Body))
@@ -150,8 +140,14 @@ func formatCommentsText(entries []ListedComment, unresolvedOnly bool) string {
 
 func formatCommentHeader(e ListedComment) string {
 	header := fmt.Sprintf("[%s] %s", e.ID, e.Scope)
+	if e.PinNumber > 0 {
+		header = fmt.Sprintf("[%s pin #%d] %s", e.ID, e.PinNumber, e.Scope)
+	}
 	if e.Path != nil {
-		header += " " + *e.Path + formatLineLoc(e.StartLine, e.EndLine)
+		header += " " + *e.Path
+		if e.Scope == "line" {
+			header += formatLineLoc(e.StartLine, e.EndLine)
+		}
 	}
 	if e.Drifted {
 		header += " (drifted)"
@@ -159,14 +155,14 @@ func formatCommentHeader(e ListedComment) string {
 	return header
 }
 
-func formatLineLoc(start, end *int) string {
-	if start == nil {
-		return ""
+func formatLineLoc(start, end int) string {
+	if end == 0 {
+		end = start
 	}
-	if end == nil || *end == *start {
-		return fmt.Sprintf(":%d", *start)
+	if end == start {
+		return fmt.Sprintf(":%d", start)
 	}
-	return fmt.Sprintf(":%d-%d", *start, *end)
+	return fmt.Sprintf(":%d-%d", start, end)
 }
 
 func indentLines(spaces int, s string) string {

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -87,13 +87,13 @@ func TestFormatCommentsText_Empty(t *testing.T) {
 
 func TestFormatCommentsText_WithReplies(t *testing.T) {
 	path := "main.go"
-	start, end := 10, 12
-	quote := "selected text"
 	entries := []ListedComment{{
-		Scope: "line", ID: "c_1", Path: &path,
-		StartLine: &start, EndLine: &end, Body: "fix this",
-		Quote: &quote, Drifted: true,
-		Replies: []Reply{{ID: "rp_1", Author: "Bot", Body: "on it"}},
+		Scope: "line", Path: &path,
+		Comment: Comment{
+			ID: "c_1", StartLine: 10, EndLine: 12, Body: "fix this",
+			Quote: "selected text", Drifted: true,
+			Replies: []Reply{{ID: "rp_1", Author: "Bot", Body: "on it"}},
+		},
 	}}
 	out := formatCommentsText(entries, true)
 	if !strings.Contains(out, "[c_1] line main.go:10-12 (drifted)") {
@@ -131,6 +131,113 @@ func TestRunComments_JSONOutput(t *testing.T) {
 	if len(entries) != 1 || entries[0].ID != "r_1" {
 		t.Fatalf("got %+v", entries)
 	}
+}
+
+func TestListCommentsFromCritJSON_PreservesPreviewFields(t *testing.T) {
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"/preview-content/": {
+				Comments: []Comment{{
+					ID: "c_pin", Body: "fix heading", StartLine: 0, EndLine: 0,
+					Author: "Alice", CreatedAt: "2026-01-01T00:00:00Z",
+					PinNumber: 3,
+					DOMAnchor: &DOMAnchor{
+						Pathname:       "/preview-content/",
+						CSSSelector:    "#deck > h1",
+						TagChain:       []string{"MAIN", "H1"},
+						AccessibleName: "Give us the reins.",
+						OuterHTML:      "<h1>Give us the reins.</h1>",
+						ViewportWidth:  1280,
+						ViewportHeight: 800,
+					},
+				}},
+			},
+		},
+	}
+
+	entries := listCommentsFromCritJSON(cj, true)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.PinNumber != 3 {
+		t.Errorf("pin_number = %d, want 3", e.PinNumber)
+	}
+	if e.Author != "Alice" {
+		t.Errorf("author = %q, want Alice", e.Author)
+	}
+	if e.DOMAnchor == nil || e.DOMAnchor.CSSSelector != "#deck > h1" {
+		t.Errorf("dom_anchor = %+v", e.DOMAnchor)
+	}
+
+	data, err := encodeCommentsJSON(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"dom_anchor"`) {
+		t.Fatalf("dom_anchor missing from JSON: %s", data)
+	}
+	var roundtrip []ListedComment
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatal(err)
+	}
+	if roundtrip[0].DOMAnchor == nil {
+		t.Fatalf("dom_anchor missing after JSON roundtrip: %s", data)
+	}
+}
+
+func TestListedCommentJSONIncludesAllCommentFields(t *testing.T) {
+	offset := 4
+	c := Comment{
+		ID: "c_full", StartLine: 7, EndLine: 9, Side: "RIGHT", Body: "note",
+		Quote: "quoted", QuoteOffset: &offset, Anchor: "anchor-text",
+		Drifted: true, DriftedOnRound: 2, Author: "alice", UserID: "u1",
+		CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-02T00:00:00Z",
+		Resolved: true, ResolvedRound: 2, Live: true, CarriedForward: true,
+		ReviewRound: 1, GitHubID: 99, HeadSHA: "abc", DiffScope: "layer",
+		PinNumber: 5, FocusKey: "pr:42",
+		DOMAnchor: &DOMAnchor{
+			Pathname: "/preview-content/", CSSSelector: "#main", TagChain: []string{"MAIN"},
+			AccessibleName: "title", OuterHTML: "<main/>", ViewportWidth: 100, ViewportHeight: 200,
+		},
+		Replies: []Reply{{ID: "rp_1", Body: "reply", Author: "bob", CreatedAt: "2026-01-03T00:00:00Z"}},
+	}
+
+	commentKeys := jsonObjectKeys(t, c)
+	lc := toListedComment("line", "f.go", c)
+	listedKeys := jsonObjectKeys(t, lc)
+
+	for key := range commentKeys {
+		if key == "scope" {
+			continue // ListedComment.scope is the list location, not Comment.scope
+		}
+		if !listedKeys[key] {
+			t.Errorf("ListedComment JSON missing key %q present on Comment", key)
+		}
+	}
+	if !listedKeys["scope"] {
+		t.Error("ListedComment JSON missing list-specific key scope")
+	}
+	if !listedKeys["path"] {
+		t.Error("ListedComment JSON missing list-specific key path")
+	}
+}
+
+func jsonObjectKeys(t *testing.T, v any) map[string]bool {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	keys := make(map[string]bool, len(obj))
+	for k := range obj {
+		keys[k] = true
+	}
+	return keys
 }
 
 func TestRunComments_ExplicitReviewJSONPath(t *testing.T) {

--- a/internal/comment/types.go
+++ b/internal/comment/types.go
@@ -9,6 +9,7 @@ type (
 	CritJSON       = session.CritJSON
 	CritJSONFile   = session.CritJSONFile
 	Comment        = session.Comment
+	DOMAnchor      = session.DOMAnchor
 	Reply          = session.Reply
 	Focus          = session.Focus
 	inheritedScope = session.InheritedScope

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1912,25 +1912,31 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	stats := s.buildSessionStats(sess)
 
 	prompt, approved, comments := buildFinishFeedback(sess)
+	nextCommand := buildNextCommand(s.cliArgs)
+	copyPrompt := buildCopyPrompt(sess, approved, comments, nextCommand)
 	if !approved {
 		sess.SetWaitingForAgent(true)
 	}
 
 	writeJSON(w, map[string]any{
-		"status":   "finished",
-		"prompt":   prompt,
-		"approved": approved,
-		"comments": comments,
-		"stats":    stats,
+		"status":       "finished",
+		"prompt":       prompt,
+		"copy_prompt":  copyPrompt,
+		"approved":     approved,
+		"comments":     comments,
+		"next_command": nextCommand,
+		"stats":        stats,
 	})
 
 	// Encode approved status into SSE event content as JSON so review-cycle
 	// clients can extract it without string matching on the prompt.
 	eventData, _ := json.Marshal(map[string]any{
-		"prompt":   prompt,
-		"approved": approved,
-		"stats":    stats,
-		"comments": comments,
+		"prompt":       prompt,
+		"copy_prompt":  copyPrompt,
+		"approved":     approved,
+		"stats":        stats,
+		"comments":     comments,
+		"next_command": nextCommand,
 	})
 	sess.Notify(SSEEvent{
 		Type:    "finish",
@@ -2004,20 +2010,62 @@ func buildFinishPrompt(sess *Session, approved bool, totalComments int) string {
 }
 
 func buildUnresolvedInstructions(sess *Session) string {
-	return fmt.Sprintf(
-		"Address each comment in the comments array. "+
-			"For each comment, reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> \"<explanation>\"`. "+
-			"When done run: `%s`",
-		sess.ReinvokeCommand())
+	return buildUnresolvedActions(sess) + fmt.Sprintf(" When done run: `%s`", sess.ReinvokeCommand())
 }
 
-func buildPlanInstructions(sess *Session) string {
+func buildUnresolvedActions(sess *Session) string {
+	return "Address each comment. For each one, reply explaining what you did using `crit comment --reply-to <comment-id> --author <your-name> \"<explanation>\"`."
+}
+
+func buildPlanActions(sess *Session) string {
 	slug := filepath.Base(sess.PlanDir)
 	return fmt.Sprintf(
-		"Plan review feedback — revise the plan to address the comments above. "+
+		"Revise the plan to address each comment. "+
 			"If you are running under Codex, re-emit the revised plan inside <proposed_plan>...</proposed_plan> so Crit can review the new version. "+
 			"To reply to comments, use `crit comment --plan %s --reply-to <id> --author <your-name> \"<explanation>\"`.",
 		slug)
+}
+
+func buildPlanInstructions(sess *Session) string {
+	return buildPlanActions(sess)
+}
+
+// buildCopyPrompt is pasted directly to the agent from the finish modal.
+func buildCopyPrompt(sess *Session, approved bool, comments []comment.ListedComment, nextCommand string) string {
+	var b strings.Builder
+	if approved {
+		totalComments := sess.TotalCommentCount()
+		switch {
+		case totalComments == 0:
+			b.WriteString("Review approved — no changes requested.")
+		default:
+			b.WriteString("Review approved. All comments are resolved — proceed with implementation.")
+		}
+		return b.String()
+	}
+
+	n := len(comments)
+	if n == 1 {
+		b.WriteString("The review finished with 1 unresolved comment.\n\n")
+	} else {
+		fmt.Fprintf(&b, "The review finished with %d unresolved comments.\n\n", n)
+	}
+	b.WriteString("Load them with:\n\n")
+	fmt.Fprintf(&b, "  %s\n\n", buildCommentsListCommand(sess))
+	if sess.Mode == "plan" {
+		b.WriteString(buildPlanActions(sess))
+	} else {
+		b.WriteString(buildUnresolvedActions(sess))
+	}
+	if nextCommand != "" {
+		b.WriteString("\n\nWhen you're done, run:\n\n  ")
+		b.WriteString(nextCommand)
+	}
+	return b.String()
+}
+
+func buildCommentsListCommand(sess *Session) string {
+	return fmt.Sprintf("crit comments --json %s", shellQuoteArg(sess.CritJSONPath()))
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -2098,13 +2146,16 @@ func (s *Server) handleReviewCycle(w http.ResponseWriter, r *http.Request) {
 					Comments []comment.ListedComment `json:"comments"`
 				}
 				json.Unmarshal([]byte(event.Content), &finishData)
+				nextCommand := buildNextCommand(s.cliArgs)
+				copyPrompt := buildCopyPrompt(sess, finishData.Approved, finishData.Comments, nextCommand)
 				writeJSON(w, map[string]any{
 					"status":       "finished",
 					"prompt":       finishData.Prompt,
+					"copy_prompt":  copyPrompt,
 					"approved":     finishData.Approved,
 					"comments":     finishData.Comments,
 					"stats":        finishData.Stats,
-					"next_command": buildNextCommand(s.cliArgs),
+					"next_command": nextCommand,
 				})
 				return
 			}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -525,11 +525,56 @@ func TestFinish_IncludesStructuredComments(t *testing.T) {
 		t.Errorf("comment body = %v, want fix this", c0["body"])
 	}
 	prompt, _ := resp["prompt"].(string)
-	if !strings.Contains(prompt, "comments array") {
+	if !strings.Contains(prompt, "Address each comment") {
 		t.Errorf("expected instructions in prompt, got: %s", prompt)
 	}
 	if !strings.Contains(prompt, "run: `crit`") {
 		t.Errorf("expected reinvoke command in prompt, got: %s", prompt)
+	}
+	copyPrompt, _ := resp["copy_prompt"].(string)
+	if !strings.Contains(copyPrompt, "1 unresolved comment") {
+		t.Errorf("copy_prompt should summarize comment count, got: %s", copyPrompt)
+	}
+	wantCommentsCmd := buildCommentsListCommand(session)
+	if !strings.Contains(copyPrompt, wantCommentsCmd) {
+		t.Errorf("copy_prompt should mention %q, got: %s", wantCommentsCmd, copyPrompt)
+	}
+	if strings.Contains(copyPrompt, "Next review round") {
+		t.Errorf("copy_prompt should not use legacy next review round heading, got: %s", copyPrompt)
+	}
+	if !strings.Contains(copyPrompt, "When you're done, run:") {
+		t.Errorf("copy_prompt should include a single next-command instruction, got: %s", copyPrompt)
+	}
+	if strings.Contains(copyPrompt, "When done run:") {
+		t.Errorf("copy_prompt should not duplicate next-command wording, got: %s", copyPrompt)
+	}
+	nextCmd, _ := resp["next_command"].(string)
+	if nextCmd != "crit" {
+		t.Errorf("next_command = %q, want crit", nextCmd)
+	}
+}
+
+func TestFinish_CopyPromptApproved(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.cliArgs = []string{"preview", "/tmp/page.html"}
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	copyPrompt, _ := resp["copy_prompt"].(string)
+	if !strings.Contains(copyPrompt, "Review approved") {
+		t.Errorf("copy_prompt = %q", copyPrompt)
+	}
+	if strings.Contains(copyPrompt, "Next review round") {
+		t.Errorf("approved copy_prompt should not mention next review round, got: %s", copyPrompt)
+	}
+	if strings.Contains(copyPrompt, "crit comments") {
+		t.Errorf("approved copy_prompt should not mention crit comments, got: %s", copyPrompt)
 	}
 }
 
@@ -3078,7 +3123,7 @@ func TestBuildPlanInstructions(t *testing.T) {
 	if !strings.Contains(result, "my-feature") {
 		t.Errorf("expected slug 'my-feature' in feedback, got: %s", result)
 	}
-	if !strings.Contains(result, "comments above") {
+	if !strings.Contains(result, "each comment") {
 		t.Errorf("expected comments reference in feedback, got: %s", result)
 	}
 	if !strings.Contains(result, "crit comment --plan") {

--- a/web/__tests__/crit-shared.test.js
+++ b/web/__tests__/crit-shared.test.js
@@ -434,16 +434,30 @@ test('runFinishReview resets copy button via .copy-label span, not textContent (
   assert.ok(els.waitingClipboard.querySelector('.copy-label'), '.copy-label span still accessible');
 });
 
-test('runFinishReview not-approved path: leaves approved class off + uses default prompt fallback', async () => {
-  const fetch = async () => ({ ok: true, json: async () => ({ approved: false }) });
+test('runFinishReview not-approved path: leaves approved class off + uses copy_prompt', async () => {
+  const fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      approved: false,
+      copy_prompt: 'The review finished with 2 unresolved comments.\n\nLoad them with:\n\n  crit comments --json /tmp/review.json\n\nAddress each comment.\n\nWhen you\'re done, run:\n\n  crit test.md',
+    }),
+  });
   const { shared: s, els } = makeFinishSandbox(fetch, { writeText: async () => {} });
   let waitingCalled = false;
   const result = await s.runFinishReview({ onWaiting: () => { waitingCalled = true; } });
   assert.equal(result.approved, false);
-  assert.equal(result.prompt, 'I reviewed the changes, no feedback, good to go!');
+  assert.match(result.prompt, /crit comments --json/);
   assert.equal(els.waitingHeading.textContent, 'Review Complete');
+  assert.match(els.waitingMessage.textContent, /wasn't listening/);
   assert.equal(els.waitingDialog.classList.contains('approved'), false);
   assert.equal(waitingCalled, true);
+});
+
+test('runFinishReview not-approved path: falls back when copy_prompt missing', async () => {
+  const fetch = async () => ({ ok: true, json: async () => ({ approved: false }) });
+  const { shared: s, els } = makeFinishSandbox(fetch, { writeText: async () => {} });
+  const result = await s.runFinishReview({ onWaiting: () => {} });
+  assert.equal(result.prompt, 'I reviewed the changes, no feedback, good to go!');
 });
 
 test('runFinishReview dedup blocks the second concurrent call', async () => {

--- a/web/crit-shared.js
+++ b/web/crit-shared.js
@@ -300,7 +300,7 @@
       if (!resp.ok) throw new Error('Finish review failed: HTTP ' + resp.status);
       var data = await resp.json();
       var approved = !!data.approved;
-      var prompt = data.prompt || 'I reviewed the changes, no feedback, good to go!';
+      var prompt = data.copy_prompt || data.prompt || 'I reviewed the changes, no feedback, good to go!';
 
       var dialog = document.getElementById('waitingDialog');
       var headingEl = document.getElementById('waitingHeading');


### PR DESCRIPTION
## Summary
- Embed `Comment` in `ListedComment` so finish stdout and `crit comments --json` carry all `review.json` fields (including `dom_anchor`, `pin_number`, author, replies, etc.)
- Add `copy_prompt` for the finish modal: agent-directed wording, explicit `crit comments --json <review-path>`, and a single next-command instruction when changes are requested (none when approved)
- `/api/finish` now also returns `next_command`; browser copies `copy_prompt` instead of the brief stdout `prompt`

## Review
- [x] Code review: passed (static diff review)
- [x] Parity audit: N/A (crit only)

## Test plan
- [x] Pre-commit hook (gofmt, golangci-lint, go test, ESLint)
- [x] `go test -race ./internal/comment/... ./internal/server/... ./cmd/crit/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)