### PR TITLE
fix: render PR diff hunks when default scope is branch

### DIFF
--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -876,7 +876,10 @@ func computeScopedDiffHunks(path, scope, commit, status, oldPath, content, baseR
 // When commit is non-empty, returns the diff for that single commit.
 // When ignoreWhitespace is true, whitespace-only changes collapse to context (code diffs only).
 func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string, ignoreWhitespace bool) (map[string]any, bool) {
-	if commit == "" && (scope == "" || scope == "all" || s.Mode == "files" || s.Mode == "plan") {
+	s.mu.RLock()
+	inRange := s.Focus.Kind == FocusRange
+	s.mu.RUnlock()
+	if commit == "" && (scope == "" || scope == "all" || s.Mode == "files" || s.Mode == "plan" || inRange) {
 		return s.GetFileDiffSnapshot(path, ignoreWhitespace)
 	}
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4875,6 +4875,42 @@ func TestGetFileDiffSnapshotScoped_CommitRangeRename(t *testing.T) {
 	}
 }
 
+// Regression #701: range focus must ignore working-tree scope on /api/file/diff.
+func TestGetFileDiffSnapshotScoped_RangeFocus_IgnoresBranchScope(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	commitAt(t, dir, "changed.go", "line1\nline2\nline3\n", "add file")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		BaseRef:  base,
+		VCS:      &vcs.GitVCS{},
+		Focus: Focus{
+			Kind:    FocusRange,
+			BaseSHA: base,
+			HeadSHA: head,
+		},
+		Files: []*FileEntry{{
+			Path:      "changed.go",
+			Status:    "added",
+			Content:   "line1\nline2\nline3\n",
+			DiffHunks: vcs.FileDiffUnifiedNewFile("line1\nline2\nline3\n"),
+		}},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	result, ok := s.GetFileDiffSnapshotScoped("changed.go", "branch", "", false)
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+	hunks, _ := result["hunks"].([]DiffHunk)
+	if len(hunks) == 0 {
+		t.Fatal("range focus with scope=branch must return preloaded range hunks, not empty working-tree diff")
+	}
+}
+
 func TestGetFileDiffSnapshotScoped_CommitRangeRename_PreloadedFile(t *testing.T) {
 	dir := initTestRepo(t)
 	commitAt(t, dir, "old.go", "package x\n", "add old")

--- a/web/__tests__/range-focus-diff-scope.test.js
+++ b/web/__tests__/range-focus-diff-scope.test.js
@@ -1,0 +1,32 @@
+'use strict';
+// Regression: #701 — crit pr showed correct line counts but "No changes"
+// because diffScope defaulted to "branch" while range focus diffs are pinned
+// to BaseSHA..HeadSHA (working-tree scopes return empty hunks).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+test('range focus forces diffScope to all on init', () => {
+  assert.match(
+    appJs,
+    /inRangeFocus\)\s*\{\s*diffScope\s*=\s*'all'/s,
+    'init must reset diffScope when session is in range focus'
+  );
+});
+
+test('file diff loads use effectiveDiffScope helper', () => {
+  assert.match(
+    appJs,
+    /function effectiveDiffScope\(\)\s*\{\s*return sessionInRangeFocus\(\) \? 'all' : diffScope;/,
+    'effectiveDiffScope must bypass working-tree scope in range focus'
+  );
+  assert.match(
+    appJs,
+    /loadAllFileData\(session\.files[^)]*effectiveDiffScope\(\)/,
+    'loadAllFileData must use effectiveDiffScope'
+  );
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1023,11 +1023,15 @@
       // correct, and the scope toggle will be hidden once the range chrome
       // renders.
       const inRangeFocus = session.focus && session.focus.kind === 'range';
-      if (diffScope === null) {
+      // Working-tree scopes (branch/staged/unstaged) filter against HEAD;
+      // range focus diffs are pinned to BaseSHA..HeadSHA server-side.
+      if (inRangeFocus) {
+        diffScope = 'all';
+      } else if (diffScope === null) {
         // First launch — prefer "branch" (committed changes only) over "all"
         // (which includes untracked files and can overwhelm large repos).
         diffScope = scopes.indexOf('branch') !== -1 ? 'branch' : 'all';
-        if (diffScope !== 'all' && !inRangeFocus) {
+        if (diffScope !== 'all') {
           const corrected = await fetchWhenReady('/api/session?scope=' + enc(diffScope));
           session = corrected;
           reviewComments = corrected.review_comments || [];
@@ -1053,7 +1057,7 @@
       ? 'Crit — ' + (session.branch || 'review')
       : 'Crit — ' + (session.files || []).map(f => f.path).join(', '));
 
-    files = await loadAllFileData(session.files || [], diffScope);
+    files = await loadAllFileData(session.files || [], effectiveDiffScope());
     hiddenUnresolved = session.hidden_unresolved || 0;
 
     files.sort(fileSortComparator);
@@ -2044,7 +2048,7 @@
           file_type: file.fileType,
           additions: file.additions,
           deletions: file.deletions,
-        }, diffScope).then(function(loaded) {
+        }, effectiveDiffScope()).then(function(loaded) {
           // Copy loaded data into the existing file object
           file.oldPath = loaded.oldPath;
           file.content = loaded.content;
@@ -6922,7 +6926,7 @@
         reviewComments = sessionRes.review_comments || [];
 
         // Reload all files
-        files = await loadAllFileData(session.files || [], diffScope);
+        files = await loadAllFileData(session.files || [], effectiveDiffScope());
         hiddenUnresolved = session.hidden_unresolved || 0;
 
         // Restore per-file user state from previous round
@@ -7056,6 +7060,9 @@
             session.last_range_focus = inner.last_range_focus || null;
           }
           applyFocusToHeader(focus);
+          if (focus.kind === 'range') {
+            diffScope = 'all';
+          }
           // Re-fetch the stack on any range focus transition — the new
           // focus may live in a different stack, and the breadcrumb's
           // visibility uses stack.length (not is_stacked) so we need the
@@ -7424,6 +7431,13 @@
 
   function sessionInRangeFocus() {
     return !!(session && session.focus && session.focus.kind === 'range');
+  }
+
+  // Scope passed to /api/file and /api/file/diff. Working-tree scopes are
+  // meaningless in range (PR) focus — the file list and hunks are pinned to
+  // BaseSHA..HeadSHA server-side.
+  function effectiveDiffScope() {
+    return sessionInRangeFocus() ? 'all' : diffScope;
   }
 
   function compareTargetChromeVisible() {
@@ -8027,7 +8041,7 @@
           return;
         }
 
-        files = await loadAllFileData(session.files, diffScope);
+        files = await loadAllFileData(session.files, effectiveDiffScope());
         hiddenUnresolved = session.hidden_unresolved || 0;
         files.sort(fileSortComparator);
         restoreViewedState();


### PR DESCRIPTION
## Summary
- Fixes `crit pr <url>` showing correct line-count badges but "No changes" in every file diff pane
- Root cause: range (PR) focus pins diffs to `BaseSHA..HeadSHA`, but the UI defaulted `diffScope` to `branch` and passed it to `/api/file/diff`, which queried the working tree instead of the PR range
- Frontend now forces `scope=all` in range focus; backend ignores working-tree scopes when `Focus.Kind == range`

## Review
- [x] Code review: passed (focused fix, regression tests added)
- [x] Parity audit: N/A (crit-only; crit-web has no PR review mode)

## Test plan
- [x] `go test ./internal/session/... -run TestGetFileDiffSnapshotScoped_RangeFocus`
- [x] `node --test web/__tests__/range-focus-diff-scope.test.js`
- [x] `go test -race ./internal/session/...`

Closes #701

Made with [Cursor](https://cursor.com)