### PR TITLE
fix: preserve unstaged changes in branch-added files

### DIFF
--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -684,7 +684,11 @@ func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v v
 		}
 		return nil
 	}
-	if fc.Status == "added" || fc.Status == "untracked" {
+	showWholeFile := fc.Status == "untracked"
+	if fc.Status == "added" {
+		showWholeFile = scope != "unstaged"
+	}
+	if showWholeFile {
 		absPath := filepath.Join(repoRoot, fc.Path)
 		if data, err := os.ReadFile(absPath); err == nil {
 			return vcs.FileDiffUnifiedNewFile(string(data))

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -659,6 +659,15 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 	}
 }
 
+// addedFileRendersWhole reports whether a file that is "added" relative to the
+// merge-base (committed on the branch, new vs base) should render as an entire
+// new file for the given scope. A branch-added file already exists in HEAD, so
+// the "staged"/"unstaged" scopes must show the real index/working-tree delta —
+// not the whole file. Every other scope (branch/all/"") renders it whole.
+func addedFileRendersWhole(scope string) bool {
+	return scope != "staged" && scope != "unstaged"
+}
+
 func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v vcs.VCS, ignoreWhitespace bool) []vcs.DiffHunk {
 	if v == nil {
 		return nil
@@ -686,7 +695,7 @@ func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v v
 	}
 	showWholeFile := fc.Status == "untracked"
 	if fc.Status == "added" {
-		showWholeFile = scope != "unstaged"
+		showWholeFile = addedFileRendersWhole(scope)
 	}
 	if showWholeFile {
 		absPath := filepath.Join(repoRoot, fc.Path)
@@ -895,7 +904,7 @@ func computeScopedDiffHunks(path, scope, commit, status, oldPath, content, baseR
 	if status == "untracked" && (scope == "unstaged" || scope == "all" || scope == "") {
 		return vcs.FileDiffUnifiedNewFile(content)
 	}
-	if status == "added" && scope != "unstaged" {
+	if status == "added" && addedFileRendersWhole(scope) {
 		return vcs.FileDiffUnifiedNewFile(content)
 	}
 	return scopedHunks(vcs.FileChange{Path: path, OldPath: oldPath, Status: status}, scope, commit, baseRef, repoRoot, v, ignoreWhitespace)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -863,13 +863,32 @@ func TestSession_LoadCritJSON_OutputDir(t *testing.T) {
 }
 
 func TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope(t *testing.T) {
-	// Issue #25: When a file has status "added" (committed on branch, new relative
-	// to merge-base) and the user switches to "unstaged" scope, we should NOT show
-	// the entire file as a diff. Only truly untracked files should get that treatment.
-	s := newTestSession(t)
-	// Simulate a file that is "added" relative to merge-base (committed on branch)
-	s.Files[1].Status = "added"
-	s.Files[1].Content = "package main\n\nfunc main() {}\n"
+	dir := initTestRepo(t)
+	gitT(t, dir, "checkout", "-b", "feature")
+	path := filepath.Join(dir, "main.go")
+	committedContent := "package main\n\nfunc main() {}\n"
+	workingContent := "package main\n\nfunc renamed() {}\n"
+	writeFile(t, path, committedContent)
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "add main")
+	writeFile(t, path, workingContent)
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     "main",
+		VCS:         &vcs.GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{{
+			Path:     "main.go",
+			AbsPath:  path,
+			Status:   "added",
+			FileType: "code",
+			Content:  workingContent,
+			Comments: []Comment{},
+		}},
+	}
 
 	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "", false)
 	if !ok {
@@ -877,15 +896,13 @@ func TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope(t *testing.T) {
 	}
 	hunks := result["hunks"].([]vcs.DiffHunk)
 
-	// With "added" status + "unstaged" scope, the bug would show the entire file
-	// as added lines (3 lines). The fix should return empty hunks because there
-	// are no actual unstaged changes.
-	if len(hunks) != 0 {
-		totalLines := 0
-		for _, h := range hunks {
-			totalLines += len(h.Lines)
-		}
-		t.Errorf("expected 0 hunks for committed 'added' file in unstaged scope, got %d hunks with %d lines", len(hunks), totalLines)
+	additions, deletions := countHunkStats(hunks)
+	if additions != 1 || deletions != 1 {
+		t.Errorf(
+			"unstaged diff for branch-added file = +%d/-%d, want +1/-1",
+			additions,
+			deletions,
+		)
 	}
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -906,6 +906,54 @@ func TestGetFileDiffSnapshotScoped_AddedFileUnstagedScope(t *testing.T) {
 	}
 }
 
+func TestGetFileDiffSnapshotScoped_AddedFileStagedScope(t *testing.T) {
+	// Twin of the unstaged case: a file committed on the branch (status "added"
+	// vs merge-base) that is modified AND staged must show the real index-vs-HEAD
+	// delta in "staged" scope, not the entire file as newly added.
+	dir := initTestRepo(t)
+	gitT(t, dir, "checkout", "-b", "feature")
+	path := filepath.Join(dir, "main.go")
+	committedContent := "package main\n\nfunc main() {}\n"
+	stagedContent := "package main\n\nfunc renamed() {}\n"
+	writeFile(t, path, committedContent)
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "add main")
+	writeFile(t, path, stagedContent)
+	gitT(t, dir, "add", "main.go")
+
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     "main",
+		VCS:         &vcs.GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{{
+			Path:     "main.go",
+			AbsPath:  path,
+			Status:   "added",
+			FileType: "code",
+			Content:  stagedContent,
+			Comments: []Comment{},
+		}},
+	}
+
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "staged", "", false)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	hunks := result["hunks"].([]vcs.DiffHunk)
+
+	additions, deletions := countHunkStats(hunks)
+	if additions != 1 || deletions != 1 {
+		t.Errorf(
+			"staged diff for branch-added file = +%d/-%d, want +1/-1",
+			additions,
+			deletions,
+		)
+	}
+}
+
 func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
 	// Truly untracked files should still show the full file as added in unstaged scope
 	s := newTestSession(t)


### PR DESCRIPTION
## Summary

  - Preserve actual working-tree modifications instead of rendering the entire file as newly added.
  - Delegate unstaged diffs for branch-added files to the VCS backend.
  - Add a regression test using a real Git repository.

  ## Testing

  - `gofmt -l .`
  - `golangci-lint run ./...`
  - `go test ./...`
  - `make build-all`
  - `make e2e` — 867 passed, 8 skipped