### PR TITLE
test: improve command hooks coverage

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -895,3 +895,34 @@ func TestMergeConfigs_AutoViewedPatternsUnion(t *testing.T) {
 		t.Error("expected PLAN.md in merged auto-viewed patterns")
 	}
 }
+
+func TestLoadHookMaps(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"),
+		[]byte(`{"hooks":{"on_finish_approved":"inline:global"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"hooks":{"on_finish_unresolved":"inline:project"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	global, project := LoadHookMaps(projectDir)
+	if global["on_finish_approved"] != "inline:global" {
+		t.Fatalf("global hooks = %v", global)
+	}
+	if project["on_finish_unresolved"] != "inline:project" {
+		t.Fatalf("project hooks = %v", project)
+	}
+}
+
+func TestMergeConfigs_ProjectHooksOverride(t *testing.T) {
+	global := Config{Hooks: map[string]string{"on_finish_approved": "inline:global"}}
+	project := Config{Hooks: map[string]string{"on_finish_approved": "inline:project"}}
+	merged := mergeConfigs(global, project, ConfigPresence{})
+	if merged.Hooks["on_finish_approved"] != "inline:project" {
+		t.Fatalf("hooks = %v", merged.Hooks)
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -263,3 +263,107 @@ func TestEnvMapAndJSONPayload(t *testing.T) {
 		t.Fatalf("payload missing empty array: %s", payload)
 	}
 }
+
+func TestEnvMapAndJSONPayload_WithSessionStats(t *testing.T) {
+	ctx := prompt.Context{
+		ReviewPath: "/tmp/r.json",
+		SessionKey: "sk1",
+		SessionStats: &prompt.SessionStats{
+			DurationSeconds:   42,
+			FilesReviewed:     3,
+			CommentsSubmitted: 7,
+		},
+		CommentsUnresolvedJSON: `[{"id":"c1"}]`,
+		CommentsJSON:           `[{"id":"c1"},{"id":"c2"}]`,
+	}
+	env := hooks.EnvMap(ctx)
+	if env["CRIT_SESSION_DURATION_SECONDS"] != "42" {
+		t.Fatalf("duration env = %q", env["CRIT_SESSION_DURATION_SECONDS"])
+	}
+	if env["CRIT_SESSION_FILES_REVIEWED"] != "3" {
+		t.Fatalf("files reviewed env = %q", env["CRIT_SESSION_FILES_REVIEWED"])
+	}
+	if env["CRIT_SESSION_COMMENTS_SUBMITTED"] != "7" {
+		t.Fatalf("comments submitted env = %q", env["CRIT_SESSION_COMMENTS_SUBMITTED"])
+	}
+	if env["CRIT_COMMENTS_UNRESOLVED_JSON"] != `[{"id":"c1"}]` {
+		t.Fatalf("unresolved json env = %q", env["CRIT_COMMENTS_UNRESOLVED_JSON"])
+	}
+	payload := string(hooks.JSONPayload(ctx))
+	if !strings.Contains(payload, `"duration_seconds": 42`) {
+		t.Fatalf("payload missing session_stats: %s", payload)
+	}
+	if !strings.Contains(payload, `"comments_json": [`) || !strings.Contains(payload, `"c2"`) {
+		t.Fatalf("payload missing comments_json array: %s", payload)
+	}
+}
+
+func TestResolveFinishCommand_GlobalDiscoveredFile(t *testing.T) {
+	home := t.TempDir()
+	hooksDir := filepath.Join(home, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(hooksDir, "on_finish_approved.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ec, err := hooks.ResolveFinishCommand(nil, nil, t.TempDir(), home, prompt.HookFinishApproved, "files", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Kind != "file" || ec.Arg != script {
+		t.Fatalf("ec = %+v", ec)
+	}
+	if ec.Source != "global:.crit/hooks/on_finish_approved.sh" {
+		t.Fatalf("source = %q", ec.Source)
+	}
+}
+
+func TestResolveFinishCommand_ModeSpecificDiscoveredWins(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	generic := filepath.Join(hooksDir, "on_finish_unresolved.sh")
+	specific := filepath.Join(hooksDir, "on_finish_unresolved.diff.sh")
+	for _, path := range []string{generic, specific} {
+		if err := os.WriteFile(path, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ec, err := hooks.ResolveFinishCommand(nil, nil, dir, t.TempDir(), prompt.HookFinishUnresolved, "diff", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Arg != specific {
+		t.Fatalf("ec = %+v want mode-specific %q", ec, specific)
+	}
+	if ec.Hook != "on_finish_unresolved:diff" {
+		t.Fatalf("hook = %q", ec.Hook)
+	}
+}
+
+func TestResolveFinishCommand_ProjectBlockedFallsBackToGlobal(t *testing.T) {
+	global := map[string]string{"on_finish_approved": "inline:global"}
+	project := map[string]string{"on_finish_approved": "inline:project"}
+	ec, err := hooks.ResolveFinishCommand(global, project, "/unused", t.TempDir(), prompt.HookFinishApproved, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec == nil || ec.Arg != "global" || ec.Layer != hooks.LayerGlobal {
+		t.Fatalf("ec = %+v", ec)
+	}
+}
+
+func TestResolveFinishCommand_LoadCommandError(t *testing.T) {
+	project := map[string]string{"on_finish_approved": "file:missing.sh"}
+	_, err := hooks.ResolveFinishCommand(nil, project, t.TempDir(), t.TempDir(), prompt.HookFinishApproved, "", true)
+	if err == nil {
+		t.Fatal("expected error for missing file: hook")
+	}
+	if !strings.Contains(err.Error(), "missing.sh") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -183,3 +183,173 @@ func TestEvaluateTrust_DefaultsIgnoresProject(t *testing.T) {
 		t.Fatalf("defaults mode: %+v", st)
 	}
 }
+
+func TestEvaluateTrust_HooksOnlyConfig(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	projectDir := t.TempDir()
+	projectHooks := map[string]string{
+		"on_finish_approved": "inline:echo approved",
+	}
+
+	st, err := prompt.EvaluateTrust(projectDir, nil, projectHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.HasProjectPrompts {
+		t.Fatal("expected HasProjectPrompts for hooks-only project")
+	}
+	if !st.Untrusted {
+		t.Fatal("expected untrusted initially")
+	}
+}
+
+func TestEvaluateTrust_HookUntilChangeInvalidatedByDiscoveredScriptEdit(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	projectDir := t.TempDir()
+	hooksDir := filepath.Join(projectDir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(hooksDir, "on_finish_approved.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := prompt.ContentHash(nil, nil, projectDir)
+	if err := prompt.SaveTrustChoice(projectDir, prompt.TrustUntilChange, hash); err != nil {
+		t.Fatal(err)
+	}
+	st, err := prompt.EvaluateTrust(projectDir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Untrusted || !st.UseProject {
+		t.Fatalf("expected trusted after save: %+v", st)
+	}
+
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	st, err = prompt.EvaluateTrust(projectDir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Untrusted {
+		t.Fatal("expected re-block after discovered hook script body change")
+	}
+}
+
+func TestEvaluateTrust_HookUntilChangeInvalidatedByFileHookEdit(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	projectDir := t.TempDir()
+	script := filepath.Join(projectDir, ".crit", "hooks", "custom.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectHooks := map[string]string{
+		"on_finish_approved": "file:.crit/hooks/custom.sh",
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), []byte(`{"hooks":{"on_finish_approved":"file:.crit/hooks/custom.sh"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := prompt.ContentHash(nil, projectHooks, projectDir)
+	if err := prompt.SaveTrustChoice(projectDir, prompt.TrustUntilChange, hash); err != nil {
+		t.Fatal(err)
+	}
+	st, err := prompt.EvaluateTrust(projectDir, nil, projectHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Untrusted || !st.UseProject {
+		t.Fatalf("expected trusted after save: %+v", st)
+	}
+
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho v2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	st, err = prompt.EvaluateTrust(projectDir, nil, projectHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Untrusted {
+		t.Fatal("expected re-block after file: hook body change")
+	}
+}
+
+func TestEvaluateTrust_DiscoveredHookSourcesFilterNonFinishScripts(t *testing.T) {
+	projectDir := t.TempDir()
+	hooksDir := filepath.Join(projectDir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string]string{
+		"foo.sh":                "#!/bin/sh\n",
+		"on_finish_approved.sh": "#!/bin/sh\necho ok\n",
+		"on_finish_other.txt":   "nope\n",
+	} {
+		if err := os.WriteFile(filepath.Join(hooksDir, name), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	st, err := prompt.EvaluateTrust(projectDir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.HasProjectPrompts {
+		t.Fatal("expected hooks-only project")
+	}
+	want := "project:.crit/hooks/on_finish_approved.sh"
+	found := false
+	for _, src := range st.Sources {
+		if src == want {
+			found = true
+		}
+		if strings.Contains(src, "foo.sh") || strings.Contains(src, "other.txt") {
+			t.Fatalf("unexpected hook source %q in %v", src, st.Sources)
+		}
+	}
+	if !found {
+		t.Fatalf("sources = %v, want %q", st.Sources, want)
+	}
+}
+
+func TestEvaluateTrust_HookFileSourcesInConfig(t *testing.T) {
+	projectDir := t.TempDir()
+	script := filepath.Join(projectDir, ".crit", "hooks", "notify.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), []byte(`{"hooks":{"on_finish_approved":"file:.crit/hooks/notify.sh"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectHooks := map[string]string{"on_finish_approved": "file:.crit/hooks/notify.sh"}
+
+	st, err := prompt.EvaluateTrust(projectDir, nil, projectHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasConfig := false
+	hasFile := false
+	for _, src := range st.Sources {
+		if src == "project:.crit.config.json" {
+			hasConfig = true
+		}
+		if src == "project:.crit/hooks/notify.sh" {
+			hasFile = true
+		}
+	}
+	if !hasConfig || !hasFile {
+		t.Fatalf("sources = %v, want config + file hook paths", st.Sources)
+	}
+}

--- a/internal/server/hooks_test.go
+++ b/internal/server/hooks_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -226,5 +227,81 @@ func addUnresolvedComment(t *testing.T, s *Server, sess *Session, dir string) {
 	}
 	if err := sess.SyncWriteFiles(); err != nil {
 		t.Fatalf("SyncWriteFiles: %v", err)
+	}
+}
+
+// TestHandleFinish_HookFailureStillReturns200 verifies a failing hook is logged
+// but never blocks the finish response.
+func TestHandleFinish_HookFailureStillReturns200(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, _ := newTestServer(t)
+	s.homeDir = home
+
+	writeFileGlobal(t, home, `{"hooks":{"on_finish_approved":"inline:exit 7"}}`)
+
+	req := httptest.NewRequest("POST", "/api/finish", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleConfig_ProjectHookSources lists hook config and discovered scripts
+// in the trust payload shown before the user trusts a project.
+func TestHandleConfig_ProjectHookSources(t *testing.T) {
+	s, session := newTestServer(t)
+	dir := session.RepoRoot
+	hooksDir := filepath.Join(dir, ".crit", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "on_finish_approved.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"hooks":{"on_finish_unresolved":"file:.crit/hooks/notify.sh"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["project_prompts_untrusted"] != true {
+		t.Fatalf("untrusted = %v", resp["project_prompts_untrusted"])
+	}
+	raw, ok := resp["project_prompt_sources"].([]any)
+	if !ok {
+		t.Fatalf("sources = %T %v", resp["project_prompt_sources"], resp["project_prompt_sources"])
+	}
+	sources := make([]string, len(raw))
+	for i, v := range raw {
+		sources[i], _ = v.(string)
+	}
+	hasConfig := false
+	hasFile := false
+	hasDiscovered := false
+	for _, src := range sources {
+		switch src {
+		case "project:.crit.config.json":
+			hasConfig = true
+		case "project:.crit/hooks/notify.sh":
+			hasFile = true
+		case "project:.crit/hooks/on_finish_approved.sh":
+			hasDiscovered = true
+		}
+	}
+	if !hasConfig || !hasFile || !hasDiscovered {
+		t.Fatalf("sources = %v, want config + file + discovered hook paths", sources)
 	}
 }


### PR DESCRIPTION
## Summary
- Add pragmatic test coverage for command hooks added in #726
- Cover hook trust hashing (discovered/file script edits invalidate trust), `LoadHookMaps`, resolution edge cases, session stats env payload, and finish/config HTTP contracts

## Review
- [x] Code review: passed (test-only follow-up)
- [x] Parity audit: N/A

## Test plan
- [x] `gofmt`, `golangci-lint`, `go test -race ./...`
- [x] Pre-commit hook passed on commit

Follow-up to #726 (command hooks feature).

Made with [Cursor](https://cursor.com)