### PR TITLE
fix: guard null commitList in file-changed handler

### DIFF
--- a/web/__tests__/commit-list-null-guard.test.js
+++ b/web/__tests__/commit-list-null-guard.test.js
@@ -1,0 +1,29 @@
+'use strict';
+// Regression: #692 — /api/commits JSON null left commitList null; clearCommitPins
+// during file-changed then threw in normalizeCommitPins and stuck the Waiting overlay.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+test('normalizeCommitPins coalesces null commitList before map', () => {
+  const fnStart = appJs.indexOf('function normalizeCommitPins()');
+  assert.ok(fnStart >= 0, 'normalizeCommitPins must exist');
+  const fnBody = appJs.slice(fnStart, fnStart + 400);
+  assert.match(
+    fnBody,
+    /if\s*\(\s*!commitList\s*\)\s*commitList\s*=\s*\[\s*\]/,
+    'normalizeCommitPins must guard null commitList before .map'
+  );
+});
+
+test('fetchCommits coalesces null JSON response to empty array', () => {
+  assert.match(
+    appJs,
+    /commitList\s*=\s*\(\s*await\s+res\.json\(\)\s*\)\s*\|\|\s*\[\s*\]/,
+    'fetchCommits must not assign null to commitList'
+  );
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7450,6 +7450,7 @@
   }
 
   function normalizeCommitPins() {
+    if (!commitList) commitList = [];
     if (commitFrom && commitThrough && commitFrom === commitThrough) {
       commitThrough = '';
     }
@@ -7520,7 +7521,7 @@
         commitDropdownEl.style.display = 'none';
         return;
       }
-      commitList = await res.json();
+      commitList = (await res.json()) || [];
       if (gen !== commitsFetchGen || !commitRangeChromeVisible()) return;
       if (!commitList || commitList.length < 2) {
         commitDropdownEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- Coalesce null `/api/commits` JSON responses to `[]` in `fetchCommits()`
- Guard `normalizeCommitPins()` so `clearCommitPins()` never calls `.map()` on null
- Fixes round-complete SSE leaving the Waiting overlay stuck when commit chrome was previously opened

Closes #692

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (compare-against commits UI is crit-only)

## Test plan
- [x] `node --test web/__tests__/commit-list-null-guard.test.js`
- [x] `go test ./...`
- [x] Pre-commit hooks passed

Made with [Cursor](https://cursor.com)