### PR TITLE
fix: harden story review lifecycle

### DIFF
--- a/cmd/crit/cli_handlers_story.go
+++ b/cmd/crit/cli_handlers_story.go
@@ -50,6 +50,9 @@ var storyStartDaemon = daemon.StartDaemon
 // storyPostStory POSTs the story to a running daemon. Package var for tests.
 var storyPostStory = postStoryToDaemon
 
+// storyDeleteStory removes the story from a running daemon. Package var for tests.
+var storyDeleteStory = deleteStoryFromDaemon
+
 // storyDaemonAlive reports whether a daemon for the session key is running.
 // Package var so tests can force the "no daemon" or "daemon present" branch.
 var storyDaemonAlive = daemon.FindAliveSession
@@ -191,14 +194,7 @@ func runStoryE(args []string) error {
 
 	// --clear: drop the story and save. No-op if none present.
 	if f.clear {
-		cj.Story = nil
-		if err := review.SaveCritJSON(critPath, cj); err != nil {
-			return clicmd.ExitError{Code: 1, Err: err}
-		}
-		fmt.Fprintln(os.Stderr, "Cleared story from review.")
-		// TODO(story): post-ingest daemon notify (later task) — signal the
-		// daemon to re-render in flat file layout.
-		return nil
+		return clearStory(f, critPath, cj)
 	}
 
 	// --prep: write the prep text + snapshot scope, print path, exit 0.
@@ -222,6 +218,26 @@ func runStoryE(args []string) error {
 	default:
 		return runStoryLLM(f, critPath, cj)
 	}
+}
+
+func clearStory(f storyFlags, critPath string, cj review.CritJSON) error {
+	key, _, keyErr := storyReviewSessionKey(f)
+	if keyErr == nil {
+		if entry, alive := storyDaemonAlive(key); alive {
+			if err := storyDeleteStory(entry); err == nil {
+				fmt.Fprintln(os.Stderr, "Cleared story from review.")
+				return nil
+			} else if _, stillAlive := storyDaemonAlive(key); stillAlive {
+				return clicmd.ExitError{Code: 1, Err: fmt.Errorf("clearing story from running review: %w", err)}
+			}
+		}
+	}
+	cj.Story = nil
+	if err := review.SaveCritJSON(critPath, cj); err != nil {
+		return clicmd.ExitError{Code: 1, Err: err}
+	}
+	fmt.Fprintln(os.Stderr, "Cleared story from review.")
+	return nil
 }
 
 func wantsStoryHelp(args []string) bool {
@@ -257,16 +273,14 @@ func resolveStoryReviewPath(scopeArgs []string) (string, error) {
 		return "", clicmd.ExitError{Code: 1, Err: err}
 	}
 
-	// Prefer a running daemon's review path (matches crit review reconnect).
-	if path := review.ResolveReviewPathFromDaemon(cwd); path != "" {
-		return path, nil
-	}
-
 	branch := ""
 	if v := vcs.DetectVCS(reviewCfg.VCSOverride); v != nil {
 		branch = v.CurrentBranch()
 	}
 	key := daemon.SessionKey(cwd, branch, session.FocusKeyArgs(reviewCfg))
+	if entry, alive := storyDaemonAlive(key); alive && entry.ReviewPath != "" {
+		return entry.ReviewPath, nil
+	}
 	path, err := daemon.ReviewFilePath(key)
 	if err != nil {
 		return "", clicmd.ExitError{Code: 1, Err: err}
@@ -873,6 +887,27 @@ func postStoryToDaemon(entry daemon.SessionEntry, st *session.Story) error {
 	return nil
 }
 
+func deleteStoryFromDaemon(entry daemon.SessionEntry) error {
+	base := entry.ConnURL()
+	if err := waitDaemonReady(base); err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodDelete, base+"/api/story", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("daemon returned %s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
 // waitDaemonReady polls GET base+"/api/session" until it stops returning 503
 // (session init done) or a bounded deadline elapses. Mirrors the canonical
 // readiness loop in daemon.RunReviewClient. base is a ConnURL (scheme+host+port).
@@ -885,8 +920,11 @@ func waitDaemonReady(base string) error {
 		}
 		status := resp.StatusCode
 		resp.Body.Close()
-		if status != http.StatusServiceUnavailable {
+		if status >= 200 && status < 300 {
 			return nil
+		}
+		if status != http.StatusServiceUnavailable {
+			return fmt.Errorf("daemon readiness check returned HTTP %d", status)
 		}
 		if time.Now().After(deadline) {
 			return errors.New("daemon did not become ready within 30s")

--- a/cmd/crit/cli_handlers_story_llm_test.go
+++ b/cmd/crit/cli_handlers_story_llm_test.go
@@ -600,6 +600,50 @@ func TestPostStoryToDaemon_RejectsNonReadinessError(t *testing.T) {
 	}
 }
 
+func TestDeleteStoryFromDaemon(t *testing.T) {
+	deleted := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/session":
+			w.WriteHeader(http.StatusOK)
+		case "/api/story":
+			if r.Method != http.MethodDelete {
+				t.Errorf("method = %s, want DELETE", r.Method)
+			}
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+	if err := deleteStoryFromDaemon(daemon.SessionEntry{Host: u.Hostname(), Port: port}); err != nil {
+		t.Fatalf("deleteStoryFromDaemon: %v", err)
+	}
+	if !deleted {
+		t.Fatal("DELETE /api/story was not called")
+	}
+}
+
+func TestDeleteStoryFromDaemonRejectsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/session" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Error(w, "could not clear", http.StatusConflict)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+	err := deleteStoryFromDaemon(daemon.SessionEntry{Host: u.Hostname(), Port: port})
+	if err == nil || !strings.Contains(err.Error(), "could not clear") {
+		t.Fatalf("expected daemon error body, got %v", err)
+	}
+}
+
 // TestPostStoryToDaemon_ErrorOnNon2xx verifies a non-2xx daemon response is a
 // returned error (so postIngest logs it as a note rather than silently
 // succeeding).

--- a/cmd/crit/cli_handlers_story_llm_test.go
+++ b/cmd/crit/cli_handlers_story_llm_test.go
@@ -578,6 +578,28 @@ func TestPostStoryToDaemon_PollsReadinessThenPosts(t *testing.T) {
 	}
 }
 
+func TestPostStoryToDaemon_RejectsNonReadinessError(t *testing.T) {
+	posted := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/session" {
+			http.Error(w, "broken", http.StatusInternalServerError)
+			return
+		}
+		posted = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+	err := postStoryToDaemon(daemon.SessionEntry{Host: u.Hostname(), Port: port}, &session.Story{Version: 1})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("expected readiness error, got %v", err)
+	}
+	if posted {
+		t.Fatal("story mutation ran before daemon was ready")
+	}
+}
+
 // TestPostStoryToDaemon_ErrorOnNon2xx verifies a non-2xx daemon response is a
 // returned error (so postIngest logs it as a note rather than silently
 // succeeding).

--- a/cmd/crit/cli_handlers_story_test.go
+++ b/cmd/crit/cli_handlers_story_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -250,6 +251,77 @@ func TestStoryClearRemovesStory(t *testing.T) {
 	reloaded, _ := review.LoadCritJSON(critPath)
 	if reloaded.Story != nil {
 		t.Fatal("--clear did not remove the story")
+	}
+}
+
+func TestStoryClearUsesExactRunningDaemon(t *testing.T) {
+	setupStoryRepo(t)
+	origAlive, origDelete := storyDaemonAlive, storyDeleteStory
+	t.Cleanup(func() { storyDaemonAlive, storyDeleteStory = origAlive, origDelete })
+	wantKey := storySessionKey(t, nil)
+	var gotKey string
+	deleted := false
+	storyDaemonAlive = func(key string) (daemon.SessionEntry, bool) {
+		gotKey = key
+		return daemon.SessionEntry{ReviewPath: "exact-review"}, true
+	}
+	storyDeleteStory = func(entry daemon.SessionEntry) error {
+		deleted = entry.ReviewPath == "exact-review"
+		return nil
+	}
+	if err := runStoryE([]string{"--clear"}); err != nil {
+		t.Fatalf("clear failed: %v", err)
+	}
+	if gotKey != wantKey || !deleted {
+		t.Fatalf("clear targeted key %q (want %q), deleted=%v", gotKey, wantKey, deleted)
+	}
+}
+
+func TestStoryClearFallsBackWhenDaemonDies(t *testing.T) {
+	setupStoryRepo(t)
+	critPath, err := resolveStoryReviewPath(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cj, _ := review.LoadCritJSON(critPath)
+	cj.Story = &session.Story{Version: 1}
+	if err := review.SaveCritJSON(critPath, cj); err != nil {
+		t.Fatal(err)
+	}
+	origAlive, origDelete := storyDaemonAlive, storyDeleteStory
+	t.Cleanup(func() { storyDaemonAlive, storyDeleteStory = origAlive, origDelete })
+	checks := 0
+	storyDaemonAlive = func(string) (daemon.SessionEntry, bool) {
+		checks++
+		return daemon.SessionEntry{}, checks <= 2
+	}
+	storyDeleteStory = func(daemon.SessionEntry) error { return errors.New("connection refused") }
+	if err := runStoryE([]string{"--clear"}); err != nil {
+		t.Fatalf("clear should fall back after daemon exits: %v", err)
+	}
+	reloaded, _ := review.LoadCritJSON(critPath)
+	if reloaded.Story != nil {
+		t.Fatal("fallback clear left story on disk")
+	}
+}
+
+func TestResolveStoryReviewPathIgnoresOtherScopedDaemon(t *testing.T) {
+	setupStoryRepo(t)
+	origAlive := storyDaemonAlive
+	t.Cleanup(func() { storyDaemonAlive = origAlive })
+	wantKey := storySessionKey(t, nil)
+	storyDaemonAlive = func(key string) (daemon.SessionEntry, bool) {
+		if key != wantKey {
+			return daemon.SessionEntry{ReviewPath: "wrong-review"}, true
+		}
+		return daemon.SessionEntry{ReviewPath: "exact-review"}, true
+	}
+	path, err := resolveStoryReviewPath(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "exact-review" {
+		t.Fatalf("path = %q, want exact scoped daemon path", path)
 	}
 }
 

--- a/cmd/crit/cli_handlers_story_test.go
+++ b/cmd/crit/cli_handlers_story_test.go
@@ -305,6 +305,18 @@ func TestStoryClearFallsBackWhenDaemonDies(t *testing.T) {
 	}
 }
 
+func TestStoryClearReturnsErrorWhileDaemonStillAlive(t *testing.T) {
+	setupStoryRepo(t)
+	origAlive, origDelete := storyDaemonAlive, storyDeleteStory
+	t.Cleanup(func() { storyDaemonAlive, storyDeleteStory = origAlive, origDelete })
+	storyDaemonAlive = func(string) (daemon.SessionEntry, bool) { return daemon.SessionEntry{}, true }
+	storyDeleteStory = func(daemon.SessionEntry) error { return errors.New("delete failed") }
+	err := runStoryE([]string{"--clear"})
+	if err == nil || !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("expected live daemon delete error, got %v", err)
+	}
+}
+
 func TestResolveStoryReviewPathIgnoresOtherScopedDaemon(t *testing.T) {
 	setupStoryRepo(t)
 	origAlive := storyDaemonAlive

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -492,9 +492,16 @@ func DaemonHasBrowser(s SessionEntry) bool {
 	}
 	defer resp.Body.Close()
 	var result struct {
-		BrowserClients *bool `json:"browser_clients"`
+		Status         string `json:"status"`
+		BrowserClients *bool  `json:"browser_clients"`
+	}
+	if resp.StatusCode != http.StatusOK {
+		return true
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return true
+	}
+	if result.Status != "ok" {
 		return true
 	}
 	if result.BrowserClients == nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -453,6 +453,13 @@ func TestDaemonHasBrowser(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "returns true when health status is not ok",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(map[string]any{"status": "starting", "browser_clients": false})
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/hooks_test.go
+++ b/internal/server/hooks_test.go
@@ -163,6 +163,38 @@ func TestHandleFinish_ProjectHookRunsAfterTrust(t *testing.T) {
 	}
 }
 
+func TestHandleFinish_ProjectHookRunsWithPromptUntilChangeTrust(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh -c inline hook tested on unix")
+	}
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	s, session := newTestServer(t)
+	s.homeDir = home
+	dir := session.RepoRoot
+	s.projectDir = dir
+	_, marker := markerCmd(t)
+	configBody := `{"prompts":{"on_finish_approved":"inline:Approved."},"hooks":{"on_finish_approved":"inline:printf p > '` + marker + `'"}}`
+	if err := os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	trustReq := httptest.NewRequest("POST", "/api/project-prompts/trust", strings.NewReader(`{"mode":"until_change"}`))
+	trustReq.Header.Set("Content-Type", "application/json")
+	tw := httptest.NewRecorder()
+	s.ServeHTTP(tw, trustReq)
+	if tw.Code != http.StatusOK {
+		t.Fatalf("trust status = %d body=%s", tw.Code, tw.Body.String())
+	}
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest("POST", "/api/finish", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("finish status = %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("project hook did not run with prompt+hook until_change trust: %v", err)
+	}
+}
+
 // TestHandleFinish_DiscoveredFileHook runs a discovered .crit/hooks/*.sh script.
 func TestHandleFinish_DiscoveredFileHook(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -178,7 +178,8 @@ func (s *Server) runFinishHooks(sess *Session, approved bool, stats map[string]a
 	mode := prompt.PromptMode(sess.ReviewType, sess.Mode)
 
 	globalHooks, projectHooks := config.LoadHookMaps(s.projectDir)
-	trust, err := prompt.EvaluateTrust(s.projectDir, nil, projectHooks)
+	_, projectPrompts := config.LoadPromptMaps(s.projectDir)
+	trust, err := prompt.EvaluateTrust(s.projectDir, projectPrompts, projectHooks)
 	if err != nil {
 		log.Printf("finish-hook: evaluating project trust: %v", err)
 		return

--- a/internal/session/story_roundtrip_test.go
+++ b/internal/session/story_roundtrip_test.go
@@ -5,7 +5,29 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
+
+func TestStoryScopeRangeIncludesIgnoredHunks(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	commitAt(t, dir, "visible.go", "package visible\n", "add visible")
+	commitAt(t, dir, "ignored.go", "package ignored\n", "add ignored")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+	s := &Session{
+		Mode: "git", RepoRoot: dir, BaseRef: base, VCS: &vcs.GitVCS{},
+		Focus: Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer},
+		Files: []*FileEntry{{Path: "visible.go", Status: "added", Content: "package visible\n", DiffHunks: vcs.FileDiffUnifiedNewFile("package visible\n")}},
+	}
+	scope := s.StoryScope([]string{"ignored.go"})
+	for _, file := range scope.Files {
+		if file.Path == "ignored.go" && file.Ignored && len(file.Hunks) > 0 {
+			return
+		}
+	}
+	t.Fatalf("range story scope omitted ignored hunks: %+v", scope.Files)
+}
 
 // TestBuildCritJSONPreservesStory verifies that an externally-set story on
 // review.json survives the daemon's read-merge-modify write cycle, because

--- a/internal/session/story_scope.go
+++ b/internal/session/story_scope.go
@@ -111,24 +111,39 @@ func (s *Session) StoryScope(ignorePatterns []string) StoryScope {
 
 	// Re-derive ignored files: the session filtered them out, but ingest needs
 	// to pre-place their hunks into support[]. Only meaningful in a git scope.
-	if s.VCS != nil && len(ignorePatterns) > 0 && s.Focus.Kind != FocusRange {
-		if all, err := s.VCS.ChangedFilesFromBaseInDir(s.BaseRef, s.RepoRoot); err == nil {
-			for _, fc := range all {
-				if !matchesAny(fc.Path, ignorePatterns) {
-					continue
-				}
-				hunks, _ := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, s.BaseRef, s.RepoRoot, false, s.VCS)
-				scope.Files = append(scope.Files, StoryScopeFile{
-					Path:    fc.Path,
-					Status:  fc.Status,
-					Hunks:   convertHunks(hunks),
-					Ignored: true,
-				})
-			}
-		}
-	}
+	scope.Files = append(scope.Files, s.ignoredStoryScopeFiles(ignorePatterns)...)
 
 	return scope
+}
+
+func (s *Session) ignoredStoryScopeFiles(ignorePatterns []string) []StoryScopeFile {
+	if s.VCS == nil || len(ignorePatterns) == 0 {
+		return nil
+	}
+	var all []vcs.FileChange
+	var err error
+	if s.Focus.Kind == FocusRange {
+		all, err = s.VCS.ChangedFilesBetweenSHAs(s.Focus.DiffBaseSHA(), s.Focus.HeadSHA, s.RepoRoot)
+	} else {
+		all, err = s.VCS.ChangedFilesFromBaseInDir(s.BaseRef, s.RepoRoot)
+	}
+	if err != nil {
+		return nil
+	}
+	var out []StoryScopeFile
+	for _, fc := range all {
+		if !matchesAny(fc.Path, ignorePatterns) {
+			continue
+		}
+		var hunks []vcs.DiffHunk
+		if s.Focus.Kind == FocusRange {
+			hunks, _ = s.VCS.FileDiffBetweenSHAs(fc.Path, fc.OldPath, s.Focus.DiffBaseSHA(), s.Focus.HeadSHA, s.RepoRoot, false)
+		} else {
+			hunks, _ = diffHunksForFile(fc.Path, fc.OldPath, fc.Status, s.BaseRef, s.RepoRoot, false, s.VCS)
+		}
+		out = append(out, StoryScopeFile{Path: fc.Path, Status: fc.Status, Hunks: convertHunks(hunks), Ignored: true})
+	}
+	return out
 }
 
 // resolveSHA turns a ref (branch, tag, "HEAD~2") into a full commit SHA. On

--- a/internal/story/ingest.go
+++ b/internal/story/ingest.go
@@ -82,10 +82,11 @@ type Result struct {
 
 // Sentinel errors so callers can distinguish rejection reasons if needed.
 var (
-	ErrInvalidPrologue = errors.New("story prologue must include title, overview, key_changes, and risks")
-	ErrDrift           = errors.New("diff changed since prep — re-run `crit story --prep` and re-author")
-	ErrDuplicate       = errors.New("story places the same hunk in more than one chapter/support entry")
-	ErrBelowFloor      = errors.New("story places fewer than half of the diff's hunks")
+	ErrInvalidPrologue  = errors.New("story prologue must include title, overview, key_changes, and risks")
+	ErrInvalidChapterID = errors.New("story chapter IDs must be unique URL-safe names and cannot be overview or support")
+	ErrDrift            = errors.New("diff changed since prep — re-run `crit story --prep` and re-author")
+	ErrDuplicate        = errors.New("story places the same hunk in more than one chapter/support entry")
+	ErrBelowFloor       = errors.New("story places fewer than half of the diff's hunks")
 )
 
 // Fingerprint computes a stable sha256 over the sorted hunk IDs. It is used
@@ -181,7 +182,30 @@ func ValidateShape(st *session.Story) error {
 		!hasNonEmptyBullet(prologue.Risks) {
 		return ErrInvalidPrologue
 	}
+	seen := make(map[string]struct{}, len(st.Chapters))
+	for _, chapter := range st.Chapters {
+		id := chapter.ID
+		if !validChapterID(id) || id == "overview" || id == "support" {
+			return ErrInvalidChapterID
+		}
+		if _, exists := seen[id]; exists {
+			return ErrInvalidChapterID
+		}
+		seen[id] = struct{}{}
+	}
 	return nil
+}
+
+func validChapterID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '-' && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 func hasNonEmptyBullet(items []string) bool {

--- a/internal/story/ingest_test.go
+++ b/internal/story/ingest_test.go
@@ -68,6 +68,26 @@ func TestIngest_InvalidPrologueReject(t *testing.T) {
 	}
 }
 
+func TestIngest_InvalidChapterIDsReject(t *testing.T) {
+	tests := []struct {
+		name     string
+		chapters []session.StoryChapter
+	}{
+		{"duplicate", []session.StoryChapter{chapter("same", "One"), chapter("same", "Two")}},
+		{"reserved", []session.StoryChapter{chapter("support", "Support")}},
+		{"slash", []session.StoryChapter{chapter("part/one", "Part")}},
+		{"empty", []session.StoryChapter{chapter("", "Empty")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &session.Story{Prologue: validPrologue(), Chapters: tt.chapters}
+			if _, err := Run(baseScope(t, st, nil)); !errors.Is(err, ErrInvalidChapterID) {
+				t.Fatalf("expected ErrInvalidChapterID, got %v", err)
+			}
+		})
+	}
+}
+
 func TestIngest_DriftReject(t *testing.T) {
 	indexed := []HunkID{hunk("a.go", 1), hunk("b.go", 10)}
 	story := &session.Story{

--- a/web/__tests__/crit-settings-overlay.test.js
+++ b/web/__tests__/crit-settings-overlay.test.js
@@ -339,10 +339,10 @@ test('? toggles shortcuts tab when overlay is open; closes when already on short
   var ctl = api.install({ overlay: dom.overlay, document: doc });
   ctl.open('settings');
 
-  doc.fire('keydown', { key: '?', preventDefault: function () {} });
+  doc.fire('keydown', { key: '?', preventDefault: function () {}, stopImmediatePropagation: function () {} });
   assert.equal(ctl.getActiveTab(), 'shortcuts');
 
-  doc.fire('keydown', { key: '?', preventDefault: function () {} });
+  doc.fire('keydown', { key: '?', preventDefault: function () {}, stopImmediatePropagation: function () {} });
   assert.equal(ctl.isOpen(), false, 'second ? closes overlay when on shortcuts');
 });
 

--- a/web/__tests__/range-focus-diff-scope.test.js
+++ b/web/__tests__/range-focus-diff-scope.test.js
@@ -18,7 +18,7 @@ test('range focus forces diffScope to all on init', () => {
   );
 });
 
-test('file diff loads use effectiveDiffScope helper', () => {
+test('file diff loads use the story-aware file data scope helper', () => {
   assert.match(
     appJs,
     /function effectiveDiffScope\(\)\s*\{\s*return sessionInRangeFocus\(\) \? 'all' : diffScope;/,
@@ -26,7 +26,7 @@ test('file diff loads use effectiveDiffScope helper', () => {
   );
   assert.match(
     appJs,
-    /loadAllFileData\(session\.files[^)]*effectiveDiffScope\(\)/,
-    'loadAllFileData must use effectiveDiffScope'
+    /loadAllFileData\(session\.files[^)]*currentFileDataScope\(\)/,
+    'loadAllFileData must use currentFileDataScope so story and range scopes agree'
   );
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6981,7 +6981,7 @@
         clearCommitPins();
 
         // Re-fetch everything on file-changed (round complete)
-        let sessionRes = await hydrateStoryIfMissing(await fetch('/api/session?scope=' + enc(currentSessionFetchScope())).then(r => r.json()));
+        let sessionRes = await hydrateStoryIfMissing(await fetchWhenReady('/api/session?scope=' + enc(currentSessionFetchScope())));
         sessionRes = await hydrateFullSessionForStoryIfNeeded(sessionRes);
         session = sessionRes;
         reviewComments = sessionRes.review_comments || [];
@@ -8183,7 +8183,7 @@
 
         let sessionUrl = '/api/session?scope=' + enc(currentSessionFetchScope());
         if (diffCommit) sessionUrl += '&commit=' + enc(diffCommit);
-        let sessionRes = await fetch(sessionUrl).then(function(r) { return r.json(); });
+        let sessionRes = await fetchWhenReady(sessionUrl);
         if (!storyHasContent(sessionRes.story) && storyHasContent(session && session.story)) {
           sessionRes.story = session.story;
         } else {

--- a/web/live-mode.sse.js
+++ b/web/live-mode.sse.js
@@ -105,6 +105,7 @@
     }
 
     function showLiveDisconnected() {
+      if (typeof window === 'undefined') return;
       var shared = window.crit && window.crit.shared;
       if (shared && typeof shared.showDisconnected === 'function') {
         shared.showDisconnected();
@@ -112,6 +113,7 @@
     }
 
     function install() {
+      if (typeof window === 'undefined') return;
       if (!window.crit || !window.crit.sse) return;
       var conn = window.crit.sse.createSSE('/api/events', {
         'live-round-start': function (data) {


### PR DESCRIPTION
## Summary
- keep story clear and resume operations scoped to the exact live daemon
- make project prompt and hook trust use one fingerprint
- preserve ignored hunks in range stories and validate chapter routing IDs
- harden readiness/session refresh behavior and repair related frontend regressions

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: passed
- [x] Security scan: passed
- [x] Red-team checks: passed

## Test plan
- `go test -race -count=1 ./...`
- `golangci-lint run ./...`
- 442 frontend unit tests
- CSS/theme variable validation

See also: tomasz-tomczyk/crit-web#299
