### PR TITLE
fix: unblock project prompt trust dialog

### DIFF
--- a/web/__tests__/crit-shared.test.js
+++ b/web/__tests__/crit-shared.test.js
@@ -28,11 +28,11 @@ test('escapeHTML returns empty string for null/undefined', () => {
   assert.equal(shared.escapeHTML(undefined), '');
 });
 
-test('applyProjectPromptTrustUI re-enables finish button after trust', () => {
+test('applyProjectPromptTrustUI keeps finish button enabled so trust dialog can open', () => {
   const btn = { disabled: false, textContent: 'Approve', title: '' };
   shared.applyProjectPromptTrustUI({ project_prompts_untrusted: true }, btn);
-  assert.equal(btn.disabled, true);
-  assert.equal(btn.title, 'Trust project prompts before finishing');
+  assert.equal(btn.disabled, false);
+  assert.equal(btn.title, 'Review project prompts before finishing');
   shared.applyProjectPromptTrustUI({ project_prompts_untrusted: false }, btn);
   assert.equal(btn.disabled, false);
   assert.equal(btn.title, '');
@@ -42,6 +42,13 @@ test('applyProjectPromptTrustUI does not re-enable while waiting', () => {
   const btn = { disabled: true, textContent: 'Waiting...', title: 'Trust project prompts before finishing' };
   shared.applyProjectPromptTrustUI({ project_prompts_untrusted: false }, btn);
   assert.equal(btn.disabled, true);
+});
+
+test('applyProjectPromptTrustUI keeps waiting button disabled when prompts become untrusted', () => {
+  const btn = { disabled: true, textContent: 'Waiting...', title: '' };
+  shared.applyProjectPromptTrustUI({ project_prompts_untrusted: true }, btn);
+  assert.equal(btn.disabled, true);
+  assert.equal(btn.title, 'Review project prompts before finishing');
 });
 
 test('getCookie reads document.cookie and URL-decodes the value', () => {

--- a/web/crit-shared.js
+++ b/web/crit-shared.js
@@ -874,8 +874,13 @@
   function applyProjectPromptTrustUI(cfg, finishBtn) {
     if (!finishBtn || !cfg) return;
     if (cfg.project_prompts_untrusted) {
-      finishBtn.disabled = true;
-      finishBtn.title = 'Trust project prompts before finishing';
+      // The trust dialog is opened by the finish button's click handler.
+      // Keep the button actionable so the user can make that trust choice;
+      // /api/finish remains guarded server-side until they do.
+      finishBtn.title = 'Review project prompts before finishing';
+      if (finishBtn.textContent !== 'Waiting...') {
+        finishBtn.disabled = false;
+      }
       return;
     }
     finishBtn.title = '';


### PR DESCRIPTION
## Summary
- keep Finish/Approve actionable when project prompts require a trust decision
- preserve the disabled state while waiting for the agent
- add regression coverage for both UI states

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A

## Test plan
- targeted project-prompt trust frontend tests
- project-prompt server guard and trust-transition tests
- full frontend unit suite
- gofmt and golangci-lint
- full Go race suite
- real-browser Playwright smoke test with a discovered project prompt