### PR TITLE
fix: resolve relative markdown image paths in file mode

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2378,7 +2378,8 @@ func (s *Server) handleFiles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqPath := strings.TrimPrefix(r.URL.Path, "/files/")
-	if reqPath == "" || strings.Contains(reqPath, "..") {
+	reqPath = filepath.ToSlash(filepath.Clean(reqPath))
+	if reqPath == "" || reqPath == "." || strings.HasPrefix(reqPath, "../") || strings.Contains(reqPath, "/../") {
 		http.Error(w, "Invalid file path", http.StatusBadRequest)
 		return
 	}

--- a/web/app.js
+++ b/web/app.js
@@ -1218,10 +1218,24 @@
     );
   }
 
-  function rewriteImageSrcs(html) {
+  function resolveImagePath(filePath, src) {
+    const fileDir = filePath.includes('/') ? filePath.replace(/\/[^/]*$/, '') : '';
+    const combined = fileDir ? fileDir + '/' + src : src;
+    const parts = combined.split('/');
+    const stack = [];
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i];
+      if (!p || p === '.') continue;
+      if (p === '..') { if (stack.length) stack.pop(); }
+      else stack.push(p);
+    }
+    return stack.join('/');
+  }
+
+  function rewriteImageSrcs(html, filePath) {
     return html.replace(/(<img\s[^>]*src=")([^"]+)(")/gi, function(match, pre, src, post) {
       if (/^https?:\/\/|^data:|^\//.test(src)) return match;
-      return pre + '/files/' + src + post;
+      return pre + '/files/' + resolveImagePath(filePath || '', src) + post;
     });
   }
 
@@ -2463,7 +2477,7 @@
     contentEl.className = buildContentClasses(block);
     let html = block.wordDiffHtml || block.html;
     html = processTaskLists(html);
-    html = rewriteImageSrcs(html);
+    html = rewriteImageSrcs(html, file.path);
     contentEl.innerHTML = html;
     lineBlockEl.appendChild(contentEl);
 
@@ -2692,7 +2706,7 @@
       content.className = buildContentClasses(block);
       let html = block.html;
       html = processTaskLists(html);
-      html = rewriteImageSrcs(html);
+      html = rewriteImageSrcs(html, file.path);
       content.innerHTML = html;
 
       gutter.appendChild(commentGutter);


### PR DESCRIPTION
## Summary
- Resolve relative markdown image paths (e.g. `./screenshot.png`) against the document's directory before rewriting to `/files/...`
- Normalize `./` segments in the `/files/` handler via `filepath.Clean`
- Fixes 404s when reviewing markdown documents whose images live in the same folder

## Review
- [x] Code review: passed
- [x] Parity audit: paired with tomasz-tomczyk/crit-web#280 (hosted `/r/:token/raw/` route)

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — all pass
- [x] Manual: `crit how_to_plan_document_and_review/index.md` — screenshots load after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)