### PR TITLE
fix: tolerate trailing commas in opencode config during plugin registration

### DIFF
--- a/cmd/crit/opencode_install.go
+++ b/cmd/crit/opencode_install.go
@@ -62,6 +62,7 @@ func installOpencodePluginEntry(path, entry string, force bool) error {
 			printManualPluginInstruction(path, "contains comments", entry)
 			return nil
 		}
+		data = stripTrailingCommas(data)
 		if err := json.Unmarshal(data, &root); err != nil {
 			return fmt.Errorf("%s contains invalid JSON: %w", path, err)
 		}
@@ -154,6 +155,60 @@ func looksLikeJSONC(data []byte) bool {
 	// Strip strings before scanning so `"// not a comment"` doesn't trigger.
 	stripped := stripJSONStrings(data)
 	return strings.Contains(stripped, "//") || strings.Contains(stripped, "/*")
+}
+
+// stripTrailingCommas removes commas that appear immediately before a closing
+// `}` or `]` outside of JSON string literals. This lets us tolerate configs
+// that are otherwise plain JSON but contain a trailing comma, which many
+// editors and JSONC-style configs allow but encoding/json rejects.
+func stripTrailingCommas(data []byte) []byte {
+	var out []byte
+	inString := false
+	escape := false
+	lastComma := -1 // index in out of the most recent unconfirmed comma
+
+	for _, c := range data {
+		if inString {
+			if escape {
+				escape = false
+				out = append(out, c)
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				out = append(out, c)
+				continue
+			}
+			out = append(out, c)
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		switch c {
+		case '"':
+			inString = true
+			lastComma = -1 // a value/key follows, so the comma was not trailing
+			out = append(out, c)
+		case ',':
+			lastComma = len(out)
+			out = append(out, c)
+		case ' ', '\t', '\n', '\r':
+			out = append(out, c)
+		case '}', ']':
+			if lastComma >= 0 {
+				out = out[:lastComma]
+				lastComma = -1
+			}
+			out = append(out, c)
+		default:
+			lastComma = -1 // any other token means the comma was not trailing
+			out = append(out, c)
+		}
+	}
+
+	return out
 }
 
 // stripJSONStrings replaces every JSON string literal in data with empty

--- a/cmd/crit/opencode_install_test.go
+++ b/cmd/crit/opencode_install_test.go
@@ -43,6 +43,16 @@ func TestInstallOpencodePluginEntry(t *testing.T) {
 			expectPlugin: []interface{}{[]interface{}{projectEntry, map[string]interface{}{}}},
 		},
 		{
+			name:         "trailing comma tolerated",
+			initial:      `{"plugin": ["other-plugin"],}`,
+			expectPlugin: []interface{}{"other-plugin", projectEntry},
+		},
+		{
+			name:       "trailing comma with schema key left untouched",
+			initial:    "{\n  \"$schema\": \"https://opencode.ai/config.json\",\n}",
+			expectSkip: true,
+		},
+		{
 			name:      "malformed json errors",
 			initial:   `{"plugin": [`,
 			expectErr: true,
@@ -121,6 +131,31 @@ func TestInstallOpencodePluginEntry(t *testing.T) {
 				if string(gotJSON) != string(wantJSON) {
 					t.Errorf("plugin[%d] = %s want %s", i, gotJSON, wantJSON)
 				}
+			}
+		})
+	}
+}
+
+func TestStripTrailingCommas(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no trailing comma", `{"plugin":[]}`, `{"plugin":[]}`},
+		{"object trailing comma", `{"plugin":[],}`, `{"plugin":[]}`},
+		{"array trailing comma", `[1,2,3,]`, `[1,2,3]`},
+		{"nested trailing commas", `{"a":[1,],}`, `{"a":[1]}`},
+		{"comma inside string preserved", `{"a":"1,",}`, `{"a":"1,"}`},
+		{"whitespace before close", "{\n  \"plugin\": [],\n}", "{\n  \"plugin\": []}"},
+		{"non-trailing comma preserved", `{"a":1,"b":2}`, `{"a":1,"b":2}`},
+		{"escaped quote inside string", `{"a":"he said \"hello\"","b":[],}`, `{"a":"he said \"hello\"","b":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(stripTrailingCommas([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("stripTrailingCommas(%q) = %q want %q", tc.in, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes the invalid JSON error users see when running `crit install opencode` against an OpenCode config that contains a trailing comma (e.g. after a `$schema` key).

Changes:
- Add `stripTrailingCommas` helper in `cmd/crit/opencode_install.go` to remove commas before closing `}` or `]` outside of string literals.
- Apply it before `json.Unmarshal` so otherwise-plain JSONC-style configs parse correctly.
- Add unit tests for the helper and for the install entry point.