### PR TITLE
fix: reject --json with --reply-to on crit comment

### DIFF
--- a/internal/comment/run.go
+++ b/internal/comment/run.go
@@ -77,6 +77,9 @@ func RunComment(args []string) error { //nolint:gocyclo // CLI dispatcher
 }
 
 func resolveCommentFlags(f *commentFlags) error {
+	if f.json && f.replyTo != "" {
+		return fmt.Errorf("--json and --reply-to cannot be used together; for a single reply use: crit comment --reply-to <id> [--author <name>] <body>")
+	}
 	if f.plan != "" {
 		if f.outputDir != "" {
 			return fmt.Errorf("--plan and --output cannot be used together")

--- a/internal/comment/run_cli_test.go
+++ b/internal/comment/run_cli_test.go
@@ -139,6 +139,19 @@ func TestRunComment_PlanAndOutputConflict(t *testing.T) {
 	}
 }
 
+func TestRunComment_JSONAndReplyToConflict(t *testing.T) {
+	err := RunComment([]string{"--json", "--reply-to", "c_6ab5c4", "--author", "Cursor", "Added crit install prompts"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--json and --reply-to cannot be used together") {
+		t.Errorf("got %v", err)
+	}
+	if !strings.Contains(err.Error(), "crit comment --reply-to <id>") {
+		t.Errorf("expected reply usage hint, got %v", err)
+	}
+}
+
 func TestRunCommentJSONScoped_CountsCommentsAndReplies(t *testing.T) {
 	tmp := t.TempDir()
 	// Seed a comment to reply to.


### PR DESCRIPTION
## Summary
- Reject `crit comment --json` when combined with `--reply-to`, instead of routing to bulk JSON stdin mode and hanging silently
- Error message points agents to the correct single-reply form: `crit comment --reply-to <id> [--author <name>] <body>`
- Adds regression test for the exact hung invocation from #693

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (CLI-only, no review page changes)

## Test plan
- [x] `go test -race ./internal/comment/...`
- [x] `golangci-lint run ./internal/comment/...`
- [x] Pre-commit hook passed on commit

Closes #693

Made with [Cursor](https://cursor.com)