### PR TITLE
feat: improve stack popover orientation cues

### DIFF
--- a/test/e2e/tests/focus-picker.rangemode.spec.ts
+++ b/test/e2e/tests/focus-picker.rangemode.spec.ts
@@ -64,21 +64,21 @@ test('popover renders the default branch as the last entry (base marker)', async
   await page.locator('#stackChipBtn').click();
   const dbItem = page.locator('#stackPopover .stack-popover-default');
   await expect(dbItem).toBeVisible();
-  await expect(dbItem).toContainText(/base:.*main/);
+  await expect(dbItem).toContainText(/stack root:.*main/);
 });
 
-test('popover order is head->base (feat-c, feat-b, feat-a, base: main)', async ({ page }) => {
+test('popover order is head->base (feat-c, feat-b, feat-a, stack root: main)', async ({ page }) => {
   await loadPage(page);
   await openStackPopover(page);
   const items = page.locator('#stackPopover .stack-popover-item');
   await expect(items.first()).toBeVisible();
-  // 4 entries expected: feat-c/b/a + base: main.
+  // 4 entries expected: feat-c/b/a + stack root: main.
   await expect(items).toHaveCount(4);
   const labels = await items.evaluateAll((els) =>
     els.map((el) => (el as HTMLElement).innerText.replace(/\s*\(reviewing\)\s*/i, '').replace(/\s*\(full stack\)\s*/i, '').trim())
   );
-  // Last entry is the base marker.
-  expect(labels[labels.length - 1]).toMatch(/base:.*main/);
+  // Last entry is the stack root marker.
+  expect(labels[labels.length - 1]).toMatch(/stack root:.*main/);
   const feats = labels.filter((s) => /feat-[abc]/.test(s));
   expect(feats.map((s) => (s.match(/feat-[abc]/) || [''])[0])).toEqual(['feat-c', 'feat-b', 'feat-a']);
 });

--- a/test/e2e/tests/stack-popover.rangemode.spec.ts
+++ b/test/e2e/tests/stack-popover.rangemode.spec.ts
@@ -95,7 +95,7 @@ test('default branch is rendered ONCE (no ghost duplicate stack entry)', async (
   // doesn't snapshot the empty pre-fetch DOM.
   await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
   const allLabels = await page.locator('#stackPopover .stack-popover-label').allTextContents();
-  const mainCount = allLabels.filter((s) => s.trim() === 'base: main').length;
+  const mainCount = allLabels.filter((s) => s.trim() === 'stack root: main').length;
   expect(mainCount).toBe(1);
 });
 
@@ -115,4 +115,37 @@ test('non-current entry click switches focus', async ({ page, request }) => {
     const s = await r.json();
     return s.focus.head_sha;
   }, { timeout: 5_000 }).not.toBe(before.focus.head_sha);
+});
+
+test('popover shows target/base markers and range highlighting in layer scope', async ({ page }) => {
+  await loadPage(page);
+  await page.locator('#stackChipBtn').click();
+  await expect(page.locator('#stackPopover .stack-popover-item').first()).toBeVisible();
+
+  await expect(page.locator('#stackPopover .stack-popover-marker-target')).toHaveCount(1);
+  await expect(page.locator('#stackPopover .stack-popover-marker-base')).toHaveCount(1);
+  await expect(page.locator('#stackPopover .stack-popover-in-range')).toHaveCount(2);
+});
+
+test('full stack mode highlights stack root in compare range', async ({ page, request }) => {
+  await loadPage(page);
+  await page.locator('#stackChipBtn').click();
+  const fullStack = page.locator('#stackPopover [data-action="scope"][data-diff-scope="full_stack"]');
+  await expect(fullStack).toBeVisible();
+  await fullStack.click();
+
+  await expect.poll(async () => {
+    const r = await request.get('/api/session');
+    return (await r.json()).focus.diff_scope;
+  }, { timeout: 5_000 }).toBe('full_stack');
+
+  await page.locator('#stackChipBtn').click();
+  await expect(page.locator('#stackPopover .stack-popover-default')).toHaveClass(/stack-popover-in-range/);
+  await expect(page.locator('#stackPopover .stack-popover-default .stack-popover-marker-base')).toHaveCount(0);
+});
+
+test('stack entries display short commit hashes', async ({ page }) => {
+  await loadPage(page);
+  await page.locator('#stackChipBtn').click();
+  await expect(page.locator('#stackPopover .stack-popover-item .stack-popover-sha').first()).toHaveText(/^[0-9a-f]{7}$/i);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -9090,6 +9090,34 @@
 
     const ordered = stack.slice();
     const defaultBranchName = defaultBranchNameCache || (ordered[0] && ordered[0].base_ref_name) || 'main';
+    const activeScope = focus.diff_scope || 'layer';
+    const targetIdx = ordered.findIndex(function(entry) { return entry.head_sha === focus.head_sha; });
+    const baseIdx = ordered.findIndex(function(entry) { return entry.head_sha === focus.base_sha; });
+    const hasRootBase = activeScope === 'full_stack' && !!focus.default_sha;
+    // Layer parent is usually focus.base_sha on a stack entry; when base_sha is a
+    // merge-base off-stack, fall back to the next older stack entry below target.
+    let parentIdx = baseIdx;
+    if (!hasRootBase && parentIdx < 0 && targetIdx >= 0 && targetIdx < ordered.length - 1) {
+      parentIdx = targetIdx + 1;
+    }
+
+    function rangeStateForIndex(i) {
+      // Layer scope marks target + any entries down to base when base is present.
+      // Full stack marks target + all entries down to the root default-base marker.
+      if (targetIdx < 0) {
+        return { inRange: false, isRangeStart: false, isRangeEnd: false };
+      }
+      let start = targetIdx;
+      let end = targetIdx;
+      if (hasRootBase) {
+        end = ordered.length - 1;
+      } else if (baseIdx >= 0) {
+        start = Math.min(targetIdx, baseIdx);
+        end = Math.max(targetIdx, baseIdx);
+      }
+      const inRange = i >= start && i <= end;
+      return { inRange: inRange };
+    }
 
     const parts = [];
     parts.push('<div class="stack-popover-title">Stack</div>');
@@ -9099,11 +9127,22 @@
       const isLast = i === ordered.length - 1;
       const tree = isLast ? '\u2514\u2500 ' : '\u251C\u2500 ';
       const isCurrent = entry.head_sha === focus.head_sha;
+      const isBase = !hasRootBase && parentIdx >= 0 && i === parentIdx;
+      const rangeState = rangeStateForIndex(i);
+      let rowClass = 'stack-popover-item';
+      if (rangeState.inRange) rowClass += ' stack-popover-in-range';
+      if (isBase) rowClass += ' stack-popover-is-base';
+      if (isCurrent) rowClass += ' stack-popover-current stack-popover-is-target';
       const label = entryLabel(entry, 34);
       const shortSha = entry.head_sha ? entry.head_sha.slice(0, 7) : '';
+      const marker = '<span class="stack-popover-marker-wrap" aria-hidden="true">'
+        + (isCurrent ? '<span class="stack-popover-marker stack-popover-marker-target">target</span>' : '')
+        + (isBase ? '<span class="stack-popover-marker stack-popover-marker-base">parent</span>' : '')
+        + '</span>';
       if (isCurrent) {
-        parts.push('<span class="stack-popover-item stack-popover-current" aria-current="page" role="menuitem"' +
+        parts.push('<span class="' + rowClass + '" aria-current="page" role="menuitem"' +
           ' data-head-sha="' + escapeHtml(entry.head_sha || '') + '">' +
+          marker +
           '<span class="stack-popover-tree" aria-hidden="true">' + tree + '</span>' +
           '<span class="stack-popover-label">' + escapeHtml(label) + '</span>' +
           (shortSha ? '<span class="stack-popover-sha">' + escapeHtml(shortSha) + '</span>' : '') +
@@ -9111,11 +9150,12 @@
       } else {
         const payload = focusPayloadFromStackEntry(entry, focus);
         const aria = entry.pr_number ? ('Switch to PR #' + entry.pr_number) : ('Switch to ' + label);
-        parts.push('<button type="button" class="stack-popover-item" role="menuitem"' +
+        parts.push('<button type="button" class="' + rowClass + '" role="menuitem"' +
           ' data-action="switch"' +
           ' data-head-sha="' + escapeHtml(entry.head_sha || '') + '"' +
           ' data-focus-payload="' + escapeHtml(JSON.stringify(payload)) + '"' +
           ' aria-label="' + escapeHtml(aria) + '">' +
+          marker +
           '<span class="stack-popover-tree" aria-hidden="true">' + tree + '</span>' +
           '<span class="stack-popover-label">' + escapeHtml(label) + '</span>' +
           (shortSha ? '<span class="stack-popover-sha">' + escapeHtml(shortSha) + '</span>' : '') +
@@ -9124,9 +9164,11 @@
     });
 
     // Base marker — non-interactive root at the bottom of the tree.
-    parts.push('<span class="stack-popover-item stack-popover-root stack-popover-default" role="presentation">' +
+    parts.push('<span class="stack-popover-item stack-popover-root stack-popover-default' + (hasRootBase ? ' stack-popover-in-range' : '') + '"' +
+      ' role="presentation">' +
+      '<span class="stack-popover-marker-wrap" aria-hidden="true"></span>' +
       '<span class="stack-popover-tree" aria-hidden="true">  </span>' +
-      '<span class="stack-popover-label">base: ' + escapeHtml(defaultBranchName) + '</span>' +
+      '<span class="stack-popover-label">stack root: ' + escapeHtml(defaultBranchName) + '</span>' +
       '</span>');
 
     // "Compare against" radio section. Lives inside the popover so the
@@ -9139,7 +9181,6 @@
     // user understands why they can't reach it rather than wondering
     // where the option went.
     {
-      const activeScope = focus.diff_scope || 'layer';
       const fullStackEnabled = !!focus.default_sha;
       // Subcopy mirrors what full-stack diffs against: the literal
       // default branch tip.

--- a/web/style.css
+++ b/web/style.css
@@ -5200,6 +5200,7 @@ body.sidebar-resizing * {
 .stack-popover-item {
   display: flex;
   align-items: center;
+  gap: 6px;
   width: 100%;
   padding: 4px 8px;
   border: 0;
@@ -5228,6 +5229,36 @@ body.sidebar-resizing * {
   font-weight: 600;
   cursor: default;
 }
+.stack-popover-marker-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  width: 54px;
+  flex-shrink: 0;
+}
+.stack-popover-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.stack-popover-marker-target {
+  color: var(--crit-brand);
+  background: var(--crit-brand-subtle);
+}
+.stack-popover-marker-base {
+  color: var(--crit-editor-fg-muted);
+  background: color-mix(in srgb, var(--crit-editor-fg-muted) 14%, transparent);
+}
+.stack-popover-in-range:not(.stack-popover-current) {
+  background: color-mix(in srgb, var(--crit-brand-subtle) 45%, transparent);
+}
 .stack-popover-tree {
   font-family: monospace;
   color: var(--crit-editor-fg-muted);
@@ -5255,6 +5286,10 @@ body.sidebar-resizing * {
   color: var(--crit-editor-fg-muted);
 }
 .stack-popover-root:hover { background: transparent; }
+.stack-popover-root.stack-popover-is-base {
+  color: var(--crit-editor-fg);
+  background: color-mix(in srgb, var(--crit-editor-bg-hover) 65%, transparent);
+}
 
 /* Compare-against radio rows. Live inside the stack popover — saves a
    second toolbar bar in the page header for what's a relatively rare


### PR DESCRIPTION
## Summary
- Add TARGET and PARENT badges in the stack popover so the active compare range is obvious at a glance
- Rename the root row label to `stack root:` and highlight in-range stack entries with a subtle row tint
- Extend range-mode E2E coverage for layer and full_stack orientation behavior

Closes #537

## Test plan
- [x] `mise exec -- bash run.sh tests/stack-popover.rangemode.spec.ts`
- [x] `mise exec -- bash run.sh tests/focus-picker.rangemode.spec.ts`

Made with [Cursor](https://cursor.com)