### PR TITLE
fix: resolve/delete preview comments imported from crit-web

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4501,6 +4501,39 @@ func TestAPIDeleteComment_FansOutSSE(t *testing.T) {
 	}
 }
 
+// TestAPIResolveComment_WrongPathHint covers preview imports: comments merged
+// from crit-web live under index.html but the client sends the iframe route
+// as ?path= when resolving.
+func TestAPIResolveComment_WrongPathHint(t *testing.T) {
+	srv, sess := newTestServer(t)
+	sess.Files = append(sess.Files, &FileEntry{
+		Path: "index.html",
+		Comments: []Comment{{
+			ID:        "web-1",
+			Body:      "imported pin",
+			DOMAnchor: &DOMAnchor{Pathname: "/preview-content", CSSSelector: "h1"},
+		}},
+	})
+
+	body := strings.NewReader(`{"resolved":true}`)
+	req := httptest.NewRequest("PUT", "/api/comment/web-1/resolve?path=/preview-content", body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	for _, f := range sess.Files {
+		if f.Path != "index.html" {
+			continue
+		}
+		for _, c := range f.Comments {
+			if c.ID == "web-1" && !c.Resolved {
+				t.Fatal("comment not resolved after PUT with route path hint")
+			}
+		}
+	}
+}
+
 // TestAPIResolveComment_FansOutSSE pins down that PUT
 // /api/comment/{id}/resolve emits a comments-changed SSE event for both
 // resolve and unresolve transitions, on both the file-scoped and

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1337,29 +1337,23 @@ func (s *Session) UpdateComment(filePath, id, body string) (Comment, bool) {
 func (s *Session) UpdateCommentWithAnchor(filePath, id, body string, newAnchor *DOMAnchor) (Comment, bool, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	fe := s.fileByPathLocked(filePath)
+	fe, i := s.locateFileCommentLocked(filePath, id)
 	if fe == nil {
 		return Comment{}, false, "not_found"
 	}
-	for i := range fe.Comments {
-		c := &fe.Comments[i]
-		if c.ID != id {
-			continue
-		}
-		if newAnchor != nil && c.DOMAnchor == nil {
-			return Comment{}, false, "anchor_on_code_comment"
-		}
-		if body != "" {
-			c.Body = body
-		}
-		if newAnchor != nil {
-			c.DOMAnchor = newAnchor
-		}
-		c.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		s.scheduleWrite()
-		return *c, true, ""
+	c := &fe.Comments[i]
+	if newAnchor != nil && c.DOMAnchor == nil {
+		return Comment{}, false, "anchor_on_code_comment"
 	}
-	return Comment{}, false, "not_found"
+	if body != "" {
+		c.Body = body
+	}
+	if newAnchor != nil {
+		c.DOMAnchor = newAnchor
+	}
+	c.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.scheduleWrite()
+	return *c, true, ""
 }
 
 // PatchCommentDrift partially updates the live-pin drift fields on a
@@ -1369,26 +1363,20 @@ func (s *Session) UpdateCommentWithAnchor(filePath, id, body string, newAnchor *
 func (s *Session) PatchCommentDrift(filePath, id string, drifted *bool, driftedOnRound *int) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	fe := s.fileByPathLocked(filePath)
+	fe, i := s.locateFileCommentLocked(filePath, id)
 	if fe == nil {
 		return Comment{}, false
 	}
-	for i := range fe.Comments {
-		c := &fe.Comments[i]
-		if c.ID != id {
-			continue
-		}
-		if drifted != nil {
-			c.Drifted = *drifted
-		}
-		if driftedOnRound != nil {
-			c.DriftedOnRound = *driftedOnRound
-		}
-		c.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		s.scheduleWrite()
-		return *c, true
+	c := &fe.Comments[i]
+	if drifted != nil {
+		c.Drifted = *drifted
 	}
-	return Comment{}, false
+	if driftedOnRound != nil {
+		c.DriftedOnRound = *driftedOnRound
+	}
+	c.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.scheduleWrite()
+	return *c, true
 }
 
 // SetCommentResolved sets or clears the resolved flag on a comment.
@@ -1397,42 +1385,32 @@ func (s *Session) PatchCommentDrift(filePath, id string, drifted *bool, driftedO
 func (s *Session) SetCommentResolved(filePath, id string, resolved bool) (Comment, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, id)
 	if f == nil {
 		return Comment{}, false
 	}
-	for i, c := range f.Comments {
-		if c.ID == id {
-			f.Comments[i].Resolved = resolved
-			if resolved {
-				f.Comments[i].ResolvedRound = s.ReviewRound
-			} else {
-				f.Comments[i].ResolvedRound = 0
-			}
-			f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-			s.scheduleWrite()
-			return f.Comments[i], true
-		}
+	f.Comments[i].Resolved = resolved
+	if resolved {
+		f.Comments[i].ResolvedRound = s.ReviewRound
+	} else {
+		f.Comments[i].ResolvedRound = 0
 	}
-	return Comment{}, false
+	f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.scheduleWrite()
+	return f.Comments[i], true
 }
 
 // SetCommentLive marks a comment as live (sent to an agent).
 func (s *Session) SetCommentLive(filePath, id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, id)
 	if f == nil {
 		return false
 	}
-	for i, c := range f.Comments {
-		if c.ID == id {
-			f.Comments[i].Live = true
-			s.scheduleWrite()
-			return true
-		}
-	}
-	return false
+	f.Comments[i].Live = true
+	s.scheduleWrite()
+	return true
 }
 
 // DeleteComment deletes a comment from a specific file. The record is always
@@ -1459,47 +1437,38 @@ const (
 func (s *Session) DeleteFileCommentAs(filePath, id, requesterID string) deleteResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, id)
 	if f == nil {
 		return deleteResultNotFound
 	}
-	for i, c := range f.Comments {
-		if c.ID != id {
-			continue
-		}
-		if c.UserID != "" && c.UserID != requesterID {
-			return deleteResultForbidden
-		}
-		if c.GitHubID != 0 {
-			s.appendPendingGHDelete(c.GitHubID)
-		}
-		f.Comments = append(f.Comments[:i], f.Comments[i+1:]...)
-		s.trackDeletedComment(filePath, id)
-		s.scheduleWrite()
-		return deleteResultDeleted
+	c := f.Comments[i]
+	if c.UserID != "" && c.UserID != requesterID {
+		return deleteResultForbidden
 	}
-	return deleteResultNotFound
+	if c.GitHubID != 0 {
+		s.appendPendingGHDelete(c.GitHubID)
+	}
+	f.Comments = append(f.Comments[:i], f.Comments[i+1:]...)
+	s.trackDeletedComment(f.Path, id)
+	s.scheduleWrite()
+	return deleteResultDeleted
 }
 
 func (s *Session) DeleteComment(filePath, id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, id)
 	if f == nil {
 		return false
 	}
-	for i, c := range f.Comments {
-		if c.ID == id {
-			if c.GitHubID != 0 {
-				s.appendPendingGHDelete(c.GitHubID)
-			}
-			f.Comments = append(f.Comments[:i], f.Comments[i+1:]...)
-			s.trackDeletedComment(filePath, id)
-			s.scheduleWrite()
-			return true
-		}
+	c := f.Comments[i]
+	if c.GitHubID != 0 {
+		s.appendPendingGHDelete(c.GitHubID)
 	}
-	return false
+	f.Comments = append(f.Comments[:i], f.Comments[i+1:]...)
+	s.trackDeletedComment(f.Path, id)
+	s.scheduleWrite()
+	return true
 }
 
 // appendPendingGHDelete adds a GitHub comment ID to the pending-deletes list
@@ -1552,51 +1521,41 @@ func (s *Session) RefreshFileContent() {
 func (s *Session) AddReply(filePath, commentID, body, author, userID string) (Reply, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, commentID)
 	if f == nil {
 		return Reply{}, false
 	}
-	for i, c := range f.Comments {
-		if c.ID == commentID {
-			now := time.Now().UTC().Format(time.RFC3339)
-			r := Reply{
-				ID:          RandomReplyID(),
-				Body:        body,
-				Author:      author,
-				UserID:      userID,
-				CreatedAt:   now,
-				ReviewRound: s.ReviewRound,
-			}
-			f.Comments[i].Replies = append(f.Comments[i].Replies, r)
-			f.Comments[i].Resolved = false
-			f.Comments[i].ResolvedRound = 0
-			f.Comments[i].UpdatedAt = now
-			s.scheduleWrite()
-			return r, true
-		}
+	now := time.Now().UTC().Format(time.RFC3339)
+	r := Reply{
+		ID:          RandomReplyID(),
+		Body:        body,
+		Author:      author,
+		UserID:      userID,
+		CreatedAt:   now,
+		ReviewRound: s.ReviewRound,
 	}
-	return Reply{}, false
+	f.Comments[i].Replies = append(f.Comments[i].Replies, r)
+	f.Comments[i].Resolved = false
+	f.Comments[i].ResolvedRound = 0
+	f.Comments[i].UpdatedAt = now
+	s.scheduleWrite()
+	return r, true
 }
 
 // UpdateReply updates a reply's body on a specific comment.
 func (s *Session) UpdateReply(filePath, commentID, replyID, body string) (Reply, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, commentID)
 	if f == nil {
 		return Reply{}, false
 	}
-	for i, c := range f.Comments {
-		if c.ID == commentID {
-			for j, r := range c.Replies {
-				if r.ID == replyID {
-					f.Comments[i].Replies[j].Body = body
-					f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-					s.scheduleWrite()
-					return f.Comments[i].Replies[j], true
-				}
-			}
-			return Reply{}, false
+	for j, r := range f.Comments[i].Replies {
+		if r.ID == replyID {
+			f.Comments[i].Replies[j].Body = body
+			f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			s.scheduleWrite()
+			return f.Comments[i].Replies[j], true
 		}
 	}
 	return Reply{}, false
@@ -1609,24 +1568,19 @@ func (s *Session) UpdateReply(filePath, commentID, replyID, body string) (Reply,
 func (s *Session) DeleteReply(filePath, commentID, replyID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	f := s.fileByPathLocked(filePath)
+	f, i := s.locateFileCommentLocked(filePath, commentID)
 	if f == nil {
 		return false
 	}
-	for i, c := range f.Comments {
-		if c.ID == commentID {
-			for j, r := range c.Replies {
-				if r.ID == replyID {
-					if r.GitHubID != 0 {
-						s.appendPendingGHDelete(r.GitHubID)
-					}
-					f.Comments[i].Replies = append(f.Comments[i].Replies[:j], f.Comments[i].Replies[j+1:]...)
-					f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-					s.scheduleWrite()
-					return true
-				}
+	for j, r := range f.Comments[i].Replies {
+		if r.ID == replyID {
+			if r.GitHubID != 0 {
+				s.appendPendingGHDelete(r.GitHubID)
 			}
-			return false
+			f.Comments[i].Replies = append(f.Comments[i].Replies[:j], f.Comments[i].Replies[j+1:]...)
+			f.Comments[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			s.scheduleWrite()
+			return true
 		}
 	}
 	return false
@@ -1748,6 +1702,30 @@ func (s *Session) UnresolvedCommentCount() int {
 		}
 	}
 	return total
+}
+
+// locateFileCommentLocked finds a file comment by ID. hintPath is the route
+// pathname the client sent (?path=); when it differs from the on-disk file
+// key (e.g. preview pins re-keyed to index.html on crit-web share), the
+// global search still finds the comment.
+func (s *Session) locateFileCommentLocked(hintPath, id string) (*FileEntry, int) {
+	if hintPath != "" {
+		if f := s.fileByPathLocked(hintPath); f != nil {
+			for i, c := range f.Comments {
+				if c.ID == id {
+					return f, i
+				}
+			}
+		}
+	}
+	for _, f := range s.Files {
+		for i, c := range f.Comments {
+			if c.ID == id {
+				return f, i
+			}
+		}
+	}
+	return nil, -1
 }
 
 func (s *Session) fileByPathLocked(path string) *FileEntry {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3425,6 +3425,25 @@ func TestSession_SetCommentResolved_NotFound(t *testing.T) {
 	}
 }
 
+func TestSession_SetCommentResolved_WrongPathHint(t *testing.T) {
+	s := newTestSession(t)
+	s.Files = append(s.Files, &FileEntry{
+		Path: "index.html",
+		Comments: []Comment{{
+			ID:        "web-1",
+			Body:      "imported preview pin",
+			DOMAnchor: &DOMAnchor{Pathname: "/preview-content", CSSSelector: "h1"},
+		}},
+	})
+	resolved, ok := s.SetCommentResolved("/preview-content", "web-1", true)
+	if !ok {
+		t.Fatal("SetCommentResolved with route hint should find comment stored under index.html")
+	}
+	if !resolved.Resolved {
+		t.Error("comment not resolved")
+	}
+}
+
 func TestSession_FindCommentByID(t *testing.T) {
 	s := newTestSession(t)
 	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -124,19 +124,20 @@ type ShareReply struct {
 // If we add other sync sources (GitLab, Gerrit) later, we can introduce a
 // `source` enum at that point.
 type ShareComment struct {
-	File        string       `json:"file,omitempty"`
-	StartLine   int          `json:"start_line,omitempty"`
-	EndLine     int          `json:"end_line,omitempty"`
-	Body        string       `json:"body"`
-	Quote       string       `json:"quote,omitempty"`
-	Author      string       `json:"author_display_name,omitempty"`
-	UserID      string       `json:"user_id,omitempty"`
-	Scope       string       `json:"scope,omitempty"`
-	ReviewRound int          `json:"review_round,omitempty"`
-	Replies     []ShareReply `json:"replies,omitempty"`
-	ExternalID  string       `json:"external_id,omitempty"`
-	Resolved    bool         `json:"resolved,omitempty"`
-	GitHubID    int64        `json:"github_id,omitempty"`
+	File        string             `json:"file,omitempty"`
+	StartLine   int                `json:"start_line,omitempty"`
+	EndLine     int                `json:"end_line,omitempty"`
+	Body        string             `json:"body"`
+	Quote       string             `json:"quote,omitempty"`
+	Author      string             `json:"author_display_name,omitempty"`
+	UserID      string             `json:"user_id,omitempty"`
+	Scope       string             `json:"scope,omitempty"`
+	ReviewRound int                `json:"review_round,omitempty"`
+	Replies     []ShareReply       `json:"replies,omitempty"`
+	ExternalID  string             `json:"external_id,omitempty"`
+	Resolved    bool               `json:"resolved,omitempty"`
+	GitHubID    int64              `json:"github_id,omitempty"`
+	DOMAnchor   *session.DOMAnchor `json:"dom_anchor,omitempty"`
 }
 
 // shareFileEntries serializes ShareFile values into the JSON-friendly maps
@@ -440,6 +441,7 @@ func commentToShareComment(c session.Comment, filePath, scope, fallbackAuthor, c
 		UserID:    c.UserID,
 		Scope:     scope,
 		GitHubID:  c.GitHubID,
+		DOMAnchor: c.DOMAnchor,
 	}
 	if includeResolved {
 		sc.Resolved = c.Resolved
@@ -529,20 +531,21 @@ type WebReply struct {
 // is the verified user id, set when the comment was authored by a logged-in
 // user (either CLI with bearer token or LiveView while signed in).
 type WebComment struct {
-	Body              string     `json:"body"`
-	FilePath          string     `json:"file_path"`
-	StartLine         int        `json:"start_line"`
-	EndLine           int        `json:"end_line"`
-	ReviewRound       int        `json:"review_round"`
-	Resolved          bool       `json:"resolved"`
-	ResolvedRound     int        `json:"resolved_round"`
-	ExternalID        string     `json:"external_id"`
-	AuthorDisplayName string     `json:"author_display_name"`
-	AuthorIdentity    string     `json:"author_identity"`
-	UserID            string     `json:"user_id"`
-	Quote             string     `json:"quote"`
-	Scope             string     `json:"scope"`
-	Replies           []WebReply `json:"replies"`
+	Body              string             `json:"body"`
+	FilePath          string             `json:"file_path"`
+	StartLine         int                `json:"start_line"`
+	EndLine           int                `json:"end_line"`
+	ReviewRound       int                `json:"review_round"`
+	Resolved          bool               `json:"resolved"`
+	ResolvedRound     int                `json:"resolved_round"`
+	ExternalID        string             `json:"external_id"`
+	AuthorDisplayName string             `json:"author_display_name"`
+	AuthorIdentity    string             `json:"author_identity"`
+	UserID            string             `json:"user_id"`
+	Quote             string             `json:"quote"`
+	Scope             string             `json:"scope"`
+	Replies           []WebReply         `json:"replies"`
+	DOMAnchor         *session.DOMAnchor `json:"dom_anchor,omitempty"`
 }
 
 // buildLocalFingerprintIndex returns both the fingerprint set and a map from
@@ -857,18 +860,21 @@ func MergeWebComments(critPath string, newComments []WebComment, replyUpdates ma
 			})
 		}
 		c := session.StampWithFocus(session.Comment{
-			ID:          fmt.Sprintf("web-%d", webCount),
-			StartLine:   wc.StartLine,
-			EndLine:     wc.EndLine,
-			Body:        wc.Body,
-			Quote:       wc.Quote,
-			Author:      wc.AuthorDisplayName,
-			UserID:      wc.UserID,
-			Scope:       wc.Scope,
-			ReviewRound: wc.ReviewRound,
-			Replies:     replies,
-			CreatedAt:   now,
-			UpdatedAt:   now,
+			ID:            fmt.Sprintf("web-%d", webCount),
+			StartLine:     wc.StartLine,
+			EndLine:       wc.EndLine,
+			Body:          wc.Body,
+			Quote:         wc.Quote,
+			Author:        wc.AuthorDisplayName,
+			UserID:        wc.UserID,
+			Scope:         wc.Scope,
+			ReviewRound:   wc.ReviewRound,
+			Resolved:      wc.Resolved,
+			ResolvedRound: wc.ResolvedRound,
+			DOMAnchor:     wc.DOMAnchor,
+			Replies:       replies,
+			CreatedAt:     now,
+			UpdatedAt:     now,
 		}, scope.AsFocus())
 		if wc.Scope == "review" {
 			cj.ReviewComments = append(cj.ReviewComments, c)

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1573,6 +1573,37 @@ func TestMergeWebComments(t *testing.T) {
 	}
 }
 
+func TestMergeWebComments_PreviewPinPreservesDOMAnchor(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit")
+	cj := CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{}}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	os.WriteFile(session.MustMkdirAll(review.ReviewPathsFor(critPath).Review), data, 0644)
+
+	anchor := &session.DOMAnchor{Pathname: "/preview-content", CSSSelector: "h1"}
+	newComments := []WebComment{{
+		Body:              "imported pin",
+		FilePath:          session.PreviewMainHTMLKey,
+		DOMAnchor:         anchor,
+		AuthorDisplayName: "Alice",
+	}}
+	if err := MergeWebComments(critPath, newComments, nil); err != nil {
+		t.Fatalf("MergeWebComments: %v", err)
+	}
+
+	data, _ = os.ReadFile(review.ReviewPathsFor(critPath).Review)
+	var result CritJSON
+	json.Unmarshal(data, &result)
+
+	stored := result.Files[session.PreviewMainHTMLKey].Comments
+	if len(stored) != 1 {
+		t.Fatalf("expected 1 comment under %s, got %d", session.PreviewMainHTMLKey, len(stored))
+	}
+	if stored[0].DOMAnchor == nil || stored[0].DOMAnchor.Pathname != "/preview-content" {
+		t.Fatalf("dom_anchor not preserved: %+v", stored[0].DOMAnchor)
+	}
+}
+
 func TestBuildLocalFingerprints(t *testing.T) {
 	t.Run("file comments with path body lines", func(t *testing.T) {
 		cj := CritJSON{

--- a/web/__tests__/live-mode.row.test.js
+++ b/web/__tests__/live-mode.row.test.js
@@ -106,6 +106,21 @@ test('renderLivePinRow includes a Delete button on top-level comment cards', () 
     assert.equal(del.dataset.pathname, '/p');
     assert.equal(del._attrs['aria-label'], 'Delete comment');
     assert.equal(del._cls.has('delete-btn'), true, 'should reuse shared .delete-btn class');
+
+    // Imported preview pins: API path is the session file key, not the route.
+    renderLivePinRow(
+      {
+        id: 'c-del-2',
+        body: 'imported',
+        file_path: 'index.html',
+        dom_anchor: { pathname: '/preview-content' },
+      },
+      { iconDelete: '<svg/>' },
+    );
+    const importedDel = fakeActions.children.filter(
+      (b) => b._cls && b._cls.has('crit-live-comment-delete'),
+    ).pop();
+    assert.equal(importedDel.dataset.pathname, 'index.html');
   } finally {
     if (origDocument === undefined) delete global.document; else global.document = origDocument;
     if (origWindow === undefined) delete global.window; else global.window = origWindow;

--- a/web/live-mode.comments-loader.js
+++ b/web/live-mode.comments-loader.js
@@ -65,10 +65,10 @@
           .then(function (list) {
             if (!Array.isArray(list)) return [];
             return list.map(function (c) {
-              // Use dom_anchor.pathname for live comments; fallback to
-              // file path.
-              var path = (c.dom_anchor && c.dom_anchor.pathname) || p;
-              c.path = path;
+              // file_path is the session file key used by mutation APIs
+              // (?path=). path is the iframe route for panel grouping.
+              c.file_path = p;
+              c.path = (c.dom_anchor && c.dom_anchor.pathname) || p;
               // Stamp _createdInRound from the persisted review_round so
               // the drift guard in handlePinResolutionResult survives
               // reloads (initial boot, SSE refresh,

--- a/web/live-mode.js
+++ b/web/live-mode.js
@@ -805,7 +805,7 @@
     for (var i = 0; i < all.length; i++) {
       var c = all[i];
       if (!c || c.resolved) continue;
-      var path = (c.dom_anchor && c.dom_anchor.pathname) || c.path || '/';
+      var path = commentStoragePath(c);
       try {
         var rr = await fetch('/api/comment/' + encodeURIComponent(c.id) + '/resolve?path=' + encodeURIComponent(path), {
           method: 'PUT',
@@ -980,6 +980,11 @@
     return (state.comments || []).find(function (x) { return x && x.id === id; });
   }
 
+  function commentStoragePath(c) {
+    if (!c) return '/';
+    return c.file_path || (c.dom_anchor && c.dom_anchor.pathname) || c.path || '/';
+  }
+
   function focusReplyTextareaFor(id) {
     requestAnimationFrame(function () {
       var card = document.querySelector('.crit-live-comment-row[data-comment-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
@@ -1128,7 +1133,7 @@
     if (!commentId || !replyId) return;
     var c = findCommentById(commentId);
     if (!c) return;
-    var pathname = (c.dom_anchor && c.dom_anchor.pathname) || '/';
+    var pathname = commentStoragePath(c);
     var replyEl = document.querySelector('[data-reply-id="' + (window.CSS && CSS.escape ? CSS.escape(replyId) : replyId) + '"]');
     if (!replyEl) return;
     if (replyEl.querySelector('.crit-live-reply-edit-textarea')) return; // already editing
@@ -1215,7 +1220,7 @@
     if (!commentId || !replyId) return;
     var c = findCommentById(commentId);
     if (!c) return;
-    var pathname = (c.dom_anchor && c.dom_anchor.pathname) || '/';
+    var pathname = commentStoragePath(c);
     try {
       var res = await fetch(replyMutationUrl(commentId, replyId, pathname), { method: 'DELETE' });
       if (!res.ok) throw new Error('Server returned ' + res.status);
@@ -1242,7 +1247,7 @@
     if (!commentId) return;
     var c = findCommentById(commentId);
     if (!c) return;
-    var pathname = btn.dataset.pathname || (c.dom_anchor && c.dom_anchor.pathname) || '/';
+    var pathname = btn.dataset.pathname || commentStoragePath(c) || '/';
     try {
       var res = await fetch('/api/comment/' + encodeURIComponent(commentId) + '?path=' + encodeURIComponent(pathname), { method: 'DELETE' });
       if (!res.ok) throw new Error('Server returned ' + res.status);
@@ -1754,8 +1759,8 @@
     try {
       var list = await shared.fetchJSON('/api/file/comments?path=' + encodeURIComponent(pathname));
       var out = (list || []).map(function (c) {
-        var path = (c.dom_anchor && c.dom_anchor.pathname) || pathname;
-        c.path = path;
+        c.file_path = pathname;
+        c.path = (c.dom_anchor && c.dom_anchor.pathname) || pathname;
         // Same _createdInRound stamping as loadAllComments — see comment
         // there. refreshCommentsForRoute fires immediately after a pin POST
         // (saveComposer) and would otherwise wipe the optimistic stamp.

--- a/web/live-mode.row.js
+++ b/web/live-mode.row.js
@@ -192,7 +192,8 @@
     // Default author to 'Reviewer' when user_id present but name missing
     if (!c.author && c.user_id) c.author = 'Reviewer';
     var anchor = c.dom_anchor || {};
-    var pathname = anchor.pathname || '';
+    var routePath = anchor.pathname || c.path || '/';
+    var storagePath = c.file_path || routePath;
     var commentId = c.id || '';
 
     var card = window.crit && window.crit.commentCard;
@@ -203,7 +204,7 @@
       fallback.className = 'comment-card crit-live-comment-row';
       fallback.dataset.id = commentId;
       fallback.dataset.commentId = commentId;
-      fallback.dataset.liveRoute = pathname;
+      fallback.dataset.liveRoute = routePath;
       fallback.textContent = c.body || '';
       return fallback;
     }
@@ -216,7 +217,7 @@
       iconDelete: deps.iconDelete || '',
     });
 
-    var parts = card.buildCommentCard(c, pathname, {
+    var parts = card.buildCommentCard(c, routePath, {
       // Include `panel-comment-block` so the row gets the panel's tight
       // 12px padding instead of the 56px left-gutter padding that
       // `.comment-block` applies for inline (under-line) comments in
@@ -271,9 +272,9 @@
     // Mark wrapper + card with the data attributes the existing CSS / event
     // handlers / E2E selectors expect.
     parts.wrapper.dataset.commentId = commentId;
-    parts.wrapper.dataset.liveRoute = pathname;
+    parts.wrapper.dataset.liveRoute = routePath;
     parts.card.dataset.id = commentId;
-    parts.card.dataset.liveRoute = pathname;
+    parts.card.dataset.liveRoute = routePath;
     if (c.resolved) {
       parts.card.dataset.resolved = 'true';
       parts.wrapper.dataset.resolved = 'true';
@@ -311,7 +312,7 @@
     if (c.resolved) resolveCls += ' resolve-btn--active';
     resolveBtn.className = resolveCls;
     resolveBtn.dataset.commentId = commentId;
-    resolveBtn.dataset.pathname = pathname;
+    resolveBtn.dataset.pathname = storagePath;
     var resolveLabel = c.resolved ? 'Unresolve' : 'Resolve';
     resolveBtn.title = resolveLabel;
     resolveBtn.setAttribute('aria-label', resolveLabel + ' thread');
@@ -325,7 +326,7 @@
     editBtn.type = 'button';
     editBtn.className = 'crit-live-comment-edit';
     editBtn.dataset.commentId = commentId;
-    editBtn.dataset.pathname = pathname;
+    editBtn.dataset.pathname = storagePath;
     editBtn.title = 'Edit';
     editBtn.setAttribute('aria-label', 'Edit comment');
     editBtn.innerHTML = deps.iconEdit || '';
@@ -335,7 +336,7 @@
     replyBtn.type = 'button';
     replyBtn.className = 'crit-live-comment-reply';
     replyBtn.dataset.commentId = commentId;
-    replyBtn.dataset.pathname = pathname;
+    replyBtn.dataset.pathname = storagePath;
     replyBtn.title = 'Reply';
     replyBtn.setAttribute('aria-label', 'Reply to comment');
     replyBtn.innerHTML = deps.iconReply || '';
@@ -349,7 +350,7 @@
     deleteBtn.type = 'button';
     deleteBtn.className = 'delete-btn crit-live-comment-delete';
     deleteBtn.dataset.commentId = commentId;
-    deleteBtn.dataset.pathname = pathname;
+    deleteBtn.dataset.pathname = storagePath;
     deleteBtn.title = 'Delete';
     deleteBtn.setAttribute('aria-label', 'Delete comment');
     deleteBtn.innerHTML = deps.iconDelete || '';
@@ -357,7 +358,7 @@
 
     // Inline reply composer when open.
     if (c._replyOpen) {
-      parts.card.appendChild(buildLiveReplyComposer(commentId, pathname, c._replyDraft || ''));
+      parts.card.appendChild(buildLiveReplyComposer(commentId, storagePath, c._replyDraft || ''));
     }
 
     // Inline edit composer — replaces the body when open. Locating the body
@@ -367,7 +368,7 @@
     if (c._editOpen) {
       var bodyEl = parts.card.querySelector('.comment-body');
       var draft = c._editDraft != null ? c._editDraft : (c.body || '');
-      var ec = buildLiveEditComposer(commentId, pathname, draft);
+      var ec = buildLiveEditComposer(commentId, storagePath, draft);
       if (bodyEl && bodyEl.parentNode) {
         bodyEl.parentNode.insertBefore(ec, bodyEl);
         bodyEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- Look up file comments by ID across all session file entries when the client sends a route pathname that differs from the on-disk storage key (preview pins re-keyed to `index.html` on crit-web share)
- Round-trip `dom_anchor` through share import/export so imported preview pins keep their iframe route metadata
- Teach live-mode to send the session `file_path` (storage key) on resolve/delete/reply/edit mutations instead of only the iframe route

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (live/preview mode only; no crit-web changes)

## Test plan
- [x] `go test ./internal/session/... ./internal/share/... ./internal/server/...`
- [x] `node --test web/__tests__/live-mode.row.test.js`
- [x] New tests: `SetCommentResolved_WrongPathHint`, `APIResolveComment_WrongPathHint`, `MergeWebComments_PreviewPinPreservesDOMAnchor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)