### PR TITLE
feat: honor instance share policy in share modal

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,6 +161,7 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, proxyAuth
 	mux.HandleFunc("/api/share/payload", s.withReady(s.handleSharePayload))
 	mux.HandleFunc("/api/share/preview-payload", s.withReady(s.handlePreviewPayload))
 	mux.HandleFunc("/api/share/upsert-payload", s.withReady(s.handleUpsertPayload))
+	mux.HandleFunc("/api/share-policy", s.withReady(s.handleSharePolicy))
 	mux.HandleFunc("/api/share-url", s.withReady(s.handleShareURL))
 	mux.HandleFunc("/api/comments/merge", s.withReady(s.handleMergeComments))
 	mux.HandleFunc("/api/finish", s.withReady(s.handleFinish))
@@ -2822,6 +2823,53 @@ func (s *Server) handleAuthOrgs(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode != http.StatusOK {
 		emptyArray()
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	io.Copy(w, resp.Body)
+}
+
+// handleSharePolicy proxies GET /api/share-policy to the configured crit-web
+// service. Older self-hosted instances do not expose it, so every failure falls
+// back to the historical client behaviour: all current share options allowed.
+func (s *Server) handleSharePolicy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	defaultPolicy := func() {
+		writeJSON(w, map[string]any{
+			"allowed_comment_policies":    []string{"open", "logged_in_only", "disallowed"},
+			"allowed_review_visibilities": []string{"organization", "unlisted", "public"},
+		})
+	}
+
+	if s.shareURL == "" {
+		defaultPolicy()
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.shareURL+"/api/share-policy", nil)
+	if err != nil {
+		defaultPolicy()
+		return
+	}
+	share.SetBearer(req, s.authTokenSnapshot())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		defaultPolicy()
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		defaultPolicy()
 		return
 	}
 

--- a/internal/server/server_orgs_test.go
+++ b/internal/server/server_orgs_test.go
@@ -123,3 +123,105 @@ func TestHandleAuthOrgs_MethodNotAllowed(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
 	}
 }
+
+func TestHandleSharePolicy(t *testing.T) {
+	defaultBody := `{"allowed_comment_policies":["open","logged_in_only","disallowed"],"allowed_review_visibilities":["organization","unlisted","public"]}`
+
+	tests := []struct {
+		name           string
+		shareURL       string
+		authToken      string
+		upstreamStatus int
+		upstreamBody   string
+		wantBody       string
+	}{
+		{
+			name:           "proxies upstream response",
+			shareURL:       "UPSTREAM",
+			authToken:      "valid-token",
+			upstreamStatus: http.StatusOK,
+			upstreamBody:   `{"allowed_comment_policies":["logged_in_only"],"allowed_review_visibilities":["unlisted"]}`,
+			wantBody:       `{"allowed_comment_policies":["logged_in_only"],"allowed_review_visibilities":["unlisted"]}`,
+		},
+		{
+			name:     "default policy when share_url not set",
+			shareURL: "",
+			wantBody: defaultBody,
+		},
+		{
+			name:           "default policy when upstream does not support endpoint",
+			shareURL:       "UPSTREAM",
+			upstreamStatus: http.StatusNotFound,
+			upstreamBody:   `{"error":"not found"}`,
+			wantBody:       defaultBody,
+		},
+		{
+			name:           "default policy when upstream returns error",
+			shareURL:       "UPSTREAM",
+			upstreamStatus: http.StatusInternalServerError,
+			upstreamBody:   `{"error":"boom"}`,
+			wantBody:       defaultBody,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBearer string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBearer = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.upstreamStatus)
+				w.Write([]byte(tt.upstreamBody))
+			}))
+			defer upstream.Close()
+
+			s, _ := newTestServer(t)
+			if tt.shareURL == "UPSTREAM" {
+				s.shareURL = upstream.URL
+			} else {
+				s.shareURL = tt.shareURL
+			}
+			s.authMu.Lock()
+			s.authToken = tt.authToken
+			s.authMu.Unlock()
+
+			req := httptest.NewRequest(http.MethodGet, "/api/share-policy", nil)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+
+			var got, want any
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal response: %v (body: %s)", err, w.Body.String())
+			}
+			if err := json.Unmarshal([]byte(tt.wantBody), &want); err != nil {
+				t.Fatalf("unmarshal want: %v", err)
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("body = %s, want %s", gotJSON, wantJSON)
+			}
+
+			if tt.authToken != "" && tt.upstreamStatus == http.StatusOK {
+				if want := "Bearer " + tt.authToken; gotBearer != want {
+					t.Errorf("Authorization = %q, want %q", gotBearer, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleSharePolicy_MethodNotAllowed(t *testing.T) {
+	s, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/share-policy", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}

--- a/web/__tests__/crit-share.test.js
+++ b/web/__tests__/crit-share.test.js
@@ -151,6 +151,7 @@ test('share policy fetch falls back to historical allowed visibility options', (
 
   assert.match(src, /DEFAULT_SHARE_POLICY[\s\S]*allowed_review_visibilities:\s*\['organization', 'unlisted', 'public'\]/);
   assert.match(src, /fetch\('\/api\/share-policy'\)/);
+  assert.match(src, /popupSession\.run\('sharePolicy'/);
   assert.match(src, /cachedSharePolicy = normalizeSharePolicy\(null\)/);
 });
 
@@ -159,5 +160,6 @@ test('share modal disables policy-blocked visibility options', () => {
 
   assert.match(src, /setAttribute\('aria-disabled', allowed \? 'false' : 'true'\)/);
   assert.match(src, /getAttribute\('aria-disabled'\) !== 'true'/);
+  assert.match(src, /if \(isSharePolicyRejection\(err\)\) clearSharePolicyCache\(\)/);
   assert.match(src, /That sharing option is not allowed by this Crit instance/);
 });

--- a/web/__tests__/crit-share.test.js
+++ b/web/__tests__/crit-share.test.js
@@ -13,6 +13,8 @@
 
 const { test, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function makeButton() {
   return {
@@ -142,4 +144,20 @@ test('setButtonState toggles label/disabled/btn-success for sharing/shared/defau
   assert.equal(btn.textContent, 'Share');
   assert.equal(btn.disabled, false);
   assert.equal(btn.classList.contains('btn-success'), false);
+});
+
+test('share policy fetch falls back to historical allowed visibility options', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'crit-share.js'), 'utf8');
+
+  assert.match(src, /DEFAULT_SHARE_POLICY[\s\S]*allowed_review_visibilities:\s*\['organization', 'unlisted', 'public'\]/);
+  assert.match(src, /fetch\('\/api\/share-policy'\)/);
+  assert.match(src, /cachedSharePolicy = normalizeSharePolicy\(null\)/);
+});
+
+test('share modal disables policy-blocked visibility options', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'crit-share.js'), 'utf8');
+
+  assert.match(src, /setAttribute\('aria-disabled', allowed \? 'false' : 'true'\)/);
+  assert.match(src, /getAttribute\('aria-disabled'\) !== 'true'/);
+  assert.match(src, /That sharing option is not allowed by this Crit instance/);
 });

--- a/web/crit-share.js
+++ b/web/crit-share.js
@@ -64,6 +64,8 @@
     // ---- internal share state ----
     var cachedOrgs = null;
     var fetchOrgsPromise = null;
+    var cachedSharePolicy = null;
+    var fetchSharePolicyPromise = null;
     var shareInFlight = false;
     var shareModalEl = null;
 
@@ -232,6 +234,71 @@
       return fetchOrgsPromise;
     }
 
+    const DEFAULT_SHARE_POLICY = {
+      allowed_comment_policies: ['open', 'logged_in_only', 'disallowed'],
+      allowed_review_visibilities: ['organization', 'unlisted', 'public'],
+    };
+
+    function normalizeSharePolicy(raw) {
+      const validVisibilities = DEFAULT_SHARE_POLICY.allowed_review_visibilities;
+      const rawVisibilities = raw && Array.isArray(raw.allowed_review_visibilities)
+        ? raw.allowed_review_visibilities
+        : validVisibilities;
+      const allowedVisibilities = rawVisibilities.filter(function(v) {
+        return validVisibilities.indexOf(v) !== -1;
+      });
+
+      const rawCommentPolicies = raw && Array.isArray(raw.allowed_comment_policies)
+        ? raw.allowed_comment_policies
+        : DEFAULT_SHARE_POLICY.allowed_comment_policies;
+
+      return {
+        allowed_comment_policies: rawCommentPolicies,
+        allowed_review_visibilities: allowedVisibilities.length > 0 ? allowedVisibilities : validVisibilities,
+      };
+    }
+
+    async function fetchSharePolicy() {
+      if (cachedSharePolicy !== null) return cachedSharePolicy;
+      if (fetchSharePolicyPromise) return fetchSharePolicyPromise;
+      fetchSharePolicyPromise = (async function() {
+        try {
+          const resp = await fetch('/api/share-policy');
+          if (!resp.ok) {
+            cachedSharePolicy = normalizeSharePolicy(null);
+            return cachedSharePolicy;
+          }
+          cachedSharePolicy = normalizeSharePolicy(await resp.json());
+        } catch {
+          cachedSharePolicy = normalizeSharePolicy(null);
+        }
+        fetchSharePolicyPromise = null;
+        return cachedSharePolicy;
+      })();
+      return fetchSharePolicyPromise;
+    }
+
+    function sharePolicyAllowsVisibility(policy, visibility) {
+      const normalized = normalizeSharePolicy(policy);
+      return normalized.allowed_review_visibilities.indexOf(visibility) !== -1;
+    }
+
+    function isSharePolicyRejection(err) {
+      const msg = (err && err.message ? err.message : String(err || '')).toLowerCase();
+      return msg.indexOf('visibility') !== -1 ||
+        msg.indexOf('comment_policy') !== -1 ||
+        msg.indexOf('comment policy') !== -1 ||
+        msg.indexOf('not allowed') !== -1 ||
+        msg.indexOf('disallowed') !== -1;
+    }
+
+    function shareErrorMessage(err) {
+      if (isSharePolicyRejection(err)) {
+        return 'That sharing option is not allowed by this Crit instance. Choose another option and try again.';
+      }
+      return err && err.message ? err.message : String(err || 'unknown error');
+    }
+
     async function performShare(org, visibility, orgMeta, popupSession) {
       if (shareInFlight) return;
       shareInFlight = true;
@@ -314,8 +381,9 @@
       }
     }
 
-    function showOrgShareModal(orgs) {
+    function showOrgShareModal(orgs, sharePolicy) {
       closeShareModal();
+      sharePolicy = normalizeSharePolicy(sharePolicy);
       const overlay = document.createElement('div');
       overlay.className = 'share-overlay';
       overlay.setAttribute('role', 'dialog');
@@ -334,11 +402,13 @@
       const ICON_VIS_PUBLIC = '<svg class="sd-org-vis-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>';
 
       const isPersonalSelected = !savedOrg || !orgs.some(function(o) { return o.slug === savedOrg; });
+      const initialPersonalVis = sharePolicyAllowsVisibility(sharePolicy, 'unlisted') ? 'unlisted' : sharePolicy.allowed_review_visibilities[0];
+      const initialOrgVis = sharePolicyAllowsVisibility(sharePolicy, 'organization') ? 'organization' : sharePolicy.allowed_review_visibilities[0];
 
       // Build owner rows using sd-org-owner-option (custom radio, no native input)
       let ownerRows = '';
       ownerRows +=
-        '<div class="sd-org-owner-option" role="radio" aria-checked="' + isPersonalSelected + '" tabindex="' + (isPersonalSelected ? '0' : '-1') + '" data-owner="" data-default-vis="unlisted">' +
+        '<div class="sd-org-owner-option" role="radio" aria-checked="' + isPersonalSelected + '" tabindex="' + (isPersonalSelected ? '0' : '-1') + '" data-owner="" data-default-vis="' + escapeHtml(initialPersonalVis) + '">' +
           '<span class="sd-org-radio"><span class="sd-org-radio-dot"></span></span>' +
           '<span class="sd-org-avatar sd-org-avatar--personal">' + escapeHtml(initials || '?') + '</span>' +
           '<span class="sd-org-owner-info"><span class="sd-org-owner-name">' + escapeHtml(authUserName || 'Personal') + '</span><span class="sd-org-owner-slug">Personal</span></span>' +
@@ -347,7 +417,7 @@
         const org = orgs[oi];
         const isSelected = savedOrg === org.slug;
         ownerRows +=
-          '<div class="sd-org-owner-option" role="radio" aria-checked="' + isSelected + '" tabindex="' + (isSelected ? '0' : '-1') + '" data-owner="' + escapeHtml(org.slug) + '" data-default-vis="organization">' +
+          '<div class="sd-org-owner-option" role="radio" aria-checked="' + isSelected + '" tabindex="' + (isSelected ? '0' : '-1') + '" data-owner="' + escapeHtml(org.slug) + '" data-default-vis="' + escapeHtml(initialOrgVis) + '">' +
             '<span class="sd-org-radio"><span class="sd-org-radio-dot"></span></span>' +
             '<span class="sd-org-avatar sd-org-avatar--org">' + ICON_ORG + '</span>' +
             '<span class="sd-org-owner-info"><span class="sd-org-owner-name">' + escapeHtml(org.name) + '</span><span class="sd-org-owner-slug">' + escapeHtml(org.slug) + '</span></span>' +
@@ -404,6 +474,33 @@
       const orgVisOption = visOptions.querySelector('[data-vis="organization"]');
       const orgVisDesc = overlay.querySelector('#orgVisOrgDesc');
       const unlistedVisDesc = overlay.querySelector('#orgVisUnlistedDesc');
+      const shareButton = overlay.querySelector('#orgShareBtn');
+
+      function isVisAvailable(el) {
+        return !!el && el.style.display !== 'none' && el.getAttribute('aria-disabled') !== 'true';
+      }
+
+      function firstAvailableVis() {
+        return Array.from(visOptions.querySelectorAll('.sd-org-vis-option')).find(isVisAvailable) || null;
+      }
+
+      function applyPolicyToVisOptions() {
+        visOptions.querySelectorAll('.sd-org-vis-option').forEach(function(el) {
+          const visibility = el.getAttribute('data-vis');
+          const allowed = sharePolicyAllowsVisibility(sharePolicy, visibility);
+          el.setAttribute('aria-disabled', allowed ? 'false' : 'true');
+          if (!allowed) {
+            el.setAttribute('tabindex', '-1');
+            el.setAttribute('title', 'Disabled by this Crit instance');
+          } else {
+            el.removeAttribute('title');
+          }
+        });
+      }
+
+      function syncShareButtonState() {
+        if (shareButton) shareButton.disabled = !firstAvailableVis();
+      }
 
       function selectOwner(el) {
         ownerList.querySelectorAll('.sd-org-owner-option').forEach(function(o) {
@@ -426,11 +523,13 @@
             selectVis(visOptions.querySelector('[data-vis="unlisted"]'));
           }
         }
-        selectVis(visOptions.querySelector('[data-vis="' + el.getAttribute('data-default-vis') + '"]'));
+        const defaultVis = visOptions.querySelector('[data-vis="' + el.getAttribute('data-default-vis') + '"]');
+        selectVis(isVisAvailable(defaultVis) ? defaultVis : firstAvailableVis());
+        syncShareButtonState();
       }
 
       function selectVis(el) {
-        if (!el || el.style.display === 'none') return;
+        if (!isVisAvailable(el)) return;
         visOptions.querySelectorAll('.sd-org-vis-option').forEach(function(o) {
           o.setAttribute('aria-checked', 'false');
           o.setAttribute('tabindex', '-1');
@@ -441,7 +540,10 @@
 
       function radioKeyNav(container, selector, selectFn) {
         container.addEventListener('keydown', function(e) {
-          const items = Array.from(container.querySelectorAll(selector)).filter(function(o) { return o.style.display !== 'none'; });
+          const items = Array.from(container.querySelectorAll(selector)).filter(function(o) {
+            return o.style.display !== 'none' && o.getAttribute('aria-disabled') !== 'true';
+          });
+          if (items.length === 0) return;
           const current = e.target.closest(selector);
           if (!current) return;
           const idx = items.indexOf(current);
@@ -463,11 +565,12 @@
 
       visOptions.addEventListener('click', function(e) {
         const opt = e.target.closest('.sd-org-vis-option');
-        if (opt && opt.style.display !== 'none') { selectVis(opt); opt.focus(); }
+        if (isVisAvailable(opt)) { selectVis(opt); opt.focus(); }
       });
       radioKeyNav(visOptions, '.sd-org-vis-option', function(el) { selectVis(el); el.focus(); });
 
       // Apply initial selection
+      applyPolicyToVisOptions();
       const initialOwner = ownerList.querySelector('[aria-checked="true"]');
       if (initialOwner) {
         const owner = initialOwner.getAttribute('data-owner');
@@ -479,12 +582,14 @@
         }
         const defVis = savedVis || initialOwner.getAttribute('data-default-vis');
         const visEl = visOptions.querySelector('[data-vis="' + defVis + '"]');
-        if (visEl && visEl.style.display !== 'none') {
+        if (isVisAvailable(visEl)) {
           selectVis(visEl);
         } else {
-          selectVis(visOptions.querySelector('[data-vis="' + initialOwner.getAttribute('data-default-vis') + '"]'));
+          const defaultVis = visOptions.querySelector('[data-vis="' + initialOwner.getAttribute('data-default-vis') + '"]');
+          selectVis(isVisAvailable(defaultVis) ? defaultVis : firstAvailableVis());
         }
       }
+      syncShareButtonState();
 
       // Close handlers
       overlay.addEventListener('click', function(e) { if (e.target === overlay) closeShareModal(); });
@@ -988,7 +1093,7 @@
 
     function showShareError(err) {
       const el = showToast('share', 'error',
-        '<span>Share failed: ' + escapeHtml(err.message) + '</span>' +
+        '<span>Share failed: ' + escapeHtml(shareErrorMessage(err)) + '</span>' +
         '<div class="toast-actions">' +
           '<button class="toast-btn toast-btn-filled" id="shareRetryBtn">Retry</button>' +
           '<button class="toast-btn toast-btn-ghost" data-dismiss-toast="share">Dismiss</button>' +
@@ -1021,11 +1126,13 @@
       // If user has orgs, show org share modal (handles consent inline)
       if (authUserName) {
         shareBtnEl.disabled = true;
-        const orgs = await fetchOrgs();
+        const results = await Promise.all([fetchOrgs(), fetchSharePolicy()]);
+        const orgs = results[0];
+        const sharePolicy = results[1];
         shareBtnEl.disabled = false;
         if (orgs.length > 0) {
           if (popupSession) popupSession.close();
-          showOrgShareModal(orgs);
+          showOrgShareModal(orgs, sharePolicy);
           return;
         }
       }

--- a/web/crit-share.js
+++ b/web/crit-share.js
@@ -258,17 +258,26 @@
       };
     }
 
-    async function fetchSharePolicy() {
+    function clearSharePolicyCache() {
+      cachedSharePolicy = null;
+      fetchSharePolicyPromise = null;
+    }
+
+    async function fetchSharePolicy(popupSession) {
       if (cachedSharePolicy !== null) return cachedSharePolicy;
       if (fetchSharePolicyPromise) return fetchSharePolicyPromise;
       fetchSharePolicyPromise = (async function() {
         try {
-          const resp = await fetch('/api/share-policy');
-          if (!resp.ok) {
-            cachedSharePolicy = normalizeSharePolicy(null);
-            return cachedSharePolicy;
+          if (popupSession) {
+            cachedSharePolicy = normalizeSharePolicy(await popupSession.run('sharePolicy', {}, 30000));
+          } else {
+            const resp = await fetch('/api/share-policy');
+            if (!resp.ok) {
+              cachedSharePolicy = normalizeSharePolicy(null);
+              return cachedSharePolicy;
+            }
+            cachedSharePolicy = normalizeSharePolicy(await resp.json());
           }
-          cachedSharePolicy = normalizeSharePolicy(await resp.json());
         } catch {
           cachedSharePolicy = normalizeSharePolicy(null);
         }
@@ -1092,6 +1101,7 @@
     }
 
     function showShareError(err) {
+      if (isSharePolicyRejection(err)) clearSharePolicyCache();
       const el = showToast('share', 'error',
         '<span>Share failed: ' + escapeHtml(shareErrorMessage(err)) + '</span>' +
         '<div class="toast-actions">' +
@@ -1126,7 +1136,7 @@
       // If user has orgs, show org share modal (handles consent inline)
       if (authUserName) {
         shareBtnEl.disabled = true;
-        const results = await Promise.all([fetchOrgs(), fetchSharePolicy()]);
+        const results = await Promise.all([fetchOrgs(), fetchSharePolicy(popupSession)]);
         const orgs = results[0];
         const sharePolicy = results[1];
         shareBtnEl.disabled = false;

--- a/web/style.css
+++ b/web/style.css
@@ -861,6 +861,8 @@ body {
 .sd-org-vis-option { display: flex; align-items: flex-start; gap: 10px; padding: 8px 10px; border-radius: 8px; cursor: pointer; transition: background 100ms; border: 0; background: transparent; text-align: left; font: inherit; color: inherit; width: 100%; }
 .sd-org-vis-option:hover { background: var(--crit-option-hover); }
 .sd-org-vis-option[aria-checked="true"] { background: var(--crit-option-selected-bg); }
+.sd-org-vis-option[aria-disabled="true"] { opacity: 0.42; cursor: not-allowed; }
+.sd-org-vis-option[aria-disabled="true"]:hover { background: transparent; }
 .sd-org-vis-option .sd-org-radio { margin-top: 1px; }
 .sd-org-vis-icon { flex-shrink: 0; color: var(--crit-fg-muted); margin-top: 1px; transition: color 120ms; }
 .sd-org-vis-option[aria-checked="true"] .sd-org-vis-icon { color: var(--crit-fg-secondary); }


### PR DESCRIPTION
## Summary
- add local `/api/share-policy` support with backward-compatible fallback when older self-hosted instances do not expose the endpoint
- fetch share policy in the share modal, including through the proxy-auth popup relay, and disable known-disallowed visibility choices
- gracefully surface policy rejection errors and refetch policy on retry after a server-side rejection

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Red-team pass: passed

## Test plan
- `node --check web/crit-share.js`
- `node --test web/__tests__/crit-share.test.js`
- `go test ./internal/server`
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`
- `CRIT_WEB_DIR=/Users/tomasztomczyk/Server/side/crit-mono/crit-web.feat-instance-share-policy make e2e-share`

See also: https://github.com/tomasz-tomczyk/crit-web/pull/298