### PR TITLE
feat: add virtual working changes entry in commit picker

### DIFF
--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -545,6 +545,19 @@ func availableScopes(baseRef string, v vcs.VCS) []string {
 	return scopes
 }
 
+const virtualWorkingTreeCommitSHA = "__crit_virtual_working_tree__"
+
+// hasWorkingTreeChanges reports whether there are uncommitted local changes.
+// Uses the repo-root-aware in-dir helper so tests and multi-repo daemon usage
+// do not accidentally inspect the process CWD.
+func hasWorkingTreeChanges(v vcs.VCS, repoRoot string) bool {
+	if v == nil {
+		return false
+	}
+	files, err := v.ChangedFilesOnDefaultInDir(repoRoot)
+	return err == nil && len(files) > 0
+}
+
 // GetCommits returns the list of commits between the base ref and the focus's
 // upper bound. In working-tree mode the upper bound is the VCS's HEAD; in range
 // mode it's Focus.HeadSHA so the dropdown doesn't list commits past the focus.
@@ -556,14 +569,23 @@ func (s *Session) GetCommits() []CommitInfo {
 		return nil
 	}
 	baseRef, repoRoot, vc := s.BaseRef, s.RepoRoot, s.VCS
+	focus := s.Focus
 	headRef := ""
-	if s.Focus.Kind == FocusRange && s.Focus.HeadSHA != "" {
-		headRef = s.Focus.HeadSHA
+	if focus.Kind == FocusRange && focus.HeadSHA != "" {
+		headRef = focus.HeadSHA
 	}
 	s.mu.RUnlock()
 	commits, err := vc.CommitLog(baseRef, headRef, repoRoot)
 	if err != nil {
 		return nil
+	}
+	if focus.Kind == FocusWorkingTree && hasWorkingTreeChanges(vc, repoRoot) {
+		commits = append([]CommitInfo{{
+			SHA:      virtualWorkingTreeCommitSHA,
+			ShortSHA: "WT",
+			Message:  "Working changes",
+			Virtual:  true,
+		}}, commits...)
 	}
 	return commits
 }
@@ -641,6 +663,13 @@ func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v v
 	if v == nil {
 		return nil
 	}
+	if commit == virtualWorkingTreeCommitSHA {
+		h, err := v.FileDiffUnified(fc.Path, "HEAD", repoRoot, ignoreWhitespace)
+		if err == nil {
+			return h
+		}
+		return nil
+	}
 	if base, head, ok := vcs.SplitCommitRange(commit); ok {
 		h, err := v.FileDiffBetweenSHAs(fc.Path, fc.OldPath, base, head, repoRoot, ignoreWhitespace)
 		if err == nil {
@@ -674,6 +703,19 @@ func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v v
 		return h
 	}
 	return nil
+}
+
+func changesForScopeSelection(v vcs.VCS, repoRoot, baseRef, scope, commit string) ([]vcs.FileChange, error) {
+	if commit == virtualWorkingTreeCommitSHA {
+		return v.ChangedFilesOnDefaultInDir(repoRoot)
+	}
+	if base, head, ok := vcs.SplitCommitRange(commit); ok {
+		return v.ChangedFilesBetweenSHAs(base, head, repoRoot)
+	}
+	if commit != "" {
+		return v.ChangedFilesForCommit(commit, repoRoot)
+	}
+	return v.ChangedFilesScoped(scope, baseRef)
 }
 
 func countHunkStats(hunks []vcs.DiffHunk) (additions, deletions int) {
@@ -729,15 +771,7 @@ func (s *Session) GetSessionInfoScoped(scope, commit string) SessionInfo {
 		return info
 	}
 
-	var changes []vcs.FileChange
-	var err error
-	if base, head, ok := vcs.SplitCommitRange(commit); ok {
-		changes, err = snap.vc.ChangedFilesBetweenSHAs(base, head, snap.repoRoot)
-	} else if commit != "" {
-		changes, err = snap.vc.ChangedFilesForCommit(commit, snap.repoRoot)
-	} else {
-		changes, err = snap.vc.ChangedFilesScoped(scope, snap.baseRef)
-	}
+	changes, err := changesForScopeSelection(snap.vc, snap.repoRoot, snap.baseRef, scope, commit)
 	if err != nil || len(changes) == 0 {
 		return info
 	}
@@ -823,15 +857,7 @@ func (s *Session) loadScopedFileState(path, scope, commit string) (status, conte
 		if vc == nil {
 			return
 		}
-		var changes []vcs.FileChange
-		var err error
-		if base, head, ok := vcs.SplitCommitRange(commit); ok {
-			changes, err = vc.ChangedFilesBetweenSHAs(base, head, repoRoot)
-		} else if commit != "" {
-			changes, err = vc.ChangedFilesForCommit(commit, repoRoot)
-		} else {
-			changes, err = vc.ChangedFilesScoped(scope, baseRef)
-		}
+		changes, err := changesForScopeSelection(vc, repoRoot, baseRef, scope, commit)
 		if err == nil {
 			for _, fc := range changes {
 				if fc.Path == path {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -5077,6 +5077,7 @@ func TestSession_GetCommits_RangeMode(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
 	gitT(t, dir, "add", "b.go")
 	gitT(t, dir, "commit", "-m", "B")
+	gitT(t, dir, "clean", "-fd")
 	shaB := gitT(t, dir, "rev-parse", "HEAD")
 
 	writeFile(t, filepath.Join(dir, "c.go"), "package main\n\nfunc C() {}\n")
@@ -5124,6 +5125,7 @@ func TestSession_GetCommits_WorkingTreeMode(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
 	gitT(t, dir, "add", "b.go")
 	gitT(t, dir, "commit", "-m", "B")
+	gitT(t, dir, "clean", "-fd")
 
 	s := &Session{
 		Mode:        "git",
@@ -5141,6 +5143,87 @@ func TestSession_GetCommits_WorkingTreeMode(t *testing.T) {
 	}
 	if commits[0].Message != "B" || commits[1].Message != "A" {
 		t.Errorf("messages = [%q, %q], want [B, A]", commits[0].Message, commits[1].Message)
+	}
+}
+
+func TestSession_GetCommits_WorkingTreeMode_WithDirtyTreeAddsVirtualTop(t *testing.T) {
+	dir := initTestRepo(t)
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
+
+	gitT(t, dir, "checkout", "-b", "feature/get-commits-wt-virtual")
+	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
+	gitT(t, dir, "add", "a.go")
+	gitT(t, dir, "commit", "-m", "A")
+
+	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
+	gitT(t, dir, "add", "b.go")
+	gitT(t, dir, "commit", "-m", "B")
+
+	// Leave an unstaged working-tree change so the synthetic top entry appears.
+	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n\nfunc Dirty() {}\n")
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     baseRef,
+		VCS:         &vcs.GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Focus:       Focus{Kind: FocusWorkingTree, BaseRef: baseRef},
+	}
+
+	commits := s.GetCommits()
+	if len(commits) != 3 {
+		t.Fatalf("GetCommits() = %d commits, want 3 (virtual, B, A); got %+v", len(commits), commits)
+	}
+	if !commits[0].Virtual {
+		t.Fatalf("expected first entry to be virtual, got %+v", commits[0])
+	}
+	if commits[0].Message != "Working changes" {
+		t.Errorf("virtual message = %q, want %q", commits[0].Message, "Working changes")
+	}
+	if commits[1].Message != "B" || commits[2].Message != "A" {
+		t.Errorf("messages = [%q, %q], want [B, A] after virtual top", commits[1].Message, commits[2].Message)
+	}
+}
+
+func TestSession_GetSessionInfoScoped_VirtualWorkingCommitOnlyShowsUncommitted(t *testing.T) {
+	dir := initTestRepo(t)
+	baseRef := gitT(t, dir, "rev-parse", "HEAD")
+
+	gitT(t, dir, "checkout", "-b", "feature/virtual-working-scope")
+	writeFile(t, filepath.Join(dir, "committed.go"), "package main\n\nfunc Committed() {}\n")
+	gitT(t, dir, "add", "committed.go")
+	gitT(t, dir, "commit", "-m", "add committed file")
+
+	// One unstaged modification and one untracked file should appear in virtual scope.
+	writeFile(t, filepath.Join(dir, "committed.go"), "package main\n\nfunc Committed() {}\n\nfunc Dirty() {}\n")
+	writeFile(t, filepath.Join(dir, "untracked.go"), "package main\n\nfunc Untracked() {}\n")
+
+	s := &Session{
+		Mode:           "git",
+		RepoRoot:       dir,
+		BaseRef:        baseRef,
+		BaseBranchName: "main",
+		VCS:            &vcs.GitVCS{},
+		ReviewRound:    1,
+		subscribers:    make(map[chan SSEEvent]struct{}),
+		Focus:          Focus{Kind: FocusWorkingTree, BaseRef: baseRef},
+	}
+
+	info := s.GetSessionInfoScoped("", virtualWorkingTreeCommitSHA)
+	paths := map[string]bool{}
+	for _, f := range info.Files {
+		paths[f.Path] = true
+	}
+	if !paths["committed.go"] {
+		t.Fatalf("expected committed.go (dirty working copy) in virtual scope; got %+v", info.Files)
+	}
+	if !paths["untracked.go"] {
+		t.Fatalf("expected untracked.go in virtual scope; got %+v", info.Files)
+	}
+	if len(info.Files) != 2 {
+		t.Fatalf("expected exactly 2 working-tree files in virtual scope, got %d (%+v)", len(info.Files), info.Files)
 	}
 }
 

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -376,6 +376,7 @@ type CommitInfo struct {
 	Message  string `json:"message"`
 	Author   string `json:"author"`
 	Date     string `json:"date"`
+	Virtual  bool   `json:"virtual,omitempty"`
 }
 
 // CommitLog returns the commits between baseRef and headRef, newest first.

--- a/test/e2e/setup-fixtures.sh
+++ b/test/e2e/setup-fixtures.sh
@@ -20,6 +20,10 @@ cd "$DIR"
 git init -q
 git config user.email "test@test.com"
 git config user.name "Test"
+# Keep LF in the repo on Windows CI; otherwise checkout rewrites files to CRLF
+# and leaves a dirty working tree (virtual "Working changes" row in every test).
+git config core.autocrlf false
+git config core.eol lf
 
 # === Initial commit: files that will be "modified" or "deleted" ===
 

--- a/test/e2e/tests/approve-button-commit-scope.spec.ts
+++ b/test/e2e/tests/approve-button-commit-scope.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearAllComments, loadPage, addComment } from './helpers';
+import { clearAllComments, loadPage, addComment, realCommitItems } from './helpers';
 
 // Regression: switching commit scope hid out-of-scope unresolved comments from the
 // finish button label — it showed "Approve" while hidden_unresolved > 0.
@@ -16,7 +16,7 @@ test.describe('Approve Button Text — commit scope', () => {
     await expect(page.locator('#finishBtn')).toHaveText('Finish Review');
 
     await page.click('#commitDropdownBtn');
-    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const commitItem = realCommitItems(page).first();
     const responsePromise = page.waitForResponse(r =>
       r.url().includes('/api/session') && r.status() === 200
     );

--- a/test/e2e/tests/commit-selection.spec.ts
+++ b/test/e2e/tests/commit-selection.spec.ts
@@ -6,6 +6,10 @@ async function openCommitPicker(page: Page) {
   await expect(page.locator('#commitDropdown')).toHaveClass(/open/);
 }
 
+function realCommitItems(page: Page) {
+  return page.locator('#commitDropdownList .commit-picker-item:not(.is-virtual)');
+}
+
 
 test.describe('Commit Selection', () => {
   test.beforeEach(async ({ request, page }) => {
@@ -28,7 +32,7 @@ test.describe('Commit Selection', () => {
     await expect(allItem).toBeVisible();
     await expect(allItem).toHaveClass(/active/);
 
-    const firstCommit = page.locator('#commitDropdownList .commit-picker-item').first();
+    const firstCommit = realCommitItems(page).first();
     await expect(firstCommit).toBeVisible();
     await expect(firstCommit.locator('.commit-picker-item-sha')).toBeVisible();
     await expect(firstCommit.locator('.commit-picker-item-msg')).toBeVisible();
@@ -50,7 +54,7 @@ test.describe('Commit Selection', () => {
   test('clicking a commit sets from pin and filters files', async ({ page }) => {
     await openCommitPicker(page);
 
-    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const commitItem = realCommitItems(page).first();
     const responsePromise = page.waitForResponse(r =>
       r.url().includes('/api/session') && r.status() === 200
     );
@@ -71,7 +75,7 @@ test.describe('Commit Selection', () => {
 
   test('selecting "All commits" restores full view', async ({ page }) => {
     await openCommitPicker(page);
-    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const commitItem = realCommitItems(page).first();
     const firstResponsePromise = page.waitForResponse(r => r.url().includes('/api/session'));
     await commitItem.click();
     await firstResponsePromise;
@@ -135,7 +139,7 @@ test.describe('Commit Selection', () => {
 
   test('selected commit resets on page reload', async ({ page }) => {
     await openCommitPicker(page);
-    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const commitItem = realCommitItems(page).first();
     const responsePromise = page.waitForResponse(r => r.url().includes('/api/session'));
     await commitItem.click();
     await responsePromise;
@@ -181,7 +185,7 @@ test.describe('Commit Selection', () => {
   test('alt+click sets through pin and sends a range param', async ({ page }) => {
     await openCommitPicker(page);
 
-    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    const commits = realCommitItems(page);
     await expect(commits).toHaveCount(2);
 
     // List is newest-first; pick older commit as from, newer as through.
@@ -203,7 +207,7 @@ test.describe('Commit Selection', () => {
   test('alt+click through again clears the through pin', async ({ page }) => {
     await openCommitPicker(page);
 
-    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    const commits = realCommitItems(page);
     await expect(commits).toHaveCount(2);
 
     const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
@@ -226,7 +230,7 @@ test.describe('Commit Selection', () => {
   test('"All commits" row clears from/through pins', async ({ page }) => {
     await openCommitPicker(page);
 
-    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    const commits = realCommitItems(page);
     await expect(commits).toHaveCount(2);
 
     const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));
@@ -249,7 +253,7 @@ test.describe('Commit Selection', () => {
   test('dropdown stays open across multiple selections', async ({ page }) => {
     await openCommitPicker(page);
 
-    const commits = page.locator('#commitDropdownList .commit-picker-item');
+    const commits = realCommitItems(page);
     await expect(commits).toHaveCount(2);
 
     const firstResponse = page.waitForResponse(r => r.url().includes('/api/session'));

--- a/test/e2e/tests/commit-selection.spec.ts
+++ b/test/e2e/tests/commit-selection.spec.ts
@@ -173,7 +173,7 @@ test.describe('Commit Selection', () => {
 
   test('from pin marks selected commit, "All" loses active class', async ({ page }) => {
     await openCommitPicker(page);
-    const commitItem = page.locator('#commitDropdownList .commit-picker-item').first();
+    const commitItem = realCommitItems(page).first();
     const responsePromise = page.waitForResponse(r => r.url().includes('/api/session'));
     await commitItem.click();
     await responsePromise;

--- a/test/e2e/tests/commit-selection.spec.ts
+++ b/test/e2e/tests/commit-selection.spec.ts
@@ -1,15 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
-import { clearAllComments, loadPage } from './helpers';
+import { clearAllComments, loadPage, realCommitItems } from './helpers';
 
 async function openCommitPicker(page: Page) {
   await page.click('#commitDropdownBtn');
   await expect(page.locator('#commitDropdown')).toHaveClass(/open/);
 }
-
-function realCommitItems(page: Page) {
-  return page.locator('#commitDropdownList .commit-picker-item:not(.is-virtual)');
-}
-
 
 test.describe('Commit Selection', () => {
   test.beforeEach(async ({ request, page }) => {
@@ -174,12 +169,14 @@ test.describe('Commit Selection', () => {
   test('from pin marks selected commit, "All" loses active class', async ({ page }) => {
     await openCommitPicker(page);
     const commitItem = realCommitItems(page).first();
-    const responsePromise = page.waitForResponse(r => r.url().includes('/api/session'));
+    const responsePromise = page.waitForResponse(r =>
+      r.url().includes('/api/session') && r.status() === 200
+    );
     await commitItem.click();
     await responsePromise;
 
     await expect(page.locator('.commit-picker-item[data-commit=""]')).not.toHaveClass(/active/);
-    await expect(page.locator('#commitDropdownList .commit-picker-item.is-from')).toHaveCount(1);
+    await expect(commitItem).toHaveClass(/is-from/);
   });
 
   test('alt+click sets through pin and sends a range param', async ({ page }) => {

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, type APIRequestContext } from '@playwright/test';
+import { expect, type Page, type APIRequestContext, type Locator } from '@playwright/test';
 import * as path from 'path';
 
 // Return the on-disk review.json path for the running e2e daemon.
@@ -15,6 +15,11 @@ export async function getReviewFilePath(request: APIRequestContext): Promise<str
 }
 export async function clearAllComments(request: APIRequestContext) {
   await request.delete('/api/comments');
+}
+
+/** Commit picker rows excluding the virtual working-tree entry. */
+export function realCommitItems(page: Page): Locator {
+  return page.locator('#commitDropdownList .commit-picker-item:not(.is-virtual)');
 }
 
 // Navigate to the root page and wait for loading to complete.

--- a/web/app.js
+++ b/web/app.js
@@ -421,9 +421,11 @@
   //   no pins          -> ''           (full range)
   //   from only        -> '<sha>'      (single commit)
   //   from + through   -> '<from>..<through>'
+  const VIRTUAL_WORKING_COMMIT = '__crit_virtual_working_tree__';
   let diffCommit = '';
   let commitFrom = '';
   let commitThrough = '';
+  let virtualCommitSelected = false;
   let commitList = [];
   let diffActive = false; // rendered diff view toggle for file mode
 
@@ -7495,10 +7497,18 @@
     if (commitFrom && !present.has(commitFrom)) commitFrom = '';
     if (commitThrough && !present.has(commitThrough)) commitThrough = '';
     if (!commitFrom) commitThrough = '';
+    if (virtualCommitSelected) {
+      const hasVirtual = commitList.some(function(c) { return !!c.virtual; });
+      if (!hasVirtual) virtualCommitSelected = false;
+    }
   }
 
   function recomputeDiffCommit() {
     normalizeCommitPins();
+    if (virtualCommitSelected && !commitFrom && !commitThrough) {
+      diffCommit = VIRTUAL_WORKING_COMMIT;
+      return;
+    }
     if (!commitFrom && !commitThrough) {
       diffCommit = '';
       return;
@@ -7517,6 +7527,7 @@
   function clearCommitPins() {
     commitFrom = '';
     commitThrough = '';
+    virtualCommitSelected = false;
     recomputeDiffCommit();
   }
 
@@ -7578,21 +7589,21 @@
     const clearThroughBtn = commitClearThroughEl;
 
     if (!commitFrom && !commitThrough) {
-      if (allItem) allItem.classList.add('active');
-      if (label) label.textContent = 'All commits';
+      if (allItem) allItem.classList.toggle('active', !virtualCommitSelected);
+      if (label) label.textContent = virtualCommitSelected ? 'Working changes' : 'All commits';
     } else {
       if (allItem) allItem.classList.remove('active');
       if (label) {
         if (commitFrom && !commitThrough) {
           const sel = commitList.find(function(c) { return c.sha === commitFrom; });
           label.textContent = sel
-            ? sel.short_sha + ' only'
+            ? (sel.virtual ? sel.message : (sel.short_sha + ' only'))
             : compareTargetChipLabel(commitFrom) + ' only';
         } else if (commitFrom && commitThrough) {
           const a = commitList.find(function(c) { return c.sha === commitFrom; });
           const b = commitList.find(function(c) { return c.sha === commitThrough; });
-          const aLabel = a ? a.short_sha : compareTargetChipLabel(commitFrom);
-          const bLabel = b ? b.short_sha : compareTargetChipLabel(commitThrough);
+          const aLabel = a ? (a.virtual ? a.message : a.short_sha) : compareTargetChipLabel(commitFrom);
+          const bLabel = b ? (b.virtual ? b.message : b.short_sha) : compareTargetChipLabel(commitThrough);
           label.textContent = aLabel + ' \u2192 ' + bLabel;
         }
       }
@@ -7605,16 +7616,21 @@
     list.innerHTML = commitList.map(function(c) {
       const isFrom = c.sha === commitFrom;
       const isThrough = c.sha === commitThrough;
+      const isVirtualActive = c.virtual && virtualCommitSelected && !commitFrom && !commitThrough;
       let cls = 'commit-picker-item';
       if (isFrom) cls += ' is-from';
       if (isThrough) cls += ' is-through';
+      if (c.virtual) cls += ' is-virtual';
+      if (isVirtualActive) cls += ' active';
       const time = c.date ? '<span class="commit-picker-item-time">' + relativeTime(c.date) + '</span>' : '';
       const fromPin = isFrom ? '<span class="commit-pin-from">from</span>' : '';
       const throughPin = isThrough ? '<span class="commit-pin-through">through</span>' : '';
+      const virtualPill = c.virtual ? '<span class="commit-picker-item-time">virtual</span>' : '';
       return '<div class="' + cls + '" data-commit="' + c.sha + '" role="button" tabindex="0">'
         + fromPin + throughPin
         + '<span class="commit-picker-item-sha">' + escapeHtml(c.short_sha) + '</span>'
         + '<span class="commit-picker-item-msg">' + escapeHtml(c.message.length > 40 ? c.message.slice(0, 40) + '\u2026' : c.message) + '</span>'
+        + virtualPill
         + time
         + '</div>';
     }).join('');
@@ -7652,9 +7668,19 @@
     e.stopPropagation();
     const sha = item.dataset.commit;
     const prevDiffCommit = diffCommit;
+    if (item.classList.contains('is-virtual')) {
+      commitFrom = '';
+      commitThrough = '';
+      virtualCommitSelected = true;
+      recomputeDiffCommit();
+      renderCommitPicker();
+      if (diffCommit !== prevDiffCommit) reloadForScope();
+      return;
+    }
     if (sha === '') {
       clearCommitPins();
     } else if (e.altKey) {
+      virtualCommitSelected = false;
       if (commitThrough === sha) {
         commitThrough = '';
       } else {
@@ -7662,11 +7688,14 @@
         if (!commitFrom) commitFrom = sha;
       }
     } else if (commitFrom === sha && !commitThrough) {
+      virtualCommitSelected = false;
       commitFrom = '';
     } else if (commitFrom === sha) {
+      virtualCommitSelected = false;
       commitFrom = commitThrough || '';
       commitThrough = '';
     } else {
+      virtualCommitSelected = false;
       commitFrom = sha;
     }
     recomputeDiffCommit();
@@ -7773,10 +7802,11 @@
         list.innerHTML = '<div style="padding: 8px 10px; font-size: 12px; color: var(--crit-editor-fg-muted);">No matching commits</div>';
       } else {
         list.innerHTML = commits.map(function(c) {
+          const message = c.virtual ? (c.message + ' (virtual)') : c.message;
           const active = c.sha === currentCompareTarget ? ' active' : '';
           return '<div class="base-branch-item' + active + '" data-branch="' + escapeHtml(c.sha) + '">'
             + '<span class="commit-picker-item-sha">' + escapeHtml(c.short_sha) + '</span> '
-            + escapeHtml(c.message.length > 36 ? c.message.slice(0, 36) + '\u2026' : c.message)
+            + escapeHtml(message.length > 36 ? message.slice(0, 36) + '\u2026' : message)
             + '</div>';
         }).join('');
       }


### PR DESCRIPTION
## Summary
- add a synthetic \"Working changes\" entry at the top of the commit picker when the working tree is dirty
- wire virtual selection to a dedicated uncommitted-only diff scope (vs `HEAD`) so committed stack changes are excluded
- add session tests for virtual-top presence and virtual-scope file filtering, and update picker UX state handling

Closes https://github.com/tomasz-tomczyk/crit/issues/533

## Review
- [x] Code review: passed
- [x] Parity audit: skipped intentionally (shipping `crit` only)

## Test plan
- [x] `mise exec -- gofmt -l .`
- [x] `mise exec -- golangci-lint run ./...`
- [x] `mise exec -- go test -race -count=1 ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)