### PR TITLE
docs: expand Codex plugin installation guide

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -60,13 +60,32 @@ Both approaches give you the `/crit` slash command. The plugin marketplace addit
 
 ## Codex plugin
 
-For Codex, `crit install codex-plugin` installs both:
+For the full Codex experience, install the plugin. This gives you:
 
-- loose `.agents/skills/crit` and `.agents/skills/crit-cli` skills, so bare `$crit` works directly
-- a local Codex plugin marketplace entry under `.agents/plugins/` or `~/.agents/plugins/`
-- plugin files under `plugins/crit/` for project installs or `~/.codex/plugins/crit/` for global installs
+- A `$crit` skill for the review loop (plus loose copies under `.agents/skills/` so bare `$crit` works even outside the plugin)
+- A `crit-cli` skill that auto-activates when working with review files, `crit comment`, `crit pull/push`, etc.
+- A **proposed-plan review hook** — intercepts Codex's `Stop` hook when the agent proposes a plan in Plan mode, writes it to disk, and opens Crit for inline review before the turn ends
 
-The plugin bundles the same skills plus a Codex `Stop` hook that runs `crit plan-hook --mode codex` for proposed-plan review when plugin hooks are enabled.
+```bash
+cd ~ && crit install codex-plugin    # global (recommended)
+crit install codex-plugin            # per-project (commit plugins/crit/ for the whole team)
+```
+
+`crit install codex-plugin` registers the plugin in a local Codex marketplace (`.agents/plugins/marketplace.json` or `~/.agents/plugins/marketplace.json`), copies plugin files to `plugins/crit/` (project) or `~/.codex/plugins/crit/` (global), enables the plugin in `~/.codex/config.toml`, and turns on `features.plugins`, `features.hooks`, and `features.plugin_hooks`.
+
+Plugin source files live in `integrations/codex/plugin/crit/`. See [`integrations/codex/README.md`](./codex/README.md) for layout and manual setup.
+
+### `crit install codex` vs `crit install codex-plugin`
+
+| | `crit install codex` | `crit install codex-plugin` |
+|---|---|---|
+| **Scope** | Skills only (project or global) | Skills + Codex plugin + plan hook |
+| **What's installed** | `$crit` and `crit-cli` skills under `.agents/skills/` | Same skills, plus `plugins/crit/` (or `~/.codex/plugins/crit/`) with bundled skills and a `Stop` hook |
+| **Plan mode** | Agent must write the plan to a file before `$crit` works | Hook captures in-chat proposed plans (`<proposed_plan>`) and reviews them automatically |
+
+Both approaches give you `$crit` and the `crit-cli` skill. Only `codex-plugin` adds the proposed-plan hook — without it, typing `$crit` on an in-chat plan (e.g. after choosing "No and stay in Plan Mode") does nothing useful because there is no file path for `crit` to open.
+
+Disable the plan hook per-shell or globally: `export CRIT_PLAN_REVIEW=off`
 
 ## What these do
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,53 @@
+# Crit — Codex CLI Integration
+
+Drop-in configuration files that teach the OpenAI Codex CLI to use Crit for reviewing plans and code changes.
+
+## What's included
+
+| Path | Install command | Purpose |
+|------|----------------|---------|
+| `skills/crit/SKILL.md` | `crit install codex` | `$crit` skill — launches the interactive review loop |
+| `skills/crit-cli/SKILL.md` | `crit install codex` | CLI reference — `crit comment`, `crit pull/push`, review file format |
+| `plugin/crit/.codex-plugin/plugin.json` | `crit install codex-plugin` | Codex plugin manifest (skills + hooks) |
+| `plugin/crit/skills/*` | `crit install codex-plugin` | Plugin-packaged copies of the skills |
+| `plugin/crit/hooks/hooks.json` | `crit install codex-plugin` | `Stop` hook → `crit plan-hook --mode codex` for proposed-plan review |
+
+## Install
+
+**Skills only** (on-demand `$crit` when the target is already a file on disk):
+
+```bash
+crit install codex              # project: .agents/skills/
+cd ~ && crit install codex      # global: ~/.agents/skills/
+```
+
+**Full plugin** (recommended — adds proposed-plan review in Plan mode):
+
+```bash
+crit install codex-plugin              # project: plugins/crit/ + .agents/skills/
+cd ~ && crit install codex-plugin      # global: ~/.codex/plugins/crit/ + ~/.agents/skills/
+```
+
+The plugin install also:
+
+1. Registers Crit in `.agents/plugins/marketplace.json` (project) or `~/.agents/plugins/marketplace.json` (global)
+2. Enables `crit@local` in `~/.codex/config.toml`
+3. Sets `features.plugins`, `features.hooks`, and `features.plugin_hooks` to `true` in that config
+
+Safe to re-run. Existing files are skipped unless you pass `--force`.
+
+## Plan mode and in-chat plans
+
+In Codex Plan mode, the agent often keeps the plan in chat (`<proposed_plan>`) instead of writing a file. Bare `$crit` needs a path, so it cannot review those plans on its own.
+
+With `crit install codex-plugin`, the `Stop` hook reads the proposed plan from the Codex transcript, writes it to a temp file, and runs `crit plan-hook --mode codex`. You leave inline comments, the agent revises, and the turn does not complete until you approve.
+
+Disable the hook: `export CRIT_PLAN_REVIEW=off`
+
+## Usage
+
+Once installed:
+
+- Type `$crit` in Codex chat to review current git changes, a file, PR, or commit range
+- In Plan mode with the plugin, proposed plans are reviewed automatically when the agent tries to finish the turn
+- The `crit-cli` skill teaches the agent about `crit comment`, sharing, and GitHub PR sync without manual invocation


### PR DESCRIPTION
## Summary
- Expand `integrations/README.md` with Codex plugin install instructions and `codex` vs `codex-plugin` comparison
- Add dedicated `integrations/codex/README.md` covering skills, plugin bundle, and Plan mode behavior

Related to tomasz-tomczyk/crit#685

## Review
- [x] Code review: passed (human crit review on crit worktree)
- [x] Parity audit: N/A (docs only)

## Test plan
- [x] Pre-commit hook (gofmt, golangci-lint, tests)
- See also: tomasz-tomczyk/crit-web#278

🤖 Generated with [Claude Code](https://claude.com/claude-code)