### PR TITLE
fix: polish story mode rendering

### DIFF
--- a/cmd/crit/cli_handlers_story.go
+++ b/cmd/crit/cli_handlers_story.go
@@ -555,6 +555,8 @@ func runStoryLLM(f storyFlags, critPath string, cj review.CritJSON) error {
 		return clicmd.ExitError{Code: 1, Err: errors.New("no agent_cmd configured; set agent_cmd in ~/.crit.config.json, or use --story-file/--skip-llm/--guide")}
 	}
 
+	fmt.Fprintln(os.Stderr, "Generating story. This can take a minute, please wait...")
+
 	scope, err := buildStoryScope(f.scopeArgs)
 	if err != nil {
 		return err
@@ -580,6 +582,7 @@ func runStoryLLM(f storyFlags, critPath string, cj review.CritJSON) error {
 		return err
 	}
 
+	fmt.Fprintln(os.Stderr, "asking agent_cmd to write the story...")
 	st, err := generateStory(agentCmd, guide)
 	if err != nil {
 		return err

--- a/cmd/crit/cli_handlers_story_llm_test.go
+++ b/cmd/crit/cli_handlers_story_llm_test.go
@@ -124,6 +124,38 @@ func TestStoryLLM_HappyPath(t *testing.T) {
 	}
 }
 
+func TestStoryLLM_PrintsProgressWhileGenerating(t *testing.T) {
+	_, scratch := setupStoryRepoLLM(t)
+	stubPostIngest(t)
+	agent := fakeAgentScript(t, scratch, validCannedStory)
+	setAgentCmd(t, agent)
+
+	var stderr strings.Builder
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&stderr, r)
+		close(done)
+	}()
+
+	err := runStoryE(nil)
+	w.Close()
+	<-done
+	os.Stderr = old
+
+	if err != nil {
+		t.Fatalf("expected clean generation, got: %v", err)
+	}
+	out := stderr.String()
+	for _, want := range []string{"Generating story", "please wait", "asking agent_cmd"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("story generation stderr missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestStoryLLM_FencedOutput(t *testing.T) {
 	_, scratch := setupStoryRepoLLM(t)
 	stubPostIngest(t)

--- a/test/e2e/tests/story.spec.ts
+++ b/test/e2e/tests/story.spec.ts
@@ -51,7 +51,7 @@ const STORY = {
   agent: 'e2e-test',
   prologue: {
     title: 'Route registration story',
-    overview: 'Reworks route registration and documents the plan.',
+    overview: 'Reworks route registration and documents the [plan](https://example.com/plan).',
     key_changes: [
       'routes.go adds the health-check route and grouped imports.',
       'Dashboard logging and plan.md document the route behavior.',
@@ -90,9 +90,40 @@ const STORY = {
   ],
 };
 
-function writeStoryFixtureFile(): string {
+const MERGED_HUNK_STORY = {
+  version: 1,
+  agent: 'e2e-test',
+  prologue: {
+    title: 'Merged hunk story',
+    overview: 'Exercises story rendering for small-gap hunk clusters.',
+    key_changes: ['server.go raw hunks render as one small-gap cluster.'],
+    risks: ['Missing nearby raw hunks would hide part of the logical change.'],
+  },
+  chapters: [
+    {
+      id: 'ch1',
+      title: 'Server auth cluster',
+      summary: 'The first server.go hunk should render the full small-gap cluster.',
+      hunk_refs: [{ file_path: 'server.go', old_start: 2 }],
+    },
+  ],
+  support: [
+    {
+      hunk_refs: [
+        { file_path: 'server.go', old_start: 17 },
+        { file_path: 'server.go', old_start: 39 },
+        { file_path: 'routes.go', old_start: 1 },
+        { file_path: 'routes.go', old_start: 48 },
+        { file_path: 'plan.md', old_start: 0 },
+      ],
+      reason: 'Additional fixture hunks keep the story above ingestion coverage requirements.',
+    },
+  ],
+};
+
+function writeStoryFixtureFile(story: Record<string, unknown> = STORY): string {
   const file = path.join(os.tmpdir(), `crit-e2e-story-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
-  fs.writeFileSync(file, JSON.stringify(STORY));
+  fs.writeFileSync(file, JSON.stringify(story));
   return file;
 }
 
@@ -124,8 +155,8 @@ function storyView(page: Page, pageId: string) {
   return page.locator(`#crit-story-view-${pageId}`);
 }
 
-async function ingestStory(critBin: string, fixtureDir: string, fakeHome: string, opts: { refresh?: boolean } = {}) {
-  const storyFile = writeStoryFixtureFile();
+async function ingestStory(critBin: string, fixtureDir: string, fakeHome: string, opts: { refresh?: boolean; story?: Record<string, unknown> } = {}) {
+  const storyFile = writeStoryFixtureFile(opts.story || STORY);
   // --refresh forces a re-ingest (and a story-updated SSE to a running daemon)
   // even when a story is already present, where a bare `crit story` would
   // instead resume the existing one.
@@ -169,37 +200,17 @@ test.describe('Story mode', () => {
 
   test('ingesting a story activates the overview with prologue and chapter TOC', async ({ page, request }) => {
     await ingestStory(critBin, fixtureDir, fakeHome);
-    await page.route('**/api/config', async route => {
-      const res = await route.fetch();
-      const body = await res.json();
-      await route.fulfill({
-        response: res,
-        json: {
-          ...body,
-          pr_number: 735,
-          pr_url: 'https://github.com/tomasz-tomczyk/crit/pull/735',
-          pr_title: 'feat: add story review mode',
-          pr_body: 'PR description from GitHub.',
-          pr_head_ref: 'story-mode',
-          pr_base_ref: 'main',
-        },
-      });
-    });
     await loadPage(page);
 
     await expect(page.locator('body')).toHaveClass(/crit-story-active/);
     await expect(storyOverview(page)).toBeVisible();
-    const tabs = storyOverview(page).locator('.crit-story-pr__tabs');
-    await expect(tabs.locator('.crit-story-pr__tab', { hasText: 'Story' })).toHaveClass(/active/);
     await expect(storyOverview(page).locator('.crit-story-prologue')).toContainText('Reworks route registration');
     await expect(storyOverview(page).locator('.crit-story-prologue')).toContainText('Key changes');
     await expect(storyOverview(page).locator('.crit-story-prologue')).toContainText('Dashboard logging and plan.md');
     await expect(storyOverview(page).locator('.crit-story-prologue')).toContainText('Risks');
-    await tabs.locator('.crit-story-pr__tab', { hasText: 'PR' }).click();
-    await expect(storyOverview(page).locator('.crit-story-pr__panel.active')).toContainText('feat: add story review mode');
-    await expect(storyOverview(page).locator('.crit-story-pr__panel.active')).toContainText('#735');
-    await expect(storyOverview(page).locator('.crit-story-pr__panel.active')).toContainText('story-mode -> main');
-    await expect(storyOverview(page).locator('.crit-story-pr__panel.active')).toContainText('PR description from GitHub.');
+    const overviewLink = storyOverview(page).locator('.crit-story-prologue__overview a', { hasText: 'plan' });
+    await expect(overviewLink).toBeVisible();
+    await expect(overviewLink).not.toHaveCSS('color', 'rgb(0, 0, 238)');
 
     await expect(tocItem(page, 'ch1')).toContainText('Route imports + health check');
     await expect(tocItem(page, 'ch2')).toContainText('Dashboard logging + docs');
@@ -219,6 +230,7 @@ test.describe('Story mode', () => {
     const ch1View = storyView(page, 'ch1');
     await expect(ch1View).toBeVisible();
     await expect(ch1View.locator('.crit-story-file-group[data-story-file="routes.go"]')).toBeVisible();
+    await expect(ch1View.locator('.crit-story-file-header')).toHaveCSS('top', '0px');
     // Only ch1's hunk group renders — plan.md and handler.js belong to other pages.
     await expect(ch1View.locator('.crit-story-file-group')).toHaveCount(1);
     await expect(ch1View.locator('.crit-story-chapter__top .crit-story-chapter__mark')).toHaveCount(0);
@@ -362,6 +374,29 @@ test.describe('Story mode', () => {
       const rowsAfter = await group.locator('.diff-split-row').count();
       expect(rowsAfter).toBeGreaterThan(rowsBefore);
     }).toPass();
+  });
+
+  test('story chapter refs render the full small-gap hunk cluster', async ({ page, request }) => {
+    await ingestStory(critBin, fixtureDir, fakeHome, { story: MERGED_HUNK_STORY });
+    const comment = await addComment(request, 'server.go', 68, 'Story E2E: merged cluster support comment');
+    await loadPage(page);
+
+    await tocItem(page, 'ch1').click();
+    const group = storyView(page, 'ch1').locator('.crit-story-file-group[data-story-file="server.go"]');
+    await expect(group).toBeVisible();
+
+    await expect(group.locator('.diff-spacer').first()).toContainText('@@ -2,43 +2,70 @@');
+    await expect(group).toContainText('authMiddleware');
+    await expect(group).toContainText('Server starting on :%s');
+
+    await page.keyboard.press('Shift+C');
+    const panel = page.locator('#commentsPanel');
+    await expect(panel).not.toHaveClass(/comments-panel-hidden/);
+    const panelCard = panel.locator('.comment-card', { hasText: 'Story E2E: merged cluster support comment' });
+    await expect(panelCard).toBeVisible();
+    await panelCard.click();
+    await expect(page).toHaveURL(/#story\/support$/);
+    await expect(storyView(page, 'support').locator(`.comment-card[data-comment-id="${comment.id}"]`)).toBeVisible();
   });
 
   test('story chapter rail fills the viewport and uses the shared resize handle', async ({ page }) => {

--- a/web/app.js
+++ b/web/app.js
@@ -3425,11 +3425,11 @@
         const merged = {
           OldStart: hunks[i].OldStart,
           NewStart: hunks[i].NewStart,
-          Header: hunks[i].Header,
           Lines: hunks[i].Lines.concat(contextLines, hunks[i + 1].Lines)
         };
         merged.OldCount = (hunks[i + 1].OldStart + hunks[i + 1].OldCount) - merged.OldStart;
         merged.NewCount = (hunks[i + 1].NewStart + hunks[i + 1].NewCount) - merged.NewStart;
+        merged.Header = buildHunkHeader(merged.OldStart, merged.OldCount, merged.NewStart, merged.NewCount, hunks[i].Header);
         // Replace both with merged — don't increment i to check merged against next
         hunks.splice(i, 2, merged);
       } else {
@@ -8160,9 +8160,11 @@
   // the new scope is never requested. Surfaced as a Windows-only e2e flake:
   // slower file I/O made loadAllFileData() outlast the next click handler, so
   // clicks that swapped scope returned the previous scope's in-flight promise.
+  // Story/Diff also changes the effective fetch/file-data scopes without
+  // changing diffScope itself, so include those derived scopes in the key.
   let reloadInFlightKey = null;
   async function reloadForScope() {
-    const key = diffScope + '\0' + diffCommit;
+    const key = currentSessionFetchScope() + '\0' + currentFileDataScope() + '\0' + diffCommit;
     if (reloadInFlight && reloadInFlightKey === key) return reloadInFlight;
     if (reloadInFlight) {
       // Different inputs — chain after the in-flight reload finishes so we
@@ -9827,6 +9829,17 @@
     return pageId + '\0' + filePath + '\0' + (oldStarts || []).join(',');
   }
 
+  function copyDiffHunk(hunk) {
+    return Object.assign({}, hunk, { Lines: (hunk.Lines || []).slice() });
+  }
+
+  function hunkContainsOldStart(hunk, oldStart) {
+    if (!hunk) return false;
+    if (hunk.OldStart === oldStart) return true;
+    if (hunk.OldCount <= 0) return false;
+    return oldStart >= hunk.OldStart && oldStart < hunk.OldStart + hunk.OldCount;
+  }
+
   function syncStoryCloneFromFile(clone, file) {
     clone.oldPath = file.oldPath;
     clone.status = file.status;
@@ -9863,23 +9876,36 @@
     const cached = storyExpandedFileCache.get(key);
     if (cached && cached.fileHash === file.fileHash) {
       syncStoryCloneFromFile(cached.clone, file);
-      return { clone: cached.clone, total: allHunks.length, shown: cached.clone.diffHunks.length };
+      return { clone: cached.clone, total: cached.total, shown: cached.clone.diffHunks.length };
     }
 
-    const filtered = allHunks.filter(function (h) { return wanted.has(h.OldStart); });
-    // Deep-copy hunks so renderer-side expansion (expandHunksForComments /
-    // autoExpandSmallGaps) mutates the clone, never the real file's hunks.
-    const copiedHunks = filtered.map(function (h) {
-      return Object.assign({}, h, { Lines: (h.Lines || []).slice() });
+    // Deep-copy and apply the same small-gap coalescing that normal diff
+    // rendering applies before filtering. Story refs are generated from the
+    // reviewer-facing hunk starts, while the raw git diff can split a logical
+    // GitHub-style hunk into several close zero-context hunks. Filtering first
+    // drops the later pieces of that visual hunk.
+    const expandedFile = Object.assign({}, file, {
+      diffHunks: allHunks.map(copyDiffHunk),
+      _autoExpandDone: false,
+      viewMode: 'diff',
     });
+    autoExpandSmallGaps(expandedFile);
+    const expandedHunks = expandedFile.diffHunks || [];
+    const filtered = expandedHunks.filter(function (h) {
+      for (const oldStart of wanted) {
+        if (hunkContainsOldStart(h, oldStart)) return true;
+      }
+      return false;
+    });
+    const copiedHunks = filtered.map(copyDiffHunk);
     const clone = Object.assign({}, file, {
       diffHunks: copiedHunks,
       _autoExpandDone: false,
       // Force diff view for the group body regardless of markdown viewMode.
       viewMode: 'diff',
     });
-    storyExpandedFileCache.set(key, { fileHash: file.fileHash, clone: clone });
-    return { clone: clone, total: allHunks.length, shown: copiedHunks.length };
+    storyExpandedFileCache.set(key, { fileHash: file.fileHash, clone: clone, total: expandedHunks.length });
+    return { clone: clone, total: expandedHunks.length, shown: copiedHunks.length };
   }
 
   // ----- Rail -----
@@ -9987,73 +10013,6 @@
     return n;
   }
 
-  function renderStoryOverviewTabs(prologueEl) {
-    const pr = prData;
-    if (!pr || !pr.pr_number || !(pr.pr_title || (pr.pr_body && pr.pr_body.trim()))) return prologueEl;
-    const githubIcon = '<svg class="crit-story-pr__github" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.39 0-.19-.01-.83-.01-1.5-2.01.38-2.53-.5-2.69-.96-.09-.24-.48-.96-.82-1.15-.28-.15-.68-.53-.01-.54.63-.01 1.08.59 1.23.83.72 1.23 1.87.88 2.33.67.07-.53.28-.88.51-1.08-1.78-.21-3.64-.91-3.64-4.02 0-.89.31-1.62.82-2.19-.08-.2-.36-1.04.08-2.16 0 0 .67-.22 2.2.84A7.42 7.42 0 0 1 8 3.92c.68 0 1.36.09 2 .27 1.53-1.06 2.2-.84 2.2-.84.44 1.12.16 1.96.08 2.16.51.57.82 1.3.82 2.19 0 3.12-1.87 3.81-3.65 4.02.29.25.54.74.54 1.5 0 1.08-.01 1.95-.01 2.22 0 .22.15.47.55.39A8.08 8.08 0 0 0 16 8.13C16 3.64 12.42 0 8 0Z"/></svg>';
-
-    const box = document.createElement('section');
-    box.className = 'crit-story-pr';
-
-    const tabs = document.createElement('div');
-    tabs.className = 'crit-story-pr__tabs';
-    const storyBtn = document.createElement('button');
-    storyBtn.type = 'button';
-    storyBtn.className = 'crit-story-pr__tab active';
-    storyBtn.dataset.storyPrTab = 'story';
-    storyBtn.textContent = 'Story';
-    tabs.appendChild(storyBtn);
-    const summaryBtn = document.createElement('button');
-    summaryBtn.type = 'button';
-    summaryBtn.className = 'crit-story-pr__tab';
-    summaryBtn.dataset.storyPrTab = 'summary';
-    summaryBtn.innerHTML = githubIcon + '<span>PR</span>';
-    tabs.appendChild(summaryBtn);
-    box.appendChild(tabs);
-
-    const storyPanel = document.createElement('div');
-    storyPanel.className = 'crit-story-pr__panel active';
-    storyPanel.dataset.storyPrPanel = 'story';
-    storyPanel.appendChild(prologueEl);
-    box.appendChild(storyPanel);
-
-    const summaryPanel = document.createElement('div');
-    summaryPanel.className = 'crit-story-pr__panel crit-story-pr__prologue';
-    summaryPanel.dataset.storyPrPanel = 'summary';
-    const prHref = pr.pr_url ? escapeHtml(pr.pr_url) : '#';
-    const meta = (pr.pr_head_ref || pr.pr_base_ref)
-      ? '<div class="crit-story-pr__meta">' + escapeHtml(pr.pr_head_ref || '') + ' -> ' + escapeHtml(pr.pr_base_ref || '') + '</div>'
-      : '';
-    summaryPanel.innerHTML =
-      '<div class="crit-story-prologue__eyebrow">' + githubIcon + ' Pull Request</div>' +
-      '<h2><a class="crit-story-pr__title" href="' + prHref + '" target="_blank" rel="noopener noreferrer">' +
-        escapeHtml(pr.pr_title || 'Pull Request') + '</a> <span>#' + escapeHtml(String(pr.pr_number)) + '</span></h2>' +
-      meta;
-    const body = document.createElement('div');
-    body.className = 'crit-story-prologue__overview crit-story-pr__description';
-    if (pr.pr_body && pr.pr_body.trim()) {
-      body.innerHTML = commentMd.render(pr.pr_body);
-      linkifyCommentRefsInDom(body);
-    } else {
-      body.textContent = 'No PR description.';
-    }
-    summaryPanel.appendChild(body);
-    box.appendChild(summaryPanel);
-
-    tabs.addEventListener('click', function (e) {
-      const btn = e.target.closest('.crit-story-pr__tab');
-      if (!btn || btn.disabled) return;
-      const tab = btn.dataset.storyPrTab;
-      tabs.querySelectorAll('.crit-story-pr__tab').forEach(function (b) {
-        b.classList.toggle('active', b === btn);
-      });
-      box.querySelectorAll('.crit-story-pr__panel').forEach(function (panel) {
-        panel.classList.toggle('active', panel.dataset.storyPrPanel === tab);
-      });
-    });
-    return box;
-  }
-
   // ----- Overview -----
   function renderStoryOverview() {
     const inner = document.getElementById('storyPaneInner');
@@ -10099,7 +10058,7 @@
       dia.appendChild(pre);
       prologueEl.appendChild(dia);
     }
-    view.appendChild(renderStoryOverviewTabs(prologueEl));
+    view.appendChild(prologueEl);
 
     const divider = document.createElement('div');
     divider.className = 'crit-story-divider';
@@ -10599,7 +10558,17 @@
         if (ln.NewNum === line || ln.OldNum === line) { hit = true; break; }
       }
       if (hit) {
-        const owner = storyState.hunkOwner.get(hunkKey(filePath, h.OldStart));
+        let owner;
+        const ownedStarts = storyOwnedStartsInHunk(filePath, h);
+        if (ownedStarts.length) {
+          let chosen = ownedStarts[0];
+          for (let s = 0; s < ownedStarts.length; s++) {
+            if (ownedStarts[s] <= line) chosen = ownedStarts[s];
+          }
+          owner = storyState.hunkOwner.get(hunkKey(filePath, chosen));
+        } else {
+          owner = storyState.hunkOwner.get(hunkKey(filePath, h.OldStart));
+        }
         if (owner !== undefined) return storyPageId(storyState.pages[owner]);
       }
     }
@@ -10610,6 +10579,23 @@
       return storyPageId(storyState.pages[first]);
     }
     return null;
+  }
+
+  function storyOwnedStartsInHunk(filePath, hunk) {
+    if (!storyState || !hunk) return [];
+    const starts = [];
+    const oldEnd = hunk.OldStart + Math.max(1, hunk.OldCount || 0);
+    storyState.pages.forEach(function (page) {
+      const refs = page.refsByFile && page.refsByFile.get(filePath);
+      (refs || []).forEach(function (oldStart) {
+        const inRange = hunk.OldCount <= 0
+          ? oldStart === hunk.OldStart
+          : oldStart >= hunk.OldStart && oldStart < oldEnd;
+        if (inRange) starts.push(oldStart);
+      });
+    });
+    starts.sort(function (a, b) { return a - b; });
+    return starts;
   }
 
   // Ensure the chapter owning (filePath, line) is active; returns true if a

--- a/web/style.css
+++ b/web/style.css
@@ -5986,8 +5986,7 @@ body.crit-story-active .crit-story-rail-resizer { display: block; }
   color: var(--crit-fg-muted);
 }
 .crit-story-prologue__eyebrow .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--crit-brand); }
-.crit-story-prologue h2,
-.crit-story-pr__prologue h2 {
+.crit-story-prologue h2 {
   font-size: 22px; font-weight: 650; line-height: 1.3;
   margin-bottom: 12px; max-width: none;
 }
@@ -5999,6 +5998,50 @@ body.crit-story-active .crit-story-rail-resizer { display: block; }
 }
 .crit-story-prologue__overview p { margin: 0 0 8px; }
 .crit-story-prologue__overview p:last-child { margin-bottom: 0; }
+.crit-story-pane a {
+  color: var(--crit-brand);
+  text-decoration: none;
+  border-bottom: 1px solid var(--crit-brand-subtle);
+}
+.crit-story-pane a:hover {
+  color: var(--crit-brand-hover);
+  border-bottom-color: var(--crit-brand-hover);
+}
+.crit-story-prologue__overview h1,
+.crit-story-prologue__overview h2,
+.crit-story-prologue__overview h3 {
+  color: var(--crit-fg-primary);
+  font-size: 14px;
+  font-weight: 650;
+  margin: 14px 0 6px;
+}
+.crit-story-prologue__overview h1:first-child,
+.crit-story-prologue__overview h2:first-child,
+.crit-story-prologue__overview h3:first-child { margin-top: 0; }
+.crit-story-prologue__overview ul,
+.crit-story-prologue__overview ol {
+  margin: 6px 0 10px;
+  padding-left: 20px;
+}
+.crit-story-prologue__overview li { margin: 3px 0; }
+.crit-story-prologue__overview code {
+  font-family: var(--crit-font-mono);
+  font-size: 0.88em;
+  padding: 1px 5px;
+  background: var(--crit-editor-bg-elevated);
+  border-radius: 3px;
+}
+.crit-story-prologue__overview pre {
+  background: var(--crit-editor-bg-elevated);
+  border-radius: var(--crit-r-sm);
+  padding: 8px 10px;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+.crit-story-prologue__overview pre code {
+  padding: 0;
+  background: none;
+}
 .crit-story-prologue__bullets {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -6037,38 +6080,7 @@ body.crit-story-active .crit-story-rail-resizer { display: block; }
   border-radius: 50%;
   background: var(--crit-brand);
 }
-.crit-story-pr {
-  margin: 0 0 24px;
-}
-.crit-story-pr__tabs {
-  display: flex;
-  gap: 14px;
-  border-bottom: 1px solid var(--crit-l-hairline);
-}
-.crit-story-pr__tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  background: transparent;
-  color: var(--crit-fg-muted);
-  cursor: pointer;
-  font: inherit;
-  font-size: 12.5px;
-  padding: 7px 0 8px;
-}
-.crit-story-pr__tab.active { color: var(--crit-fg-primary); border-bottom-color: var(--crit-brand); }
-.crit-story-pr__tab:disabled { opacity: 0.45; cursor: default; }
-.crit-story-pr__panel { display: none; padding: 16px 0 0; color: var(--crit-fg-secondary); font-size: 13px; }
-.crit-story-pr__panel.active { display: block; }
-.crit-story-pr__title { color: var(--crit-fg-primary); font-weight: 600; text-decoration: none; }
-.crit-story-pr__title:hover { color: var(--crit-brand); }
-.crit-story-prologue h2 span,
-.crit-story-pr__prologue h2 span { color: var(--crit-fg-muted); font-weight: 400; }
-.crit-story-pr__github { width: 14px; height: 14px; flex: none; }
-.crit-story-pr__meta { margin: -4px 0 14px; color: var(--crit-fg-muted); font-size: 12px; }
-.crit-story-pr__description { margin-top: 0; }
+.crit-story-prologue h2 span { color: var(--crit-fg-muted); font-weight: 400; }
 .crit-story-divider {
   display: flex; align-items: center; gap: 10px; margin: 4px 0 14px;
   font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em;
@@ -6142,7 +6154,7 @@ body.crit-story-active .crit-story-rail-resizer { display: block; }
 .crit-story-file-group.viewed { opacity: 0.62; transition: opacity 140ms; }
 .crit-story-file-group.viewed:hover { opacity: 1; }
 .crit-story-file-header {
-  top: var(--header-height, 49px);
+  top: 0;
   border-left: 1px solid var(--crit-border);
   border-right: 1px solid var(--crit-border);
   border-radius: var(--crit-r-md) var(--crit-r-md) 0 0;


### PR DESCRIPTION
## Summary
- remove the story overview's dedicated PR tab so the overview stays focused on generated story content
- style story-mode markdown links and align sticky story file headers
- render full logical hunks in story chapters and keep comment navigation correct inside merged hunk clusters
- print progress while `crit story` is generating via configured `agent_cmd`

## Review
- [x] Intent/scope audit: clean
- [x] Static review: clean
- [x] Parity audit: N/A for local story-mode review UI

## Test plan
- `go test ./cmd/crit -run StoryLLM -count=1`
- `npx eslint web/app.js`
- `npx stylelint web/style.css`
- `npm run test:frontend`
- `bash run.sh --project=git-mode tests/story.spec.ts`
- `mise exec -- gofmt -l . && mise exec -- golangci-lint run ./... && mise exec -- go test -race -count=1 ./...`