### PR TITLE
docs: clarify cleanup_on_approve default and /crit usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Crit also works with Cursor, GitHub Copilot, OpenCode, Codex, Gemini, Qwen, Herm
 
 ### 3. Tell your agent to use `crit`
 
-Most integrations include a `/crit` slash command that automates the full review loop. 
+Most integrations include a `/crit` slash command that automates the full review loop.
 Agent launches Crit, waits for your review and acts on the feedback.
 Repeat the process until you approve the changes.
 
@@ -82,6 +82,8 @@ crit plan.md api-spec.md          # review multiple files
 crit http://localhost:3000        # review a running dev server
 crit landing.html                 # review a static HTML file
 ```
+
+If talking to an agent, you can invoke the `/crit` command and optionally provide arguments like the above examples or the agent will try to launch the right thing based on the context of the conversation.
 
 ### Live mode
 

--- a/cmd/crit/integration_hashes_gen.go
+++ b/cmd/crit/integration_hashes_gen.go
@@ -36,7 +36,7 @@ var integrationHashes = map[string]string{
 	"integrations/opencode/plugin/crit.ts":                       "139a1798dcda408520696f02981569f3188688d8995c77421f66506416fc0115",
 	"integrations/pi/skills/crit-cli/SKILL.md":                   "b8640f3387b556244d379318dba608b77970f2ff62cfd4469f449d2b76f22cc0",
 	"integrations/pi/skills/crit/SKILL.md":                       "25dd375fce11abb516a20f9b3c7f27c6498593a9fe36a2e853971f216b5fbc3b",
-	"integrations/prompts/examples/on_finish_approved.md":        "25ba61757ce2bc5c260b402f9d8ed6b3eb51063395cd87ea810c0938a87ec9c5",
+	"integrations/prompts/examples/on_finish_approved.md":        "d62d9996d95936afd669738d60977dea2641fcf9ddd37c8e9d8d98fae7a7f181",
 	"integrations/prompts/examples/on_finish_unresolved.diff.md": "2c075d2bc2ea69564d40395b46816d23004e199a39db80e483a7cfa700697f2c",
 	"integrations/prompts/on_finish_approved.md":                 "12b79ce1f7251ca00d16bf9a9af295215a55a3d69c8f264d5002404309b0a4e7",
 	"integrations/prompts/on_finish_unresolved.md":               "9be512aad3157948edb6eff08ef9715acd6e1c3f12463d9ca89ebce49278c704",

--- a/integrations/prompts/examples/on_finish_approved.md
+++ b/integrations/prompts/examples/on_finish_approved.md
@@ -1,3 +1,5 @@
+> NOTE: Approved reviews are cleaned up by default (`cleanup_on_approve=true`). If you want to keep the review file for this post-review workflow, set `cleanup_on_approve=false` in your config.
+
 Review approved. Before coding:
 
 1. Read comment threads via `{{.comments_all_cmd}}`


### PR DESCRIPTION
## Summary
- Add a note to the `on_finish_approved` example explaining that approved reviews are auto-cleaned by default (`cleanup_on_approve=true`) and how to disable it for post-review workflows.
- Document that agents can invoke `/crit` with optional arguments in the README.
- Regenerate the integration hash for the updated example prompt.

## Review
- [x] Code review: passed (docs-only change)
- [x] Parity audit: N/A

## Test plan
- [x] Pre-commit hook passed (gofmt, golangci-lint, go test, ESLint, stylelint)
- [x] `go generate ./...` run for integration hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)