### PR TITLE
fix: route bare GitHub PR URLs to range mode

### DIFF
--- a/cmd/crit/cli_routing.go
+++ b/cmd/crit/cli_routing.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/focus"
 	"github.com/tomasz-tomczyk/crit/internal/live"
 	"github.com/tomasz-tomczyk/crit/internal/preview"
+	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
 type positionalRoute int
@@ -13,6 +15,12 @@ const (
 	positionalRoutePRReview
 	positionalRouteLive
 	positionalRoutePreview
+)
+
+var (
+	runReviewForPositionalCLI  = session.RunReview
+	runLiveForPositionalCLI    = runLive
+	runPreviewForPositionalCLI = runPreview
 )
 
 // routePositionalArgs classifies bare positional crit arguments (no subcommand).
@@ -35,4 +43,19 @@ func prReviewArgs(args []string) ([]string, bool) {
 		return nil, false
 	}
 	return []string{"--pr", args[0]}, true
+}
+
+// runPositionalCLI dispatches bare positional arguments from main.
+func runPositionalCLI(args []string) {
+	switch routePositionalArgs(args) {
+	case positionalRoutePRReview:
+		prArgs, _ := prReviewArgs(args)
+		clicmd.Exit(runReviewForPositionalCLI(prArgs))
+	case positionalRouteLive:
+		runLiveForPositionalCLI(args)
+	case positionalRoutePreview:
+		runPreviewForPositionalCLI(args)
+	default:
+		clicmd.Exit(runReviewForPositionalCLI(args))
+	}
 }

--- a/cmd/crit/cli_routing.go
+++ b/cmd/crit/cli_routing.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/tomasz-tomczyk/crit/internal/focus"
+	"github.com/tomasz-tomczyk/crit/internal/live"
+	"github.com/tomasz-tomczyk/crit/internal/preview"
+)
+
+type positionalRoute int
+
+const (
+	positionalRouteReview positionalRoute = iota
+	positionalRoutePRReview
+	positionalRouteLive
+	positionalRoutePreview
+)
+
+// routePositionalArgs classifies bare positional crit arguments (no subcommand).
+func routePositionalArgs(args []string) positionalRoute {
+	if _, ok := prReviewArgs(args); ok {
+		return positionalRoutePRReview
+	}
+	if live.LooksLikeLiveArgs(args) {
+		return positionalRouteLive
+	}
+	if preview.LooksLikePreviewArgs(args) {
+		return positionalRoutePreview
+	}
+	return positionalRouteReview
+}
+
+// prReviewArgs returns --pr argv when args is a single GitHub PR URL.
+func prReviewArgs(args []string) ([]string, bool) {
+	if len(args) != 1 || !focus.LooksLikePRURL(args[0]) {
+		return nil, false
+	}
+	return []string{"--pr", args[0]}, true
+}

--- a/cmd/crit/cli_routing_test.go
+++ b/cmd/crit/cli_routing_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestRoutePositionalArgs(t *testing.T) {
+	cases := []struct {
+		args []string
+		want positionalRoute
+	}{
+		{[]string{"https://github.com/a/b/pull/295"}, positionalRoutePRReview},
+		{[]string{"https://github.com/a/b/pull/295/files"}, positionalRoutePRReview},
+		{[]string{"http://localhost:3000"}, positionalRouteLive},
+		{[]string{"https://example.com/app"}, positionalRouteLive},
+		{[]string{"README.md"}, positionalRouteReview},
+		{[]string{"http://a.com", "README.md"}, positionalRouteReview},
+	}
+	for _, c := range cases {
+		t.Run(c.args[0], func(t *testing.T) {
+			if got := routePositionalArgs(c.args); got != c.want {
+				t.Errorf("routePositionalArgs(%v) = %v, want %v", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPRReviewArgs(t *testing.T) {
+	args, ok := prReviewArgs([]string{"https://github.com/a/b/pull/42"})
+	if !ok {
+		t.Fatal("expected ok=true for PR URL")
+	}
+	want := []string{"--pr", "https://github.com/a/b/pull/42"}
+	if len(args) != len(want) || args[0] != want[0] || args[1] != want[1] {
+		t.Errorf("got %v, want %v", args, want)
+	}
+
+	if _, ok := prReviewArgs([]string{"https://example.com"}); ok {
+		t.Error("expected ok=false for non-PR URL")
+	}
+	if _, ok := prReviewArgs([]string{"295"}); ok {
+		t.Error("expected ok=false for bare PR number")
+	}
+}

--- a/cmd/crit/cli_routing_test.go
+++ b/cmd/crit/cli_routing_test.go
@@ -1,23 +1,33 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestRoutePositionalArgs(t *testing.T) {
+	dir := t.TempDir()
+	htmlFile := filepath.Join(dir, "page.html")
+	if err := os.WriteFile(htmlFile, []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
+		name string
 		args []string
 		want positionalRoute
 	}{
-		{[]string{"https://github.com/a/b/pull/295"}, positionalRoutePRReview},
-		{[]string{"https://github.com/a/b/pull/295/files"}, positionalRoutePRReview},
-		{[]string{"http://localhost:3000"}, positionalRouteLive},
-		{[]string{"https://example.com/app"}, positionalRouteLive},
-		{[]string{"README.md"}, positionalRouteReview},
-		{[]string{"http://a.com", "README.md"}, positionalRouteReview},
+		{"pr url", []string{"https://github.com/a/b/pull/295"}, positionalRoutePRReview},
+		{"pr url files tab", []string{"https://github.com/a/b/pull/295/files"}, positionalRoutePRReview},
+		{"live localhost", []string{"http://localhost:3000"}, positionalRouteLive},
+		{"live https", []string{"https://example.com/app"}, positionalRouteLive},
+		{"preview html", []string{htmlFile}, positionalRoutePreview},
+		{"plain file", []string{"README.md"}, positionalRouteReview},
+		{"url plus file", []string{"http://a.com", "README.md"}, positionalRouteReview},
 	}
 	for _, c := range cases {
-		t.Run(c.args[0], func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			if got := routePositionalArgs(c.args); got != c.want {
 				t.Errorf("routePositionalArgs(%v) = %v, want %v", c.args, got, c.want)
 			}
@@ -40,5 +50,79 @@ func TestPRReviewArgs(t *testing.T) {
 	}
 	if _, ok := prReviewArgs([]string{"295"}); ok {
 		t.Error("expected ok=false for bare PR number")
+	}
+}
+
+func TestRunPositionalCLI_PRURLRewritesToReview(t *testing.T) {
+	var got []string
+	prevReview := runReviewForPositionalCLI
+	prevLive := runLiveForPositionalCLI
+	prevPreview := runPreviewForPositionalCLI
+	t.Cleanup(func() {
+		runReviewForPositionalCLI = prevReview
+		runLiveForPositionalCLI = prevLive
+		runPreviewForPositionalCLI = prevPreview
+	})
+	runReviewForPositionalCLI = func(args []string) error {
+		got = append([]string{}, args...)
+		return nil
+	}
+	runLiveForPositionalCLI = func([]string) { t.Fatal("live dispatch should not run for PR URL") }
+	runPreviewForPositionalCLI = func([]string) { t.Fatal("preview dispatch should not run for PR URL") }
+
+	runPositionalCLI([]string{"https://github.com/a/b/pull/7"})
+
+	want := []string{"--pr", "https://github.com/a/b/pull/7"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("RunReview args = %v, want %v", got, want)
+	}
+}
+
+func TestRunPositionalCLI_LiveURL(t *testing.T) {
+	var liveCalled bool
+	prevReview := runReviewForPositionalCLI
+	prevLive := runLiveForPositionalCLI
+	t.Cleanup(func() {
+		runReviewForPositionalCLI = prevReview
+		runLiveForPositionalCLI = prevLive
+	})
+	runLiveForPositionalCLI = func([]string) { liveCalled = true }
+
+	runPositionalCLI([]string{"http://localhost:3000"})
+	if !liveCalled {
+		t.Fatal("expected live dispatch for dev-server URL")
+	}
+}
+
+func TestRunPositionalCLI_PreviewHTML(t *testing.T) {
+	dir := t.TempDir()
+	htmlFile := filepath.Join(dir, "page.html")
+	if err := os.WriteFile(htmlFile, []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var previewCalled bool
+	prevPreview := runPreviewForPositionalCLI
+	t.Cleanup(func() { runPreviewForPositionalCLI = prevPreview })
+	runPreviewForPositionalCLI = func([]string) { previewCalled = true }
+
+	runPositionalCLI([]string{htmlFile})
+	if !previewCalled {
+		t.Fatal("expected preview dispatch for .html file")
+	}
+}
+
+func TestRunPositionalCLI_PlainFileReview(t *testing.T) {
+	var got []string
+	prevReview := runReviewForPositionalCLI
+	t.Cleanup(func() { runReviewForPositionalCLI = prevReview })
+	runReviewForPositionalCLI = func(args []string) error {
+		got = append([]string{}, args...)
+		return nil
+	}
+
+	runPositionalCLI([]string{"README.md"})
+	if len(got) != 1 || got[0] != "README.md" {
+		t.Fatalf("RunReview args = %v, want [README.md]", got)
 	}
 }

--- a/cmd/crit/main.go
+++ b/cmd/crit/main.go
@@ -28,15 +28,5 @@ func main() {
 		return
 	}
 	args := resolveAtPrefixedArgs(os.Args[1:])
-	switch routePositionalArgs(args) {
-	case positionalRoutePRReview:
-		prArgs, _ := prReviewArgs(args)
-		clicmd.Exit(session.RunReview(prArgs))
-	case positionalRouteLive:
-		runLive(args)
-	case positionalRoutePreview:
-		runPreview(args)
-	default:
-		clicmd.Exit(session.RunReview(args))
-	}
+	runPositionalCLI(args)
 }

--- a/cmd/crit/main.go
+++ b/cmd/crit/main.go
@@ -5,8 +5,6 @@ import (
 
 	integrationassets "github.com/tomasz-tomczyk/crit/integrations"
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
-	"github.com/tomasz-tomczyk/crit/internal/live"
-	"github.com/tomasz-tomczyk/crit/internal/preview"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	webassets "github.com/tomasz-tomczyk/crit/web"
 )
@@ -30,13 +28,15 @@ func main() {
 		return
 	}
 	args := resolveAtPrefixedArgs(os.Args[1:])
-	if live.LooksLikeLiveArgs(args) {
+	switch routePositionalArgs(args) {
+	case positionalRoutePRReview:
+		prArgs, _ := prReviewArgs(args)
+		clicmd.Exit(session.RunReview(prArgs))
+	case positionalRouteLive:
 		runLive(args)
-		return
-	}
-	if preview.LooksLikePreviewArgs(args) {
+	case positionalRoutePreview:
 		runPreview(args)
-		return
+	default:
+		clicmd.Exit(session.RunReview(args))
 	}
-	clicmd.Exit(session.RunReview(args))
 }

--- a/internal/focus/export.go
+++ b/internal/focus/export.go
@@ -1,5 +1,10 @@
 package focus
 
+// LooksLikePRURL reports whether spec is a GitHub pull request URL.
+func LooksLikePRURL(spec string) bool {
+	return prURLRe.MatchString(spec)
+}
+
 // ParsePRSpec resolves --pr <num|url> to a numeric PR number.
 func ParsePRSpec(spec string) (int, error) {
 	return parsePRSpec(spec)

--- a/internal/focus/focus_cli_test.go
+++ b/internal/focus/focus_cli_test.go
@@ -33,6 +33,28 @@ func TestParsePRSpec(t *testing.T) {
 	}
 }
 
+func TestLooksLikePRURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"https://github.com/a/b/pull/295", true},
+		{"https://github.com/a/b/pull/295/files", true},
+		{"http://github.com/a/b/pull/1", true},
+		{"https://example.com", false},
+		{"https://github.com/a/b/issues/295", false},
+		{"295", false},
+		{"README.md", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := LooksLikePRURL(c.in); got != c.want {
+				t.Errorf("LooksLikePRURL(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestParseRangeSpec(t *testing.T) {
 	cases := []struct {
 		in       string

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/browser"
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/focus"
 )
 
 type smokeKind int
@@ -123,8 +124,12 @@ func runSmokeTest(origin, cookies string) smokeResult {
 }
 
 // LooksLikeLiveArgs returns true when args is a single http/https URL.
+// GitHub PR URLs are excluded — those route to range mode via --pr.
 func LooksLikeLiveArgs(args []string) bool {
 	if len(args) != 1 {
+		return false
+	}
+	if focus.LooksLikePRURL(args[0]) {
 		return false
 	}
 	u, err := url.Parse(args[0])

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/focus"
 )
 
 func TestAddLivePin_AssignsMonotonicGlobalPinNumbers(t *testing.T) {
@@ -81,6 +83,10 @@ func testRunLive([]string)   { lastDispatch = "live" }
 func testRunReview([]string) { lastDispatch = "review" }
 
 func dispatchForTest(args []string, liveFn, reviewFn func([]string)) {
+	if len(args) == 1 && focus.LooksLikePRURL(args[0]) {
+		reviewFn([]string{"--pr", args[0]})
+		return
+	}
 	if looksLikeLiveArgs(args) {
 		liveFn(args)
 	} else {
@@ -128,6 +134,22 @@ func TestDispatch_PlainArgNotLive(t *testing.T) {
 	}
 }
 
+func TestDispatch_GitHubPRURLUsesReview(t *testing.T) {
+	lastDispatch = ""
+	var reviewArgs []string
+	dispatchForTest([]string{"https://github.com/a/b/pull/295"}, testRunLive, func(args []string) {
+		lastDispatch = "review"
+		reviewArgs = args
+	})
+	if lastDispatch != "review" {
+		t.Errorf("dispatch = %q, want review", lastDispatch)
+	}
+	want := []string{"--pr", "https://github.com/a/b/pull/295"}
+	if len(reviewArgs) != len(want) || reviewArgs[0] != want[0] || reviewArgs[1] != want[1] {
+		t.Errorf("review args = %v, want %v", reviewArgs, want)
+	}
+}
+
 func TestLooksLikeLiveArgs(t *testing.T) {
 	cases := []struct {
 		args []string
@@ -136,6 +158,8 @@ func TestLooksLikeLiveArgs(t *testing.T) {
 		{[]string{"http://localhost:3000"}, true},
 		{[]string{"https://example.com"}, true},
 		{[]string{"https://localhost:8080/path"}, true},
+		{[]string{"https://github.com/a/b/pull/295"}, false},
+		{[]string{"https://github.com/a/b/pull/295/files"}, false},
 		{[]string{"ftp://x.com"}, false},
 		{[]string{"localhost:3000"}, false},
 		{[]string{"README.md"}, false},


### PR DESCRIPTION
## Summary
- Detect GitHub PR URLs (`https://github.com/.../pull/N`) in bare positional CLI args and rewrite them to `crit --pr <url>` before dispatch
- Exclude PR URLs from live-mode autodetection so `LooksLikeLiveArgs` no longer treats them as dev-server URLs
- Add routing unit tests in `cmd/crit`, `internal/focus`, and `internal/live`

Fixes the bug where `/crit:crit <github-pr-url>` (and `crit <url>` from a terminal) opened live mode instead of range mode. Closes #702.

## Review
- [x] Code review: passed (CLI-only routing change, no review-page parity impact)
- [x] Parity audit: N/A

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run` on changed packages
- [x] Manual: `./crit https://github.com/tomasz-tomczyk/crit/pull/698` → range mode (`focus.kind: "range"`, not `/live`)


Made with [Cursor](https://cursor.com)