### PR TITLE
fix: sync session memory after UI comment pull

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1166,15 +1166,6 @@ func (s *Server) handleMergeComments(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Flush any debounced session write (e.g. from SetSharedURLAndToken) so
-	// dedup/merge read the latest on-disk state and SyncCommentsFromDisk is
-	// not blocked by pendingWrite.
-	if err := sess.SyncWriteFiles(); err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		return
-	}
 	data, err := session.ReadFileShared(review.ReviewPathsFor(critPath).Review)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -1192,6 +1183,9 @@ func (s *Server) handleMergeComments(w http.ResponseWriter, r *http.Request) {
 
 	newComments, replyUpdates := dedupWebComments(cj, req.Comments)
 	if len(newComments) == 0 && len(replyUpdates) == 0 {
+		// Comments may already be on disk from a prior pull while memory is
+		// still stale (e.g. pendingWrite blocked the file watcher).
+		sess.SyncCommentsFromDisk()
 		writeJSON(w, map[string]any{"merged": 0, "replies_updated": 0})
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1156,6 +1156,25 @@ func (s *Server) handleMergeComments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	critPath := sess.CritJSONPath()
+	if _, err := os.Stat(review.ReviewPathsFor(critPath).Review); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if os.IsNotExist(err) {
+			json.NewEncoder(w).Encode(map[string]string{"error": "review file not found"})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		}
+		return
+	}
+	// Flush any debounced session write (e.g. from SetSharedURLAndToken) so
+	// dedup/merge read the latest on-disk state and SyncCommentsFromDisk is
+	// not blocked by pendingWrite.
+	if err := sess.SyncWriteFiles(); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
 	data, err := session.ReadFileShared(review.ReviewPathsFor(critPath).Review)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -1182,6 +1201,11 @@ func (s *Server) handleMergeComments(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
+	// mergeWebComments writes review.json outside WriteFiles; sync in-memory
+	// state immediately so /api/file/comments and the UI refresh path see
+	// pulled comments without waiting for the 1s file watcher tick (which can
+	// also miss same-second mtime updates).
+	sess.SyncCommentsFromDisk()
 	writeJSON(w, map[string]any{"merged": len(newComments), "replies_updated": len(replyUpdates)})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5149,6 +5149,51 @@ func TestHandleMergeComments_NewComment(t *testing.T) {
 	}
 }
 
+func TestHandleMergeComments_DedupStillSyncsSession(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	os.WriteFile(filePath, []byte("# Plan\n"), 0o644)
+
+	sess := &Session{
+		Mode:        "files",
+		OutputDir:   dir,
+		RepoRoot:    dir,
+		ReviewRound: 1,
+		Files:       []*FileEntry{{Path: "plan.md", AbsPath: filePath}},
+	}
+	sess.SetSharedURLAndToken("https://crit.md/r/tok123", "del-tok")
+
+	writeCritJSONForTest(t, dir, CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{{
+				ID: "web-1", Body: "already on disk", StartLine: 1, EndLine: 1,
+			}}},
+		},
+	})
+	if info, err := os.Stat(review.ReviewPathsFor(sess.CritJSONPath()).Review); err != nil {
+		t.Fatal(err)
+	} else {
+		sess.SetLastCritJSONMtimeForTest(info.ModTime())
+	}
+
+	srv, err := NewServer(sess, frontendFS, "", false, "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := `{"comments": [{"body": "already on disk", "file_path": "plan.md", "start_line": 1, "end_line": 1, "author_display_name": "Web User"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/comments/merge", strings.NewReader(payload))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if len(sess.GetComments("plan.md")) != 1 {
+		t.Fatalf("session has %d comments after dedup pull, want 1", len(sess.GetComments("plan.md")))
+	}
+}
+
 func TestHandleMergeComments_DuplicateFiltered(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "plan.md")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5114,6 +5114,13 @@ func TestHandleMergeComments_NewComment(t *testing.T) {
 			"plan.md": {Comments: []Comment{}},
 		},
 	})
+	// Simulate a recent daemon write so mergeExternalCritJSON would skip a
+	// same-second pull unless handleMergeComments forces a disk sync.
+	if info, err := os.Stat(review.ReviewPathsFor(sess.CritJSONPath()).Review); err != nil {
+		t.Fatal(err)
+	} else {
+		sess.SetLastCritJSONMtimeForTest(info.ModTime())
+	}
 
 	srv, err := NewServer(sess, frontendFS, "", false, "", "", "test", 0, "")
 	if err != nil {
@@ -5132,6 +5139,13 @@ func TestHandleMergeComments_NewComment(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["merged"].(float64) != 1 {
 		t.Errorf("merged = %v, want 1", resp["merged"])
+	}
+	comments := sess.GetComments("plan.md")
+	if len(comments) != 1 {
+		t.Fatalf("session has %d comments after merge, want 1", len(comments))
+	}
+	if comments[0].Body != "new web comment" {
+		t.Errorf("comment body = %q, want %q", comments[0].Body, "new web comment")
 	}
 }
 

--- a/internal/server/sync_comments_test.go
+++ b/internal/server/sync_comments_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/review"
+	"github.com/tomasz-tomczyk/crit/internal/share"
+)
+
+func TestSyncCommentsFromDisk_ClearsPendingWrite(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(filePath, []byte("# Plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	critPath := filepath.Join(dir, ".crit")
+	if err := review.SaveCritJSON(critPath, CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := &Session{
+		Mode:      "files",
+		OutputDir: dir,
+		RepoRoot:  dir,
+		Files:     []*FileEntry{{Path: "plan.md", AbsPath: filePath}},
+	}
+	// Mirrors share flow: scheduling a debounced write blocks mergeExternalCritJSON.
+	sess.SetSharedURLAndToken("https://crit.md/r/tok", "del")
+	if sess.PendingWriteForTest() != true {
+		t.Fatal("expected pendingWrite after SetSharedURLAndToken")
+	}
+
+	if err := share.MergeWebComments(critPath, []share.WebComment{{
+		Body: "remote", FilePath: "plan.md", StartLine: 1, EndLine: 1,
+	}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !sess.SyncCommentsFromDisk() {
+		t.Fatal("SyncCommentsFromDisk returned false with pendingWrite set")
+	}
+	if len(sess.GetComments("plan.md")) != 1 {
+		t.Fatalf("want 1 comment, got %d", len(sess.GetComments("plan.md")))
+	}
+}
+
+func TestSyncCommentsFromDisk_AfterMergeWebComments_WithNewServer(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(filePath, []byte("# Plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := &Session{
+		Mode:        "files",
+		OutputDir:   dir,
+		RepoRoot:    dir,
+		ReviewRound: 1,
+		Files:       []*FileEntry{{Path: "plan.md", AbsPath: filePath}},
+	}
+	writeCritJSONForTest(t, dir, CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{}},
+		},
+	})
+	if info, err := os.Stat(review.ReviewPathsFor(sess.CritJSONPath()).Review); err != nil {
+		t.Fatal(err)
+	} else {
+		sess.SetLastCritJSONMtimeForTest(info.ModTime())
+	}
+
+	if _, err := NewServer(sess, frontendFS, "", false, "", "", "test", 0, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	critPath := sess.CritJSONPath()
+	if err := share.MergeWebComments(critPath, []share.WebComment{{
+		Body:              "new web comment",
+		FilePath:          "plan.md",
+		StartLine:         1,
+		EndLine:           1,
+		ExternalID:        "ext-1",
+		AuthorDisplayName: "Web User",
+	}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !sess.SyncCommentsFromDisk() {
+		t.Fatalf("SyncCommentsFromDisk returned false (pendingWrite=%v)", sess.PendingWriteForTest())
+	}
+	if len(sess.GetComments("plan.md")) != 1 {
+		t.Fatalf("want 1 visible comment")
+	}
+}
+
+func TestSyncCommentsFromDisk_AfterMergeWebComments(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(filePath, []byte("# Plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	critPath := filepath.Join(dir, ".crit")
+	if err := review.SaveCritJSON(critPath, CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := &Session{
+		Mode:      "files",
+		OutputDir: dir,
+		RepoRoot:  dir,
+		Files:     []*FileEntry{{Path: "plan.md", AbsPath: filePath}},
+	}
+	if info, err := os.Stat(review.ReviewPathsFor(critPath).Review); err != nil {
+		t.Fatal(err)
+	} else {
+		sess.SetLastCritJSONMtimeForTest(info.ModTime())
+	}
+
+	if err := share.MergeWebComments(critPath, []share.WebComment{{
+		Body:              "new web comment",
+		FilePath:          "plan.md",
+		StartLine:         1,
+		EndLine:           1,
+		ExternalID:        "ext-1",
+		AuthorDisplayName: "Web User",
+	}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !sess.SyncCommentsFromDisk() {
+		t.Fatal("SyncCommentsFromDisk returned false")
+	}
+
+	sess.RLock()
+	raw := len(sess.Files[0].Comments)
+	focus := sess.Focus
+	sess.RUnlock()
+	if raw != 1 {
+		t.Fatalf("in-memory file has %d comments, want 1", raw)
+	}
+
+	visible := sess.GetComments("plan.md")
+	if len(visible) != 1 {
+		t.Fatalf("GetComments returned %d, want 1 (raw=%d focus=%+v)", len(visible), raw, focus)
+	}
+}

--- a/internal/session/export.go
+++ b/internal/session/export.go
@@ -104,6 +104,12 @@ func (s *Session) SetLastCritJSONMtimeForTest(t time.Time) {
 	s.lastCritJSONMtime = t
 }
 
+func (s *Session) PendingWriteForTest() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.pendingWrite
+}
+
 // RemoveStaleReviewPath removes a review identity folder or legacy flat file.
 func RemoveStaleReviewPath(path string) bool {
 	return removeStaleReviewPath(path)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4756,6 +4756,51 @@ func TestMergeReviewCommentsFromDisk_NewReplies(t *testing.T) {
 	}
 }
 
+// --- SyncCommentsFromDisk tests ---
+
+func TestSyncCommentsFromDisk_ClearsPendingWrite(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(filePath, []byte("# Plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	critPath := filepath.Join(dir, ".crit")
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"plan.md": {Comments: []Comment{{ID: "web-1", Body: "remote", StartLine: 1, EndLine: 1}}},
+		},
+	}
+	data, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mustMkdirAll(ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Session{
+		Mode:      "files",
+		OutputDir: dir,
+		RepoRoot:  dir,
+		Files:     []*FileEntry{{Path: "plan.md", AbsPath: filePath}},
+	}
+	s.SetSharedURLAndToken("https://crit.md/r/tok", "del")
+	if !s.PendingWriteForTest() {
+		t.Fatal("expected pendingWrite after SetSharedURLAndToken")
+	}
+
+	if !s.SyncCommentsFromDisk() {
+		t.Fatal("SyncCommentsFromDisk returned false")
+	}
+	if len(s.Files[0].Comments) != 1 {
+		t.Fatalf("want 1 comment in memory, got %d", len(s.Files[0].Comments))
+	}
+	if s.PendingWriteForTest() {
+		t.Fatal("expected pendingWrite cleared after sync")
+	}
+}
+
 // --- filterDeletedReviewComments tests ---
 
 func TestFilterDeletedReviewComments_NoneDeleted(t *testing.T) {

--- a/internal/session/session_write.go
+++ b/internal/session/session_write.go
@@ -552,6 +552,27 @@ func (s *Session) filterDeletedReviewComments(diskComments []Comment) bool {
 	return false
 }
 
+// SyncCommentsFromDisk reloads file- and review-level comments from review.json
+// on disk into the in-memory session. Call after external writers (e.g.
+// share.MergeWebComments via POST /api/comments/merge) update review.json
+// without going through WriteFiles.
+func (s *Session) SyncCommentsFromDisk() bool {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	s.mu.Lock()
+	if s.writeTimer != nil {
+		s.writeTimer.Stop()
+		s.writeTimer = nil
+	}
+	s.writeGen++
+	s.pendingWrite = false
+	s.lastCritJSONMtime = time.Time{}
+	s.mu.Unlock()
+
+	return s.mergeExternalCritJSON()
+}
+
 func (s *Session) mergeExternalCritJSON() bool {
 	critPath := s.critJSONPath()
 


### PR DESCRIPTION
## Summary
- After pulling comments via the Share modal (`POST /api/comments/merge`), comments were saved to `review.json` but the in-memory session was not updated, so the UI refresh showed stale data.
- Root cause: `mergeWebComments` writes disk outside `WriteFiles`, and `pendingWrite` (e.g. from `SetSharedURLAndToken` after sharing) blocked `mergeExternalCritJSON` from reloading.
- Add `Session.SyncCommentsFromDisk()` to cancel pending debounced writes and reload comments from disk immediately after merge; also sync on dedup-noop pulls so a repeat pull can recover the UI.

## Review
- [x] Code review: passed (blocker from upfront `SyncWriteFiles` removed before ship)
- [x] Parity audit: N/A (server-only, no review page changes)

## Test plan
- [x] `go test -race ./internal/server/... ./internal/session/...`
- [x] New tests: `TestSyncCommentsFromDisk_*`, `TestHandleMergeComments_NewComment`, `TestHandleMergeComments_DedupStillSyncsSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)