### PR TITLE
fix: dedupe review comments to prevent duplicate edit forms

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1195,9 +1195,16 @@ func (s *Session) GetReviewComments() []Comment {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]Comment, 0, len(s.reviewComments))
+	seen := make(map[string]struct{}, len(s.reviewComments))
 	for _, c := range s.reviewComments {
 		if !visibleInFocus(c, s.Focus) {
 			continue
+		}
+		if c.ID != "" {
+			if _, ok := seen[c.ID]; ok {
+				continue
+			}
+			seen[c.ID] = struct{}{}
 		}
 		out = append(out, c)
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2593,6 +2593,25 @@ func TestAddReviewComment(t *testing.T) {
 	}
 }
 
+func TestGetReviewComments_DedupesByID(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{
+			{ID: "r1", Body: "first"},
+			{ID: "r1", Body: "duplicate"},
+			{ID: "r2", Body: "second"},
+		},
+		subscribers: make(map[chan SSEEvent]struct{}),
+	}
+
+	comments := s.GetReviewComments()
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 deduped comments, got %d", len(comments))
+	}
+	if comments[0].ID != "r1" || comments[1].ID != "r2" {
+		t.Fatalf("expected IDs [r1 r2], got [%s %s]", comments[0].ID, comments[1].ID)
+	}
+}
+
 func TestDeleteReviewComment(t *testing.T) {
 	s := newTestSession(t)
 	c := s.AddReviewComment("temp", "", "")
@@ -4753,6 +4772,29 @@ func TestMergeReviewCommentsFromDisk_NewReplies(t *testing.T) {
 	}
 	if len(s.reviewComments[0].Replies) != 2 {
 		t.Errorf("expected 2 replies, got %d", len(s.reviewComments[0].Replies))
+	}
+}
+
+func TestMergeReviewCommentsFromDisk_DedupesDuplicateDiskIDs(t *testing.T) {
+	s := &Session{
+		reviewComments: []Comment{},
+		subscribers:    make(map[chan SSEEvent]struct{}),
+	}
+
+	diskComments := []Comment{
+		{ID: "r1", Body: "from disk"},
+		{ID: "r1", Body: "from disk duplicate"},
+	}
+
+	changed := s.mergeReviewCommentsFromDisk(diskComments)
+	if !changed {
+		t.Error("expected changed=true when adding new comment")
+	}
+	if len(s.reviewComments) != 1 {
+		t.Fatalf("expected 1 comment after dedupe, got %d", len(s.reviewComments))
+	}
+	if s.reviewComments[0].ID != "r1" {
+		t.Errorf("expected r1, got %s", s.reviewComments[0].ID)
 	}
 }
 

--- a/internal/session/session_write.go
+++ b/internal/session/session_write.go
@@ -493,6 +493,7 @@ func (s *Session) mergeReviewCommentsFromDisk(diskComments []Comment) bool {
 	for _, dc := range diskComments {
 		if _, exists := memReviewIDs[dc.ID]; !exists {
 			s.reviewComments = append(s.reviewComments, dc)
+			memReviewIDs[dc.ID] = struct{}{}
 			changed = true
 		} else {
 			changed = s.mergeReviewCommentRepliesAndState(dc) || changed


### PR DESCRIPTION
## Summary
- Fix `mergeReviewCommentsFromDisk` so duplicate review comment IDs from disk are not appended twice into session state.
- Dedupe review comments by ID in `GetReviewComments()` as a read-path safety net.
- Add regression tests for both merge and read paths.

## Test plan
- [x] `mise exec -- go test ./internal/session -run "Test(GetReviewComments_DedupesByID|MergeReviewCommentsFromDisk)"`
- [ ] Edit a review-level comment in the crit UI and confirm only one edit form appears


Made with [Cursor](https://cursor.com)