### PR TITLE
fix: address v0.17.0 post-release audit findings

### DIFF
--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -122,10 +122,10 @@ func (s *Server) projectPromptTrustPayload() map[string]any {
 
 func (s *Server) renderProjectPromptPreview(sess *Session) string {
 	_, projectPrompts := config.LoadPromptMaps(s.projectDir)
-	if len(projectPrompts) == 0 {
+	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts)
+	if err != nil || !trust.HasProjectPrompts {
 		return ""
 	}
-	mode := prompt.PromptMode(sess.ReviewType, sess.Mode)
 	var sections []string
 	for _, spec := range []struct {
 		hook     string
@@ -134,16 +134,22 @@ func (s *Server) renderProjectPromptPreview(sess *Session) string {
 		{prompt.HookFinishUnresolved, false},
 		{prompt.HookFinishApproved, true},
 	} {
-		value, key := prompt.LookupPrompt(projectPrompts, spec.hook, mode)
-		if value == "" || key == "" {
-			continue
-		}
 		ctx := s.buildPromptContext(sess, spec.approved, nil)
 		if !spec.approved && ctx.UnresolvedCount == 0 {
 			ctx.UnresolvedCount = 1
 		}
 		result := prompt.RenderFinish(nil, projectPrompts, s.projectDir, s.homeDir, true, ctx)
-		sections = append(sections, "=== "+key+" ===\n"+result.Prompt)
+		if result.Prompt == "" || result.Prompt == "Review finished." {
+			continue
+		}
+		if result.Meta == nil || !strings.HasPrefix(result.Meta.TemplateSource, "project:") {
+			continue
+		}
+		label := spec.hook
+		if result.Meta != nil && result.Meta.Hook != "" {
+			label = result.Meta.Hook
+		}
+		sections = append(sections, "=== "+label+" ===\n"+result.Prompt)
 	}
 	return strings.Join(sections, "\n\n")
 }

--- a/internal/server/prompts_test.go
+++ b/internal/server/prompts_test.go
@@ -117,3 +117,39 @@ func TestRenderProjectPromptPreview_SkipsStockFallback(t *testing.T) {
 		t.Fatalf("preview = %q, want project approved text", preview)
 	}
 }
+
+func TestRenderProjectPromptPreview_ConfigPrompts(t *testing.T) {
+	s, session := newTestServer(t)
+	dir := session.RepoRoot
+	os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{
+		"prompts": {
+			"on_finish_approved": "inline:Config approved prompt.",
+			"on_finish_unresolved": "inline:Config unresolved prompt."
+		}
+	}`), 0644)
+
+	preview := s.renderProjectPromptPreview(session)
+	if !strings.Contains(preview, "Config approved prompt.") {
+		t.Fatalf("preview = %q, want approved config text", preview)
+	}
+	if !strings.Contains(preview, "Config unresolved prompt.") {
+		t.Fatalf("preview = %q, want unresolved config text", preview)
+	}
+}
+
+func TestRenderProjectPromptPreview_DiscoveredUnresolved(t *testing.T) {
+	s, session := newTestServer(t)
+	dir := session.RepoRoot
+	promptDir := filepath.Join(dir, ".crit", "prompts")
+	if err := os.MkdirAll(promptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "on_finish_unresolved.md"), []byte("Discovered unresolved hook."), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	preview := s.renderProjectPromptPreview(session)
+	if !strings.Contains(preview, "Discovered unresolved hook.") {
+		t.Fatalf("preview = %q, want discovered unresolved text", preview)
+	}
+}

--- a/internal/server/prompts_test.go
+++ b/internal/server/prompts_test.go
@@ -80,3 +80,20 @@ func TestHandleConfig_ProjectPromptUntrusted(t *testing.T) {
 		t.Fatalf("untrusted = %v", resp["project_prompts_untrusted"])
 	}
 }
+
+func TestRenderProjectPromptPreview_DiscoveredOnly(t *testing.T) {
+	s, session := newTestServer(t)
+	dir := session.RepoRoot
+	promptDir := filepath.Join(dir, ".crit", "prompts")
+	if err := os.MkdirAll(promptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "on_finish_approved.md"), []byte("Custom discovered approve text."), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	preview := s.renderProjectPromptPreview(session)
+	if !strings.Contains(preview, "Custom discovered approve text.") {
+		t.Fatalf("preview = %q, want discovered prompt text", preview)
+	}
+}

--- a/internal/server/prompts_test.go
+++ b/internal/server/prompts_test.go
@@ -97,3 +97,23 @@ func TestRenderProjectPromptPreview_DiscoveredOnly(t *testing.T) {
 		t.Fatalf("preview = %q, want discovered prompt text", preview)
 	}
 }
+
+func TestRenderProjectPromptPreview_SkipsStockFallback(t *testing.T) {
+	s, session := newTestServer(t)
+	dir := session.RepoRoot
+	promptDir := filepath.Join(dir, ".crit", "prompts")
+	if err := os.MkdirAll(promptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "on_finish_approved.md"), []byte("Only project approved."), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	preview := s.renderProjectPromptPreview(session)
+	if strings.Contains(preview, "The review finished with") {
+		t.Fatalf("preview should not include stock unresolved fallback: %q", preview)
+	}
+	if !strings.Contains(preview, "Only project approved.") {
+		t.Fatalf("preview = %q, want project approved text", preview)
+	}
+}

--- a/internal/session/review_cli.go
+++ b/internal/session/review_cli.go
@@ -45,6 +45,7 @@ func RunReview(args []string) error {
 			return fmt.Errorf("invalid session ID %q (expected 12-character hex)", sc.SessionID)
 		}
 		key = sc.SessionID
+		staleEntry, _ := daemon.ReadSessionFile(key)
 		entry, alive = daemon.FindAliveSession(key)
 		if alive {
 			fmt.Fprintf(os.Stderr, "Connected to crit daemon at %s (session %s)\n", entry.BaseURL(), key)
@@ -52,7 +53,7 @@ func RunReview(args []string) error {
 				go browser.OpenBrowserWithCommand(entry.BaseURL(), sc.OpenCmd)
 			}
 		} else {
-			entry, err = reconnectDeadSession(key)
+			entry, err = reconnectDeadSession(key, staleEntry)
 			if err != nil {
 				return err
 			}

--- a/internal/session/session_reconnect.go
+++ b/internal/session/session_reconnect.go
@@ -67,9 +67,64 @@ func daemonArgsFromCliArgs(sessionKey string, cliArgs []string) []string {
 	return append(args, cliArgs...)
 }
 
+// resolveReconnectReviewDir picks the review folder for a dead-daemon reconnect.
+// Prefers the stale session registry's review_path (needed for --output reviews).
+func resolveReconnectReviewDir(key string, stale daemon.SessionEntry) (string, error) {
+	if stale.ReviewPath != "" {
+		critPath := ReviewPathsFor(stale.ReviewPath).Review
+		if _, err := os.Stat(critPath); err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("no review found for session %s at %s", key, stale.ReviewPath)
+			}
+			return "", fmt.Errorf("stat review for session %s: %w", key, err)
+		}
+		return stale.ReviewPath, nil
+	}
+	return daemon.ReviewFilePath(key)
+}
+
+// daemonArgsForReconnect rebuilds _serve argv including flags not stored in cli_args.
+func daemonArgsForReconnect(sessionKey string, cliArgs []string, stale daemon.SessionEntry, reviewDir string) []string {
+	args := daemonArgsFromCliArgs(sessionKey, cliArgs)
+	args = appendReconnectPathFlags(sessionKey, args, reviewDir)
+	args = daemon.AppendCommonDaemonFlags(args, daemon.CommonDaemonFlags{
+		Host:      stale.Host,
+		PublicURL: stale.PublicURL,
+	})
+	return args
+}
+
+// appendReconnectPathFlags adds --output or --plan-dir/--name when the review
+// folder is outside the default ~/.crit/reviews/<key> layout.
+func appendReconnectPathFlags(sessionKey string, args []string, reviewDir string) []string {
+	if !strings.HasSuffix(filepath.ToSlash(reviewDir), "/.crit") {
+		return args
+	}
+	defaultDir, err := daemon.ReviewFilePath(sessionKey)
+	if err == nil && filepath.Clean(reviewDir) == filepath.Clean(defaultDir) {
+		return args
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		plansRoot := filepath.Join(home, ".crit", "plans")
+		parent := filepath.Dir(reviewDir)
+		if strings.HasPrefix(filepath.Clean(parent), filepath.Clean(plansRoot)+string(filepath.Separator)) {
+			slug := filepath.Base(parent)
+			if slug != "" && slug != "." {
+				return append(args, "--plan-dir", parent, "--name", slug)
+			}
+		}
+	}
+	outputDir := filepath.Dir(reviewDir)
+	if outputDir != "" && outputDir != "." {
+		return append(args, "--output", outputDir)
+	}
+	return args
+}
+
 // reconnectDeadSession restarts a daemon for an existing review folder.
-func reconnectDeadSession(key string) (daemon.SessionEntry, error) {
-	revDir, err := daemon.ReviewFilePath(key)
+func reconnectDeadSession(key string, stale daemon.SessionEntry) (daemon.SessionEntry, error) {
+	revDir, err := resolveReconnectReviewDir(key, stale)
 	if err != nil {
 		return daemon.SessionEntry{}, err
 	}
@@ -85,7 +140,7 @@ func reconnectDeadSession(key string) (daemon.SessionEntry, error) {
 	if err := json.Unmarshal(data, &cj); err != nil {
 		return daemon.SessionEntry{}, fmt.Errorf("parsing review for session %s: %w", key, err)
 	}
-	daemonArgs := daemonArgsFromCliArgs(key, cj.CliArgs)
+	daemonArgs := daemonArgsForReconnect(key, cj.CliArgs, stale, revDir)
 	entry, err := startDaemonForReconnect(key, daemonArgs)
 	if err != nil {
 		return daemon.SessionEntry{}, err

--- a/internal/session/session_reconnect_test.go
+++ b/internal/session/session_reconnect_test.go
@@ -277,6 +277,36 @@ func TestAppendReconnectPathFlags_PlanDir(t *testing.T) {
 	assertDaemonFlag(t, args, "--name", "auth-flow")
 }
 
+func TestAppendReconnectPathFlags_DefaultLayout(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "839f3b4cd5d6"
+	defaultDir, err := daemon.ReviewFilePath(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := appendReconnectPathFlags(key, []string{"--session-key", key}, defaultDir)
+	if _, ok := daemonFlagValue(args, "--output"); ok {
+		t.Fatalf("default layout should not add --output: %v", args)
+	}
+	if _, ok := daemonFlagValue(args, "--plan-dir"); ok {
+		t.Fatalf("default layout should not add --plan-dir: %v", args)
+	}
+}
+
+func TestDaemonArgsForReconnect_Host(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "839f3b4cd5d6"
+	defaultDir, err := daemon.ReviewFilePath(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := daemon.SessionEntry{Host: "0.0.0.0"}
+	args := daemonArgsForReconnect(key, nil, stale, defaultDir)
+	assertDaemonFlag(t, args, "--host", "0.0.0.0")
+}
+
 func TestReconnectDeadSession_StalePathMissing(t *testing.T) {
 	home := t.TempDir()
 	testutil.SetHome(t, home)

--- a/internal/session/session_reconnect_test.go
+++ b/internal/session/session_reconnect_test.go
@@ -14,6 +14,33 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
+func daemonFlagValue(args []string, flag string) (string, bool) {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+func assertDaemonFlag(t *testing.T, args []string, flag, want string) {
+	t.Helper()
+	got, ok := daemonFlagValue(args, flag)
+	if !ok {
+		t.Fatalf("args %v missing flag %q", args, flag)
+	}
+	switch flag {
+	case "--output", "--plan-dir":
+		if filepath.Clean(got) != filepath.Clean(want) {
+			t.Fatalf("flag %q = %q, want %q", flag, got, want)
+		}
+	default:
+		if got != want {
+			t.Fatalf("flag %q = %q, want %q", flag, got, want)
+		}
+	}
+}
+
 func TestReconnectDeadSession_MissingReview(t *testing.T) {
 	home := t.TempDir()
 	testutil.SetHome(t, home)
@@ -167,6 +194,12 @@ func TestReconnectDeadSession_OutputReviewPath(t *testing.T) {
 			t.Fatalf("args = %v, want %v", args, want)
 		}
 		for i := range want {
+			if want[i] == outputDir {
+				if filepath.Clean(args[i]) != filepath.Clean(outputDir) {
+					t.Fatalf("args = %v, want %v", args, want)
+				}
+				continue
+			}
 			if args[i] != want[i] {
 				t.Fatalf("args = %v, want %v", args, want)
 			}
@@ -182,25 +215,79 @@ func TestReconnectDeadSession_OutputReviewPath(t *testing.T) {
 
 func TestDaemonArgsForReconnect_OutputAndPublicURL(t *testing.T) {
 	key := "839f3b4cd5d6"
-	outputDir := "/tmp/review-out"
+	outputDir := filepath.Join(os.TempDir(), "review-out")
 	revDir := filepath.Join(outputDir, ".crit")
 	stale := daemon.SessionEntry{
 		ReviewPath: revDir,
 		PublicURL:  "https://crit.example.com",
 	}
 	args := daemonArgsForReconnect(key, []string{"doc.md"}, stale, revDir)
-	wantSub := []string{"--output", outputDir, "--public-url", "https://crit.example.com", "doc.md"}
-	for _, w := range wantSub {
-		found := false
-		for _, a := range args {
-			if a == w {
-				found = true
-				break
-			}
+	assertDaemonFlag(t, args, "--output", outputDir)
+	assertDaemonFlag(t, args, "--public-url", "https://crit.example.com")
+	if !containsArg(args, "doc.md") {
+		t.Fatalf("args %v missing doc.md", args)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
 		}
-		if !found {
-			t.Fatalf("args %v missing %q", args, w)
-		}
+	}
+	return false
+}
+
+func TestResolveReconnectReviewDir_MissingStaleReview(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), ".crit")
+	_, err := resolveReconnectReviewDir("839f3b4cd5d6", daemon.SessionEntry{ReviewPath: missing})
+	if err == nil {
+		t.Fatal("expected error for missing stale review_path")
+	}
+	if !strings.Contains(err.Error(), "no review found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveReconnectReviewDir_UsesStalePath(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	outputDir := filepath.Join(t.TempDir(), "out")
+	revDir := filepath.Join(outputDir, ".crit")
+	if err := SaveCritJSON(revDir, CritJSON{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveReconnectReviewDir("839f3b4cd5d6", daemon.SessionEntry{ReviewPath: revDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Clean(got) != filepath.Clean(revDir) {
+		t.Fatalf("got %q, want %q", got, revDir)
+	}
+}
+
+func TestAppendReconnectPathFlags_PlanDir(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "839f3b4cd5d6"
+	planStorage := filepath.Join(home, ".crit", "plans", "auth-flow")
+	reviewDir := filepath.Join(planStorage, ".crit")
+	args := appendReconnectPathFlags(key, []string{"--session-key", key}, reviewDir)
+	assertDaemonFlag(t, args, "--plan-dir", planStorage)
+	assertDaemonFlag(t, args, "--name", "auth-flow")
+}
+
+func TestReconnectDeadSession_StalePathMissing(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "839f3b4cd5d6"
+	missing := filepath.Join(t.TempDir(), ".crit")
+	_, err := reconnectDeadSession(key, daemon.SessionEntry{ReviewPath: missing})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no review found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/session/session_reconnect_test.go
+++ b/internal/session/session_reconnect_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,7 +18,7 @@ func TestReconnectDeadSession_MissingReview(t *testing.T) {
 	home := t.TempDir()
 	testutil.SetHome(t, home)
 
-	_, err := reconnectDeadSession("839f3b4cd5d6")
+	_, err := reconnectDeadSession("839f3b4cd5d6", daemon.SessionEntry{})
 	if err == nil {
 		t.Fatal("expected error for missing review")
 	}
@@ -41,7 +42,7 @@ func TestReconnectDeadSession_InvalidJSON(t *testing.T) {
 	}
 	writeFile(t, critPath, "not json")
 
-	_, err = reconnectDeadSession(key)
+	_, err = reconnectDeadSession(key, daemon.SessionEntry{})
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
@@ -83,7 +84,7 @@ func TestReconnectDeadSession_RestartsDaemon(t *testing.T) {
 	t.Cleanup(func() { startDaemonForReconnect = orig })
 
 	stderr := captureStderr(t, func() {
-		entry, err := reconnectDeadSession(key)
+		entry, err := reconnectDeadSession(key, daemon.SessionEntry{})
 		if err != nil {
 			t.Fatalf("reconnectDeadSession: %v", err)
 		}
@@ -140,6 +141,66 @@ func TestRunReview_SessionByID_ReconnectsDeadDaemon(t *testing.T) {
 
 	if err := RunReview(nil); err != nil {
 		t.Fatalf("RunReview: %v", err)
+	}
+}
+
+func TestReconnectDeadSession_OutputReviewPath(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "839f3b4cd5d6"
+
+	outputDir := filepath.Join(t.TempDir(), "out")
+	revDir := filepath.Join(outputDir, ".crit")
+	cj := CritJSON{CliArgs: []string{"a.md"}}
+	if err := SaveCritJSON(revDir, cj); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := daemon.SessionEntry{ReviewPath: revDir}
+	orig := startDaemonForReconnect
+	startDaemonForReconnect = func(gotKey string, args []string) (daemon.SessionEntry, error) {
+		if gotKey != key {
+			t.Fatalf("key = %q, want %q", gotKey, key)
+		}
+		want := []string{"--session-key", key, "--quiet", "a.md", "--output", outputDir}
+		if len(args) != len(want) {
+			t.Fatalf("args = %v, want %v", args, want)
+		}
+		for i := range want {
+			if args[i] != want[i] {
+				t.Fatalf("args = %v, want %v", args, want)
+			}
+		}
+		return daemon.SessionEntry{PID: 42, Port: 3001}, nil
+	}
+	t.Cleanup(func() { startDaemonForReconnect = orig })
+
+	if _, err := reconnectDeadSession(key, stale); err != nil {
+		t.Fatalf("reconnectDeadSession: %v", err)
+	}
+}
+
+func TestDaemonArgsForReconnect_OutputAndPublicURL(t *testing.T) {
+	key := "839f3b4cd5d6"
+	outputDir := "/tmp/review-out"
+	revDir := filepath.Join(outputDir, ".crit")
+	stale := daemon.SessionEntry{
+		ReviewPath: revDir,
+		PublicURL:  "https://crit.example.com",
+	}
+	args := daemonArgsForReconnect(key, []string{"doc.md"}, stale, revDir)
+	wantSub := []string{"--output", outputDir, "--public-url", "https://crit.example.com", "doc.md"}
+	for _, w := range wantSub {
+		found := false
+		for _, a := range args {
+			if a == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("args %v missing %q", args, w)
+		}
 	}
 }
 

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -392,6 +392,12 @@ func RunFetch(args []string) error {
 		return err
 	}
 
+	return session.WithShareLock(critPath, func() error {
+		return runFetchUnderLock(critPath)
+	})
+}
+
+func runFetchUnderLock(critPath string) error {
 	data, readErr := session.ReadFileShared(session.ReviewPathsFor(critPath).Review)
 	if readErr != nil {
 		return clicmd.Usage("Error: no review file found. Run `crit share` first.")

--- a/internal/share/cli_fetch_test.go
+++ b/internal/share/cli_fetch_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/review"
@@ -99,6 +100,127 @@ func TestRunFetch_NoShareURL(t *testing.T) {
 	err := RunFetch([]string{"--output", dir})
 	if err == nil {
 		t.Fatal("expected error when share URL missing")
+	}
+}
+
+func TestRunFetch_InvalidReviewFile(t *testing.T) {
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit")
+	if err := os.WriteFile(testutil.MustMkdirAll(review.ReviewPathsFor(critPath).Review), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := RunFetch([]string{"--output", dir})
+	if err == nil || !strings.Contains(err.Error(), "invalid review file") {
+		t.Fatalf("RunFetch() = %v, want invalid review file error", err)
+	}
+}
+
+func TestRunFetch_ReplyUpdates(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"body":        "web-authored note",
+				"file_path":   "plan.md",
+				"start_line":  3,
+				"end_line":    3,
+				"resolved":    false,
+				"external_id": nil,
+				"replies": []map[string]any{
+					{"body": "follow-up reply", "author_display_name": "Alice"},
+				},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	cj := session.CritJSON{
+		ShareURL: ts.URL + "/r/tok",
+		Files: map[string]session.CritJSONFile{
+			"plan.md": {Comments: []session.Comment{{
+				ID:        "web-1",
+				Body:      "web-authored note",
+				StartLine: 3,
+				EndLine:   3,
+			}}},
+		},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	critPath := filepath.Join(tmpDir, ".crit")
+	if err := os.WriteFile(testutil.MustMkdirAll(review.ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err = RunFetch([]string{"--output", tmpDir})
+	w.Close()
+	os.Stdout = old
+	io.Copy(&buf, r)
+	if err != nil {
+		t.Fatalf("RunFetch: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Updated 1 comment(s) with 1 new reply") {
+		t.Fatalf("output = %q, want reply update summary", out)
+	}
+
+	merged, err := os.ReadFile(review.ReviewPathsFor(critPath).Review)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var after session.CritJSON
+	if err := json.Unmarshal(merged, &after); err != nil {
+		t.Fatal(err)
+	}
+	replies := after.Files["plan.md"].Comments[0].Replies
+	if len(replies) != 1 || replies[0].Body != "follow-up reply" {
+		t.Fatalf("replies = %+v, want follow-up reply", replies)
+	}
+}
+
+func TestConcurrentFetchSameReview(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(nil)
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	cj := session.CritJSON{
+		ShareURL: ts.URL + "/r/tok",
+		Files:    map[string]session.CritJSONFile{},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	critPath := filepath.Join(tmpDir, ".crit")
+	if err := os.WriteFile(testutil.MustMkdirAll(review.ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			errs <- RunFetch([]string{"--output", tmpDir})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent fetch: %v", err)
+		}
 	}
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -892,14 +892,6 @@
       project_prompt_content_hash: configRes.project_prompt_content_hash || '',
     };
     window.crit.shared.applyProjectPromptTrustUI(promptTrustConfig, document.getElementById('finishBtn'));
-    if (promptTrustConfig.project_prompts_untrusted) {
-      window.crit.shared.ensureProjectPromptTrust(promptTrustConfig).then(function (ok) {
-        if (ok) {
-          window.crit.shared.applyProjectPromptTrustUI(promptTrustConfig, document.getElementById('finishBtn'));
-          if (uiState === 'reviewing') setUIState('reviewing');
-        }
-      });
-    }
 
     // Update notifications (brew upgrade + stale integrations)
     pendingUpdates = [];
@@ -7061,10 +7053,12 @@
             // server snapshot so renderResumePill sees the latest value.
             session.last_range_focus = inner.last_range_focus || null;
           }
-          applyFocusToHeader(focus);
           if (focus.kind === 'range') {
             diffScope = 'all';
+          } else {
+            restoreWorkingTreeDiffScope();
           }
+          applyFocusToHeader(focus);
           // Re-fetch the stack on any range focus transition — the new
           // focus may live in a different stack, and the breadcrumb's
           // visibility uses stack.length (not is_stacked) so we need the
@@ -7442,6 +7436,23 @@
     return sessionInRangeFocus() ? 'all' : diffScope;
   }
 
+  function restoreWorkingTreeDiffScope() {
+    if (!session || session.mode !== 'git' || sessionInRangeFocus()) return;
+    const scopes = session.available_scopes || ['all', 'staged', 'unstaged'];
+    const saved = getSetting('diffScope');
+    if (saved && scopes.indexOf(saved) !== -1) {
+      diffScope = saved;
+    } else if (scopes.indexOf(diffScope) === -1) {
+      diffScope = scopes.indexOf('branch') !== -1 ? 'branch' : 'all';
+    }
+    const scopeToggle = document.getElementById('scopeToggle');
+    if (scopeToggle) {
+      scopeToggle.querySelectorAll('.toggle-btn').forEach(function(b) {
+        b.classList.toggle('active', b.dataset.scope === diffScope);
+      });
+    }
+  }
+
   function compareTargetChromeVisible() {
     if (!session || session.mode !== 'git') return false;
     if (sessionInRangeFocus()) return false;
@@ -7450,6 +7461,7 @@
 
   function commitRangeChromeVisible() {
     if (!session || session.mode !== 'git') return false;
+    if (sessionInRangeFocus()) return false;
     if (diffScope === 'staged' || diffScope === 'unstaged') return false;
     return true;
   }
@@ -7466,7 +7478,7 @@
   function isRevishQuery(q) {
     const t = q.trim();
     if (!t) return false;
-    if (/^[0-9a-f]{4,40}$/i.test(t)) return true;
+    if (/^[0-9a-f]{7,40}$/i.test(t)) return true;
     if (/^HEAD(?:[~^]\d+)?$/i.test(t)) return true;
     if (t === '@' || /^@[-a-z0-9]+$/i.test(t)) return true;
     return false;
@@ -7785,10 +7797,6 @@
     const q = (filter || '').trim();
     const lower = q.toLowerCase();
 
-    if (compareTargetTabsEl) {
-      compareTargetTabsEl.style.display = compareTargetTab === 'commits' ? '' : '';
-    }
-
     if (compareTargetTab === 'commits') {
       let commits = commitList;
       if (lower) {
@@ -8049,7 +8057,7 @@
         document.getElementById('filesContainer').innerHTML =
           '<div class="loading" style="padding: 40px; text-align: center; color: var(--crit-editor-fg-muted);">Loading...</div>';
 
-        let sessionUrl = '/api/session?scope=' + enc(diffScope);
+        let sessionUrl = '/api/session?scope=' + enc(effectiveDiffScope());
         if (diffCommit) sessionUrl += '&commit=' + enc(diffCommit);
         const sessionRes = await fetch(sessionUrl).then(function(r) { return r.json(); });
         session = sessionRes;

--- a/web/live-mode.js
+++ b/web/live-mode.js
@@ -936,9 +936,9 @@
     if (!btn) return;
     e.stopPropagation();
     var id = btn.dataset.commentId;
-    var path = btn.dataset.pathname || '/';
     if (!id) return;
     var c = (state.comments || []).find(function (x) { return x && x.id === id; });
+    var path = btn.dataset.pathname || (c && commentStoragePath(c)) || '/';
     var resolved = c ? !c.resolved : true;
     // Dedup: second click (or click on a different button targeting the same
     // pin from the panel vs. a thread row) while the first PUT is in flight
@@ -1092,9 +1092,9 @@
     if (!btn) return;
     e.stopPropagation();
     var id = btn.dataset.commentId;
-    var path = btn.dataset.pathname || '/';
     var c = findCommentById(id);
     if (!c) return;
+    var path = btn.dataset.pathname || commentStoragePath(c) || '/';
     var card = btn.closest('.crit-live-comment-row');
     var ta = card && card.querySelector('.crit-live-reply-textarea');
     var errEl = card && card.querySelector('.crit-live-reply-error');
@@ -1407,9 +1407,9 @@
     if (!btn) return;
     e.stopPropagation();
     var id = btn.dataset.commentId;
-    var path = btn.dataset.pathname || '/';
     var c = findCommentById(id);
     if (!c) return;
+    var path = btn.dataset.pathname || commentStoragePath(c) || '/';
     var card = btn.closest('.crit-live-comment-row');
     var ta = card && card.querySelector('.crit-live-edit-textarea');
     var errEl = card && card.querySelector('.crit-live-edit-error');


### PR DESCRIPTION
## Summary
- Fix dead `crit --session` reconnect for `--output` reviews by reading stale `review_path` before session cleanup and rebuilding daemon argv
- Show trust-dialog previews for discovered `.crit/prompts/` files (project templates only, not stock fallbacks)
- Serialize `crit fetch` with the per-review share lock
- Fix range-focus UX: restore working-tree scope after PR exit, hide commit picker in range mode, use `effectiveDiffScope()` for session reload

## Review
- [x] Code review: passed (intent check CLEAN, blockers fixed pre-ship)
- [x] Parity audit: N/A (compare-against picker not in crit-web yet)

## Test plan
- [x] `go test ./internal/session/... ./internal/server/... ./internal/share/...`
- [x] Pre-commit hook (golangci-lint, ESLint, CSS vars)
- [x] `node --test web/__tests__/range-focus-diff-scope.test.js`


Made with [Cursor](https://cursor.com)