### PR TITLE
feat: add command hooks for finish lifecycle side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,12 +313,29 @@ All keys are optional — omit any you don't need.
 | `live_cookie_file`     | string   | `""`                       | Path to a file with upstream cookies for live mode (raw header lines or Netscape jar). Global or project; relative paths resolve from repo root. |
 | `live_cdp_url`         | string   | `""`                       | Chrome DevTools URL (e.g. `http://127.0.0.1:9222`) to reuse browser cookies for the live upstream. Global or project. |
 | `prompts`              | object   | `{}`                       | Custom finish-hook templates (project overrides global per key). See [Agent prompts](docs/agent-prompts.md). |
+| `hooks`                | object   | `{}`                       | Custom finish-hook **commands** executed at Finish/Approve (project overrides global per key). Deterministic side effects — `crit` pipes a JSON payload to stdin and sets `CRIT_*` env vars. See [Command hooks](docs/agent-hooks.md). |
 
 ### Agent prompts
 
 Customize what Crit tells your agent when you **Finish Review** or **Approve**. Hooks are templates in global or project config (`prompts` map) and `.crit/prompts/*.md` files.
 
 See the **[agent prompts guide](docs/agent-prompts.md)** for hook reference, template variables, trust flow, and examples.
+
+### Command hooks
+
+Run your own scripts when you **Finish Review** or **Approve** — deterministic side effects, no LLM in the loop. Crit pipes a JSON payload to the hook's stdin and sets `CRIT_*` env vars (review path, session key, mode, unresolved count, files-with-comments, …). Keys and resolution mirror the prompt system (`on_finish_unresolved` / `on_finish_approved`, optionally `:files` / `:diff` / `:live` / `:preview`), and project hooks go through the same trust gate as project prompts.
+
+```bash
+# ~/.crit.config.json
+{
+  "hooks": {
+    "on_finish_unresolved": "inline:rsync -a \"$CRIT_REVIEW_PATH\" ~/reviews/$CRIT_SESSION_KEY.json",
+    "on_finish_approved":   "file:~/.crit/hooks/approved.sh"
+  }
+}
+```
+
+See the **[command hooks guide](docs/agent-hooks.md)** for the full env-var/stdin reference, trust flow, and examples (including the “snapshot commented-on files” recipe). Reference example hook scripts live under [`docs/example-hooks/`](https://github.com/tomasz-tomczyk/crit/tree/main/docs/example-hooks) in the repo — they're documentation, not installed by `crit install` and not tracked among the integrations (hooks are opt-in and not used by default).
 
 ### Global-only config keys
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -1,0 +1,220 @@
+# Command hooks
+
+Crit can run **your** shell scripts when a review finishes or is approved — deterministic, auditable side effects, no LLM in the loop. This is the executable counterpart to [agent prompts](agent-prompts.md): prompts feed the agent *text*; command hooks *do* things.
+
+## At a glance
+
+- **What:** user-defined shell commands/scripts executed at the same finish lifecycle points as prompt templates (`on_finish_unresolved` / `on_finish_approved`, optionally mode-suffixed `:files` / `:diff` / `:live` / `:preview`).
+- **Why:** deterministic side effects the agent prompt can't reliably do itself — snapshot commented-on files to a dataset, write an audit log, notify Slack, etc.
+- **How:** `inline:<cmd>` (run via `sh -c`) or `file:<path>` (exec'd directly, shebang respected). Crit pipes a JSON payload to the hook's stdin and sets `CRIT_*` env vars (review path, session key, mode, counts, files-with-comments, …).
+- **Opt-in:** Crit runs zero command hooks by default. You configure them in the `hooks` map of `~/.crit.config.json` / `.crit.config.json` or drop scripts at `.crit/hooks/*.sh`.
+- **Trust:** project-level hooks run arbitrary code and go through the same trust gate as project prompts — Finish is blocked until you trust the project's hook config/files. Global hooks (user-installed) run without the gate.
+- **Timeout:** each hook is capped at 60 seconds (killed and warned on timeout). Network-bound or long-running work should fork-and-detach from the hook.
+- **Failure never blocks finish:** a hook that errors, times out, or exits non-zero is logged as a warning; the review flow proceeds regardless.
+
+Command hooks are **opt-in and not used by default** — Crit runs zero command hooks out of the box. Config lives under the `hooks` map (`~/.crit.config.json` and/or `.crit.config.json`) and/or conventional files under `.crit/hooks/` (project) and `~/.crit/hooks/` (global). They reuse the same hook names, mode suffixes, resolution order, and project trust flow as prompt templates.
+
+## When hooks fire
+
+| Hook | Fires when |
+| --- | --- |
+| `on_finish_unresolved` | Finish review with open comments (fallback for all modes) |
+| `on_finish_unresolved:files` | Unresolved finish — single-file or plan review |
+| `on_finish_unresolved:diff` | Unresolved finish — branch / PR / range review |
+| `on_finish_unresolved:live` | Unresolved finish — live URL review |
+| `on_finish_unresolved:preview` | Unresolved finish — static HTML preview |
+| `on_finish_approved` | Approve with zero unresolved comments (fallback) |
+| `on_finish_approved:files` / `:diff` / `:live` / `:preview` | Mode-specific approve hooks |
+
+Resolution order for e.g. `on_finish_unresolved` in a PR review:
+
+1. `on_finish_unresolved:diff` (if set)
+2. `on_finish_unresolved` (fallback)
+
+Internally, git/Sapling/JJ branch/PR/range reviews use mode `diff`; plan and file-based reviews use `files`. This is identical to the prompt system.
+
+Only **one** hook fires per finish: the most specific key that resolves wins (mode-specific over generic). There is no stock hook — if nothing is configured, nothing executes.
+
+## Configuration
+
+**Global:** `~/.crit.config.json` `hooks` map and/or `~/.crit/hooks/`
+**Project:** `.crit.config.json` `hooks` map and/or `.crit/hooks/` in the repo root (committable, team-shared)
+
+### How paths are resolved
+
+Precedence for each hook (e.g. `on_finish_unresolved` in a PR review) is identical to prompts:
+
+1. **Project** `.crit.config.json` `hooks` entry (mode-specific key, then generic)
+2. **Global** `~/.crit.config.json` `hooks` entry (same fallback order)
+3. **Project** conventional file under `.crit/hooks/` (e.g. `on_finish_unresolved.diff.sh`, then `on_finish_unresolved.sh`)
+4. **Global** conventional file under `~/.crit/hooks/` (same naming)
+5. Nothing — no stock command hook is run.
+
+Config `file:` paths and conventional filenames both use `.` instead of `:` for mode suffixes (`on_finish_unresolved:diff` → `on_finish_unresolved.diff.sh`).
+
+You do **not** need a `hooks` map entry when the script already lives at the conventional path. Copy the example scripts from `docs/example-hooks/` into place:
+
+- **Global:** `cp docs/example-hooks/*.sh ~/.crit/hooks/` (create the dir first)
+- **Project:** `cp docs/example-hooks/*.sh .crit/hooks/` (from your repo root)
+
+The example scripts are **reference material** — copying them does not enable behavior until you edit them (or add a `hooks` config map entry) to opt in.
+
+**Discovered** hook files under `.crit/hooks/` must be named `on_finish_*.sh` (mode suffix uses `.` not `:`). For other extensions or paths, use an explicit `file:` entry in the `hooks` config map — Crit execs the script directly and respects its shebang.
+
+Explicit `hooks` config still wins over conventional files and is useful for non-standard paths or `inline:` overrides.
+
+| Config key | Typical project path |
+| --- | --- |
+| `on_finish_unresolved` | `.crit/hooks/on_finish_unresolved.sh` |
+| `on_finish_unresolved:diff` | `.crit/hooks/on_finish_unresolved.diff.sh` |
+| `on_finish_approved` | `.crit/hooks/on_finish_approved.sh` |
+| `on_finish_approved:files` | `.crit/hooks/on_finish_approved.files.sh` |
+
+Config keys use `:` for mode suffixes; filenames use `.` instead.
+
+`agent_cmd`, `auth_token`, and `share_url` stay global-only; `hooks` is allowed in project config (but project hooks are gated by trust — see below).
+
+### Value forms
+
+| Form | Example | Use |
+| --- | --- | --- |
+| `inline:…` | `"inline:rsync \"$CRIT_REVIEW_PATH\" ~/reviews/"` | One-liner commands run via `sh -c` |
+| `file:…` | `"file:.crit/hooks/on_finish_approved.sh"` | A script exec'd directly (shebang + exec bit respected) |
+
+`inline:` values run as a single `sh -c` command on Unix (`cmd /c` on Windows). `file:` values exec the resolved path directly so its `#!/interpreter` line applies; the file must be executable (`chmod +x`) on Unix.
+
+### Example project config
+
+```json
+{
+  "hooks": {
+    "on_finish_approved": "file:.crit/hooks/on_finish_approved.sh",
+    "on_finish_unresolved": "file:.crit/hooks/on_finish_unresolved.sh",
+    "on_finish_unresolved:diff": "inline:echo \"unresolved diff finish\" >> ~/.crit/reviews/finishes.log"
+  }
+}
+```
+
+## What the hook receives
+
+Hooks run **synchronously** during `POST /api/finish`, **after** the review file has been persisted to disk (so `$CRIT_REVIEW_PATH` is readable). The working directory is the repo root. A hook that times out or exits non-zero is logged as a warning and **never blocks finish** — the agent still gets its prompt.
+
+### Environment variables (snake_case, `CRIT_`-prefixed)
+
+All `CRIT_*` env vars are strings (shell env vars can only carry strings). Numeric and boolean values are conveyed as decimal/`"true"`/`"false"` string literals; the stdin JSON carries them as native types.
+
+| Variable | Description |
+| --- | --- |
+| `CRIT_REVIEW_PATH` | Path to the review JSON file (`~/.crit/reviews/<key>.json`) |
+| `CRIT_SESSION_KEY` | Daemon session key |
+| `CRIT_MODE` | `files`, `diff`, `live`, or `preview` |
+| `CRIT_APPROVED` | `true` or `false` |
+| `CRIT_UNRESOLVED_COUNT` | Open comments at finish time |
+| `CRIT_TOTAL_COUNT` | Total comments in the session |
+| `CRIT_FILES_WITH_COMMENTS` | Newline-joined repo-relative paths with unresolved comments |
+| `CRIT_FILES_WITH_COMMENTS_COUNT` | Count of the above |
+| `CRIT_PLAN_SLUG` | Plan slug when reviewing a plan file |
+| `CRIT_INTERNAL_SESSION_MODE` | `files`, `git`, or `plan` |
+| `CRIT_COMMENTS_CMD` | `crit comments --json '<review>'` — retrieve unresolved comments |
+| `CRIT_COMMENTS_ALL_CMD` | `crit comments --json --all '<review>'` — all comments |
+| `CRIT_NEXT_ROUND_CMD` | Command to start the next round |
+| `CRIT_COMMENTS_UNRESOLVED_JSON` | Unresolved comment threads as a JSON array |
+| `CRIT_COMMENTS_JSON` | All comments in the session as a JSON array |
+| `CRIT_SESSION_DURATION_SECONDS` | Session duration (when stats available) |
+| `CRIT_SESSION_FILES_REVIEWED` | Files reviewed |
+| `CRIT_SESSION_COMMENTS_SUBMITTED` | Comments you submitted |
+
+### stdin
+
+A pretty-printed JSON object with the same fields as the env vars (snake_case), plus an explicit `files_with_comments` array and a `session_stats` object. Empty comment arrays render as `[]` (never `null`), so `jq`/awk always see an array.
+
+```sh
+payload="$(cat)"
+echo "$payload" | jq -r '.files_with_comments[]'
+```
+
+### stdout / stderr
+
+Hook **stdout and stderr are captured, not forwarded to the agent.** The agent-facing prompt (Crit's blocking `stdout`) is untouched — prompts and command hooks are independent. Crit logs a one-line summary on success (`exit=N stdout=NB stderr=NB`) and prints captured stderr on failure so you can debug. Hook stdout is recorded in the daemon log but not echoed to the terminal by default.
+
+### Timeout
+
+Each hook is capped at **60 seconds**. A hung hook is killed and reported as a warning; finish proceeds. (Network-bound or long-running work should fork-and-detach from the hook.)
+
+## Project hook trust
+
+Project-level **command hooks run arbitrary code**, so they are gated by the *same* trust flow as project prompts. A checked-in `.crit.config.json` `hooks` entry or `.crit/hooks/*.sh` triggers the trust dialog before Finish/Approve:
+
+1. Everything else works normally — browse, comment, reply, Send now.
+2. **Finish / Approve is blocked** until you choose:
+   - **Trust until prompts change** (recommended) — re-prompt if `.crit.config.json`, any `file:` hook path in the config map, or any discovered `.crit/hooks/*.sh` changes. Crit hashes the **full file contents** of every referenced/discovered hook script (same as prompt templates), so editing a `.sh` body invalidates trust even when the filename stays the same.
+   - **Always trust this project** — use project prompts + hooks on future changes without re-prompting
+   - **Use Crit defaults** — ignore project prompts *and* project hooks for this repo
+3. The trust dialog lists every source file (including `.crit/hooks/*.sh`).
+
+The trust decision is stored in global config under `trusted_project_prompts` (keyed by repo root hash) — the same store already used for prompt trust, extended to cover hooks. **Global** hooks (`~/.crit.config.json` / `~/.crit/hooks/`) are user-installed and run without the trust dialog.
+
+## Examples
+
+### Snapshot commented-on files
+
+Build a dataset of "things the agent got wrong" by copying each commented-on file alongside the review JSON:
+
+```sh
+#!/usr/bin/env sh
+# .crit/hooks/on_finish_unresolved.sh
+set -eu
+: "${CRIT_REVIEW_PATH:?}" "${CRIT_SESSION_KEY:?}"
+
+[ "${CRIT_UNRESOLVED_COUNT:-0}" -eq 0 ] && exit 0
+
+dest="$HOME/.crit/reviews/references/$CRIT_SESSION_KEY"
+mkdir -p "$dest"
+cp "$CRIT_REVIEW_PATH" "$dest/review.json"
+
+printf '%s\n' "$CRIT_FILES_WITH_COMMENTS" | while IFS= read -r f; do
+  [ -n "$f" ] && [ -f "$f" ] || continue
+  mkdir -p "$dest/files/$(dirname "$f")"
+  cp "$f" "$dest/files/$f"
+done
+
+echo "crit: snapshotted $CRIT_UNRESOLVED_COUNT comment(s) to $dest" >&2
+```
+
+This mirrors the example shipped at `docs/example-hooks/on_finish_unresolved.sh` — copy it into `.crit/hooks/` or `~/.crit/hooks/` and edit to taste.
+
+($PWD is the repo root, so `$CRIT_FILES_WITH_COMMENTS` entries are repo-relative and copy directly. When there are no per-file comments — e.g. file-level / review-level comments only — the script falls back to deriving paths from the stdin JSON via `jq` if available.)
+
+### Audit log on approve
+
+```sh
+#!/usr/bin/env sh
+# ~/.crit/hooks/on_finish_approved.sh
+: "${CRIT_REVIEW_PATH:?}"
+log="$HOME/.crit/reviews/approved.log"
+mkdir -p "$(dirname "$log")"
+printf '%s\t%s\t%s\t%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  "${CRIT_SESSION_KEY:-?}" "$CRIT_MODE" "$CRIT_REVIEW_PATH" >>"$log"
+```
+
+### Drive an external tool deterministically
+
+```json
+{
+  "hooks": {
+    "on_finish_unresolved:diff": "inline:~/.crit/hooks/post-to-slack \"crit review finished\" \"unresolved=$CRIT_UNRESOLVED_COUNT mode=$CRIT_MODE\""
+  }
+}
+```
+
+## Limitations & security
+
+- **Project hooks execute arbitrary code.** Treat a checked-in `.crit/hooks/*.sh` or project `hooks` config the way you'd treat a post-install npm script — the trust flow is your gate, but once trusted, the script runs on every Finish/Approve.
+- A 60s timeout caps each hook; long work must detach.
+- Hook output never reaches the agent prompt. If you want to *instruct* the agent (e.g. change what it does next), use [agent prompts](agent-prompts.md), not command hooks.
+
+## See also
+
+- [Agent prompts](agent-prompts.md) — the template-based counterpart that feeds the agent text
+- [Configuration](../README.md#configuration) — `crit config --generate`, global vs project keys

--- a/docs/example-hooks/on_finish_approved.sh
+++ b/docs/example-hooks/on_finish_approved.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Example on_finish_approved hook — append an audit line per approved review.
+#
+# Crit exposes the review context as env vars (CRIT_*) and a JSON payload on
+# stdin. See docs/agent-hooks.md for the full reference. Runs with $PWD = repo
+# root. Edit freely — this file is an example, not a default behavior.
+
+: "${CRIT_REVIEW_PATH:?missing CRIT_REVIEW_PATH}"
+: "${CRIT_SESSION_KEY:=unknown}"
+: "${CRIT_MODE:=}"
+
+log="$HOME/.crit/reviews/approved.log"
+mkdir -p "$(dirname "$log")"
+
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date 2>/dev/null || echo "?")
+printf '%s\t%s\t%s\t%s\n' "$ts" "$CRIT_SESSION_KEY" "$CRIT_MODE" "$CRIT_REVIEW_PATH" >>"$log"
+
+echo "crit: logged approval to $log" >&2

--- a/docs/example-hooks/on_finish_unresolved.sh
+++ b/docs/example-hooks/on_finish_unresolved.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Example on_finish_unresolved hook — snapshot commented-on files.
+#
+# Build up a persistent dataset of code patterns the agent handled poorly by
+# copying the files you commented on alongside the review JSON.
+#
+# Crit exposes the review context as env vars (CRIT_*) and a JSON payload on
+# stdin. See docs/agent-hooks.md for the full reference.
+#
+# Runs with $PWD = the repo root, so $CRIT_FILES_WITH_COMMENTS (repo-relative,
+# newline-separated) can be copied directly. Existing snapshots are not
+# overwritten — each session gets its own directory keyed by $CRIT_SESSION_KEY.
+
+set -eu
+
+: "${CRIT_REVIEW_PATH:?missing CRIT_REVIEW_PATH}"
+: "${CRIT_SESSION_KEY:?missing CRIT_SESSION_KEY}"
+: "${CRIT_UNRESOLVED_COUNT:=0}"
+
+if [ "$CRIT_UNRESOLVED_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+dest="$HOME/.crit/reviews/references/$CRIT_SESSION_KEY"
+mkdir -p "$dest"
+
+# Persist the review JSON itself (comments + quotes + anchors).
+cp "$CRIT_REVIEW_PATH" "$dest/review.json"
+
+# Snapshot each commented-on file. File-level / review-level comments don't
+# list a file, so fall back to every file in $CRIT_FILES_WITH_COMMENTS — when
+# empty, jq (if available) can derive paths from the stdin JSON payload.
+if [ -n "${CRIT_FILES_WITH_COMMENTS:-}" ]; then
+  printf '%s\n' "$CRIT_FILES_WITH_COMMENTS" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    [ -f "$f" ] || continue
+    mkdir -p "$dest/files/$(dirname "$f")"
+    cp "$f" "$dest/files/$f"
+  done
+else
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.files_with_comments[]?' | while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      [ -f "$f" ] || continue
+      mkdir -p "$dest/files/$(dirname "$f")"
+      cp "$f" "$dest/files/$f"
+    done
+  fi
+fi
+
+echo "crit: snapshotted $CRIT_UNRESOLVED_COUNT unresolved comment(s) to $dest" >&2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,13 @@ type Config struct {
 	LiveCookieFile     string            `json:"live_cookie_file,omitempty"`
 	LiveCDPURL         string            `json:"live_cdp_url,omitempty"`
 	Prompts            map[string]string `json:"prompts,omitempty"`
+	// Hooks are shell commands/scripts executed at the same finish lifecycle
+	// points as prompt templates (on_finish_unresolved / on_finish_approved,
+	// optionally mode-suffixed :files/:diff/:live/:preview). Values use the
+	// inline:/file: forms like prompts, but resolve to an executable instead of
+	// template text. Project-level hooks are gated by the same trust flow as
+	// project prompts (they run arbitrary code).
+	Hooks map[string]string `json:"hooks,omitempty"`
 }
 
 // needsShareConsent reports whether the user must confirm before sharing.
@@ -109,6 +116,7 @@ func defaultConfig() generatedConfig {
 		CleanupOnApprove:   true,
 		VCS:                "",
 		Prompts:            map[string]string{},
+		Hooks:              map[string]string{},
 	}
 }
 
@@ -136,6 +144,7 @@ type generatedConfig struct {
 	CleanupOnApprove   bool              `json:"cleanup_on_approve"`
 	VCS                string            `json:"vcs"`
 	Prompts            map[string]string `json:"prompts"`
+	Hooks              map[string]string `json:"hooks"`
 }
 
 func (c generatedConfig) String() string {
@@ -269,6 +278,7 @@ func mergeConfigs(global, project Config, projectPresence ConfigPresence) Config
 	// Union auto-viewed patterns (global + project both apply)
 	merged.AutoViewedPatterns = append(merged.AutoViewedPatterns, project.AutoViewedPatterns...)
 	mergeProjectPrompts(&merged, project)
+	mergeProjectHooks(&merged, project)
 	return merged
 }
 
@@ -281,6 +291,20 @@ func mergeProjectPrompts(merged *Config, project Config) {
 	}
 	for k, v := range project.Prompts {
 		merged.Prompts[k] = v
+	}
+}
+
+// mergeProjectHooks unions project hook config onto merged (project overrides
+// per key), mirroring mergeProjectPrompts.
+func mergeProjectHooks(merged *Config, project Config) {
+	if len(project.Hooks) == 0 {
+		return
+	}
+	if merged.Hooks == nil {
+		merged.Hooks = make(map[string]string, len(project.Hooks))
+	}
+	for k, v := range project.Hooks {
+		merged.Hooks[k] = v
 	}
 }
 
@@ -367,6 +391,29 @@ func LoadPromptMaps(projectDir string) (global, project map[string]string) {
 			fmt.Fprintf(os.Stderr, "Warning: reading project config: %v\n", err)
 		} else {
 			project = projectCfg.Prompts
+		}
+	}
+	return global, project
+}
+
+// LoadHookMaps reads hooks from global and project config without merging,
+// mirroring LoadPromptMaps for command hooks.
+func LoadHookMaps(projectDir string) (global, project map[string]string) {
+	globalCfg, _, err := LoadConfigFile(GlobalConfigPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: reading global config: %v\n", err)
+	}
+	global = globalCfg.Hooks
+
+	projectConfigPath := filepath.Join(projectDir, ".crit.config.json")
+	globalAbs, _ := filepath.Abs(GlobalConfigPath())
+	projectAbs, _ := filepath.Abs(projectConfigPath)
+	if globalAbs != projectAbs {
+		projectCfg, _, err := LoadConfigFile(projectConfigPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: reading project config: %v\n", err)
+		} else {
+			project = projectCfg.Hooks
 		}
 	}
 	return global, project

--- a/internal/hooks/env.go
+++ b/internal/hooks/env.go
@@ -1,0 +1,94 @@
+package hooks
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/tomasz-tomczyk/crit/internal/prompt"
+)
+
+// EnvPrefix is the namespace for hook environment variables. Crit sets
+// CRIT_REVIEW_PATH, CRIT_SESSION_KEY, CRIT_MODE, CRIT_APPROVED, etc.
+const EnvPrefix = "CRIT_"
+
+// EnvMap converts a finish prompt.Context to CRIT_-prefixed environment
+// variables available to a hook. Numbers become their decimal strings; lists
+// become newline-joined strings (and also a _count var); JSON payload vars
+// (comments_unresolved_json, comments_json) are exposed verbatim.
+func EnvMap(c prompt.Context) map[string]string {
+	m := map[string]string{
+		EnvPrefix + "REVIEW_PATH":               c.ReviewPath,
+		EnvPrefix + "COMMENTS_CMD":              c.CommentsCmd,
+		EnvPrefix + "COMMENTS_ALL_CMD":          c.CommentsAllCmd,
+		EnvPrefix + "NEXT_ROUND_CMD":            c.NextRoundCmd,
+		EnvPrefix + "SESSION_KEY":               c.SessionKey,
+		EnvPrefix + "MODE":                      c.Mode,
+		EnvPrefix + "UNRESOLVED_COUNT":          strconv.Itoa(c.UnresolvedCount),
+		EnvPrefix + "TOTAL_COUNT":               strconv.Itoa(c.TotalCount),
+		EnvPrefix + "APPROVED":                  boolStr(c.Approved),
+		EnvPrefix + "PLAN_SLUG":                 c.PlanSlug,
+		EnvPrefix + "INTERNAL_SESSION_MODE":     c.InternalSessionMode,
+		EnvPrefix + "FILES_WITH_COMMENTS":       joinNewline(c.FilesWithComments),
+		EnvPrefix + "FILES_WITH_COMMENTS_COUNT": strconv.Itoa(len(c.FilesWithComments)),
+		EnvPrefix + "COMMENTS_UNRESOLVED_JSON":  c.CommentsUnresolvedJSON,
+		EnvPrefix + "COMMENTS_JSON":             c.CommentsJSON,
+	}
+	if c.SessionStats != nil {
+		m[EnvPrefix+"SESSION_DURATION_SECONDS"] = strconv.Itoa(c.SessionStats.DurationSeconds)
+		m[EnvPrefix+"SESSION_FILES_REVIEWED"] = strconv.Itoa(c.SessionStats.FilesReviewed)
+		m[EnvPrefix+"SESSION_COMMENTS_SUBMITTED"] = strconv.Itoa(c.SessionStats.CommentsSubmitted)
+	}
+	return m
+}
+
+// JSONPayload serializes the finish context as JSON for the hook's stdin.
+// It mirrors the prompt template variables (snake_case) plus an explicit
+// files_with_comments array and session_stats object.
+func JSONPayload(c prompt.Context) []byte {
+	payload := map[string]any{
+		"review_path":              c.ReviewPath,
+		"comments_cmd":             c.CommentsCmd,
+		"comments_all_cmd":         c.CommentsAllCmd,
+		"next_round_cmd":           c.NextRoundCmd,
+		"session_key":              c.SessionKey,
+		"mode":                     c.Mode,
+		"unresolved_count":         c.UnresolvedCount,
+		"total_count":              c.TotalCount,
+		"approved":                 c.Approved,
+		"plan_slug":                c.PlanSlug,
+		"internal_session_mode":    c.InternalSessionMode,
+		"files_with_comments":      c.FilesWithComments,
+		"comments_unresolved_json": json.RawMessage(nilOrJSON(c.CommentsUnresolvedJSON)),
+		"comments_json":            json.RawMessage(nilOrJSON(c.CommentsJSON)),
+	}
+	if c.SessionStats != nil {
+		payload["session_stats"] = map[string]any{
+			"duration_seconds":   c.SessionStats.DurationSeconds,
+			"files_reviewed":     c.SessionStats.FilesReviewed,
+			"comments_submitted": c.SessionStats.CommentsSubmitted,
+		}
+	}
+	b, _ := json.MarshalIndent(payload, "", "  ")
+	return b
+}
+
+// nilOrJSON returns a non-null JSON fragment; empty input becomes `[]` so hooks
+// parsing with jq/awk always see an array.
+func nilOrJSON(s string) json.RawMessage {
+	if s == "" {
+		return json.RawMessage("[]")
+	}
+	return json.RawMessage(s)
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func joinNewline(s []string) string {
+	return strings.Join(s, "\n")
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,265 @@
+package hooks_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/hooks"
+	"github.com/tomasz-tomczyk/crit/internal/prompt"
+)
+
+func TestFilenames(t *testing.T) {
+	got := hooks.Filenames(prompt.HookFinishUnresolved, "diff")
+	want := []string{"on_finish_unresolved.diff.sh", "on_finish_unresolved.sh"}
+	if len(got) != len(want) {
+		t.Fatalf("filenames = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("filenames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoadCommand_Inline(t *testing.T) {
+	ec, err := hooks.LoadCommand("inline:echo hi", "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec.Kind != "inline" || ec.Arg != "echo hi" {
+		t.Fatalf("ec = %+v", ec)
+	}
+}
+
+func TestLoadCommand_FileRelative(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "myhook.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ec, err := hooks.LoadCommand("file:myhook.sh", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec.Kind != "file" || ec.Arg != script {
+		t.Fatalf("ec = %+v want %q", ec, script)
+	}
+}
+
+func TestLoadCommand_BadPrefix(t *testing.T) {
+	if _, err := hooks.LoadCommand("echo hi", "/tmp"); err == nil {
+		t.Fatal("expected error for missing prefix")
+	}
+}
+
+func TestLoadCommand_FileMissing(t *testing.T) {
+	if _, err := hooks.LoadCommand("file:nope.sh", t.TempDir()); err == nil {
+		t.Fatal("expected error for missing script")
+	}
+}
+
+func TestResolveFinishCommand_GlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	global := map[string]string{"on_finish_approved": "inline:echo approved"}
+	ec, err := hooks.ResolveFinishCommand(global, nil, "/unused", home, prompt.HookFinishApproved, "diff", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Kind != "inline" || ec.Arg != "echo approved" {
+		t.Fatalf("ec = %+v", ec)
+	}
+	if ec.Hook != "on_finish_approved" {
+		t.Fatalf("hook = %q", ec.Hook)
+	}
+	if ec.Source != "global:inline" {
+		t.Fatalf("source = %q", ec.Source)
+	}
+}
+
+func TestResolveFinishCommand_ProjectOverridesGlobal(t *testing.T) {
+	global := map[string]string{"on_finish_approved": "inline:global"}
+	project := map[string]string{"on_finish_approved": "inline:project"}
+	ec, err := hooks.ResolveFinishCommand(global, project, "/unused", t.TempDir(), prompt.HookFinishApproved, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Arg != "project" || ec.Layer != hooks.LayerProject {
+		t.Fatalf("ec = %+v", ec)
+	}
+}
+
+func TestResolveFinishCommand_ModeSpecificKey(t *testing.T) {
+	global := map[string]string{
+		"on_finish_unresolved":      "inline:generic",
+		"on_finish_unresolved:diff": "inline:diff",
+	}
+	ec, err := hooks.ResolveFinishCommand(global, nil, "", "", prompt.HookFinishUnresolved, "diff", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Arg != "diff" || ec.Hook != "on_finish_unresolved:diff" {
+		t.Fatalf("ec = %+v", ec)
+	}
+}
+
+func TestResolveFinishCommand_DiscoveredFileProject(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(hooksDir, "on_finish_approved.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ec, err := hooks.ResolveFinishCommand(nil, nil, dir, t.TempDir(), prompt.HookFinishApproved, "files", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Kind != "file" || ec.Arg != script {
+		t.Fatalf("ec = %+v", ec)
+	}
+	if ec.Source != "project:.crit/hooks/on_finish_approved.sh" {
+		t.Fatalf("source = %q", ec.Source)
+	}
+}
+
+func TestResolveFinishCommand_ProjectBlockedWhenUntrusted(t *testing.T) {
+	project := map[string]string{"on_finish_approved": "inline:project"}
+	ec, err := hooks.ResolveFinishCommand(nil, project, "/unused", t.TempDir(), prompt.HookFinishApproved, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec != nil {
+		t.Fatalf("expected nil when project hook present but useProject=false, got %+v", ec)
+	}
+}
+
+func TestResolveFinishCommand_None(t *testing.T) {
+	ec, err := hooks.ResolveFinishCommand(nil, nil, t.TempDir(), t.TempDir(), prompt.HookFinishApproved, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec != nil {
+		t.Fatalf("expected nil, got %+v", ec)
+	}
+}
+
+func TestRun_InlineWritesStdoutStdinEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("inline sh -c hook tested on unix")
+	}
+	ec := hooks.ExecutableCommand{Kind: "inline", Arg: "printf %s \"$CRIT_SESSION_KEY\" > \"$HOOK_OUT\"; cat; echo -$CRIT_MODE"}
+	out := t.TempDir()
+	marker := filepath.Join(out, "marker.txt")
+	in := hooks.Input{
+		Stdin: []byte("STDINPAYLOAD"),
+		Env: map[string]string{
+			"CRIT_SESSION_KEY": "sk123",
+			"CRIT_MODE":        "diff",
+			"HOOK_OUT":         marker,
+		},
+		Timeout: 5 * time.Second,
+	}
+	res, err := hooks.Run(context.Background(), ec, in)
+	if err != nil {
+		t.Fatalf("run: %v stderr=%s", err, string(res.Stderr))
+	}
+	got, _ := os.ReadFile(marker)
+	if string(got) != "sk123" {
+		t.Fatalf("marker = %q want sk123 (env propagation)", string(got))
+	}
+	if !strings.Contains(string(res.Stdout), "STDINPAYLOAD-diff") {
+		t.Fatalf("stdout = %q want stdin echoed + mode appended", string(res.Stdout))
+	}
+}
+
+func TestRun_FileHookShebang(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file shebang hook tested on unix")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "hook.sh")
+	marker := filepath.Join(dir, "out.txt")
+	body := "#!/bin/sh\nprintf %s \"$CRIT_APPROVED\" > \"" + marker + "\"\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ec, err := hooks.LoadCommand("file:hook.sh", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = hooks.Run(context.Background(), ec, hooks.Input{
+		Env: map[string]string{"CRIT_APPROVED": "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(marker)
+	if string(got) != "true" {
+		t.Fatalf("marker = %q", string(got))
+	}
+}
+
+func TestRun_NonZeroExitReturnsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-zero exit hook tested on unix")
+	}
+	ec := hooks.ExecutableCommand{Kind: "inline", Arg: "exit 3"}
+	out, err := hooks.Run(context.Background(), ec, hooks.Input{Timeout: 5 * time.Second})
+	if err == nil {
+		t.Fatal("expected error for exit 3")
+	}
+	if out == nil || out.ExitCode != 3 {
+		t.Fatalf("exitcode = %d", out.ExitCode)
+	}
+}
+
+func TestRun_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("timeout hook tested on unix")
+	}
+	ec := hooks.ExecutableCommand{Kind: "inline", Arg: "sleep 5"}
+	out, err := hooks.Run(context.Background(), ec, hooks.Input{Timeout: 100 * time.Millisecond})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if out != nil && !out.TimedOut {
+		t.Fatalf("expected TimedOut=true, err=%v", err)
+	}
+}
+
+func TestEnvMapAndJSONPayload(t *testing.T) {
+	ctx := prompt.Context{
+		ReviewPath:        "/tmp/r.json",
+		SessionKey:        "sk1",
+		Mode:              "diff",
+		UnresolvedCount:   3,
+		TotalCount:        5,
+		Approved:          false,
+		FilesWithComments: []string{"a.go", "b.go"},
+	}
+	env := hooks.EnvMap(ctx)
+	if env["CRIT_REVIEW_PATH"] != "/tmp/r.json" || env["CRIT_UNRESOLVED_COUNT"] != "3" || env["CRIT_APPROVED"] != "false" {
+		t.Fatalf("env = %+v", env)
+	}
+	if env["CRIT_FILES_WITH_COMMENTS"] != "a.go\nb.go" {
+		t.Fatalf("files env = %q", env["CRIT_FILES_WITH_COMMENTS"])
+	}
+	payload := string(hooks.JSONPayload(ctx))
+	if !strings.Contains(payload, `"unresolved_count": 3`) {
+		t.Fatalf("payload missing unresolved_count: %s", payload)
+	}
+	if !strings.Contains(payload, `"files_with_comments"`) || !strings.Contains(payload, `"a.go"`) || !strings.Contains(payload, `"b.go"`) {
+		t.Fatalf("payload missing files_with_comments: %s", payload)
+	}
+	// empty comments arrays render as [] (not null)
+	if !strings.Contains(payload, `"comments_unresolved_json": []`) {
+		t.Fatalf("payload missing empty array: %s", payload)
+	}
+}

--- a/internal/hooks/resolve.go
+++ b/internal/hooks/resolve.go
@@ -1,0 +1,187 @@
+// Package hooks resolves and executes user-defined shell commands at Crit
+// finish lifecycle points — the executable counterpart to internal/prompt's
+// text templates.
+//
+// A hook value uses the same inline:/file: forms as a prompt value but resolves
+// to an executable instead of template text:
+//
+//   - inline:<command>  → run `sh -c "<command>"`
+//   - file:<path>       → execute the script at <path> directly (shebang + exec bit)
+//
+// Hooks are keyed exactly like prompt templates (on_finish_unresolved /
+// on_finish_approved, optionally mode-suffixed :files/:diff/:live/:preview).
+// Project-level hooks run arbitrary code and are gated by the same trust flow
+// as project prompts (see internal/prompt/trust.go).
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tomasz-tomczyk/crit/internal/prompt"
+)
+
+// Subdir is the conventional on-disk directory for discovered hook scripts,
+// parallel to .crit/prompts for prompt templates.
+const Subdir = ".crit/hooks"
+
+// Hook script filenames use a leading dot (not colon) for the mode separator,
+// mirroring prompt filenames: on_finish_unresolved:diff → on_finish_unresolved.diff.sh
+//
+// .sh is the suffix used by DISCOVERED files (.crit/hooks/on_finish_*.sh) and
+// is required for the conventional lookup — the discoverer needs a deterministic
+// filename pattern. file: config values point at any executable and are run
+// directly via its shebang, so .py / .ts / .fish / etc. work via the config
+// form without changing this suffix.
+const (
+	PrefixInline = "inline:"
+	PrefixFile   = "file:"
+	fileSuffix   = ".sh"
+)
+
+// Layer re-exports prompt.Layer so callers don't need to import both packages
+// for the global/project distinction.
+type Layer = prompt.Layer
+
+const (
+	LayerGlobal  = prompt.LayerGlobal
+	LayerProject = prompt.LayerProject
+)
+
+// ExecutableCommand is a resolved hook ready to run.
+type ExecutableCommand struct {
+	// Kind is "inline" (sh -c string) or "file" (direct exec of a script path).
+	Kind string
+	// Arg is the command string (inline) or the resolved absolute script path (file).
+	Arg    string
+	Hook   string // resolved key, e.g. on_finish_unresolved:diff
+	Source string // provenance label, e.g. project:.crit/hooks/on_finish_unresolved.diff.sh
+	Layer  Layer
+}
+
+// Filenames returns conventional on-disk names for hook+mode (mode-specific first).
+func Filenames(hook, mode string) []string {
+	specific, generic := prompt.ResolveHookKey(hook, mode)
+	var out []string
+	if specific != generic {
+		out = append(out, hookKeyToFilename(specific))
+	}
+	out = append(out, hookKeyToFilename(generic))
+	return out
+}
+
+func hookKeyToFilename(key string) string {
+	return strings.ReplaceAll(key, ":", ".") + fileSuffix
+}
+
+// DiscoverFile loads the first matching conventional hook script under
+// baseDir/.crit/hooks/. Returns the resolved command, its source label, and ok.
+func DiscoverFile(baseDir, hook, mode string, layer Layer) (cmd ExecutableCommand, ok bool) {
+	dir := filepath.Join(baseDir, Subdir)
+	for _, name := range Filenames(hook, mode) {
+		path := filepath.Join(dir, name)
+		abs := path
+		if a, err := filepath.Abs(path); err == nil {
+			abs = a
+		}
+		if _, err := os.Stat(abs); err != nil {
+			continue
+		}
+		source := string(layer) + ":" + filepath.ToSlash(filepath.Join(Subdir, name))
+		return ExecutableCommand{
+			Kind:   "file",
+			Arg:    abs,
+			Hook:   modeSpecificKey(hook, mode),
+			Source: source,
+			Layer:  layer,
+		}, true
+	}
+	return ExecutableCommand{}, false
+}
+
+func modeSpecificKey(hook, mode string) string {
+	specific, _ := prompt.ResolveHookKey(hook, mode)
+	return specific
+}
+
+// LoadCommand resolves a config value (inline:/file:) to an ExecutableCommand.
+// baseDir is the directory for relative file: paths (project root or home).
+// The returned Hook/Source/Layer are zero — ResolveFinishCommand fills them.
+func LoadCommand(value, baseDir string) (ExecutableCommand, error) {
+	switch {
+	case strings.HasPrefix(value, PrefixInline):
+		return ExecutableCommand{Kind: "inline", Arg: strings.TrimPrefix(value, PrefixInline)}, nil
+	case strings.HasPrefix(value, PrefixFile):
+		path := strings.TrimPrefix(value, PrefixFile)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(baseDir, path)
+		}
+		abs := path
+		if a, err := filepath.Abs(path); err == nil {
+			abs = a
+		}
+		if _, err := os.Stat(abs); err != nil {
+			return ExecutableCommand{}, fmt.Errorf("hook script %s: %w", abs, err)
+		}
+		return ExecutableCommand{Kind: "file", Arg: abs}, nil
+	default:
+		return ExecutableCommand{}, fmt.Errorf("hook value must start with %q or %q", PrefixInline, PrefixFile)
+	}
+}
+
+// ResolveFinishCommand picks the effective executable command for a finish hook.
+// Resolution order mirrors prompt.ResolveFinishTemplate:
+//
+//  1. Project config map (when useProject)
+//  2. Global config map
+//  3. Project discovered .crit/hooks/*.sh (when useProject)
+//  4. Global discovered ~/.crit/hooks/*.sh
+//
+// There are no stock command hooks — returns nil when nothing is configured.
+func ResolveFinishCommand(globalHooks, projectHooks map[string]string, projectDir, homeDir, hook, mode string, useProject bool) (*ExecutableCommand, error) {
+	if v, key := prompt.LookupPrompt(projectHooks, hook, mode); v != "" && useProject {
+		ec, err := LoadCommand(v, projectDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading project hook %s: %w", key, err)
+		}
+		ec.Hook = key
+		ec.Source = commandSource(string(LayerProject), v)
+		ec.Layer = LayerProject
+		return &ec, nil
+	}
+	if v, key := prompt.LookupPrompt(globalHooks, hook, mode); v != "" {
+		ec, err := LoadCommand(v, homeDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading global hook %s: %w", key, err)
+		}
+		ec.Hook = key
+		ec.Source = commandSource(string(LayerGlobal), v)
+		ec.Layer = LayerGlobal
+		return &ec, nil
+	}
+	if useProject {
+		if ec, ok := DiscoverFile(projectDir, hook, mode, LayerProject); ok {
+			return &ec, nil
+		}
+	}
+	if ec, ok := DiscoverFile(homeDir, hook, mode, LayerGlobal); ok {
+		return &ec, nil
+	}
+	return nil, nil
+}
+
+// commandSource describes where a config-driven hook came from (file: → path; inline → inline).
+func commandSource(layer, value string) string {
+	if strings.HasPrefix(value, PrefixFile) {
+		return layer + ":" + strings.TrimPrefix(value, PrefixFile)
+	}
+	return layer + ":inline"
+}
+
+// Note: this file intentionally does not reference runtime.GOOS.
+// Discovered project hook files and source labels are enumerated by the
+// prompt package's trust gate (internal/prompt/trust.go) so that the trust
+// hash covers both prompts and hooks without an import cycle
+// (internal/hooks imports internal/prompt for resolution helpers).

--- a/internal/hooks/run.go
+++ b/internal/hooks/run.go
@@ -1,0 +1,148 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// DefaultTimeout caps a finish hook so a hung script cannot block the review
+// finish indefinitely. Override per-call via Input.Timeout.
+const DefaultTimeout = 60 * time.Second
+
+// Input configures a hook run.
+type Input struct {
+	// Stdin bytes are piped to the hook's standard input (the JSON payload).
+	Stdin []byte
+	// Env are extra environment variables (merged onto os.Environ()).
+	Env map[string]string
+	// Dir is the working directory (defaults to the process cwd when empty).
+	Dir string
+	// Timeout caps execution. Zero falls back to DefaultTimeout; negative means
+	// no timeout (not recommended — a hung hook would block finish).
+	Timeout time.Duration
+}
+
+// Output is the captured result of running a hook.
+type Output struct {
+	Stdout   []byte
+	Stderr   []byte
+	ExitCode int
+	Duration time.Duration
+	TimedOut bool
+}
+
+// Run executes the resolved hook and captures its output.
+//
+//   - inline hooks run via `sh -c "<Arg>"`
+//   - file hooks exec the resolved path directly (its shebang/interpreter applies)
+//
+// Hook stdout/stderr are captured for auditability — they are NOT forwarded to
+// the blocking crit client's stdout (that channel carries the agent prompt).
+// A non-zero exit or timeout returns an error so the caller can log a warning,
+// but finish is never blocked by a hook failure.
+func Run(ctx context.Context, ec ExecutableCommand, in Input) (*Output, error) {
+	if ec.Kind != "inline" && ec.Kind != "file" {
+		return nil, fmt.Errorf("unknown hook kind %q", ec.Kind)
+	}
+
+	ctx, cancel := buildCtx(ctx, in)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	var cmd *exec.Cmd
+	if ec.Kind == "file" {
+		cmd = exec.CommandContext(ctx, ec.Arg)
+	} else {
+		name, args := inlineShell(ec.Arg)
+		cmd = exec.CommandContext(ctx, name, args...)
+	}
+
+	cmd.Stdin = bytes.NewReader(in.Stdin)
+	if in.Dir != "" {
+		cmd.Dir = in.Dir
+	}
+	cmd.Env = mergeEnv(in.Env)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err := cmd.Run()
+	out := &Output{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		Duration: time.Since(start),
+	}
+	if cmd.ProcessState != nil {
+		out.ExitCode = cmd.ProcessState.ExitCode()
+	}
+
+	switch {
+	case err == nil:
+		return out, nil
+	case isTimeout(ctx, err):
+		out.TimedOut = true
+		return out, fmt.Errorf("hook %s timed out after %s", ec.Hook, timeoutFor(in))
+	default:
+		return out, fmt.Errorf("hook %s exited %d: %w", ec.Hook, out.ExitCode, err)
+	}
+}
+
+// inlineShell returns the interpreter + args for an inline hook.
+// Uses `sh -c` on Unix; on Windows falls back to `cmd /c` for quotes-free commands.
+func inlineShell(command string) (name string, args []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", command}
+	}
+	return "sh", []string{"-c", command}
+}
+
+func buildCtx(ctx context.Context, in Input) (context.Context, context.CancelFunc) {
+	if in.Timeout < 0 {
+		if ctx == nil {
+			return context.Background(), nil
+		}
+		return ctx, nil
+	}
+	d := in.Timeout
+	if d == 0 {
+		d = DefaultTimeout
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithTimeout(ctx, d)
+}
+
+func timeoutFor(in Input) time.Duration {
+	if in.Timeout > 0 {
+		return in.Timeout
+	}
+	return DefaultTimeout
+}
+
+func isTimeout(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+func mergeEnv(extra map[string]string) []string {
+	env := os.Environ()
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/internal/prompt/discover.go
+++ b/internal/prompt/discover.go
@@ -8,6 +8,11 @@ import (
 
 const promptsSubdir = ".crit/prompts"
 
+// hooksSubdir is the conventional on-disk directory for discovered hook
+// scripts, parallel to promptsSubdir. Kept in the prompt package (alongside
+// the trust gate) to avoid an import cycle with internal/hooks.
+const hooksSubdir = ".crit/hooks"
+
 // PromptFilenames returns conventional on-disk names for hook+mode (mode-specific first).
 func PromptFilenames(hook, mode string) []string {
 	specific, generic := ResolveHookKey(hook, mode)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -136,9 +136,9 @@ func TestEvaluateTrust_UntilChange(t *testing.T) {
 	projectPrompts := map[string]string{
 		"on_finish_approved": "inline:Approved custom",
 	}
-	hash := prompt.ContentHash(projectPrompts, projectDir)
+	hash := prompt.ContentHash(projectPrompts, nil, projectDir)
 
-	st, err := prompt.EvaluateTrust(projectDir, projectPrompts)
+	st, err := prompt.EvaluateTrust(projectDir, projectPrompts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestEvaluateTrust_UntilChange(t *testing.T) {
 	if err := prompt.SaveTrustChoice(projectDir, prompt.TrustUntilChange, hash); err != nil {
 		t.Fatal(err)
 	}
-	st, err = prompt.EvaluateTrust(projectDir, projectPrompts)
+	st, err = prompt.EvaluateTrust(projectDir, projectPrompts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestEvaluateTrust_UntilChange(t *testing.T) {
 	}
 
 	projectPrompts["on_finish_approved"] = "inline:changed"
-	st, err = prompt.EvaluateTrust(projectDir, projectPrompts)
+	st, err = prompt.EvaluateTrust(projectDir, projectPrompts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestEvaluateTrust_DefaultsIgnoresProject(t *testing.T) {
 	if err := prompt.SaveTrustChoice(projectDir, prompt.TrustDefaults, ""); err != nil {
 		t.Fatal(err)
 	}
-	st, err := prompt.EvaluateTrust(projectDir, projectPrompts)
+	st, err := prompt.EvaluateTrust(projectDir, projectPrompts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/prompt/trust.go
+++ b/internal/prompt/trust.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,16 +36,45 @@ func RepoRootHash(projectDir string) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
-// ContentHash fingerprints project prompt config and referenced files.
-func ContentHash(projectPrompts map[string]string, projectDir string) string {
+// ContentHash fingerprints project prompt AND hook config plus referenced
+// files, so changing either prompts or hooks invalidates a "trust until
+// change" decision. Hooks are included because project hooks run arbitrary code
+// and must be gated by the same trust flow as project prompts.
+func ContentHash(projectPrompts, projectHooks map[string]string, projectDir string) string {
 	h := sha256.New()
-	keys := make([]string, 0, len(projectPrompts))
-	for k := range projectPrompts {
+	hashConfigMap(h, "prompt:", projectPrompts, projectDir)
+	for _, path := range ListDiscoveredProjectPromptFiles(projectDir) {
+		h.Write([]byte("discovered-prompt:"))
+		h.Write([]byte(filepath.Base(path)))
+		h.Write([]byte{0})
+		if data, err := os.ReadFile(path); err == nil {
+			h.Write(data)
+		}
+	}
+	hashConfigMap(h, "hook:", projectHooks, projectDir)
+	for _, path := range listDiscoveredProjectHookFiles(projectDir) {
+		h.Write([]byte("discovered-hook:"))
+		h.Write([]byte(filepath.Base(path)))
+		h.Write([]byte{0})
+		if data, err := os.ReadFile(path); err == nil {
+			h.Write(data)
+		}
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// hashConfigMap writes a sorted key/value section into the hash, and for file:
+// values it folds the referenced file's contents (resolved relative to
+// projectDir). inline: values contribute only their key+value (no file).
+func hashConfigMap(h hash.Hash, section string, m map[string]string, projectDir string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		v := projectPrompts[k]
+		v := m[k]
+		h.Write([]byte(section))
 		h.Write([]byte(k))
 		h.Write([]byte{0})
 		h.Write([]byte(v))
@@ -59,15 +89,6 @@ func ContentHash(projectPrompts map[string]string, projectDir string) string {
 			}
 		}
 	}
-	for _, path := range ListDiscoveredProjectPromptFiles(projectDir) {
-		h.Write([]byte("discovered:"))
-		h.Write([]byte(filepath.Base(path)))
-		h.Write([]byte{0})
-		if data, err := os.ReadFile(path); err == nil {
-			h.Write(data)
-		}
-	}
-	return "sha256:" + hex.EncodeToString(h.Sum(nil))
 }
 
 // LoadTrustedProjectPrompts reads trusted_project_prompts from global config.
@@ -132,18 +153,29 @@ type TrustState struct {
 	Sources           []string
 }
 
-// EvaluateTrust decides if project prompts are trusted for finish.
-func EvaluateTrust(projectDir string, projectPrompts map[string]string) (TrustState, error) {
+// EvaluateTrust decides if project prompts AND hooks are trusted for finish.
+// The trust gate now covers both: project hooks run arbitrary code, so a
+// checked-in .crit/hooks/*.sh or `hooks` config map triggers Finish blocking
+// exactly like project prompt config does.
+func EvaluateTrust(projectDir string, projectPrompts, projectHooks map[string]string) (TrustState, error) {
 	st := TrustState{
-		ContentHash: ContentHash(projectPrompts, projectDir),
+		ContentHash: ContentHash(projectPrompts, projectHooks, projectDir),
 		Sources:     ListProjectPromptSources(projectPrompts, projectDir),
 	}
-	discovered := ListDiscoveredProjectPromptFiles(projectDir)
-	for _, path := range discovered {
+	st.Sources = append(st.Sources, listProjectHookSources(projectHooks, projectDir)...)
+
+	discoveredPrompts := ListDiscoveredProjectPromptFiles(projectDir)
+	for _, path := range discoveredPrompts {
 		label := "project:" + filepath.ToSlash(filepath.Join(promptsSubdir, filepath.Base(path)))
 		st.Sources = append(st.Sources, label)
 	}
-	if len(projectPrompts) == 0 && len(discovered) == 0 {
+	discoveredHooks := listDiscoveredProjectHookFiles(projectDir)
+	for _, path := range discoveredHooks {
+		label := "project:" + filepath.ToSlash(filepath.Join(hooksSubdir, filepath.Base(path)))
+		st.Sources = append(st.Sources, label)
+	}
+
+	if len(projectPrompts) == 0 && len(projectHooks) == 0 && len(discoveredPrompts) == 0 && len(discoveredHooks) == 0 {
 		st.UseProject = false
 		return st, nil
 	}
@@ -176,4 +208,55 @@ func EvaluateTrust(projectDir string, projectPrompts map[string]string) (TrustSt
 		st.Untrusted = true
 		return st, nil
 	}
+}
+
+// listDiscoveredProjectHookFiles returns on_finish_*.sh paths under
+// project/.crit/hooks/. Mirrors ListDiscoveredProjectPromptFiles for the hook
+// half of the trust gate. Defined here (not in internal/hooks) to avoid an
+// import cycle: internal/hooks already imports internal/prompt for resolution.
+func listDiscoveredProjectHookFiles(projectDir string) []string {
+	dir := filepath.Join(projectDir, hooksSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sh") {
+			continue
+		}
+		if !strings.HasPrefix(e.Name(), "on_finish_") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	return out
+}
+
+// listProjectHookSources returns human-readable source paths for project hook
+// config. Mirrors ListProjectPromptSources for the hook half of the trust gate.
+func listProjectHookSources(projectHooks map[string]string, projectDir string) []string {
+	if len(projectHooks) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	configPath := filepath.Join(projectDir, ".crit.config.json")
+	if _, err := os.Stat(configPath); err == nil {
+		out = append(out, "project:.crit.config.json")
+		seen["project:.crit.config.json"] = struct{}{}
+	}
+	for _, v := range projectHooks {
+		if !strings.HasPrefix(v, prefixFile) {
+			continue
+		}
+		rel := strings.TrimPrefix(v, prefixFile)
+		label := "project:" + filepath.ToSlash(rel)
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	return out
 }

--- a/internal/server/hooks_test.go
+++ b/internal/server/hooks_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
+)
+
+// writeFileGlobal writes ~/.crit.config.json into home with the given JSON body.
+func writeFileGlobal(t *testing.T, home, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, ".crit.config.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func markerCmd(t *testing.T) (cmd, marker string) {
+	t.Helper()
+	marker = filepath.Join(t.TempDir(), "marker.txt")
+	// Quote the path defensively for sh -c.
+	cmd = "printf %s \"$CRIT_SESSION_KEY\" > '" + marker + "'"
+	return
+}
+
+// TestHandleFinish_RunsGlobalApprovedHook verifies that a globally-configured
+// command hook runs synchronously during /api/finish and can read CRIT_* env
+// vars. Global hooks do not require the project trust flow.
+func TestHandleFinish_RunsGlobalApprovedHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, session := newTestServer(t)
+	s.homeDir = home
+	s.projectDir = session.RepoRoot
+
+	cmd, marker := markerCmd(t)
+	writeFileGlobal(t, home, `{"hooks":{"on_finish_approved":"inline:`+strings.ReplaceAll(cmd, `"`, `\"`)+`"}}`)
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("hook did not run (marker missing): %v\nstderr output above", err)
+	}
+	if string(got) != session.SessionKey {
+		t.Fatalf("marker = %q want session key %q", string(got), session.SessionKey)
+	}
+}
+
+// TestHandleFinish_GlobalUnresolvedHookFiresWhenCommentsOpen ensures the
+// on_finish_unresolved hook fires (not on_finish_approved) when comments remain.
+func TestHandleFinish_GlobalUnresolvedHookFiresWhenCommentsOpen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+
+	s, session := newTestServer(t)
+	s.homeDir = home
+	dir := session.RepoRoot
+	s.projectDir = dir
+
+	// Add one unresolved comment so approved=false → on_finish_unresolved fires.
+	addUnresolvedComment(t, s, session, dir)
+
+	cmd, marker := markerCmd(t)
+	writeFileGlobal(t, home, `{"hooks":{"on_finish_unresolved":"inline:`+strings.ReplaceAll(cmd, `"`, `\"`)+`"}}`)
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("unresolved hook did not run: %v", err)
+	}
+
+	// The approved hook should NOT have fired — reject a second marker.
+	cmd2, marker2 := markerCmd(t)
+	writeFileGlobal(t, home, `{"hooks":{"on_finish_unresolved":"inline:true","on_finish_approved":"inline:`+strings.ReplaceAll(cmd2, `"`, `\"`)+`"}}`)
+	req = httptest.NewRequest("POST", "/api/finish", nil)
+	// resolving the comment first would approve; here we just re-finish with the
+	// same unresolved state — on_finish_unresolved fires again, approved never.
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if _, err := os.Stat(marker2); err == nil {
+		t.Fatalf("approved hook should not have fired during unresolved finish")
+	}
+}
+
+// TestHandleFinish_ProjectHookBlockedWithoutTrust verifies a checked-in project
+// hook is gated by the finish trust flow until the user explicitly trusts it.
+func TestHandleFinish_ProjectHookBlockedWithoutTrust(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, session := newTestServer(t)
+	s.homeDir = home
+	dir := session.RepoRoot
+	s.projectDir = dir
+
+	_, marker := markerCmd(t)
+	os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"hooks":{"on_finish_approved":"inline:printf p > '`+marker+`'"}}`), 0o644)
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (project hook untrusted)", w.Code)
+	}
+}
+
+// TestHandleFinish_ProjectHookRunsAfterTrust confirms that once the project is
+// trusted, the project hook executes during finish.
+func TestHandleFinish_ProjectHookRunsAfterTrust(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, session := newTestServer(t)
+	s.homeDir = home
+	dir := session.RepoRoot
+	s.projectDir = dir
+
+	_, marker := markerCmd(t)
+	os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"hooks":{"on_finish_approved":"inline:printf p > '`+marker+`'"}}`), 0o644)
+
+	// Trust the project.
+	trustReq := httptest.NewRequest("POST", "/api/project-prompts/trust", strings.NewReader(`{"mode":"always"}`))
+	trustReq.Header.Set("Content-Type", "application/json")
+	tw := httptest.NewRecorder()
+	s.ServeHTTP(tw, trustReq)
+	if tw.Code != http.StatusOK {
+		t.Fatalf("trust status = %d body=%s", tw.Code, tw.Body.String())
+	}
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("project hook did not run after trust: %v", err)
+	}
+}
+
+// TestHandleFinish_DiscoveredFileHook runs a discovered .crit/hooks/*.sh script.
+func TestHandleFinish_DiscoveredFileHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file shebang hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, session := newTestServer(t)
+	s.homeDir = home
+	dir := session.RepoRoot
+	s.projectDir = dir
+
+	marker := filepath.Join(dir, "discovered-marker.txt")
+	hooksDir := filepath.Join(dir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "#!/bin/sh\nprintf %s \"$CRIT_MODE\" > \"" + marker + "\"\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "on_finish_approved.sh"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Discovered .crit/hooks/*.sh triggers the project trust gate.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	trustReq := httptest.NewRequest("POST", "/api/project-prompts/trust", strings.NewReader(`{"mode":"always"}`))
+	trustReq.Header.Set("Content-Type", "application/json")
+	tw := httptest.NewRecorder()
+	s.ServeHTTP(tw, trustReq)
+	if tw.Code != http.StatusOK {
+		t.Fatalf("trust status = %d body=%s", tw.Code, tw.Body.String())
+	}
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("discovered hook did not run: %v", err)
+	}
+	if string(got) != "files" {
+		t.Fatalf("marker = %q want mode files", string(got))
+	}
+}
+
+// addUnresolvedComment adds a single unresolved comment to the first file so
+// handleFinish reports approved=false.
+func addUnresolvedComment(t *testing.T, s *Server, sess *Session, dir string) {
+	t.Helper()
+	for _, f := range sess.Files {
+		f.Comments = append(f.Comments, Comment{
+			ID:       "c_test1",
+			Author:   "Tester",
+			Body:     "please fix",
+			Resolved: false,
+		})
+		break
+	}
+	if err := sess.SyncWriteFiles(); err != nil {
+		t.Fatalf("SyncWriteFiles: %v", err)
+	}
+}

--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -3,18 +3,22 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/tomasz-tomczyk/crit/internal/config"
+	"github.com/tomasz-tomczyk/crit/internal/hooks"
 	"github.com/tomasz-tomczyk/crit/internal/prompt"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
 func (s *Server) promptTrustState() (prompt.TrustState, error) {
 	_, projectPrompts := config.LoadPromptMaps(s.projectDir)
-	return prompt.EvaluateTrust(s.projectDir, projectPrompts)
+	_, projectHooks := config.LoadHookMaps(s.projectDir)
+	return prompt.EvaluateTrust(s.projectDir, projectPrompts, projectHooks)
 }
 
 func (s *Server) buildPromptContext(sess *Session, approved bool, stats map[string]any) prompt.Context {
@@ -88,7 +92,8 @@ func filesWithUnresolvedComments(sess *Session) []string {
 
 func (s *Server) renderFinishPrompts(sess *Session, approved bool, stats map[string]any) (promptStr string, meta *prompt.Meta) {
 	globalPrompts, projectPrompts := config.LoadPromptMaps(s.projectDir)
-	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts)
+	_, projectHooks := config.LoadHookMaps(s.projectDir)
+	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts, projectHooks)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: evaluating project prompt trust: %v\n", err)
 	}
@@ -122,7 +127,8 @@ func (s *Server) projectPromptTrustPayload() map[string]any {
 
 func (s *Server) renderProjectPromptPreview(sess *Session) string {
 	_, projectPrompts := config.LoadPromptMaps(s.projectDir)
-	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts)
+	_, projectHooks := config.LoadHookMaps(s.projectDir)
+	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts, projectHooks)
 	if err != nil || !trust.HasProjectPrompts {
 		return ""
 	}
@@ -152,4 +158,66 @@ func (s *Server) renderProjectPromptPreview(sess *Session) string {
 		sections = append(sections, "=== "+label+" ===\n"+result.Prompt)
 	}
 	return strings.Join(sections, "\n\n")
+}
+
+// runFinishHooks resolves and executes the configured command hook for the
+// current finish state (on_finish_unresolved / on_finish_approved, mode-suffix
+// resolved like prompt templates). Hooks run synchronously with the finish
+// flow so the review file is already on disk when they read it; a hook timeout
+// or non-zero exit is logged as a warning and never blocks finish.
+func (s *Server) runFinishHooks(sess *Session, approved bool, stats map[string]any) {
+	hook := prompt.HookForFinish(approved)
+	mode := prompt.PromptMode(sess.ReviewType, sess.Mode)
+
+	globalHooks, projectHooks := config.LoadHookMaps(s.projectDir)
+	trust, err := prompt.EvaluateTrust(s.projectDir, nil, projectHooks)
+	if err != nil {
+		log.Printf("finish-hook: evaluating project trust: %v", err)
+		return
+	}
+	ec, err := hooks.ResolveFinishCommand(globalHooks, projectHooks, s.projectDir, s.homeDir, hook, mode, trust.UseProject)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: resolving finish hook %s: %v\n", hook, err)
+		return
+	}
+	if ec == nil {
+		return
+	}
+
+	ctx := s.buildPromptContext(sess, approved, stats)
+	in := hooks.Input{
+		Stdin:   hooks.JSONPayload(ctx),
+		Env:     hooks.EnvMap(ctx),
+		Dir:     sess.RepoRoot,
+		Timeout: s.hookTimeout(),
+	}
+	out, err := hooks.Run(s.effectiveCtx(), *ec, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: finish hook %s failed: %v\n", ec.Hook, err)
+		if out != nil && len(out.Stderr) > 0 {
+			fmt.Fprintf(os.Stderr, "  hook stderr:\n%s\n", trimLog(out.Stderr))
+		}
+		return
+	}
+	log.Printf("finish-hook %s (%s): exit=%d stdout=%dB stderr=%dB",
+		ec.Hook, ec.Source, out.ExitCode, len(out.Stdout), len(out.Stderr))
+	if len(out.Stderr) > 0 {
+		fmt.Fprintf(os.Stderr, "%s\n", trimLog(out.Stderr))
+	}
+}
+
+func (s *Server) hookTimeout() time.Duration {
+	// A hard cap so a hung hook cannot pin the daemon's finish flow. Generous
+	// enough for snapshot/dataset-collection scripts, short enough that the
+	// user isn't left staring at the finish UI.
+	return 60 * time.Second
+}
+
+func trimLog(b []byte) string {
+	s := strings.TrimRight(string(b), "\n")
+	const max = 4 << 10 // 4 KiB
+	if len(s) > max {
+		return s[:max] + "\n...[truncated]"
+	}
+	return s
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -708,7 +708,8 @@ func (s *Server) handleProjectPromptTrust(w http.ResponseWriter, r *http.Request
 		return
 	}
 	_, projectPrompts := config.LoadPromptMaps(s.projectDir)
-	hash := prompt.ContentHash(projectPrompts, s.projectDir)
+	_, projectHooks := config.LoadHookMaps(s.projectDir)
+	hash := prompt.ContentHash(projectPrompts, projectHooks, s.projectDir)
 	if err := prompt.SaveTrustChoice(s.projectDir, req.Mode, hash); err != nil {
 		http.Error(w, "failed to persist trust choice", http.StatusInternalServerError)
 		return
@@ -2013,6 +2014,11 @@ func (s *Server) handleFinish(w http.ResponseWriter, r *http.Request) {
 	if !approved {
 		sess.SetWaitingForAgent(true)
 	}
+
+	// Run the configured command hook (if any) for this finish state. Hooks run
+	// synchronously after the review file is persisted so scripts can read
+	// $CRIT_REVIEW_PATH; failures/timeouts are logged and never block finish.
+	s.runFinishHooks(sess, approved, stats)
 
 	writeJSON(w, map[string]any{
 		"status":       "finished",


### PR DESCRIPTION
## Summary
- Add opt-in command hooks that run user shell scripts on finish/approve lifecycle points (`on_finish_unresolved`, `on_finish_approved`, with mode suffixes)
- Pipe a JSON payload to stdin and set `CRIT_*` env vars (review path, session key, mode, counts, files-with-comments, comment JSON, next-round command)
- Reuse prompt resolution order (`inline:` / `file:` config, conventional `.crit/hooks/*.sh` discovery) and extend the project trust gate to cover hook scripts
- Ship reference examples under `docs/example-hooks/` (snapshot commented-on files, audit log) plus `docs/agent-hooks.md`

Closes #723

## Review
- [x] Code review: passed (crit session + static review)
- [x] Parity audit: N/A (crit CLI only)

## Test plan
- [x] `gofmt`, `golangci-lint`, `go test -race ./...`
- [x] Pre-commit hook passed on commit
- [x] Dogfooded `docs/example-hooks/on_finish_unresolved.sh` against live review file

Made with [Cursor](https://cursor.com)