### PR TITLE
feat: configurable advertised URL for reverse-proxy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | `open_cmd`             | string   | `""`                       | Custom command to open review URLs — receives the URL as its only argument (must be a single executable, no flags). Use when the browser isn't on the machine running crit, e.g. crit runs on a remote host over SSH and a small wrapper script opens the URL on your local machine. When unset, crit uses the platform default opener. |
 | `auth_token`           | string   | `""`                       | Authentication token for crit.md. Set automatically by `crit auth login`. |
 | `share_url`            | string   | `"https://crit.md"`        | Base URL of the share service. Set to `""` to disable sharing entirely. Self-host with [`crit-web`](https://github.com/tomasz-tomczyk/crit-web). |
+| `public_url`           | string   | `""`                       | Advertised base URL for stderr and browser-open (e.g. `https://machine.ts.net` via tailscale serve). Listen address unchanged. |
 | `share_consented`      | bool     | `false`                    | Written automatically to `true` after you confirm the first-time share prompt. Reset to `false` to see the prompt again. Not used when `share_url` is a custom (self-hosted) URL. |
 | `proxy_auth`           | bool     | `false`                    | When `true`, share / pull / unpublish / re-share use the browser popup relay instead of the local Go server contacting crit-web directly. Use when crit-web is behind an SSO reverse proxy that the terminal cannot authenticate against. No flag or env var — this is a property of the deployment, not a per-invocation choice. |
 
@@ -325,6 +326,7 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | --------------- | ----- | --------------------- | -------------------------------------- |
 | `--port`        | `-p`  | `port`                | Port to listen on                      |
 | `--host`        |       | `host`                | Listen host (default `127.0.0.1`)      |
+| `--public-url`  |       | `public_url`          | Advertised review URL (listen unchanged) |
 | `--no-open`     |       | `no_open`             | Don't auto-open browser                |
 | `--share-url`   |       | `share_url`           | Share service URL                      |
 | `--output`      | `-o`  | `output`              | Output directory for review files      |
@@ -364,6 +366,7 @@ crit --no-ignore
 | --------------------------- | ------------------------------------------------- |
 | `CRIT_PORT`                 | Default port for the local server                 |
 | `CRIT_HOST`                 | Listen host (default `127.0.0.1`)                 |
+| `CRIT_PUBLIC_URL`           | Advertised review URL (e.g. tailscale serve)      |
 | `CRIT_SHARE_URL`            | Override the share service URL                    |
 | `CRIT_AUTH_TOKEN`           | Override the auth token (skips `crit auth login`) |
 | `CRIT_NO_UPDATE_CHECK`      | Disable the update check on startup               |

--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -85,6 +85,7 @@ Setup & management:
 Options:
   -p, --port <port>           Port to listen on (default: random)
       --host <host>           Listen host (default: 127.0.0.1; e.g. 0.0.0.0 for LAN)
+      --public-url <url>      Advertised base URL (e.g. https://machine.ts.net via tailscale serve)
   -o, --output <dir>          Output directory for review file
       --no-open               Don't auto-open browser
       --no-ignore             Disable all file ignore patterns
@@ -99,6 +100,7 @@ Options:
 
 Environment:
   CRIT_SHARE_URL              Override the share service URL
+  CRIT_PUBLIC_URL             Override the advertised review URL (listen address unchanged)
   CRIT_PORT                   Override the default port
   CRIT_HOST                   Override the listen host (default 127.0.0.1)
   CRIT_NO_UPDATE_CHECK        Disable update check on startup

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -120,6 +120,7 @@ func runServe(args []string) {
 		daemonFatal(pipe, "Error creating server: %v", err)
 	}
 	srv.SetListenHost(sc.Host)
+	srv.SetPublicURL(sc.PublicURL)
 
 	cwd, _ := resolvedCWD()
 	homeDir := ""
@@ -154,6 +155,7 @@ func runServe(args []string) {
 		PID:        os.Getpid(),
 		Port:       addr.Port,
 		Host:       sc.Host,
+		PublicURL:  sc.PublicURL,
 		CWD:        cwd,
 		Args:       sessionArgs,
 		Branch:     branch,
@@ -201,13 +203,13 @@ func runServe(args []string) {
 	signalReadiness(pipe, addr.Port)
 
 	if !sc.NoOpen {
-		dh := hostForDisplay(sc.Host)
-		openURL := fmt.Sprintf("http://%s:%d", dh, addr.Port)
+		openPath := ""
 		if sc.LiveOrigin != "" {
-			openURL = fmt.Sprintf("http://%s:%d/live", dh, addr.Port)
+			openPath = "/live"
 		} else if sc.PreviewFile != "" {
-			openURL = fmt.Sprintf("http://%s:%d/preview", dh, addr.Port)
+			openPath = "/preview"
 		}
+		openURL := advertisedURL(sc.PublicURL, sc.Host, addr.Port, openPath)
 		go openBrowser(openURL, sc.OpenCmd)
 	}
 

--- a/cmd/crit/main_test.go
+++ b/cmd/crit/main_test.go
@@ -26,12 +26,24 @@ func TestPrintHelpMentionsSession(t *testing.T) {
 	old := os.Stderr
 	r, w, _ := os.Pipe()
 	os.Stderr = w
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&stderr, r)
+		close(done)
+	}()
 	printHelp()
 	w.Close()
+	<-done
 	os.Stderr = old
-	io.Copy(&stderr, r)
-	if !strings.Contains(stderr.String(), "--session") {
-		t.Fatalf("help missing --session:\n%s", stderr.String())
+	out := stderr.String()
+	if !strings.Contains(out, "--session") {
+		t.Fatalf("help missing --session:\n%s", out)
+	}
+	if !strings.Contains(out, "--public-url") {
+		t.Fatalf("help missing --public-url:\n%s", out)
+	}
+	if !strings.Contains(out, "CRIT_PUBLIC_URL") {
+		t.Fatalf("help missing CRIT_PUBLIC_URL:\n%s", out)
 	}
 }
 

--- a/cmd/crit/main_test.go
+++ b/cmd/crit/main_test.go
@@ -71,10 +71,15 @@ func TestHelperProcess_Help(t *testing.T) {
 	old := os.Stderr
 	r, w, _ := os.Pipe()
 	os.Stderr = w
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&stderr, r)
+		close(done)
+	}()
 	printHelp()
 	w.Close()
+	<-done
 	os.Stderr = old
-	io.Copy(&stderr, r)
 	if !strings.Contains(stderr.String(), "--session") {
 		t.Fatalf("help missing --session:\n%s", stderr.String())
 	}

--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -46,6 +46,7 @@ var (
 	daemonFatal       = daemon.DaemonFatal
 	signalReadiness   = daemon.SignalReadiness
 	hostForDisplay    = daemon.HostForDisplay
+	advertisedURL     = daemon.AdvertisedURL
 	shutdownSignals   = daemon.ShutdownSignals
 	openBrowser       = browser.OpenBrowserWithCommand
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,8 @@ const defaultShareURL = DefaultShareURL
 // Config holds all configuration values from config files.
 type Config struct {
 	Port               int      `json:"port,omitempty"`
-	Host               string   `json:"host,omitempty"` // listen host (default 127.0.0.1)
+	Host               string   `json:"host,omitempty"`       // listen host (default 127.0.0.1)
+	PublicURL          string   `json:"public_url,omitempty"` // advertised base URL (global-only; e.g. tailscale serve)
 	NoOpen             bool     `json:"no_open,omitempty"`
 	OpenCmd            string   `json:"open_cmd,omitempty"`
 	ShareURL           string   `json:"share_url,omitempty"`
@@ -114,6 +115,7 @@ func defaultConfig() generatedConfig {
 type generatedConfig struct {
 	Port               int      `json:"port"`
 	Host               string   `json:"host"`
+	PublicURL          string   `json:"public_url"`
 	NoOpen             bool     `json:"no_open"`
 	OpenCmd            string   `json:"open_cmd"`
 	ShareURL           string   `json:"share_url"`
@@ -243,12 +245,13 @@ func mergeConfigs(global, project Config, projectPresence ConfigPresence) Config
 	if project.LiveCookieFile != "" {
 		merged.LiveCookieFile = project.LiveCookieFile
 	}
-	// Security: agent_cmd, auth_token, share_url, proxy_auth, and open_cmd are intentionally
+	// Security: agent_cmd, auth_token, share_url, public_url, proxy_auth, and open_cmd are intentionally
 	// NOT merged from project config. They must remain global-only: agent_cmd to
 	// prevent untrusted repos from hijacking the agent command; open_cmd to prevent
 	// untrusted repos from hijacking browser launches; auth_token and
-	// share_url to prevent a malicious repo's .crit.config.json from redirecting
-	// share requests (and the bearer token) to an attacker-controlled host;
+	// share_url and public_url to prevent a malicious repo's .crit.config.json from
+	// redirecting share requests (and the bearer token) or advertised URLs to an
+	// attacker-controlled host;
 	// proxy_auth to prevent a repo from silently changing the transport mode.
 	// live_cookie/live_cookie_file DO merge from project config — common for local
 	// dev auth. Prefer live_cookie_file pointing at a gitignored path (e.g.

--- a/internal/config/public_url.go
+++ b/internal/config/public_url.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// ResolvePublicURL returns the effective advertised base URL (flag > env > config).
+// Unlike share_url there is no runtime default — empty means use the listen address.
+func ResolvePublicURL(flagValue string, cfg Config) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if envPublic, ok := os.LookupEnv("CRIT_PUBLIC_URL"); ok {
+		return envPublic
+	}
+	return cfg.PublicURL
+}
+
+// NormalizePublicURL validates and normalizes a user-facing base URL for stderr,
+// browser-open, and reverse-proxy access (e.g. tailscale serve). Trailing slashes
+// are stripped. Scheme must be http or https; host is required. An optional path
+// prefix is preserved (e.g. https://host.example/design).
+func NormalizePublicURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid public URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid public URL %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid public URL %q: missing host", raw)
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("invalid public URL %q: userinfo is not allowed", raw)
+	}
+	hostname := u.Hostname()
+	if hostname == "localhost" {
+		return "", fmt.Errorf("invalid public URL %q: loopback host is not allowed", raw)
+	}
+	if ip := net.ParseIP(hostname); ip != nil && ip.IsLoopback() {
+		return "", fmt.Errorf("invalid public URL %q: loopback host is not allowed", raw)
+	}
+	normalized := u.Scheme + "://" + u.Host + strings.TrimSuffix(u.EscapedPath(), "/")
+	return normalized, nil
+}
+
+// PublicURLHost returns the hostname from a normalized public URL for Host-header
+// validation when the daemon is reached through a reverse proxy.
+func PublicURLHost(publicURL string) string {
+	if publicURL == "" {
+		return ""
+	}
+	u, err := url.Parse(publicURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" || host == "localhost" {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return ""
+	}
+	return host
+}

--- a/internal/config/public_url_test.go
+++ b/internal/config/public_url_test.go
@@ -17,6 +17,8 @@ func TestNormalizePublicURL(t *testing.T) {
 		{"https://mymac.ts.net/design", "https://mymac.ts.net/design", false},
 		{"https://mymac.ts.net/design/", "https://mymac.ts.net/design", false},
 		{"http://localhost:8080", "", true},
+		{"https://user:pass@example.com", "", true},
+		{"https://127.0.0.1", "", true},
 		{"ftp://example.com", "", true},
 		{"not-a-url", "", true},
 	}

--- a/internal/config/public_url_test.go
+++ b/internal/config/public_url_test.go
@@ -19,6 +19,8 @@ func TestNormalizePublicURL(t *testing.T) {
 		{"http://localhost:8080", "", true},
 		{"https://user:pass@example.com", "", true},
 		{"https://127.0.0.1", "", true},
+		{"https://[::1]", "", true},
+		{"https://example.com:443/path/", "https://example.com:443/path", false},
 		{"ftp://example.com", "", true},
 		{"not-a-url", "", true},
 	}
@@ -48,6 +50,10 @@ func TestPublicURLHost(t *testing.T) {
 		{"", ""},
 		{"https://mymac.tail-scale.ts.net", "mymac.tail-scale.ts.net"},
 		{"https://mymac.ts.net/design", "mymac.ts.net"},
+		{"https://localhost", ""},
+		{"https://127.0.0.1", ""},
+		{"https://[::1]", ""},
+		{"not-a-url", ""},
 		{"http://localhost:3000", ""},
 	}
 	for _, tt := range tests {

--- a/internal/config/public_url_test.go
+++ b/internal/config/public_url_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNormalizePublicURL(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"https://mymac.ts.net", "https://mymac.ts.net", false},
+		{"https://mymac.ts.net/", "https://mymac.ts.net", false},
+		{"https://mymac.ts.net/design", "https://mymac.ts.net/design", false},
+		{"https://mymac.ts.net/design/", "https://mymac.ts.net/design", false},
+		{"http://localhost:8080", "", true},
+		{"ftp://example.com", "", true},
+		{"not-a-url", "", true},
+	}
+	for _, tt := range tests {
+		got, err := NormalizePublicURL(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("NormalizePublicURL(%q) = %q, want error", tt.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("NormalizePublicURL(%q): %v", tt.raw, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("NormalizePublicURL(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestPublicURLHost(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"", ""},
+		{"https://mymac.tail-scale.ts.net", "mymac.tail-scale.ts.net"},
+		{"https://mymac.ts.net/design", "mymac.ts.net"},
+		{"http://localhost:3000", ""},
+	}
+	for _, tt := range tests {
+		if got := PublicURLHost(tt.url); got != tt.want {
+			t.Errorf("PublicURLHost(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestResolvePublicURLPrecedence(t *testing.T) {
+	cfg := Config{PublicURL: "https://config.example.com"}
+	t.Setenv("CRIT_PUBLIC_URL", "https://env.example.com")
+
+	if got := ResolvePublicURL("https://cli.example.com", cfg); got != "https://cli.example.com" {
+		t.Errorf("flag precedence: got %q", got)
+	}
+	if got := ResolvePublicURL("", cfg); got != "https://env.example.com" {
+		t.Errorf("env precedence: got %q", got)
+	}
+
+	os.Unsetenv("CRIT_PUBLIC_URL")
+	if got := ResolvePublicURL("", cfg); got != "https://config.example.com" {
+		t.Errorf("config precedence: got %q", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -19,11 +19,12 @@ import (
 )
 
 type CommonDaemonFlags struct {
-	Port     int
-	Host     string
-	NoOpen   bool
-	Quiet    bool
-	ShareURL string
+	Port      int
+	Host      string
+	PublicURL string
+	NoOpen    bool
+	Quiet     bool
+	ShareURL  string
 }
 
 func AppendCommonDaemonFlags(args []string, f CommonDaemonFlags) []string {
@@ -32,6 +33,9 @@ func AppendCommonDaemonFlags(args []string, f CommonDaemonFlags) []string {
 	}
 	if f.Host != "" && f.Host != "127.0.0.1" {
 		args = append(args, "--host", f.Host)
+	}
+	if f.PublicURL != "" {
+		args = append(args, "--public-url", f.PublicURL)
 	}
 	if f.NoOpen {
 		args = append(args, "--no-open")
@@ -58,6 +62,7 @@ type SessionEntry struct {
 	PID        int      `json:"pid"`
 	Port       int      `json:"port"`
 	Host       string   `json:"host,omitempty"`
+	PublicURL  string   `json:"public_url,omitempty"`
 	CWD        string   `json:"cwd"`
 	Args       []string `json:"args,omitempty"`
 	Branch     string   `json:"branch"`
@@ -72,9 +77,33 @@ func (e SessionEntry) DisplayHost() string {
 	return HostForDisplay(e.Host)
 }
 
-// baseURL returns the user-facing HTTP base URL (browser, stderr).
+// BaseURL returns the user-facing HTTP base URL (browser, stderr).
 func (e SessionEntry) BaseURL() string {
-	return fmt.Sprintf("http://%s:%d", e.DisplayHost(), e.Port)
+	return AdvertisedURL(e.PublicURL, e.Host, e.Port, "")
+}
+
+// AdvertisedURL builds the URL shown to users and opened in the browser.
+// When publicURL is set it is used as-is (optional path prefix included);
+// otherwise the listen host and port are used.
+func AdvertisedURL(publicURL, listenHost string, port int, path string) string {
+	if publicURL != "" {
+		base := strings.TrimSuffix(publicURL, "/")
+		if path == "" {
+			return base
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		return base + path
+	}
+	dh := HostForDisplay(listenHost)
+	if path == "" {
+		return fmt.Sprintf("http://%s:%d", dh, port)
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return fmt.Sprintf("http://%s:%d%s", dh, port, path)
 }
 
 // connURL returns the HTTP base URL for internal connectivity (health checks, API calls).

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -150,6 +150,8 @@ func TestAdvertisedURL(t *testing.T) {
 		{"", "127.0.0.1", 3000, "/live", "http://localhost:3000/live"},
 		{"https://mymac.ts.net", "127.0.0.1", 3000, "", "https://mymac.ts.net"},
 		{"https://mymac.ts.net/design", "127.0.0.1", 3000, "/live", "https://mymac.ts.net/design/live"},
+		{"https://mymac.ts.net", "127.0.0.1", 3000, "live", "https://mymac.ts.net/live"},
+		{"", "127.0.0.1", 3000, "live", "http://localhost:3000/live"},
 	}
 	for _, tt := range tests {
 		if got := AdvertisedURL(tt.publicURL, tt.listenHost, tt.port, tt.path); got != tt.want {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -118,19 +118,42 @@ func TestSessionEntry_DisplayHost(t *testing.T) {
 
 func TestSessionEntry_BaseURL(t *testing.T) {
 	tests := []struct {
-		host string
-		port int
-		want string
+		host      string
+		port      int
+		publicURL string
+		want      string
 	}{
-		{"", 3000, "http://localhost:3000"},
-		{"127.0.0.1", 4567, "http://localhost:4567"},
-		{"0.0.0.0", 8080, "http://0.0.0.0:8080"},
-		{"192.168.1.10", 3000, "http://192.168.1.10:3000"},
+		{"", 3000, "", "http://localhost:3000"},
+		{"127.0.0.1", 4567, "", "http://localhost:4567"},
+		{"0.0.0.0", 8080, "", "http://0.0.0.0:8080"},
+		{"192.168.1.10", 3000, "", "http://192.168.1.10:3000"},
+		{"127.0.0.1", 4567, "https://mymac.ts.net", "https://mymac.ts.net"},
+		{"127.0.0.1", 4567, "https://mymac.ts.net/design", "https://mymac.ts.net/design"},
 	}
 	for _, tt := range tests {
-		e := SessionEntry{Host: tt.host, Port: tt.port}
+		e := SessionEntry{Host: tt.host, Port: tt.port, PublicURL: tt.publicURL}
 		if got := e.BaseURL(); got != tt.want {
-			t.Errorf("baseURL(host=%q, port=%d) = %q, want %q", tt.host, tt.port, got, tt.want)
+			t.Errorf("baseURL(host=%q, port=%d, publicURL=%q) = %q, want %q", tt.host, tt.port, tt.publicURL, got, tt.want)
+		}
+	}
+}
+
+func TestAdvertisedURL(t *testing.T) {
+	tests := []struct {
+		publicURL  string
+		listenHost string
+		port       int
+		path       string
+		want       string
+	}{
+		{"", "127.0.0.1", 3000, "", "http://localhost:3000"},
+		{"", "127.0.0.1", 3000, "/live", "http://localhost:3000/live"},
+		{"https://mymac.ts.net", "127.0.0.1", 3000, "", "https://mymac.ts.net"},
+		{"https://mymac.ts.net/design", "127.0.0.1", 3000, "/live", "https://mymac.ts.net/design/live"},
+	}
+	for _, tt := range tests {
+		if got := AdvertisedURL(tt.publicURL, tt.listenHost, tt.port, tt.path); got != tt.want {
+			t.Errorf("AdvertisedURL(%q, %q, %d, %q) = %q, want %q", tt.publicURL, tt.listenHost, tt.port, tt.path, got, tt.want)
 		}
 	}
 }
@@ -1072,15 +1095,17 @@ func TestAppendCommonDaemonFlags(t *testing.T) {
 		{
 			name: "all flags set",
 			f: commonDaemonFlags{
-				Port:     3456,
-				Host:     "0.0.0.0",
-				NoOpen:   true,
-				Quiet:    true,
-				ShareURL: "https://crit.md",
+				Port:      3456,
+				Host:      "0.0.0.0",
+				PublicURL: "https://mymac.ts.net",
+				NoOpen:    true,
+				Quiet:     true,
+				ShareURL:  "https://crit.md",
 			},
 			want: []string{"--preview-file", "/tmp/x.html",
 				"--port", "3456",
 				"--host", "0.0.0.0",
+				"--public-url", "https://mymac.ts.net",
 				"--no-open",
 				"--quiet",
 				"--share-url", "https://crit.md"},

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -152,6 +152,7 @@ func connectToLiveDaemon(key, openCmd string) bool {
 type liveCLIFlags struct {
 	port        int
 	host        string
+	publicURL   string
 	noOpen      bool
 	quiet       bool
 	shareURL    string
@@ -165,6 +166,7 @@ func parseLiveCLIFlags(args []string) liveCLIFlags {
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
 	host := fs.String("host", "", "Host to listen on")
+	publicURL := fs.String("public-url", "", "Advertised base URL (overrides CRIT_PUBLIC_URL)")
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
@@ -195,6 +197,7 @@ func parseLiveCLIFlags(args []string) liveCLIFlags {
 	return liveCLIFlags{
 		port:        *port,
 		host:        *host,
+		publicURL:   *publicURL,
 		noOpen:      *noOpen,
 		quiet:       *quiet,
 		shareURL:    *shareURL,
@@ -210,11 +213,12 @@ func buildLiveDaemonArgs(origin, liveCookies string, f liveCLIFlags, cfg config.
 		daemonArgs = append(daemonArgs, "--live-cookie", liveCookies)
 	}
 	return daemon.AppendCommonDaemonFlags(daemonArgs, daemon.CommonDaemonFlags{
-		Port:     config.ResolvePort(f.port, cfg.Port),
-		Host:     config.ResolveHost(f.host, cfg.Host),
-		NoOpen:   noOpenResolved,
-		Quiet:    f.quiet || cfg.Quiet,
-		ShareURL: config.ResolveShareURL(f.shareURL, cfg, ""),
+		Port:      config.ResolvePort(f.port, cfg.Port),
+		Host:      config.ResolveHost(f.host, cfg.Host),
+		PublicURL: config.ResolvePublicURL(f.publicURL, cfg),
+		NoOpen:    noOpenResolved,
+		Quiet:     f.quiet || cfg.Quiet,
+		ShareURL:  config.ResolveShareURL(f.shareURL, cfg, ""),
 	})
 }
 

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -445,6 +445,7 @@ func TestParseLiveCLIFlags(t *testing.T) {
 	f := parseLiveCLIFlags([]string{
 		"-p", "8080",
 		"--host", "0.0.0.0",
+		"--public-url", "https://mymac.ts.net",
 		"--no-open",
 		"-q",
 		"--share-url", "https://share.example",
@@ -456,7 +457,7 @@ func TestParseLiveCLIFlags(t *testing.T) {
 	if f.origin != "https://example.com/app" {
 		t.Fatalf("origin = %q", f.origin)
 	}
-	if f.port != 8080 || f.host != "0.0.0.0" || !f.noOpen || !f.quiet {
+	if f.port != 8080 || f.host != "0.0.0.0" || f.publicURL != "https://mymac.ts.net" || !f.noOpen || !f.quiet {
 		t.Fatalf("flags = %+v", f)
 	}
 	if f.shareURL != "https://share.example" || f.cookieFile != "/tmp/jar.txt" {
@@ -468,8 +469,8 @@ func TestParseLiveCLIFlags(t *testing.T) {
 }
 
 func TestBuildLiveDaemonArgs(t *testing.T) {
-	f := liveCLIFlags{port: 9000, host: "127.0.0.1", quiet: true}
-	cfg := Config{Port: 3000, Quiet: false}
+	f := liveCLIFlags{port: 9000, host: "127.0.0.1", publicURL: "https://mymac.ts.net", quiet: true}
+	cfg := Config{Port: 3000, Quiet: false, PublicURL: "https://ignored.example.com"}
 
 	withCookie := buildLiveDaemonArgs("http://localhost:3000/dashboard", "sess=abc", f, cfg, true)
 	if !containsArgPair(withCookie, "--live-origin", "http://localhost:3000/dashboard") {
@@ -477,6 +478,9 @@ func TestBuildLiveDaemonArgs(t *testing.T) {
 	}
 	if !containsArgPair(withCookie, "--live-cookie", "sess=abc") {
 		t.Fatalf("missing live-cookie: %v", withCookie)
+	}
+	if !containsArgPair(withCookie, "--public-url", "https://mymac.ts.net") {
+		t.Fatalf("missing public-url: %v", withCookie)
 	}
 	if !containsArgPair(withCookie, "--port", "9000") {
 		t.Fatalf("missing port: %v", withCookie)
@@ -493,6 +497,11 @@ func TestBuildLiveDaemonArgs(t *testing.T) {
 		if a == "--live-cookie" {
 			t.Fatalf("unexpected --live-cookie at %d in %v", i, withoutCookie)
 		}
+	}
+
+	fromCfg := buildLiveDaemonArgs("http://localhost:3000", "", liveCLIFlags{}, Config{PublicURL: "https://cfg.ts.net"}, false)
+	if !containsArgPair(fromCfg, "--public-url", "https://cfg.ts.net") {
+		t.Fatalf("missing config public-url: %v", fromCfg)
 	}
 }
 

--- a/internal/preview/export_test.go
+++ b/internal/preview/export_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 )
 
-var connectToPreviewDaemonForTest = connectToPreviewDaemon
+var (
+	connectToPreviewDaemonForTest = connectToPreviewDaemon
+	buildPreviewStartArgsForTest  = buildPreviewStartArgs
+)
 
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -104,15 +104,7 @@ func RunPreview(args []string) {
 		return
 	}
 
-	daemonArgs := []string{"--preview-file", absPath}
-	daemonArgs = daemon.AppendCommonDaemonFlags(daemonArgs, daemon.CommonDaemonFlags{
-		Port:      config.ResolvePort(*port, cfg.Port),
-		Host:      config.ResolveHost(*host, cfg.Host),
-		PublicURL: config.ResolvePublicURL(*publicURL, cfg),
-		NoOpen:    noOpenResolved,
-		Quiet:     *quiet || cfg.Quiet,
-		ShareURL:  config.ResolveShareURL(*shareURL, cfg, config.DefaultShareURL),
-	})
+	daemonArgs := buildPreviewStartArgs(absPath, *port, *host, *publicURL, noOpenResolved, *quiet || cfg.Quiet, *shareURL, cfg)
 	entry, err := daemon.StartDaemon(key, daemonArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start preview daemon: %v\n", err)
@@ -129,6 +121,18 @@ func RunPreview(args []string) {
 	}
 
 	daemon.RunReviewClient(entry, key)
+}
+
+func buildPreviewStartArgs(absPath string, port int, host, publicURL string, noOpen, quiet bool, shareURL string, cfg config.Config) []string {
+	daemonArgs := []string{"--preview-file", absPath}
+	return daemon.AppendCommonDaemonFlags(daemonArgs, daemon.CommonDaemonFlags{
+		Port:      config.ResolvePort(port, cfg.Port),
+		Host:      config.ResolveHost(host, cfg.Host),
+		PublicURL: config.ResolvePublicURL(publicURL, cfg),
+		NoOpen:    noOpen,
+		Quiet:     quiet,
+		ShareURL:  config.ResolveShareURL(shareURL, cfg, config.DefaultShareURL),
+	})
 }
 
 func installDaemonSignalHandler(pid int) {

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -60,6 +60,7 @@ func RunPreview(args []string) {
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
 	host := fs.String("host", "", "Host to listen on")
+	publicURL := fs.String("public-url", "", "Advertised base URL (overrides CRIT_PUBLIC_URL)")
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
 	shareURL := fs.String("share-url", "", "Share service URL")
@@ -105,11 +106,12 @@ func RunPreview(args []string) {
 
 	daemonArgs := []string{"--preview-file", absPath}
 	daemonArgs = daemon.AppendCommonDaemonFlags(daemonArgs, daemon.CommonDaemonFlags{
-		Port:     config.ResolvePort(*port, cfg.Port),
-		Host:     config.ResolveHost(*host, cfg.Host),
-		NoOpen:   noOpenResolved,
-		Quiet:    *quiet || cfg.Quiet,
-		ShareURL: config.ResolveShareURL(*shareURL, cfg, config.DefaultShareURL),
+		Port:      config.ResolvePort(*port, cfg.Port),
+		Host:      config.ResolveHost(*host, cfg.Host),
+		PublicURL: config.ResolvePublicURL(*publicURL, cfg),
+		NoOpen:    noOpenResolved,
+		Quiet:     *quiet || cfg.Quiet,
+		ShareURL:  config.ResolveShareURL(*shareURL, cfg, config.DefaultShareURL),
 	})
 	entry, err := daemon.StartDaemon(key, daemonArgs)
 	if err != nil {

--- a/internal/preview/preview_daemon_args_test.go
+++ b/internal/preview/preview_daemon_args_test.go
@@ -1,0 +1,31 @@
+package preview
+
+import (
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/config"
+)
+
+func TestBuildPreviewStartArgs_PublicURL(t *testing.T) {
+	cfg := config.Config{PublicURL: "https://config.ts.net"}
+	args := buildPreviewStartArgsForTest("/tmp/page.html", 0, "", "https://cli.ts.net", true, false, "", cfg)
+	want := []string{
+		"--preview-file", "/tmp/page.html",
+		"--public-url", "https://cli.ts.net",
+		"--no-open",
+		"--share-url", "https://crit.md",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("got %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("arg[%d]: got %q, want %q", i, args[i], want[i])
+		}
+	}
+
+	fromCfg := buildPreviewStartArgsForTest("/tmp/page.html", 0, "", "", false, false, "", cfg)
+	if len(fromCfg) != 6 || fromCfg[2] != "--public-url" || fromCfg[3] != "https://config.ts.net" {
+		t.Fatalf("config public-url: got %v", fromCfg)
+	}
+}

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -23,6 +23,7 @@ var PrintVersionFn func()
 type DaemonCLIConfig struct {
 	Port               int
 	Host               string
+	PublicURL          string
 	NoOpen             bool
 	OpenCmd            string
 	Quiet              bool
@@ -54,6 +55,7 @@ type DaemonCLIConfig struct {
 type daemonFlagSet struct {
 	port               int
 	host               string
+	publicURL          string
 	noOpen             bool
 	showVersion        bool
 	shareURL           string
@@ -82,6 +84,7 @@ func parseDaemonFlags(args []string) daemonFlagSet {
 	port := fs.Int("port", 0, "Port to listen on (default: random available port)")
 	fs.IntVar(port, "p", 0, "Port to listen on (shorthand)")
 	host := fs.String("host", "", "Host to listen on (default: 127.0.0.1; e.g. 0.0.0.0 to expose on LAN — no auth, opt in deliberately)")
+	publicURL := fs.String("public-url", "", "Advertised base URL for browser/stderr (overrides CRIT_PUBLIC_URL; e.g. https://machine.ts.net for tailscale serve)")
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 	fs.BoolVar(showVersion, "v", false, "Print version and exit (shorthand)")
@@ -114,6 +117,7 @@ func parseDaemonFlags(args []string) daemonFlagSet {
 	return daemonFlagSet{
 		port:               *port,
 		host:               *host,
+		publicURL:          *publicURL,
 		noOpen:             *noOpen,
 		showVersion:        *showVersion,
 		shareURL:           *shareURL,
@@ -140,6 +144,7 @@ func parseDaemonFlags(args []string) daemonFlagSet {
 func applyDaemonConfigDefaults(sf *daemonFlagSet, cfg config.Config) {
 	sf.port = config.ResolvePort(sf.port, cfg.Port)
 	sf.host = config.ResolveHost(sf.host, cfg.Host)
+	sf.publicURL = config.ResolvePublicURL(sf.publicURL, cfg)
 	if !sf.noOpen && cfg.NoOpen {
 		sf.noOpen = true
 	}
@@ -202,6 +207,14 @@ func ResolveDaemonCLIConfig(args []string) (*DaemonCLIConfig, error) {
 
 	applyDaemonConfigDefaults(&sf, cfg)
 
+	if sf.publicURL != "" {
+		normalized, err := config.NormalizePublicURL(sf.publicURL)
+		if err != nil {
+			return nil, err
+		}
+		sf.publicURL = normalized
+	}
+
 	var ignorePatterns []string
 	if !sf.noIgnore {
 		ignorePatterns = cfg.IgnorePatterns
@@ -221,6 +234,7 @@ func ResolveDaemonCLIConfig(args []string) (*DaemonCLIConfig, error) {
 	return &DaemonCLIConfig{
 		Port:               sf.port,
 		Host:               sf.host,
+		PublicURL:          sf.publicURL,
 		NoOpen:             sf.noOpen,
 		OpenCmd:            cfg.OpenCmd,
 		Quiet:              sf.quiet,

--- a/internal/server/daemon_cli_config_test.go
+++ b/internal/server/daemon_cli_config_test.go
@@ -281,6 +281,115 @@ func TestResolveServerConfig_HostPrecedence(t *testing.T) {
 	})
 }
 
+func TestResolveServerConfig_PublicURLPrecedence(t *testing.T) {
+	defer resetBranchOverride(t)
+
+	t.Run("CLI flag wins over env and config", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"public_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
+		t.Setenv("CRIT_PUBLIC_URL", "https://env.example.com")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := ResolveDaemonCLIConfig([]string{"--public-url", "https://cli.example.com"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.PublicURL != "https://cli.example.com" {
+			t.Errorf("publicURL = %q, want CLI value", sc.PublicURL)
+		}
+	})
+
+	t.Run("env var wins over config when no CLI flag", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"public_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
+		t.Setenv("CRIT_PUBLIC_URL", "https://env.example.com")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := ResolveDaemonCLIConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.PublicURL != "https://env.example.com" {
+			t.Errorf("publicURL = %q, want env value", sc.PublicURL)
+		}
+	})
+
+	t.Run("global config used when no CLI or env", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+		os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"public_url": "https://config.example.com"}`), 0644)
+		dir := t.TempDir()
+		os.Unsetenv("CRIT_PUBLIC_URL")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := ResolveDaemonCLIConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.PublicURL != "https://config.example.com" {
+			t.Errorf("publicURL = %q, want global config value", sc.PublicURL)
+		}
+	})
+
+	t.Run("project config cannot set public_url", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"public_url": "https://evil.example.com"}`), 0644)
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+		os.Unsetenv("CRIT_PUBLIC_URL")
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := ResolveDaemonCLIConfig([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.PublicURL != "" {
+			t.Errorf("publicURL = %q, want empty (project config must not apply)", sc.PublicURL)
+		}
+	})
+
+	t.Run("invalid public URL rejected", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		dir := t.TempDir()
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		_, err := ResolveDaemonCLIConfig([]string{"--public-url", "not-a-url"})
+		if err == nil {
+			t.Fatal("expected error for invalid public URL")
+		}
+	})
+}
+
 func TestResolveServerConfig_ShareURLPrecedence(t *testing.T) {
 	defer resetBranchOverride(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,8 +84,12 @@ type Server struct {
 	// listenHost is the host the server is bound to (e.g. "127.0.0.1" or
 	// "0.0.0.0"). Set via SetListenHost after construction. When set to a
 	// loopback address, ServeHTTP enforces that the request Host header is
-	// also a loopback hostname, blocking DNS-rebinding attacks.
+	// also a loopback hostname, blocking DNS-rebinding attacks — unless
+	// SetPublicURL was called with a reverse-proxy hostname (e.g. tailscale serve).
 	listenHost string
+	// publicURLHost is the hostname from --public-url / CRIT_PUBLIC_URL, allowed
+	// through the DNS-rebinding guard when requests arrive via a reverse proxy.
+	publicURLHost string
 
 	// shutdownCtx is the daemon's signal-handled context; child operations
 	// (e.g. runAgentCmd subprocesses) derive their context from this so a
@@ -207,6 +211,13 @@ func (s *Server) SetListenHost(host string) {
 	s.listenHost = host
 }
 
+// SetPublicURL records the user-facing base URL (e.g. https://machine.ts.net).
+// When set, requests whose Host header matches the URL hostname are allowed even
+// if the server is bound to loopback — needed for tailscale serve and similar proxies.
+func (s *Server) SetPublicURL(publicURL string) {
+	s.publicURLHost = config.PublicURLHost(publicURL)
+}
+
 // isLoopbackHost reports whether host (no port) is a loopback address.
 func isLoopbackHost(host string) bool {
 	if host == "localhost" {
@@ -220,10 +231,18 @@ func isLoopbackHost(host string) bool {
 // is bound to a loopback address, the request's Host header must also resolve
 // to a loopback hostname — this is the canonical DNS-rebinding defense.
 func (s *Server) checkHost(r *http.Request) bool {
+	host := requestHost(r.Host)
+	if s.publicURLHost != "" && strings.EqualFold(host, s.publicURLHost) {
+		return true
+	}
 	if s.listenHost == "" || !isLoopbackHost(s.listenHost) {
 		return true
 	}
-	host := r.Host
+	return isLoopbackHost(host)
+}
+
+func requestHost(hostport string) string {
+	host := hostport
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	} else {
@@ -231,7 +250,7 @@ func (s *Server) checkHost(r *http.Request) bool {
 		// Strip IPv6 brackets so ParseIP can recognise the address.
 		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
 	}
-	return isLoopbackHost(host)
+	return host
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -102,6 +102,8 @@ func TestHostCheck(t *testing.T) {
 		{"loopback listen, ::1 bare", "127.0.0.1", "[::1]", 200},
 		{"loopback listen, evil.com", "127.0.0.1", "evil.com", 403},
 		{"loopback listen, evil.com no port", "127.0.0.1", "evil.com:80", 403},
+		{"loopback listen, tailscale host allowed with public URL", "127.0.0.1", "mymac.ts.net", 200},
+		{"loopback listen, tailscale host with port", "127.0.0.1", "mymac.ts.net:443", 200},
 
 		// listenHost is non-loopback (user opted into LAN exposure): no check.
 		{"lan listen, evil.com", "0.0.0.0", "evil.com", 200},
@@ -111,6 +113,9 @@ func TestHostCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _ := newTestServer(t)
 			s.SetListenHost(tt.listenHost)
+			if strings.Contains(tt.name, "tailscale") {
+				s.SetPublicURL("https://mymac.ts.net")
+			}
 			req := httptest.NewRequest("GET", "/api/session", nil)
 			if tt.reqHost != "" {
 				req.Host = tt.reqHost

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -181,6 +181,29 @@ func TestHostCheckDefaultWiring(t *testing.T) {
 	}
 }
 
+func TestSetPublicURL(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.SetPublicURL("https://mymac.ts.net/design")
+	s.SetListenHost("127.0.0.1")
+
+	req := httptest.NewRequest("GET", "/api/session", nil)
+	req.Host = "mymac.ts.net"
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+
+	s.SetPublicURL("")
+	req2 := httptest.NewRequest("GET", "/api/session", nil)
+	req2.Host = "mymac.ts.net"
+	w2 := httptest.NewRecorder()
+	s.ServeHTTP(w2, req2)
+	if w2.Code != 403 {
+		t.Errorf("after clearing public URL, status = %d, want 403", w2.Code)
+	}
+}
+
 func TestGetSession_MethodNotAllowed(t *testing.T) {
 	s, _ := newTestServer(t)
 	req := httptest.NewRequest("POST", "/api/session", nil)

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -22,6 +22,7 @@ type planConfig struct {
 	stdinExpected bool
 	port          int
 	host          string
+	publicURL     string
 	noOpen        bool
 	quiet         bool
 	shareURL      string
@@ -33,6 +34,7 @@ func resolvePlanConfig(args []string) planConfig {
 	port := fs.Int("port", 0, "Port to listen on")
 	fs.IntVar(port, "p", 0, "Port (shorthand)")
 	host := fs.String("host", "", "Host to listen on")
+	publicURL := fs.String("public-url", "", "Advertised base URL (overrides CRIT_PUBLIC_URL)")
 	noOpen := fs.Bool("no-open", false, "Don't auto-open browser")
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
@@ -40,12 +42,13 @@ func resolvePlanConfig(args []string) planConfig {
 	fs.Parse(args)
 
 	pc := planConfig{
-		name:     *name,
-		port:     *port,
-		host:     *host,
-		noOpen:   *noOpen,
-		quiet:    *quiet,
-		shareURL: *shareURL,
+		name:      *name,
+		port:      *port,
+		host:      *host,
+		publicURL: *publicURL,
+		noOpen:    *noOpen,
+		quiet:     *quiet,
+		shareURL:  *shareURL,
 	}
 
 	remaining := fs.Args()
@@ -125,11 +128,12 @@ func RunPlan(args []string) error {
 	cfg := config.LoadConfig(cwd)
 	noOpenResolved := pc.noOpen || cfg.NoOpen
 	daemonArgs := BuildPlanDaemonArgs(currentPath, storageDir, slug, PlanDaemonFlags{
-		Port:     config.ResolvePort(pc.port, cfg.Port),
-		Host:     config.ResolveHost(pc.host, cfg.Host),
-		NoOpen:   noOpenResolved,
-		Quiet:    pc.quiet || cfg.Quiet,
-		ShareURL: config.ResolveShareURL(pc.shareURL, cfg, ""),
+		Port:      config.ResolvePort(pc.port, cfg.Port),
+		Host:      config.ResolveHost(pc.host, cfg.Host),
+		PublicURL: config.ResolvePublicURL(pc.publicURL, cfg),
+		NoOpen:    noOpenResolved,
+		Quiet:     pc.quiet || cfg.Quiet,
+		ShareURL:  config.ResolveShareURL(pc.shareURL, cfg, ""),
 	})
 
 	entry, weStartedDaemon, err := connectOrStartDaemon(key, daemonArgs, noOpenResolved, cfg.OpenCmd)
@@ -235,7 +239,9 @@ func runPlanReviewHook(logPrefix, sessionID string, content []byte, emitDecision
 	cfg := config.LoadConfig(cwd)
 	key := PlanSessionKey(cwd, slug)
 	currentPath := filepath.Join(storageDir, "current.md")
-	daemonArgs := BuildPlanDaemonArgs(currentPath, storageDir, slug, PlanDaemonFlags{})
+	daemonArgs := BuildPlanDaemonArgs(currentPath, storageDir, slug, PlanDaemonFlags{
+		PublicURL: config.ResolvePublicURL("", cfg),
+	})
 
 	entry, alive := daemon.FindAliveSession(key)
 	weStartedDaemon := false

--- a/internal/session/plans.go
+++ b/internal/session/plans.go
@@ -93,11 +93,12 @@ func latestPlanVersion(dir string) int {
 
 // PlanDaemonFlags carries daemon CLI flags for plan-mode spawns.
 type PlanDaemonFlags struct {
-	Port     int
-	Host     string
-	NoOpen   bool
-	Quiet    bool
-	ShareURL string
+	Port      int
+	Host      string
+	PublicURL string
+	NoOpen    bool
+	Quiet     bool
+	ShareURL  string
 }
 
 // BuildPlanDaemonArgs builds daemon argv for plan mode.
@@ -115,6 +116,9 @@ func appendPlanDaemonFlags(args []string, f PlanDaemonFlags) []string {
 	}
 	if f.Host != "" && f.Host != "127.0.0.1" {
 		args = append(args, "--host", f.Host)
+	}
+	if f.PublicURL != "" {
+		args = append(args, "--public-url", f.PublicURL)
 	}
 	if f.NoOpen {
 		args = append(args, "--no-open")

--- a/internal/session/plans_test.go
+++ b/internal/session/plans_test.go
@@ -248,6 +248,25 @@ func TestBuildPlanDaemonArgs(t *testing.T) {
 	}
 }
 
+func TestBuildPlanDaemonArgs_PublicURL(t *testing.T) {
+	args := BuildPlanDaemonArgs("/tmp/current.md", "/tmp/plans", "slug", PlanDaemonFlags{
+		PublicURL: "https://mymac.ts.net",
+	})
+	want := []string{"--public-url", "https://mymac.ts.net"}
+	for _, w := range want {
+		found := false
+		for _, a := range args {
+			if a == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in daemon args: %v", w, args)
+		}
+	}
+}
+
 func TestApplyPlanOverrides(t *testing.T) {
 	dir := t.TempDir()
 	content := "# My Plan\n\nDo things"

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3251,9 +3251,9 @@ func TestDeleteReply_NotReAddedFromDisk(t *testing.T) {
 		t.Fatal("DeleteReply failed")
 	}
 
-	// Write again
-	flushWrites(s)
-	s.WriteFiles()
+	if err := s.SyncWriteFiles(); err != nil {
+		t.Fatalf("SyncWriteFiles after delete: %v", err)
+	}
 
 	// Read .crit.json and verify the reply is gone
 	data, err := os.ReadFile(ReviewPathsFor(s.critJSONPath()).Review)
@@ -3293,17 +3293,18 @@ func TestDeleteReviewCommentReply_NotReAddedFromDisk(t *testing.T) {
 	if !ok {
 		t.Fatal("AddReviewCommentReply failed")
 	}
-	s.WriteFiles()
+	if err := s.SyncWriteFiles(); err != nil {
+		t.Fatalf("initial SyncWriteFiles: %v", err)
+	}
 
 	// Delete the reply in-memory
 	if !s.DeleteReviewCommentReply(rc.ID, reply.ID) {
 		t.Fatal("DeleteReviewCommentReply failed")
 	}
 
-	// Write again
-	flushWrites(s)
-	s.WriteFiles()
-	quiesceSession(t, s)
+	if err := s.SyncWriteFiles(); err != nil {
+		t.Fatalf("SyncWriteFiles after delete: %v", err)
+	}
 
 	// Read back .crit.json
 	data, err := os.ReadFile(ReviewPathsFor(s.critJSONPath()).Review)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3285,6 +3285,7 @@ func TestDeleteReviewCommentReply_NotReAddedFromDisk(t *testing.T) {
 		Files:       []*FileEntry{},
 		subscribers: make(map[chan SSEEvent]struct{}),
 	}
+	t.Cleanup(func() { quiesceSession(t, s) })
 
 	// Add review comment with a reply, then write to disk
 	rc := s.AddReviewComment("parent review comment", "", "")
@@ -3302,6 +3303,7 @@ func TestDeleteReviewCommentReply_NotReAddedFromDisk(t *testing.T) {
 	// Write again
 	flushWrites(s)
 	s.WriteFiles()
+	quiesceSession(t, s)
 
 	// Read back .crit.json
 	data, err := os.ReadFile(ReviewPathsFor(s.critJSONPath()).Review)


### PR DESCRIPTION
## Summary
- Add `--public-url`, `CRIT_PUBLIC_URL`, and global `public_url` in `~/.crit.config.json` for a listen-vs-advertise split (tailscale serve, etc.)
- Printed URLs, browser-open, and session registry use the advertised base while the daemon still binds loopback
- Relax the DNS-rebinding Host-header guard for the configured proxy hostname so SSE works through tailscale serve

Closes #689

## Review
- [x] Code review: passed (no blockers; reconnect-with-flag-only edge case documented via env/global config path)
- [x] Parity audit: N/A (CLI-only, no review page changes)

## Test plan
- [x] `go test -race ./...`
- [x] Pre-commit hooks (gofmt, golangci-lint, ESLint, Stylelint)
- [x] Unit tests for config precedence, `AdvertisedURL`, Host-header allowlist, daemon flag forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)