### PR TITLE
fix: filter virtual compare target and bump claude-code plugin version

### DIFF
--- a/cmd/crit/integration_hashes_gen.go
+++ b/cmd/crit/integration_hashes_gen.go
@@ -4,7 +4,7 @@ package main
 
 var integrationHashes = map[string]string{
 	"integrations/aider/CONVENTIONS.md":                          "cfefa9366a5a403ad3b856f444769ff562987d61942b4d443559a4f3e5f20dcb",
-	"integrations/claude-code/.claude-plugin/plugin.json":        "e8c916f5688dcfe8516b6d0357767d86ae0362dd290dddb0ccfc164fb77e69f9",
+	"integrations/claude-code/.claude-plugin/plugin.json":        "83249f3f485da8821c4963ccba6e2045b3f07d22f96fe209a01f1f35b8c4a079",
 	"integrations/claude-code/hooks/hooks.json":                  "beba2c8bd252637ff31b57ed868e4d56135e1a3f429f872befbd2d34b834512b",
 	"integrations/claude-code/skills/crit-cli/SKILL.md":          "3e6bf2be5eb2e441b85329e5d8ab44ccaac50220d5f51ed6a7af7c650d7e272f",
 	"integrations/claude-code/skills/crit/SKILL.md":              "2a86c3e5983ad97199a39b389186335c2ec7fbe0e16b337fd225911ddae204b3",

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Close the feedback loop on AI coding: review plans and code changes with GitHub-style inline comments, then let the agent address them.",
   "author": {
     "name": "Tomasz Tomczyk"

--- a/internal/live/live_cdp.go
+++ b/internal/live/live_cdp.go
@@ -41,8 +41,8 @@ type cdpCommand struct {
 
 var cdpHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
-// resolveCDPURL picks the CDP endpoint from CLI flag or config, falling back
-// to the default local Chrome debugging port when enabled via bare true-ish values.
+// resolveCDPURL picks the CDP endpoint from the CLI flag first, then the config
+// value, returning an empty string when neither is set.
 func resolveCDPURL(flagCDPURL string, cfgLiveCDPURL string) string {
 	if flagCDPURL != "" {
 		return normalizeCDPBaseURL(flagCDPURL)

--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -146,7 +146,7 @@ func (s *Server) renderProjectPromptPreview(sess *Session) string {
 			continue
 		}
 		label := spec.hook
-		if result.Meta != nil && result.Meta.Hook != "" {
+		if result.Meta.Hook != "" {
 			label = result.Meta.Hook
 		}
 		sections = append(sections, "=== "+label+" ===\n"+result.Prompt)

--- a/web/app.js
+++ b/web/app.js
@@ -7294,7 +7294,7 @@
     navigator.clipboard.writeText(url).then(function() {
       anchor.classList.add('heading-anchor-copied');
       setTimeout(function() { anchor.classList.remove('heading-anchor-copied'); }, 1500);
-    }).catch(function() {});
+    }).catch(function() { return; });
   });
 
   // ===== Mermaid =====
@@ -9153,8 +9153,8 @@
         start = Math.min(targetIdx, baseIdx);
         end = Math.max(targetIdx, baseIdx);
       }
-      const inRange = i >= start && i <= end;
-      return { inRange: inRange };
+      const isInRange = i >= start && i <= end;
+      return { inRange: isInRange };
     }
 
     const parts = [];

--- a/web/app.js
+++ b/web/app.js
@@ -7798,9 +7798,9 @@
     const lower = q.toLowerCase();
 
     if (compareTargetTab === 'commits') {
-      let commits = commitList;
+      let commits = commitList.filter(function(c) { return !c.virtual; });
       if (lower) {
-        commits = commitList.filter(function(c) {
+        commits = commits.filter(function(c) {
           return c.short_sha.toLowerCase().indexOf(lower) !== -1
             || c.sha.toLowerCase().indexOf(lower) === 0
             || c.message.toLowerCase().indexOf(lower) !== -1;


### PR DESCRIPTION
## Summary
- Prevent selecting the virtual working-tree pseudo-commit as a compare-target base in the review UI.
- Align minor Go cleanups from release audit: accurate CDP URL comment and redundant nil-check removal.
- Bump Claude Code plugin version to `1.8.1` so integration prompt updates are published.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)