### PR TITLE
fix: stop all repo sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ crit <file|dir> [...]         # Review specific files or directories (falls thro
 crit review [...]             # Explicit review invocation (same as default)
 crit live <url>               # Review a running web app in live mode (also: crit <url>)
 crit preview <file.html>      # Review a local HTML file in preview mode (also: crit <file.html>)
-crit stop [--all]             # Stop daemon(s) for current directory
+crit stop [--all]             # Stop daemon for current directory; --all stops every daemon
 crit status [--json]          # Show review file path, daemon status, comment stats
 crit cleanup [--days N] [--force]  # Delete stale review files from ~/.crit/reviews/
 crit pull [pr-number]         # Fetch GitHub PR comments into the review file
@@ -338,7 +338,7 @@ When the agent runs `crit` again (or calls `POST /api/round-complete`):
 2. **Subsequent `crit`**: connects to existing daemon (same cwd + args), signals round-complete, blocks
 3. **`crit plan.md`**: looks up daemon by hash(cwd + "plan.md") — reuses if alive, starts new if dead
 4. **Ctrl+C**: kills the daemon the client started
-5. **`crit stop`**: kills daemon for current cwd; `crit stop --all` kills all daemons for cwd
+5. **`crit stop`**: kills daemon for current cwd; `crit stop --all` kills every daemon
 6. **Lifetime**: daemon runs until killed (Ctrl+C, `crit stop`, or SIGINT/SIGTERM/SIGHUP). No idle timeout — walking away from a review session is fine.
 
 ### Deferred initialization & readiness

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -300,6 +300,43 @@ func listSessionsForCWD(cwd string) ([]SessionEntry, []string) {
 	return sessions, keys
 }
 
+// ListAllSessions returns all alive registered sessions and their registry
+// keys, regardless of working directory. It cleans up stale session files as a
+// side effect.
+func ListAllSessions() ([]SessionEntry, []string) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return nil, nil
+	}
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil
+	}
+	var alive []SessionEntry
+	var keys []string
+	for _, de := range dirEntries {
+		if !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		key := strings.TrimSuffix(de.Name(), ".json")
+		data, err := os.ReadFile(filepath.Join(dir, de.Name()))
+		if err != nil {
+			continue
+		}
+		var entry SessionEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			continue
+		}
+		if isDaemonAlive(entry) {
+			alive = append(alive, entry)
+			keys = append(keys, key)
+		} else {
+			RemoveSessionFile(key)
+		}
+	}
+	return alive, keys
+}
+
 // scanSessionsForCWD walks the session registry and returns the alive sessions
 // matching cwd plus their keys. Cleans up stale session files as a side
 // effect. A missing registry directory yields an empty result and nil error;

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -675,6 +675,72 @@ func TestListSessionsForRepoRoot_NoPartialMatch(t *testing.T) {
 	}
 }
 
+func TestListAllSessions_FiltersAndCleans(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts1.Close()
+	port1, _ := strconv.Atoi(ts1.URL[strings.LastIndex(ts1.URL, ":")+1:])
+
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts2.Close()
+	port2, _ := strconv.Atoi(ts2.URL[strings.LastIndex(ts2.URL, ":")+1:])
+
+	pid := os.Getpid()
+	WriteSessionFile("repo1", SessionEntry{PID: pid, Port: port1, CWD: "/tmp/repo1", Branch: "main"})
+	WriteSessionFile("repo2", SessionEntry{PID: pid, Port: port2, CWD: "/tmp/repo2/sub", Branch: "feat"})
+	WriteSessionFile("dead", SessionEntry{PID: 999999999, Port: 3333, CWD: "/tmp/dead", Branch: "main"})
+
+	sessDir := filepath.Join(home, ".crit", "sessions")
+	if err := os.WriteFile(filepath.Join(sessDir, "notes.txt"), []byte("not a session"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, "bad.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, keys := ListAllSessions()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 alive sessions, got %d", len(entries))
+	}
+
+	foundKeys := map[string]bool{}
+	for _, key := range keys {
+		foundKeys[key] = true
+	}
+	if !foundKeys["repo1"] || !foundKeys["repo2"] {
+		t.Fatalf("expected repo1 and repo2 keys, got %v", keys)
+	}
+	if foundKeys["dead"] || foundKeys["bad"] {
+		t.Fatalf("dead or malformed session should not be returned, got %v", keys)
+	}
+	if _, err := os.Stat(filepath.Join(sessDir, "dead.json")); !os.IsNotExist(err) {
+		t.Fatalf("dead session file should be cleaned up, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessDir, "notes.txt")); err != nil {
+		t.Fatalf("non-json file should be left alone: %v", err)
+	}
+}
+
+func TestListAllSessions_NoHomeReturnsEmpty(t *testing.T) {
+	t.Setenv("HOME", "")
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", "")
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+	}
+
+	entries, keys := ListAllSessions()
+	if len(entries) != 0 || len(keys) != 0 {
+		t.Fatalf("ListAllSessions without home = %d entries, %d keys; want empty", len(entries), len(keys))
+	}
+}
+
 func TestAtomicWriteFile_Success(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "test.txt")

--- a/internal/session/stop_cli.go
+++ b/internal/session/stop_cli.go
@@ -10,6 +10,8 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
+var stopDaemonByKey = daemon.StopDaemon
+
 func RunStop(args []string) error {
 	all := false
 	var fileArgs []string
@@ -24,7 +26,9 @@ func RunStop(args []string) error {
 	cwd, _ := daemon.ResolvedCWD()
 
 	if all {
-		daemon.StopAllDaemonsForCWD(cwd)
+		if err := stopAllDaemons(cwd); err != nil {
+			return err
+		}
 		fmt.Println("All daemons stopped.")
 		return nil
 	}
@@ -37,7 +41,7 @@ func RunStop(args []string) error {
 	// If file args were given, use the exact key (user knows which session).
 	if len(fileArgs) > 0 {
 		key := daemon.SessionKey(cwd, branch, fileArgs)
-		if err := daemon.StopDaemon(key); err != nil {
+		if err := stopDaemonByKey(key); err != nil {
 			return err
 		}
 		fmt.Println("Daemon stopped.")
@@ -47,7 +51,7 @@ func RunStop(args []string) error {
 	// No file args: try exact key first (git-mode session with no args).
 	key := daemon.SessionKey(cwd, branch, nil)
 	if entry, _ := daemon.ReadSessionFile(key); entry.PID > 0 {
-		if err := daemon.StopDaemon(key); err != nil {
+		if err := stopDaemonByKey(key); err != nil {
 			return err
 		}
 		fmt.Println("Daemon stopped.")
@@ -65,9 +69,24 @@ func RunStop(args []string) error {
 		return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
 	}
 
-	if err := daemon.StopDaemon(foundKey); err != nil {
+	if err := stopDaemonByKey(foundKey); err != nil {
 		return err
 	}
 	fmt.Println("Daemon stopped.")
 	return nil
+}
+
+func stopAllDaemons(cwd string) error {
+	_, keys := daemon.ListAllSessions()
+	if len(keys) == 0 {
+		daemon.StopAllDaemonsForCWD(cwd)
+		return nil
+	}
+	var stopErrs []error
+	for _, key := range keys {
+		if err := stopDaemonByKey(key); err != nil {
+			stopErrs = append(stopErrs, fmt.Errorf("%s: %w", key, err))
+		}
+	}
+	return errors.Join(stopErrs...)
 }

--- a/internal/session/stop_cli_test.go
+++ b/internal/session/stop_cli_test.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
+)
+
+func TestRunStopAllStopsEverySession(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	repoRootRaw := testutil.InitTestRepo(t)
+	repoRoot, err := filepath.EvalSymlinks(repoRootRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(repoRoot, "pkg")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoRoot)
+
+	rootKey := "root11111111"
+	subdirKey := "sub222222222"
+	otherKey := "other3333333"
+	pid := os.Getpid()
+	writeAliveSession(t, rootKey, daemon.SessionEntry{PID: pid, CWD: repoRoot, Branch: "main"})
+	writeAliveSession(t, subdirKey, daemon.SessionEntry{PID: pid, CWD: subdir, Branch: "main"})
+	writeAliveSession(t, otherKey, daemon.SessionEntry{PID: pid, CWD: filepath.Join(t.TempDir(), "other"), Branch: "main"})
+
+	stopped := map[string]bool{}
+	origStop := stopDaemonByKey
+	t.Cleanup(func() { stopDaemonByKey = origStop })
+	stopDaemonByKey = func(key string) error {
+		stopped[key] = true
+		return nil
+	}
+
+	if err := RunStop([]string{"--all"}); err != nil {
+		t.Fatalf("RunStop: %v", err)
+	}
+
+	if !stopped[rootKey] {
+		t.Fatalf("root session was not stopped; stopped keys: %v", stopped)
+	}
+	if !stopped[subdirKey] {
+		t.Fatalf("subdirectory session was not stopped; stopped keys: %v", stopped)
+	}
+	if !stopped[otherKey] {
+		t.Fatalf("other repo session was not stopped; stopped keys: %v", stopped)
+	}
+}
+
+func TestRunStopAllReturnsErrorWhenRepoSessionStopFails(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	repoRootRaw := testutil.InitTestRepo(t)
+	repoRoot, err := filepath.EvalSymlinks(repoRootRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoRoot)
+
+	rootKey := "root11111111"
+	writeAliveSession(t, rootKey, daemon.SessionEntry{PID: os.Getpid(), CWD: repoRoot, Branch: "main"})
+
+	origStop := stopDaemonByKey
+	t.Cleanup(func() { stopDaemonByKey = origStop })
+	stopDaemonByKey = func(key string) error {
+		return errors.New("boom")
+	}
+
+	err = RunStop([]string{"--all"})
+	if err == nil {
+		t.Fatal("RunStop returned nil, want stop error")
+	}
+	if !strings.Contains(err.Error(), rootKey) {
+		t.Fatalf("RunStop error = %q, want failed session key", err)
+	}
+}
+
+func TestRunStopAllSucceedsWithNoSessions(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+	if err := RunStop([]string{"--all"}); err != nil {
+		t.Fatalf("RunStop: %v", err)
+	}
+}
+
+func TestRunStopWithFileArgsStopsExactKey(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+	dir := t.TempDir()
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(resolvedDir)
+
+	wantKey := daemon.SessionKey(resolvedDir, "", []string{"plan.md"})
+	var gotKey string
+	origStop := stopDaemonByKey
+	t.Cleanup(func() { stopDaemonByKey = origStop })
+	stopDaemonByKey = func(key string) error {
+		gotKey = key
+		return nil
+	}
+
+	if err := RunStop([]string{"plan.md"}); err != nil {
+		t.Fatalf("RunStop: %v", err)
+	}
+	if gotKey != wantKey {
+		t.Fatalf("stopped key = %q, want %q", gotKey, wantKey)
+	}
+}
+
+func TestRunStopWithoutArgsStopsExactKey(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+	dir := t.TempDir()
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(resolvedDir)
+
+	key := daemon.SessionKey(resolvedDir, "", nil)
+	if err := daemon.WriteSessionFile(key, daemon.SessionEntry{PID: 1234, CWD: resolvedDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotKey string
+	origStop := stopDaemonByKey
+	t.Cleanup(func() { stopDaemonByKey = origStop })
+	stopDaemonByKey = func(key string) error {
+		gotKey = key
+		return nil
+	}
+
+	if err := RunStop(nil); err != nil {
+		t.Fatalf("RunStop: %v", err)
+	}
+	if gotKey != key {
+		t.Fatalf("stopped key = %q, want %q", gotKey, key)
+	}
+}
+
+func writeAliveSession(t *testing.T, key string, entry daemon.SessionEntry) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/health" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	t.Cleanup(ts.Close)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.Port = port
+	entry.Host = strings.TrimPrefix(u.Hostname(), "[")
+	entry.Host = strings.TrimSuffix(entry.Host, "]")
+	if err := daemon.WriteSessionFile(key, entry); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Make `crit stop --all` stop every alive crit daemon session in the registry, regardless of working directory.
- Keep plain `crit stop` scoped to the current directory/branch behavior.
- Return an error when a selected session fails to stop instead of reporting full success.
- Add regression coverage for sessions across multiple repos and partial stop failures.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- `go test ./internal/session -run 'TestRunStopAll' -count=1`
- `go test ./internal/daemon -run 'TestListSessions|TestListAll|TestCleanOrphaned' -count=1`
- `mise exec -- gofmt -l . && mise exec -- golangci-lint run ./... && mise exec -- go test -race -count=1 ./...`
- `mise exec -- go test -cover ./internal/session ./internal/daemon ./cmd/crit`
- `mise exec -- golangci-lint run --enable=gocyclo ./internal/session`