### PR TITLE
fix: block share/fetch/unpublish CLI when proxy_auth is enabled

### DIFF
--- a/.claude/rules/proxy-auth-transport.md
+++ b/.claude/rules/proxy-auth-transport.md
@@ -18,4 +18,19 @@ When adding a new crit-web interaction:
 
 The popup relay must hit the **same crit-web API endpoints** with the **same payload shapes** as the direct path. No relay-specific endpoints on crit-web. The popup handlers are same-origin fetch proxies.
 
+## Rule 3: Terminal CLI commands cannot use direct HTTP when proxy_auth is on
+
+When `proxy_auth: true` (global config), crit-web sits behind an SSO reverse proxy. The terminal cannot complete that auth flow — only the browser can (via the `/share-receiver` popup relay).
+
+**Terminal subcommands** that HTTP-call crit-web directly (today: `crit share`, `crit fetch`, `crit unpublish`) must call `checkProxyAuthCLIAllowed("crit <cmd>")` at the top of their `Run*` entrypoint and exit with the shared error message. Do not attempt the network call.
+
+**Browser UI actions** (Share / Pull / Unpublish buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+
+When adding a **new** crit-web interaction, decide which surface owns it:
+- **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.
+- **Terminal-only** (rare): document that it won't work behind SSO, or don't add it.
+- **Both**: direct Go HTTP path + browser relay path; terminal path still blocked when `proxy_auth` is on unless you have a non-HTTP auth story.
+
+Integration tests that spawn the `crit` binary must isolate config — use `runCritCmd` / `runCritCmdWithHome` with a temp `HOME`, not the developer's real `~/.crit.config.json`.
+
 </important>

--- a/.cursor/rules/proxy-auth-transport.mdc
+++ b/.cursor/rules/proxy-auth-transport.mdc
@@ -22,3 +22,18 @@ When adding a new crit-web interaction:
 ## Rule 2: Relay is transport, not protocol
 
 The popup relay must hit the **same crit-web API endpoints** with the **same payload shapes** as the direct path. No relay-specific endpoints on crit-web. The popup handlers are same-origin fetch proxies.
+
+## Rule 3: Terminal CLI commands cannot use direct HTTP when proxy_auth is on
+
+When `proxy_auth: true` (global config), crit-web sits behind an SSO reverse proxy. The terminal cannot complete that auth flow — only the browser can (via the `/share-receiver` popup relay).
+
+**Terminal subcommands** that HTTP-call crit-web directly (today: `crit share`, `crit fetch`, `crit unpublish`) must call `checkProxyAuthCLIAllowed("crit <cmd>")` at the top of their `Run*` entrypoint and exit with the shared error message. Do not attempt the network call.
+
+**Browser UI actions** (Share / Pull / Unpublish buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+
+When adding a **new** crit-web interaction, decide which surface owns it:
+- **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.
+- **Terminal-only** (rare): document that it won't work behind SSO, or don't add it.
+- **Both**: direct Go HTTP path + browser relay path; terminal path still blocked when `proxy_auth` is on unless you have a non-HTTP auth story.
+
+Integration tests that spawn the `crit` binary must isolate config — use `runCritCmd` / `runCritCmdWithHome` with a temp `HOME`, not the developer's real `~/.crit.config.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to the configured VCS user name if not set
 - `agent_cmd`, `auth_token`, `share_url`, and `proxy_auth` are **global config only**; project-level config cannot override (security — prevents malicious repos from hijacking the agent command or redirecting share requests to an attacker-controlled host)
-- `proxy_auth` (default: `false`) — when `true`, share/pull/unpublish use browser popup relay instead of direct CLI HTTP. Global-only for security.
+- `proxy_auth` (default: `false`) — when `true`, terminal `crit share` / `crit fetch` / `crit unpublish` are blocked (SSO proxy); the browser UI uses a popup relay instead. Global-only for security. See proxy-auth transport rules.
 - `cleanup_on_approve` (default: `true`) — auto-delete review file when reviewer approves with no unresolved comments
 - `disable_stats` (default: `false`) — disable session stats recording to `~/.crit/stats.json`
 - `ignore_patterns` are unioned (global + project both apply); types: `*.ext`, `dir/`, `exact.file`, `path/*.ext`
@@ -113,6 +113,18 @@ Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`
 - `live_cookie` / `live_cookie_file` forward session cookies to the upstream app in live mode (global or project; prefer gitignored `live_cookie_file` e.g. `.crit/live-cookies.txt`). CLI: `crit live --cookie`, `--cookie-file`
 - `live_cdp_url` reuses cookies from a local Chrome DevTools endpoint (global or project). CLI: `crit live --cdp-url`. Explicit `--cookie` values override CDP cookies with the same name.
 - CLI flags override config file values
+</important>
+
+<important if="you are adding or modifying a CLI subcommand that HTTP-calls crit-web (share, fetch, unpublish, or any new crit-web API interaction)">
+
+Self-hosted crit-web behind an SSO reverse proxy cannot be reached from the terminal. When `proxy_auth: true` in global config:
+
+1. **Terminal subcommands** must call `checkProxyAuthCLIAllowed("crit <cmd>")` at the top of the `Run*` entrypoint (`internal/share/cli.go` pattern). Fail fast with the shared message — do not HTTP-call crit-web and get an HTML login page.
+2. **Browser UI** must implement both transports: direct Go HTTP when `proxy_auth` is false; popup relay via `web/crit-share.js` + crit-web `assets/js/share_receiver/handlers.js` when true. See `.claude/rules/proxy-auth-transport.md`.
+3. **New crit-web endpoints**: add a popup handler in crit-web `share_receiver/handlers.js` (same-origin fetch proxy to the existing `/api/...` endpoint — no relay-specific API). Add the relay branch in `web/crit-share.js` / `web/app.js`.
+4. **Integration tests** that exec the `crit` binary must use an isolated temp `HOME` (`runCritCmd` in `share_integration_test.go`) so a developer's `proxy_auth` setting doesn't skew results.
+
+Full rules: `.cursor/rules/proxy-auth-transport.mdc` / `.claude/rules/proxy-auth-transport.md`.
 </important>
 
 <important if="you are working with crit pull, crit push, or GitHub PR sync">

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -269,6 +269,9 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 	if err != nil {
 		return err
 	}
+	if err := checkProxyAuthCLIAllowed("crit share"); err != nil {
+		return err
+	}
 
 	if sf.preview != "" {
 		return runSharePreview(sf)
@@ -382,6 +385,9 @@ func printFetchedComments(webComments []WebComment) {
 
 // RunFetch pulls remote comments from crit-web into the review file.
 func RunFetch(args []string) error {
+	if err := checkProxyAuthCLIAllowed("crit fetch"); err != nil {
+		return err
+	}
 	outputDir, err := parseFetchOutputDir(args)
 	if err != nil {
 		return err
@@ -441,6 +447,9 @@ func RunFetch(args []string) error {
 
 // RunUnpublish removes a shared review from crit-web.
 func RunUnpublish(args []string) error {
+	if err := checkProxyAuthCLIAllowed("crit unpublish"); err != nil {
+		return err
+	}
 	unpubOutputDir := ""
 	unpubSvcURL := ""
 	var unpubFiles []string

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -983,6 +983,20 @@ func clearShareState(critPath string) error {
 	return session.SaveCritJSON(critPath, cj)
 }
 
+// checkProxyAuthCLIAllowed returns an error when proxy_auth is enabled in global
+// config. Terminal share/fetch/unpublish cannot authenticate to crit-web behind
+// an SSO reverse proxy — those operations must use the browser UI relay instead.
+func checkProxyAuthCLIAllowed(command string) error {
+	if !loadShareConfig().ProxyAuth {
+		return nil
+	}
+	return fmt.Errorf(`%s is unavailable with proxy_auth enabled
+
+Your crit-web instance is behind an SSO reverse proxy. Terminal commands cannot authenticate there — use Crit's browser interface instead
+
+proxy_auth is set in ~/.crit.config.json (global config only)`, command)
+}
+
 // loadShareConfig loads the merged config.Config from the current directory context.
 // Used by share/fetch/unpublish commands to avoid redundant config parsing.
 func loadShareConfig() config.Config {

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -1875,13 +1875,17 @@ func jsonShareStub(t *testing.T) *httptest.Server {
 }
 
 // runCritCmd is a thin wrapper over exec.Command that keeps env clean (no
-// CRIT_AUTH_TOKEN, no HOME inheriting global config) and returns combined
-// output + error.
+// CRIT_AUTH_TOKEN, no inherited global config) and returns combined output + error.
 func runCritCmd(t *testing.T, binary, dir string, args ...string) (string, error) {
+	t.Helper()
+	return runCritCmdWithHome(t, binary, dir, t.TempDir(), args...)
+}
+
+func runCritCmdWithHome(t *testing.T, binary, dir, home string, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = dir
-	cmd.Env = envWithout("CRIT_AUTH_TOKEN=", "HOME=", "CRIT_SHARE_URL=")
+	cmd.Env = append(envWithout("CRIT_AUTH_TOKEN=", "HOME=", "CRIT_SHARE_URL="), "HOME="+home)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
@@ -2013,8 +2017,8 @@ func TestShareReceiver_HTMLPostReturnsProxyAuthError(t *testing.T) {
 	if !strings.Contains(out, "proxy_auth") {
 		t.Errorf("expected error to mention proxy_auth, got: %s", out)
 	}
-	if !strings.Contains(out, "popup") {
-		t.Errorf("expected error to mention popup, got: %s", out)
+	if !strings.Contains(out, "browser UI") {
+		t.Errorf("expected error to mention browser UI, got: %s", out)
 	}
 }
 
@@ -2045,6 +2049,32 @@ func TestShareReceiver_FetchHTMLReturnsProxyAuthError(t *testing.T) {
 	}
 	if !strings.Contains(out, "proxy_auth") {
 		t.Errorf("expected error to mention proxy_auth, got: %s", out)
+	}
+}
+
+// TestShareReceiver_ProxyAuthEnabledBlocksShareCLI verifies that when
+// proxy_auth is already configured, crit share fails immediately with a
+// message pointing at the browser UI — without contacting crit-web.
+func TestShareReceiver_ProxyAuthEnabledBlocksShareCLI(t *testing.T) {
+	binary := critBinary(t)
+	dir := t.TempDir()
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(`{"proxy_auth":true,"share_url":"https://crit.example.com"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestCritJSON(t, dir, CritJSON{ReviewRound: 1, Files: map[string]CritJSONFile{"plan.md": {}}})
+
+	out, err := runCritCmdWithHome(t, binary, dir, home, "share", "--output", dir, "plan.md")
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got success. output: %s", out)
+	}
+	for _, want := range []string{"proxy_auth", "Crit's browser interface"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to mention %q, got: %s", want, out)
+		}
 	}
 }
 

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -55,6 +55,77 @@ func TestDecodeJSONOrHTMLHint_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestCheckProxyAuthCLIAllowed_Blocked(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"proxy_auth":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := checkProxyAuthCLIAllowed("crit share")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"proxy_auth", "Crit's browser interface"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestCheckProxyAuthCLIAllowed_Allowed(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := checkProxyAuthCLIAllowed("crit share"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunShare_BlockedByProxyAuth(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"proxy_auth":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte("# Plan\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	err := RunShare([]string{"plan.md"})
+	if err == nil || !strings.Contains(err.Error(), "proxy_auth") {
+		t.Fatalf("got %v, want proxy_auth block error", err)
+	}
+}
+
+func TestRunFetch_BlockedByProxyAuth(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"proxy_auth":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := RunFetch(nil)
+	if err == nil || !strings.Contains(err.Error(), "proxy_auth") {
+		t.Fatalf("got %v, want proxy_auth block error", err)
+	}
+}
+
+func TestRunUnpublish_BlockedByProxyAuth(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"), []byte(`{"proxy_auth":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := RunUnpublish(nil)
+	if err == nil || !strings.Contains(err.Error(), "proxy_auth") {
+		t.Fatalf("got %v, want proxy_auth block error", err)
+	}
+}
+
 func TestTokenFromHostedURL(t *testing.T) {
 	cases := map[string]string{
 		"https://crit.example/r/abc123":      "abc123",


### PR DESCRIPTION
## Summary
- Fail fast when `proxy_auth: true` is set in global config and the user runs `crit share`, `crit fetch`, or `crit unpublish` from the terminal
- Print a clear message directing users to Crit's browser interface instead of attempting HTTP and receiving an SSO HTML login page
- Isolate integration test subprocesses from the developer's real `~/.crit.config.json` via a temp `HOME`

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit only, no review-page or crit-web changes)

## Test plan
- [x] `go test -race ./...`
- [x] `go test -tags=integration ./internal/share/ -run TestShareReceiver_(HTMLPost|FetchHTML|ProxyAuth)`
- [x] Unit tests for `checkProxyAuthCLIAllowed` and all three `Run*` entrypoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)