### PR TITLE
fix: highlight .rake files as Ruby

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1105,6 +1105,7 @@
     md: 'markdown',    // normalize: callers compare lang against 'markdown'
     heex: 'heex',
     leex: 'heex',
+    rake: 'ruby',      // hljs has no .rake alias (Rakefiles are Ruby)
   };
   // Files identified by basename rather than extension.
   const BASENAME_LANG = {


### PR DESCRIPTION
## Problem

`.rake` files aren't syntax-highlighted in diffs/document view. `EXT_OVERRIDES` in `web/app.js` maps extensions that highlight.js doesn't resolve via its built-in aliases, but `rake` was missing — highlight.js's Ruby lexer aliases `rb`, `gemspec`, `podspec`, `thor`, `irb`, but not `rake`.

Note `BASENAME_LANG` already maps the extensionless `Rakefile` to `ruby`; this just adds the equivalent for `*.rake` files (e.g. `lib/tasks/foo.rake`).

## Fix

Add `rake: 'ruby'` to `EXT_OVERRIDES` in `web/app.js`.

## Testing

- `npx eslint web/app.js` — clean
- `node --test web/__tests__/*.test.js` — same 2 pre-existing failures as on `main` (`crit-settings-overlay.test.js`, `live-mode.sse.test.js`), unrelated to this change and reproducible without it; no new failures