### PR TITLE
chore: pin golangci-lint in mise and auto-enable git hooks in worktrees

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -10,3 +10,4 @@ mise-trust = "mise trust ."
 # `cp -R` of node_modules — copy-ignored handles all gitignored paths.
 [post-start]
 copy = "wt step copy-ignored"
+hooks = "make setup-hooks"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,21 +31,16 @@ if [ -n "$UNFORMATTED" ]; then
 fi
 
 # Run golangci-lint (includes gocyclo, staticcheck, misspell, ineffassign)
-# golangci-lint is installed via `go install`, not mise — only run if on PATH.
-if command -v golangci-lint >/dev/null 2>&1; then
-    echo "  Running golangci-lint..."
-    LINT_OUTPUT=$(golangci-lint run ./... 2>/dev/null) || true
-    # Sibling worktrees (crit-mono/crit.<branch>/) share the same module path,
-    # so golangci-lint reports their issues as ../crit.<branch>/file.go paths.
-    # Keep only issue lines for files in the current directory.
-    LINT_LOCAL=$(echo "$LINT_OUTPUT" | grep -E '^[^./][^:]*\.go:[0-9]+:' || true)
-    if [ -n "$LINT_LOCAL" ]; then
-        echo "$LINT_LOCAL"
-        echo "  FAIL: Lint issues found"
-        exit 1
-    fi
-else
-    echo "  Skipping golangci-lint (not on PATH). Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+echo "  Running golangci-lint..."
+LINT_OUTPUT=$(run_tool golangci-lint run ./... 2>/dev/null) || true
+# Sibling worktrees (crit-mono/crit.<branch>/) share the same module path,
+# so golangci-lint reports their issues as ../crit.<branch>/file.go paths.
+# Keep only issue lines for files in the current directory.
+LINT_LOCAL=$(echo "$LINT_OUTPUT" | grep -E '^[^./][^:]*\.go:[0-9]+:' || true)
+if [ -n "$LINT_LOCAL" ]; then
+    echo "$LINT_LOCAL"
+    echo "  FAIL: Lint issues found"
+    exit 1
 fi
 
 # Run tests

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26.0"
 node = "22"
+golangci-lint = "2.11.4"
 
 [env]
 PORT = "8080"


### PR DESCRIPTION
## Summary
- Add `golangci-lint` to `mise.toml` so lint is always available via `mise exec`
- Pre-commit hook always runs golangci-lint through `run_tool` (no silent skip)
- `wt` post-start runs `make setup-hooks` so new worktrees enable hooks automatically

## Review
- [x] Code review: passed (small dev-tooling change)
- [x] Parity audit: N/A

## Test plan
- [x] `mise exec -- gofmt -l .`
- [x] `mise exec -- golangci-lint run ./...`
- [x] `mise exec -- go test -race -count=1 ./...`
- [x] Pre-commit hook ran on commit

Made with [Cursor](https://cursor.com)