### PR TITLE
fix: serialize crit share with per-review flock

### DIFF
--- a/internal/session/review_paths.go
+++ b/internal/session/review_paths.go
@@ -8,6 +8,7 @@ type ReviewPaths struct {
 	Review      string
 	Snapshots   string
 	Attachments string
+	ShareLock   string
 }
 
 // ReviewPathsFor returns the v4 folder-form paths for a review identity.
@@ -17,5 +18,6 @@ func ReviewPathsFor(identity string) ReviewPaths {
 		Review:      filepath.Join(identity, "review.json"),
 		Snapshots:   filepath.Join(identity, "snapshots.json"),
 		Attachments: filepath.Join(identity, "attachments"),
+		ShareLock:   filepath.Join(identity, "share.lock"),
 	}
 }

--- a/internal/session/share_lock.go
+++ b/internal/session/share_lock.go
@@ -1,0 +1,33 @@
+package session
+
+import (
+	"fmt"
+	"os"
+)
+
+// WithShareLock runs fn while holding an exclusive advisory lock on the review
+// identity's share.lock file. Concurrent crit share invocations for the same
+// review identity block here so only one POST/upsert+persist cycle runs at a
+// time. Callers must re-read share state after acquiring the lock.
+func WithShareLock(identity string, fn func() error) error {
+	if err := ensureReviewFolder(identity); err != nil {
+		return fmt.Errorf("ensuring review folder: %w", err)
+	}
+	paths := ReviewPathsFor(identity)
+	if err := os.MkdirAll(paths.Folder, 0o700); err != nil {
+		return fmt.Errorf("creating review folder: %w", err)
+	}
+	lockPath := paths.ShareLock
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening share lock %q: %w", lockPath, err)
+	}
+	defer func() {
+		_ = funlock(f)
+		_ = f.Close()
+	}()
+	if err := flockExclusive(f); err != nil {
+		return fmt.Errorf("acquiring share lock: %w", err)
+	}
+	return fn()
+}

--- a/internal/session/share_lock_test.go
+++ b/internal/session/share_lock_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -39,5 +40,13 @@ func TestWithShareLock_SerializesConcurrentCallers(t *testing.T) {
 	}
 	if _, err := os.Stat(ReviewPathsFor(identity).ShareLock); err != nil {
 		t.Errorf("share.lock not created: %v", err)
+	}
+}
+
+func TestWithShareLock_PropagatesFnError(t *testing.T) {
+	want := errors.New("boom")
+	got := WithShareLock(t.TempDir(), func() error { return want })
+	if !errors.Is(got, want) {
+		t.Fatalf("WithShareLock() = %v, want %v", got, want)
 	}
 }

--- a/internal/session/share_lock_test.go
+++ b/internal/session/share_lock_test.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWithShareLock_SerializesConcurrentCallers(t *testing.T) {
+	dir := t.TempDir()
+	identity := dir
+
+	var active atomic.Int32
+	var peak atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := WithShareLock(identity, func() error {
+				n := active.Add(1)
+				if cur := peak.Load(); n > cur {
+					peak.Store(n)
+				}
+				time.Sleep(20 * time.Millisecond)
+				active.Add(-1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithShareLock: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if peak.Load() != 1 {
+		t.Errorf("expected peak concurrency 1, got %d", peak.Load())
+	}
+	if _, err := os.Stat(ReviewPathsFor(identity).ShareLock); err != nil {
+		t.Errorf("share.lock not created: %v", err)
+	}
+}

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -304,7 +304,7 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 		sharePaths[i] = f.Path
 	}
 
-	existingCfg, ok, err := LoadExistingShareCfg(critPath, sharePaths)
+	_, ok, err := LoadExistingShareCfg(critPath, sharePaths)
 	if err != nil {
 		return err
 	}
@@ -325,11 +325,17 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 			return nil
 		}
 	}
-	if ok {
-		return runShareExisting(existingCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)
-	}
 
-	return runShareNew(critPath, files, sharePaths, sf.svcURL, authToken, cfg.Author, sf.org, sf.visibility, sf.showQR)
+	return session.WithShareLock(critPath, func() error {
+		lockedCfg, lockedOK, err := LoadExistingShareCfg(critPath, sharePaths)
+		if err != nil {
+			return err
+		}
+		if lockedOK {
+			return runShareExisting(lockedCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)
+		}
+		return runShareNew(critPath, files, sharePaths, sf.svcURL, authToken, cfg.Author, sf.org, sf.visibility, sf.showQR)
+	})
 }
 
 func parseFetchOutputDir(args []string) (string, error) {

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -327,15 +327,19 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 	}
 
 	return session.WithShareLock(critPath, func() error {
-		lockedCfg, lockedOK, err := LoadExistingShareCfg(critPath, sharePaths)
-		if err != nil {
-			return err
-		}
-		if lockedOK {
-			return runShareExisting(lockedCfg, critPath, files, sharePaths, authToken, cfg.Author, sf.showQR)
-		}
-		return runShareNew(critPath, files, sharePaths, sf.svcURL, authToken, cfg.Author, sf.org, sf.visibility, sf.showQR)
+		return runShareUnderLock(critPath, files, sharePaths, sf.svcURL, authToken, cfg.Author, sf.org, sf.visibility, sf.showQR)
 	})
+}
+
+func runShareUnderLock(critPath string, files []ShareFile, sharePaths []string, svcURL, authToken, author, org, visibility string, showQR bool) error {
+	lockedCfg, lockedOK, err := LoadExistingShareCfg(critPath, sharePaths)
+	if err != nil {
+		return err
+	}
+	if lockedOK {
+		return runShareExisting(lockedCfg, critPath, files, sharePaths, authToken, author, showQR)
+	}
+	return runShareNew(critPath, files, sharePaths, svcURL, authToken, author, org, visibility, showQR)
 }
 
 func parseFetchOutputDir(args []string) (string, error) {

--- a/internal/share/share_concurrent_test.go
+++ b/internal/share/share_concurrent_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -112,6 +113,9 @@ func critBinaryForTest(t *testing.T) string {
 	}
 	repoRoot := filepath.Join(wd, "..", "..")
 	binary := filepath.Join(t.TempDir(), "crit")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
 	cmd := exec.Command("go", "build", "-o", binary, "./cmd/crit")
 	cmd.Dir = repoRoot
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/share/share_concurrent_test.go
+++ b/internal/share/share_concurrent_test.go
@@ -94,7 +94,9 @@ func TestConcurrentShareLock(t *testing.T) {
 func critBinaryForTest(t *testing.T) string {
 	t.Helper()
 	if b := os.Getenv("CRIT_BINARY"); b != "" {
-		return b
+		if _, err := os.Stat(b); err == nil {
+			return b
+		}
 	}
 	wd, err := os.Getwd()
 	if err != nil {
@@ -108,7 +110,14 @@ func critBinaryForTest(t *testing.T) string {
 			return p
 		}
 	}
-	return filepath.Join(wd, "..", "..", "crit")
+	repoRoot := filepath.Join(wd, "..", "..")
+	binary := filepath.Join(t.TempDir(), "crit")
+	cmd := exec.Command("go", "build", "-o", binary, "./cmd/crit")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building crit for test: %v\n%s", err, out)
+	}
+	return binary
 }
 
 func runCritShareCmd(t *testing.T, binary, dir, stubURL, outputDir string) (string, error) {

--- a/internal/share/share_concurrent_test.go
+++ b/internal/share/share_concurrent_test.go
@@ -1,0 +1,135 @@
+package share
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestConcurrentShareLock verifies parallel `crit share` invocations for the
+// same review identity create only one hosted review (single POST).
+func TestConcurrentShareLock(t *testing.T) {
+	binary := critBinaryForTest(t)
+
+	var postCount atomic.Int32
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/reviews" {
+			n := postCount.Add(1)
+			time.Sleep(100 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          fmt.Sprintf("http://stub/r/token-%d", n),
+				"delete_token": fmt.Sprintf("delete-%d", n),
+			})
+			return
+		}
+		if r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"url":          "http://stub/r/token-1",
+				"review_round": 1,
+				"changed":      true,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer stub.Close()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dummy.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := runCritShareCmd(t, binary, dir, stub.URL, dir)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("crit share failed: %v", err)
+		}
+	}
+
+	if got := postCount.Load(); got != 1 {
+		t.Fatalf("expected 1 POST to crit-web, got %d", got)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	if err != nil {
+		t.Fatalf("reading review.json: %v", err)
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		t.Fatalf("parsing review.json: %v", err)
+	}
+	if cj.DeleteToken != "delete-1" {
+		t.Errorf("delete_token = %q, want delete-1", cj.DeleteToken)
+	}
+	if cj.ShareURL != "http://stub/r/token-1" {
+		t.Errorf("share_url = %q, want http://stub/r/token-1", cj.ShareURL)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".crit", "share.lock")); err != nil {
+		t.Errorf("share.lock missing: %v", err)
+	}
+}
+
+func critBinaryForTest(t *testing.T) string {
+	t.Helper()
+	if b := os.Getenv("CRIT_BINARY"); b != "" {
+		return b
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{
+		filepath.Join(wd, "..", "..", "crit"),
+		filepath.Join(wd, "crit"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return filepath.Join(wd, "..", "..", "crit")
+}
+
+func runCritShareCmd(t *testing.T, binary, dir, stubURL, outputDir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binary, "share", "--share-url", stubURL, "--output", outputDir, "dummy.md")
+	cmd.Dir = dir
+	cmd.Env = envWithout("CRIT_AUTH_TOKEN=", "HOME=", "CRIT_SHARE_URL=")
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func envWithout(prefixes ...string) []string {
+	var env []string
+outer:
+	for _, e := range os.Environ() {
+		for _, p := range prefixes {
+			if strings.HasPrefix(e, p) {
+				continue outer
+			}
+		}
+		env = append(env, e)
+	}
+	return env
+}

--- a/internal/share/share_concurrent_test.go
+++ b/internal/share/share_concurrent_test.go
@@ -6,21 +6,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
-// TestConcurrentShareLock verifies parallel `crit share` invocations for the
-// same review identity create only one hosted review (single POST).
+// TestConcurrentShareLock verifies parallel share attempts for the same review
+// identity create only one hosted review (single POST).
 func TestConcurrentShareLock(t *testing.T) {
-	binary := critBinaryForTest(t)
-
 	var postCount atomic.Int32
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/reviews" {
@@ -50,6 +47,9 @@ func TestConcurrentShareLock(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "dummy.md"), []byte("# test\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	critPath := filepath.Join(dir, ".crit")
+	files := []ShareFile{{Path: "dummy.md", Content: "# test\n"}}
+	sharePaths := []string{"dummy.md"}
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
@@ -57,15 +57,16 @@ func TestConcurrentShareLock(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := runCritShareCmd(t, binary, dir, stub.URL, dir)
-			errs <- err
+			errs <- session.WithShareLock(critPath, func() error {
+				return runShareUnderLock(critPath, files, sharePaths, stub.URL, "", "", "", "", false)
+			})
 		}()
 	}
 	wg.Wait()
 	close(errs)
 	for err := range errs {
 		if err != nil {
-			t.Fatalf("crit share failed: %v", err)
+			t.Fatalf("share under lock failed: %v", err)
 		}
 	}
 
@@ -73,7 +74,7 @@ func TestConcurrentShareLock(t *testing.T) {
 		t.Fatalf("expected 1 POST to crit-web, got %d", got)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	data, err := os.ReadFile(filepath.Join(critPath, "review.json"))
 	if err != nil {
 		t.Fatalf("reading review.json: %v", err)
 	}
@@ -87,62 +88,7 @@ func TestConcurrentShareLock(t *testing.T) {
 	if cj.ShareURL != "http://stub/r/token-1" {
 		t.Errorf("share_url = %q, want http://stub/r/token-1", cj.ShareURL)
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".crit", "share.lock")); err != nil {
+	if _, err := os.Stat(session.ReviewPathsFor(critPath).ShareLock); err != nil {
 		t.Errorf("share.lock missing: %v", err)
 	}
-}
-
-func critBinaryForTest(t *testing.T) string {
-	t.Helper()
-	if b := os.Getenv("CRIT_BINARY"); b != "" {
-		if _, err := os.Stat(b); err == nil {
-			return b
-		}
-	}
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, p := range []string{
-		filepath.Join(wd, "..", "..", "crit"),
-		filepath.Join(wd, "crit"),
-	} {
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-	repoRoot := filepath.Join(wd, "..", "..")
-	binary := filepath.Join(t.TempDir(), "crit")
-	if runtime.GOOS == "windows" {
-		binary += ".exe"
-	}
-	cmd := exec.Command("go", "build", "-o", binary, "./cmd/crit")
-	cmd.Dir = repoRoot
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("building crit for test: %v\n%s", err, out)
-	}
-	return binary
-}
-
-func runCritShareCmd(t *testing.T, binary, dir, stubURL, outputDir string) (string, error) {
-	t.Helper()
-	cmd := exec.Command(binary, "share", "--share-url", stubURL, "--output", outputDir, "dummy.md")
-	cmd.Dir = dir
-	cmd.Env = envWithout("CRIT_AUTH_TOKEN=", "HOME=", "CRIT_SHARE_URL=")
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
-}
-
-func envWithout(prefixes ...string) []string {
-	var env []string
-outer:
-	for _, e := range os.Environ() {
-		for _, p := range prefixes {
-			if strings.HasPrefix(e, p) {
-				continue outer
-			}
-		}
-		env = append(env, e)
-	}
-	return env
 }

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -14,8 +14,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -2322,82 +2320,5 @@ func TestShareSyncOrgPersistence(t *testing.T) {
 	}
 	if cj.ShareURL == "" {
 		t.Error("expected share_url to be set in review file")
-	}
-}
-
-// TestConcurrentShareLock verifies parallel `crit share` invocations for the
-// same review identity create only one hosted review (single POST).
-func TestConcurrentShareLock(t *testing.T) {
-	binary := critBinary(t)
-
-	var postCount atomic.Int32
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && r.URL.Path == "/api/reviews" {
-			n := postCount.Add(1)
-			time.Sleep(100 * time.Millisecond)
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"url":          fmt.Sprintf("http://stub/r/token-%d", n),
-				"delete_token": fmt.Sprintf("delete-%d", n),
-			})
-			return
-		}
-		if r.Method == http.MethodPut {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"url":          "http://stub/r/token-1",
-				"review_round": 1,
-				"changed":      true,
-			})
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer stub.Close()
-
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "dummy.md"), []byte("# test\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var wg sync.WaitGroup
-	errs := make(chan error, 2)
-	wg.Add(2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			defer wg.Done()
-			_, err := runCritCmd(t, binary, dir,
-				"share", "--share-url", stub.URL, "--output", dir, "dummy.md")
-			errs <- err
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("crit share failed: %v", err)
-		}
-	}
-
-	if got := postCount.Load(); got != 1 {
-		t.Fatalf("expected 1 POST to crit-web, got %d", got)
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
-	if err != nil {
-		t.Fatalf("reading review.json: %v", err)
-	}
-	var cj CritJSON
-	if err := json.Unmarshal(data, &cj); err != nil {
-		t.Fatalf("parsing review.json: %v", err)
-	}
-	if cj.DeleteToken != "delete-1" {
-		t.Errorf("delete_token = %q, want delete-1", cj.DeleteToken)
-	}
-	if cj.ShareURL != "http://stub/r/token-1" {
-		t.Errorf("share_url = %q, want http://stub/r/token-1", cj.ShareURL)
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".crit", "share.lock")); err != nil {
-		t.Errorf("share.lock missing: %v", err)
 	}
 }

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -2320,5 +2322,82 @@ func TestShareSyncOrgPersistence(t *testing.T) {
 	}
 	if cj.ShareURL == "" {
 		t.Error("expected share_url to be set in review file")
+	}
+}
+
+// TestConcurrentShareLock verifies parallel `crit share` invocations for the
+// same review identity create only one hosted review (single POST).
+func TestConcurrentShareLock(t *testing.T) {
+	binary := critBinary(t)
+
+	var postCount atomic.Int32
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/reviews" {
+			n := postCount.Add(1)
+			time.Sleep(100 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          fmt.Sprintf("http://stub/r/token-%d", n),
+				"delete_token": fmt.Sprintf("delete-%d", n),
+			})
+			return
+		}
+		if r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"url":          "http://stub/r/token-1",
+				"review_round": 1,
+				"changed":      true,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer stub.Close()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dummy.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := runCritCmd(t, binary, dir,
+				"share", "--share-url", stub.URL, "--output", dir, "dummy.md")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("crit share failed: %v", err)
+		}
+	}
+
+	if got := postCount.Load(); got != 1 {
+		t.Fatalf("expected 1 POST to crit-web, got %d", got)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	if err != nil {
+		t.Fatalf("reading review.json: %v", err)
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		t.Fatalf("parsing review.json: %v", err)
+	}
+	if cj.DeleteToken != "delete-1" {
+		t.Errorf("delete_token = %q, want delete-1", cj.DeleteToken)
+	}
+	if cj.ShareURL != "http://stub/r/token-1" {
+		t.Errorf("share_url = %q, want http://stub/r/token-1", cj.ShareURL)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".crit", "share.lock")); err != nil {
+		t.Errorf("share.lock missing: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `share.lock` inside each review identity folder and `session.WithShareLock` (advisory flock)
- Run the `crit share` POST/upsert + persist path inside that lock, re-reading `share_url` after acquiring it
- Prevents overlapping CLI shares from creating two hosted reviews and orphaning the first `delete_token`

## Review
- [x] Code review: passed (no blockers)
- [x] Parity audit: N/A (CLI-only; UI share already idempotent in-process)

## Test plan
- [x] `go test -race ./internal/session/ ./internal/share/`
- [x] `go test -tags=integration -run TestConcurrentShareLock ./internal/share/`
- [x] Manual repro: parallel `crit share` against stub — old binary POST×2, new binary POST×1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)