### PR TITLE
fix: reshare when remote review was deleted

### DIFF
--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -109,8 +109,21 @@ func TestHandleShare_NoShareURL(t *testing.T) {
 }
 
 func TestHandleShare_AlreadyShared(t *testing.T) {
-	s, sess := newShareTestServer(t, "https://example.com", true)
-	sess.SetSharedURLAndToken("https://crit.md/r/existing", "tok_existing")
+	var getCount int
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/reviews/existing/comments" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		getCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/existing", "tok_existing")
 	req := httptest.NewRequest(http.MethodPost, "/api/share", nil)
 	w := httptest.NewRecorder()
 	s.ServeHTTP(w, req)
@@ -119,8 +132,11 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 	}
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
-	if result["url"] != "https://crit.md/r/existing" {
+	if result["url"] != critWeb.URL+"/r/existing" {
 		t.Errorf("url = %v", result["url"])
+	}
+	if getCount != 1 {
+		t.Errorf("GET comments count = %d, want 1", getCount)
 	}
 }
 

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -140,6 +140,49 @@ func TestHandleShare_AlreadyShared(t *testing.T) {
 	}
 }
 
+func TestWriteExistingShareIfPresent_NoExistingShare(t *testing.T) {
+	s, _ := newShareTestServer(t, "https://example.com", true)
+	w := httptest.NewRecorder()
+
+	handled, err := s.writeExistingShareIfPresent(w)
+	if err != nil {
+		t.Fatalf("writeExistingShareIfPresent: %v", err)
+	}
+	if handled {
+		t.Fatal("handled = true, want false")
+	}
+	if w.Body.Len() != 0 {
+		t.Fatalf("body = %q, want empty", w.Body.String())
+	}
+}
+
+func TestHandleShare_ExistingShareServiceError(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/reviews/existing/comments" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/existing", "tok_existing")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result["error"] == "" {
+		t.Fatal("expected error in response body")
+	}
+}
+
 func TestHandleShare_ShareServiceError(t *testing.T) {
 	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -804,6 +804,32 @@ func (s *Server) shareFilesForSession() (files []ShareFile, reviewType string, e
 	return sess.LoadShareFilesFromDisk(), "", nil
 }
 
+func (s *Server) writeExistingShareIfPresent(w http.ResponseWriter) (bool, error) {
+	// Uses GetShareState() to read both fields under a single lock (avoids TOCTOU race
+	// where a concurrent DELETE /api/share-url could clear the token between two calls).
+	existingURL, existingToken := s.session.Load().GetShareState()
+	if existingURL == "" {
+		return false, nil
+	}
+
+	_, err := share.FetchWebComments(existingURL, map[string]bool{}, map[string]bool{}, map[string]string{}, s.authTokenSnapshot())
+	if errors.Is(err, share.ErrShareNotFound) {
+		s.session.Load().SetSharedURLAndToken("", "")
+		s.session.Load().SetShareScope("")
+		s.session.Load().SetShareOrgInfo("", "", "")
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	writeJSON(w, map[string]any{
+		"url":          existingURL,
+		"delete_token": existingToken,
+	})
+	return true, nil
+}
+
 // handleShare uploads the current session to crit-web and returns the share URL.
 // POST /api/share
 func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
@@ -820,14 +846,15 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Idempotent: if already shared, return the existing URL without calling crit-web.
-	// Uses GetShareState() to read both fields under a single lock (avoids TOCTOU race
-	// where a concurrent DELETE /api/share-url could clear the token between two calls).
-	if existingURL, existingToken := s.session.Load().GetShareState(); existingURL != "" {
-		writeJSON(w, map[string]any{
-			"url":          existingURL,
-			"delete_token": existingToken,
-		})
+	// Idempotent: if already shared and still present on crit-web, return the
+	// existing URL without uploading. If the remote review was deleted, clear the
+	// stale local state and create a fresh share below.
+	if handled, err := s.writeExistingShareIfPresent(w); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	} else if handled {
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1218,6 +1218,61 @@ func TestPostShareURL(t *testing.T) {
 	}
 }
 
+func TestPostShare_RemoteDeletedCreatesFreshShare(t *testing.T) {
+	s, session := newTestServer(t)
+
+	var postCount int
+	var baseURL string
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/reviews/oldtoken/comments":
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/reviews":
+			postCount++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          baseURL + "/r/newtoken",
+				"delete_token": "new-delete-token",
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer critWeb.Close()
+	baseURL = critWeb.URL
+
+	s.shareURL = critWeb.URL
+	session.SetSharedURLAndToken(critWeb.URL+"/r/oldtoken", "old-delete-token")
+	session.SetShareScope("old-scope")
+	session.SetShareOrgInfo("old-org", "Old Org", "organization")
+
+	req := httptest.NewRequest("POST", "/api/share", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if postCount != 1 {
+		t.Fatalf("POST /api/reviews count = %d, want 1", postCount)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["url"] != critWeb.URL+"/r/newtoken" {
+		t.Fatalf("url = %q, want fresh share URL", resp["url"])
+	}
+	if got := session.GetSharedURL(); got != critWeb.URL+"/r/newtoken" {
+		t.Fatalf("session shared URL = %q, want fresh share URL", got)
+	}
+	if got := session.GetDeleteToken(); got != "new-delete-token" {
+		t.Fatalf("session delete token = %q, want fresh delete token", got)
+	}
+}
+
 func TestPostShareURL_MethodNotAllowed(t *testing.T) {
 	s, _ := newTestServer(t)
 	req := httptest.NewRequest("PUT", "/api/share-url", nil)

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -185,13 +185,20 @@ func handleShareAuthError() {
 	fmt.Fprintln(os.Stderr, "Auth token rejected by server; cleared local credentials. Run 'crit auth login' to re-authenticate.")
 }
 
-func runShareExisting(existingCfg session.CritJSON, critPath string, files []ShareFile, sharePaths []string, authToken, fallbackAuthor string, showQR bool) error {
+func runShareExisting(existingCfg session.CritJSON, critPath string, files []ShareFile, sharePaths []string, svcURL, authToken, fallbackAuthor, org, visibility string, showQR bool) error {
 	localIDs := BuildLocalIDSet(existingCfg)
 	localFingerprints, localFingerprintIDs := BuildLocalFingerprintIndex(existingCfg)
 	if fetched, err := FetchWebComments(existingCfg.ShareURL, localIDs, localFingerprints, localFingerprintIDs, authToken); err != nil {
 		if errors.Is(err, ErrShareUnauthorized) {
 			handleShareAuthError()
 			return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
+		}
+		if errors.Is(err, ErrShareNotFound) {
+			fmt.Fprintln(os.Stderr, "warning: previous shared review no longer exists; creating a new share")
+			if err := ClearShareState(critPath); err != nil {
+				return err
+			}
+			return runShareNew(critPath, files, sharePaths, svcURL, authToken, fallbackAuthor, org, visibility, showQR)
 		}
 		fmt.Fprintf(os.Stderr, "warning: could not pull remote comments: %v\n", err)
 	} else if len(fetched.NewComments) > 0 || len(fetched.ReplyUpdates) > 0 {
@@ -206,6 +213,13 @@ func runShareExisting(existingCfg session.CritJSON, critPath string, files []Sha
 	if err != nil {
 		if errors.Is(err, ErrShareUnauthorized) {
 			handleShareAuthError()
+		}
+		if errors.Is(err, ErrShareNotFound) {
+			fmt.Fprintln(os.Stderr, "warning: previous shared review no longer exists; creating a new share")
+			if err := ClearShareState(critPath); err != nil {
+				return err
+			}
+			return runShareNew(critPath, files, sharePaths, svcURL, authToken, fallbackAuthor, org, visibility, showQR)
 		}
 		return err
 	}
@@ -340,7 +354,7 @@ func runShareUnderLock(critPath string, files []ShareFile, sharePaths []string, 
 		return err
 	}
 	if lockedOK {
-		return runShareExisting(lockedCfg, critPath, files, sharePaths, authToken, author, showQR)
+		return runShareExisting(lockedCfg, critPath, files, sharePaths, svcURL, authToken, author, org, visibility, showQR)
 	}
 	return runShareNew(critPath, files, sharePaths, svcURL, authToken, author, org, visibility, showQR)
 }

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -58,6 +58,7 @@ func checkGitHubSyncAllowed(cj session.CritJSON, op string) error {
 }
 
 var ErrShareUnauthorized = errors.New("auth token rejected by share service")
+var ErrShareNotFound = errors.New("shared review not found")
 
 // shareScope computes a hash of sorted file paths, used to detect when
 // share state belongs to a different file set.
@@ -613,7 +614,7 @@ func fetchWebComments(shareURL string, localIDs map[string]bool, localFingerprin
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return result, nil // review gone
+		return result, ErrShareNotFound
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		return result, ErrShareUnauthorized
@@ -715,6 +716,9 @@ func upsertShareToWeb(cfg session.CritJSON, files []ShareFile, comments []ShareC
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return result, ErrShareUnauthorized
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return result, ErrShareNotFound
 	}
 	if resp.StatusCode >= 400 {
 		return result, fmt.Errorf("upsert failed with status %d", resp.StatusCode)

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -682,6 +682,27 @@ func TestUpsertShareToWeb_CallsPUTOnChange(t *testing.T) {
 	}
 }
 
+func TestUpsertShareToWeb_RemoteDeleted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/reviews/tok" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := CritJSON{
+		ShareURL:      srv.URL + "/r/tok",
+		DeleteToken:   "dt",
+		LastShareHash: "old-hash",
+		ReviewRound:   1,
+	}
+	_, err := upsertShareToWeb(cfg, []ShareFile{{Path: "plan.md", Content: "# changed"}}, []shareComment{}, "")
+	if !errors.Is(err, ErrShareNotFound) {
+		t.Fatalf("err = %v, want ErrShareNotFound", err)
+	}
+}
+
 func TestUpsertShareToWeb_SkipsPUTWhenUnchanged(t *testing.T) {
 	putCalled := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -914,6 +935,85 @@ func TestRunShareExisting_RemoteDeletedCreatesFreshShare(t *testing.T) {
 	}
 	if updated.DeleteToken != "new-delete-token" {
 		t.Fatalf("delete_token = %q, want fresh token", updated.DeleteToken)
+	}
+}
+
+func TestRunShareExisting_UpsertRemoteDeletedCreatesFreshShare(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit")
+
+	var putCount int
+	var postCount int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/reviews/oldtoken/comments":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/reviews/oldtoken":
+			putCount++
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/reviews":
+			postCount++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          baseURL + "/r/newtoken",
+				"delete_token": "new-delete-token",
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	cj := CritJSON{
+		ShareURL:      srv.URL + "/r/oldtoken",
+		DeleteToken:   "old-delete-token",
+		ShareScope:    ShareScope([]string{"plan.md"}),
+		LastShareHash: "old-hash",
+		ReviewRound:   1,
+		Files:         map[string]CritJSONFile{"plan.md": {}},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(session.MustMkdirAll(review.ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runShareExisting(
+		cj,
+		critPath,
+		[]ShareFile{{Path: "plan.md", Content: "# changed\n"}},
+		[]string{"plan.md"},
+		srv.URL,
+		"",
+		"",
+		"",
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("runShareExisting: %v", err)
+	}
+	if putCount != 1 {
+		t.Fatalf("PUT /api/reviews/oldtoken count = %d, want 1", putCount)
+	}
+	if postCount != 1 {
+		t.Fatalf("POST /api/reviews count = %d, want 1", postCount)
+	}
+
+	updated, ok, err := loadExistingShareCfg(critPath, []string{"plan.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected fresh share state")
+	}
+	if updated.ShareURL != srv.URL+"/r/newtoken" {
+		t.Fatalf("share_url = %q, want fresh URL", updated.ShareURL)
 	}
 }
 

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -2,6 +2,7 @@ package share
 
 import (
 	"encoding/json"
+	"errors"
 	"image/color"
 	"io"
 	"net/http"
@@ -309,18 +310,15 @@ func TestFetchWebComments(t *testing.T) {
 		}
 	})
 
-	t.Run("404 returns no comments without error", func(t *testing.T) {
+	t.Run("404 reports deleted remote share", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer srv.Close()
 
-		result, err := fetchWebComments(srv.URL+"/r/gone", nil, nil, nil, "")
-		if err != nil {
-			t.Fatalf("unexpected error for 404: %v", err)
-		}
-		if result.NewComments != nil {
-			t.Errorf("expected nil for 404, got %v", result.NewComments)
+		_, err := fetchWebComments(srv.URL+"/r/gone", nil, nil, nil, "")
+		if !errors.Is(err, ErrShareNotFound) {
+			t.Fatalf("err = %v, want ErrShareNotFound", err)
 		}
 	})
 
@@ -835,6 +833,87 @@ func TestLoadExistingShareCfg_ScopeMismatch(t *testing.T) {
 	}
 	if cfg.ShareURL != "https://crit.md/r/old" {
 		t.Errorf("expected URL for matching scope, got %q", cfg.ShareURL)
+	}
+}
+
+func TestRunShareExisting_RemoteDeletedCreatesFreshShare(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+
+	dir := t.TempDir()
+	critPath := filepath.Join(dir, ".crit")
+	filePath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(filePath, []byte("# Plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var postCount int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/reviews/oldtoken/comments":
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/reviews":
+			postCount++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"url":          baseURL + "/r/newtoken",
+				"delete_token": "new-delete-token",
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	cj := CritJSON{
+		ShareURL:    srv.URL + "/r/oldtoken",
+		DeleteToken: "old-delete-token",
+		ShareScope:  ShareScope([]string{"plan.md"}),
+		LastShareHash: ComputeShareHash(
+			[]ShareFile{{Path: "plan.md", Content: "# Plan\n"}},
+			nil,
+		),
+		ReviewRound: 1,
+		Files:       map[string]CritJSONFile{"plan.md": {}},
+	}
+	data, _ := json.MarshalIndent(cj, "", "  ")
+	if err := os.WriteFile(session.MustMkdirAll(review.ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runShareExisting(
+		cj,
+		critPath,
+		[]ShareFile{{Path: "plan.md", Content: "# Plan\n"}},
+		[]string{"plan.md"},
+		srv.URL,
+		"",
+		"",
+		"",
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("runShareExisting: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("POST /api/reviews count = %d, want 1", postCount)
+	}
+
+	updated, ok, err := loadExistingShareCfg(critPath, []string{"plan.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected fresh share state")
+	}
+	if updated.ShareURL != srv.URL+"/r/newtoken" {
+		t.Fatalf("share_url = %q, want fresh URL", updated.ShareURL)
+	}
+	if updated.DeleteToken != "new-delete-token" {
+		t.Fatalf("delete_token = %q, want fresh token", updated.DeleteToken)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Detect when locally saved share state points at a deleted remote review
- Make `crit share` clear stale share state and create a fresh review instead of reusing the deleted token
- Make the UI share endpoint validate an existing hosted URL before returning it, and create a fresh share on remote 404
- Add CLI and UI regression coverage for deleted-then-reshared reviews

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`
- `make e2e-share`