### PR TITLE
fix: preserve daemon initialization errors for clients

### DIFF
--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -236,6 +236,9 @@ func runServe(args []string) {
 	if initErr != nil {
 		log.Printf("Error: %v", initErr)
 		srv.SetInitErr(initErr)
+		if err := writeDaemonFailure(key, os.Getpid(), initErr); err != nil {
+			log.Printf("Warning: could not preserve daemon initialization error: %v", err)
+		}
 		stop()
 		<-ctx.Done()
 		// Keep the session entry and log until stale-session cleanup. The client

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -238,7 +238,9 @@ func runServe(args []string) {
 		srv.SetInitErr(initErr)
 		stop()
 		<-ctx.Done()
-		removeSessionFile(key)
+		// Keep the session entry and log until stale-session cleanup. The client
+		// may already have received the entry and needs the log to report this
+		// fatal initialization error after the server stops.
 		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		_ = httpServer.Shutdown(shutCtx)

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -150,6 +150,7 @@ func runServe(args []string) {
 		sessionArgs = []string{"preview", sc.PreviewFile}
 	}
 	sessionStartedAt := time.Now().UTC()
+	sessionGeneration := sessionStartedAt.Format(time.RFC3339Nano)
 	srv.ConfigureDaemon(sc.Cfg, cwd, homeDir, sc.ReviewPath, cliArgs, sessionStartedAt)
 	if err := writeSessionFile(key, sessionEntry{
 		PID:        os.Getpid(),
@@ -160,7 +161,7 @@ func runServe(args []string) {
 		Args:       sessionArgs,
 		Branch:     branch,
 		ReviewPath: sc.ReviewPath,
-		StartedAt:  sessionStartedAt.Format(time.RFC3339),
+		StartedAt:  sessionGeneration,
 	}); err != nil {
 		daemonFatal(pipe, "Error writing session file: %v", err)
 	}
@@ -236,7 +237,7 @@ func runServe(args []string) {
 	if initErr != nil {
 		log.Printf("Error: %v", initErr)
 		srv.SetInitErr(initErr)
-		if err := writeDaemonFailure(key, os.Getpid(), initErr); err != nil {
+		if err := writeDaemonFailure(key, sessionGeneration, initErr); err != nil {
 			log.Printf("Warning: could not preserve daemon initialization error: %v", err)
 		}
 		stop()

--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -34,21 +34,22 @@ var (
 	NewServer    = server.NewServer
 	mustGetwd    = session.MustGetwd
 
-	resolvedCWD       = daemon.ResolvedCWD
-	sessionKey        = daemon.SessionKey
-	liveSessionKey    = daemon.LiveSessionKey
-	previewSessionKey = preview.PreviewSessionKey
-	planSessionKey    = session.PlanSessionKey
-	writeSessionFile  = daemon.WriteSessionFile
-	removeSessionFile = daemon.RemoveSessionFile
-	reviewFilePath    = daemon.ReviewFilePath
-	openReadyPipe     = daemon.OpenReadyPipe
-	daemonFatal       = daemon.DaemonFatal
-	signalReadiness   = daemon.SignalReadiness
-	hostForDisplay    = daemon.HostForDisplay
-	advertisedURL     = daemon.AdvertisedURL
-	shutdownSignals   = daemon.ShutdownSignals
-	openBrowser       = browser.OpenBrowserWithCommand
+	resolvedCWD        = daemon.ResolvedCWD
+	sessionKey         = daemon.SessionKey
+	liveSessionKey     = daemon.LiveSessionKey
+	previewSessionKey  = preview.PreviewSessionKey
+	planSessionKey     = session.PlanSessionKey
+	writeSessionFile   = daemon.WriteSessionFile
+	writeDaemonFailure = daemon.WriteDaemonFailure
+	removeSessionFile  = daemon.RemoveSessionFile
+	reviewFilePath     = daemon.ReviewFilePath
+	openReadyPipe      = daemon.OpenReadyPipe
+	daemonFatal        = daemon.DaemonFatal
+	signalReadiness    = daemon.SignalReadiness
+	hostForDisplay     = daemon.HostForDisplay
+	advertisedURL      = daemon.AdvertisedURL
+	shutdownSignals    = daemon.ShutdownSignals
+	openBrowser        = browser.OpenBrowserWithCommand
 
 	reviewPathsFor = session.ReviewPathsFor
 	detectPRInfo   = github.DetectPRInfo

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -14,20 +14,13 @@ import (
 func RunReviewClient(entry SessionEntry, sessionKey string) (approved bool) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
-	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.PID)
+	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.StartedAt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	if statusCode == http.StatusInternalServerError {
-		var status struct {
-			Message string `json:"message"`
-		}
-		if json.Unmarshal(body, &status) == nil && status.Message != "" {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", status.Message)
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", body)
-		}
+		fmt.Fprintf(os.Stderr, "Error: %s\n", daemonInitError(body))
 		os.Exit(1)
 	}
 
@@ -73,9 +66,15 @@ func RunReviewClient(entry SessionEntry, sessionKey string) (approved bool) {
 func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, prompt string) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
-	if _, _, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.PID); err != nil {
+	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.StartedAt)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
 		return false, "crit daemon was unreachable; plan was not reviewed."
+	}
+	if statusCode == http.StatusInternalServerError {
+		message := daemonInitError(body)
+		fmt.Fprintf(os.Stderr, "crit plan-hook: %s\n", message)
+		return false, "crit daemon failed to initialize: " + message
 	}
 
 	resp, err := client.Post(entry.ConnURL()+"/api/review-cycle", "application/json", nil)
@@ -85,7 +84,7 @@ func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, p
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: could not read daemon response: %v\n", err)
 		return false, "crit daemon response could not be read."
@@ -107,7 +106,7 @@ func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, p
 	return result.Approved, result.Prompt
 }
 
-func waitForDaemonReady(client *http.Client, host string, port int, sessionKey string, daemonPID int) (statusCode int, body []byte, err error) {
+func waitForDaemonReady(client *http.Client, host string, port int, sessionKey, daemonGeneration string) (statusCode int, body []byte, err error) {
 	connHost := host
 	if connHost == "" {
 		connHost = "127.0.0.1"
@@ -118,7 +117,7 @@ func waitForDaemonReady(client *http.Client, host string, port int, sessionKey s
 		resp, reqErr := client.Get(base + "/api/session")
 		if reqErr != nil {
 			if sessionKey != "" {
-				if msg := ReadDaemonFailure(sessionKey, daemonPID); msg != "" {
+				if msg := ReadDaemonFailure(sessionKey, daemonGeneration); msg != "" {
 					return 0, nil, fmt.Errorf("%s", msg)
 				}
 				if msg := ReadDaemonLog(sessionKey); msg != "" {
@@ -137,6 +136,16 @@ func waitForDaemonReady(client *http.Client, host string, port int, sessionKey s
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+func daemonInitError(body []byte) string {
+	var status struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &status) == nil && status.Message != "" {
+		return status.Message
+	}
+	return string(body)
 }
 
 func readReviewCycleResponse(resp *http.Response) ([]byte, error) {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -14,7 +14,7 @@ import (
 func RunReviewClient(entry SessionEntry, sessionKey string) (approved bool) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
-	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey)
+	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.PID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -73,7 +73,7 @@ func RunReviewClient(entry SessionEntry, sessionKey string) (approved bool) {
 func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, prompt string) {
 	client := &http.Client{Timeout: 24 * time.Hour}
 
-	if _, _, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey); err != nil {
+	if _, _, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.PID); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
 		return false, "crit daemon was unreachable; plan was not reviewed."
 	}
@@ -107,7 +107,7 @@ func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, p
 	return result.Approved, result.Prompt
 }
 
-func waitForDaemonReady(client *http.Client, host string, port int, sessionKey string) (statusCode int, body []byte, err error) {
+func waitForDaemonReady(client *http.Client, host string, port int, sessionKey string, daemonPID int) (statusCode int, body []byte, err error) {
 	connHost := host
 	if connHost == "" {
 		connHost = "127.0.0.1"
@@ -118,6 +118,9 @@ func waitForDaemonReady(client *http.Client, host string, port int, sessionKey s
 		resp, reqErr := client.Get(base + "/api/session")
 		if reqErr != nil {
 			if sessionKey != "" {
+				if msg := ReadDaemonFailure(sessionKey, daemonPID); msg != "" {
+					return 0, nil, fmt.Errorf("%s", msg)
+				}
 				if msg := ReadDaemonLog(sessionKey); msg != "" {
 					return 0, nil, fmt.Errorf("%s", msg)
 				}

--- a/internal/daemon/client_main_test.go
+++ b/internal/daemon/client_main_test.go
@@ -223,7 +223,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		os.WriteFile(filepath.Join(sessDir, "testkey123.log"), []byte("Error: not in a git repository"), 0600)
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, "", port, "testkey123")
+		_, _, err = waitForDaemonReady(client, "", port, "testkey123", 0)
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}
@@ -241,7 +241,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		ln.Close()
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, "", port, "")
+		_, _, err = waitForDaemonReady(client, "", port, "", 0)
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}
@@ -249,4 +249,35 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 			t.Errorf("expected 'could not reach daemon' fallback, got: %v", err)
 		}
 	})
+}
+
+func TestWaitForDaemonReady_SurfacesFailureAfterSameKeyCleanup(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	key := "fatalinit123"
+	pid := 999999999
+	if err := WriteSessionFile(key, SessionEntry{PID: pid, Port: port}); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDaemonFailure(key, pid, fmt.Errorf("not in a version-controlled repository and no files specified")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A concurrent same-key invocation removes the stale session and its log.
+	if _, alive := FindAliveSession(key); alive {
+		t.Fatal("dead daemon should not be considered alive")
+	}
+
+	client := &http.Client{Timeout: time.Second}
+	_, _, err = waitForDaemonReady(client, "", port, key, pid)
+	if err == nil || !strings.Contains(err.Error(), "not in a version-controlled repository") {
+		t.Fatalf("expected preserved initialization error, got %v", err)
+	}
 }

--- a/internal/daemon/client_main_test.go
+++ b/internal/daemon/client_main_test.go
@@ -223,7 +223,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		os.WriteFile(filepath.Join(sessDir, "testkey123.log"), []byte("Error: not in a git repository"), 0600)
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, "", port, "testkey123", 0)
+		_, _, err = waitForDaemonReady(client, "", port, "testkey123", "")
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}
@@ -241,7 +241,7 @@ func TestWaitForDaemonReady_SurfacesDaemonLog(t *testing.T) {
 		ln.Close()
 
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, _, err = waitForDaemonReady(client, "", port, "", 0)
+		_, _, err = waitForDaemonReady(client, "", port, "", "")
 		if err == nil {
 			t.Fatal("expected error for unreachable daemon")
 		}
@@ -262,11 +262,11 @@ func TestWaitForDaemonReady_SurfacesFailureAfterSameKeyCleanup(t *testing.T) {
 	home := t.TempDir()
 	testutil.SetHome(t, home)
 	key := "fatalinit123"
-	pid := 999999999
-	if err := WriteSessionFile(key, SessionEntry{PID: pid, Port: port}); err != nil {
+	generation := "2026-07-17T12:00:00.123456789Z"
+	if err := WriteSessionFile(key, SessionEntry{PID: 999999999, Port: port, StartedAt: generation}); err != nil {
 		t.Fatal(err)
 	}
-	if err := WriteDaemonFailure(key, pid, fmt.Errorf("not in a version-controlled repository and no files specified")); err != nil {
+	if err := WriteDaemonFailure(key, generation, fmt.Errorf("not in a version-controlled repository and no files specified")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -276,8 +276,34 @@ func TestWaitForDaemonReady_SurfacesFailureAfterSameKeyCleanup(t *testing.T) {
 	}
 
 	client := &http.Client{Timeout: time.Second}
-	_, _, err = waitForDaemonReady(client, "", port, key, pid)
+	_, _, err = waitForDaemonReady(client, "", port, key, generation)
 	if err == nil || !strings.Contains(err.Error(), "not in a version-controlled repository") {
 		t.Fatalf("expected preserved initialization error, got %v", err)
+	}
+}
+
+func TestRunReviewClientRaw_ReturnsInitializationError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/session" {
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  "error",
+			"message": "not in a version-controlled repository and no files specified",
+		})
+	}))
+	defer ts.Close()
+
+	port := 0
+	fmt.Sscanf(ts.URL, "http://127.0.0.1:%d", &port)
+	approved, prompt := RunReviewClientRaw(SessionEntry{Port: port}, "")
+	if approved {
+		t.Fatal("expected approved=false")
+	}
+	if !strings.Contains(prompt, "not in a version-controlled repository") {
+		t.Fatalf("expected initialization error in prompt, got %q", prompt)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -57,6 +57,8 @@ var aliveClient = &http.Client{Timeout: time.Second}
 // daemon lifecycle and can tolerate a longer timeout.
 var browserClient = &http.Client{Timeout: 2 * time.Second}
 
+const daemonFailureRetention = 10 * time.Minute
+
 // SessionEntry tracks a running daemon process in ~/.crit/sessions/.
 type SessionEntry struct {
 	PID        int      `json:"pid"`
@@ -740,6 +742,38 @@ func sessionLogPath(key string) (string, error) {
 	return filepath.Join(dir, key+".log"), nil
 }
 
+func daemonFailurePath(key string, pid int) (string, error) {
+	dir, err := sessionsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%d.error", key, pid)), nil
+}
+
+// WriteDaemonFailure preserves a fatal post-readiness initialization error for
+// the client that started this daemon. Failure records are PID-scoped so a
+// subsequent daemon using the same session key cannot replace its diagnosis.
+func WriteDaemonFailure(key string, pid int, err error) error {
+	path, pathErr := daemonFailurePath(key, pid)
+	if pathErr != nil {
+		return pathErr
+	}
+	return config.AtomicWriteFile(path, []byte(err.Error()), 0600)
+}
+
+// ReadDaemonFailure returns the fatal initialization error for one daemon PID.
+func ReadDaemonFailure(key string, pid int) string {
+	path, err := daemonFailurePath(key, pid)
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // ReadDaemonLog reads and returns the trimmed contents of a daemon log file.
 func ReadDaemonLog(key string) string {
 	logPath, err := sessionLogPath(key)
@@ -751,6 +785,23 @@ func ReadDaemonLog(key string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
+}
+
+func cleanExpiredDaemonFailures(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-daemonFailureRetention)
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".error") {
+			continue
+		}
+		info, err := entry.Info()
+		if err == nil && info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
 }
 
 // OpenReadyPipe returns the readiness pipe (the inherited stdout) if this
@@ -852,6 +903,7 @@ func cleanOrphanedSessions() {
 	if err != nil {
 		return
 	}
+	cleanExpiredDaemonFailures(sessDir)
 	for _, de := range entries {
 		if !strings.HasSuffix(de.Name(), ".json") {
 			continue

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -742,28 +742,29 @@ func sessionLogPath(key string) (string, error) {
 	return filepath.Join(dir, key+".log"), nil
 }
 
-func daemonFailurePath(key string, pid int) (string, error) {
+func daemonFailurePath(key, generation string) (string, error) {
 	dir, err := sessionsDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, fmt.Sprintf("%s-%d.error", key, pid)), nil
+	digest := sha256.Sum256([]byte(generation))
+	return filepath.Join(dir, fmt.Sprintf("%s-%x.error", key, digest[:8])), nil
 }
 
 // WriteDaemonFailure preserves a fatal post-readiness initialization error for
-// the client that started this daemon. Failure records are PID-scoped so a
-// subsequent daemon using the same session key cannot replace its diagnosis.
-func WriteDaemonFailure(key string, pid int, err error) error {
-	path, pathErr := daemonFailurePath(key, pid)
+// the client that started this daemon. Failure records are generation-scoped
+// so a reused PID cannot be mistaken for an earlier daemon with the same key.
+func WriteDaemonFailure(key, generation string, err error) error {
+	path, pathErr := daemonFailurePath(key, generation)
 	if pathErr != nil {
 		return pathErr
 	}
 	return config.AtomicWriteFile(path, []byte(err.Error()), 0600)
 }
 
-// ReadDaemonFailure returns the fatal initialization error for one daemon PID.
-func ReadDaemonFailure(key string, pid int) string {
-	path, err := daemonFailurePath(key, pid)
+// ReadDaemonFailure returns the fatal initialization error for one daemon generation.
+func ReadDaemonFailure(key, generation string) string {
+	path, err := daemonFailurePath(key, generation)
 	if err != nil {
 		return ""
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -603,6 +603,14 @@ func setupDaemonCmd(key string, args []string) (*exec.Cmd, *os.File, *os.File, *
 	return cmd, readEnd, writeEnd, logFile, nil
 }
 
+// prepareDaemonCmd removes stale session state before creating the log that
+// the new daemon inherits. This keeps fatal initialization errors readable by
+// the client after the daemon exits.
+func prepareDaemonCmd(key string, args []string) (*exec.Cmd, *os.File, *os.File, *os.File, error) {
+	RemoveSessionFile(key)
+	return setupDaemonCmd(key, args)
+}
+
 func readPortFromPipe(readEnd *os.File) (portCh chan int, errCh chan error) {
 	portCh = make(chan int, 1)
 	errCh = make(chan error, 1)
@@ -680,12 +688,10 @@ func StartDaemon(key string, args []string) (SessionEntry, error) {
 		return entry, nil
 	}
 
-	cmd, readEnd, writeEnd, logFile, err := setupDaemonCmd(key, args)
+	cmd, readEnd, writeEnd, logFile, err := prepareDaemonCmd(key, args)
 	if err != nil {
 		return SessionEntry{}, err
 	}
-
-	RemoveSessionFile(key)
 
 	if err := cmd.Start(); err != nil {
 		logFile.Close()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -748,7 +748,7 @@ func daemonFailurePath(key, generation string) (string, error) {
 		return "", err
 	}
 	digest := sha256.Sum256([]byte(generation))
-	return filepath.Join(dir, fmt.Sprintf("%s-%x.error", key, digest[:8])), nil
+	return filepath.Join(dir, fmt.Sprintf("%s-%x.error", key, digest)), nil
 }
 
 // WriteDaemonFailure preserves a fatal post-readiness initialization error for

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -996,10 +996,11 @@ func TestCleanOrphanedSessions_ExpiresOldDaemonFailures(t *testing.T) {
 	testutil.SetHome(t, home)
 
 	key := "expirederror"
-	if err := WriteDaemonFailure(key, 123, fmt.Errorf("initialization failed")); err != nil {
+	generation := "2026-07-17T12:00:00.123456789Z"
+	if err := WriteDaemonFailure(key, generation, fmt.Errorf("initialization failed")); err != nil {
 		t.Fatal(err)
 	}
-	path, err := daemonFailurePath(key, 123)
+	path, err := daemonFailurePath(key, generation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,8 +1010,23 @@ func TestCleanOrphanedSessions_ExpiresOldDaemonFailures(t *testing.T) {
 	}
 
 	cleanOrphanedSessions()
-	if got := ReadDaemonFailure(key, 123); got != "" {
+	if got := ReadDaemonFailure(key, generation); got != "" {
 		t.Errorf("ReadDaemonFailure = %q, want expired failure removed", got)
+	}
+}
+
+func TestDaemonFailure_GenerationScoped(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+
+	key := "generation12"
+	firstGeneration := "2026-07-17T12:00:00.123456789Z"
+	secondGeneration := "2026-07-17T12:00:00.987654321Z"
+	if err := WriteDaemonFailure(key, firstGeneration, fmt.Errorf("first failure")); err != nil {
+		t.Fatal(err)
+	}
+	if got := ReadDaemonFailure(key, secondGeneration); got != "" {
+		t.Errorf("ReadDaemonFailure for another generation = %q, want empty", got)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -990,6 +990,39 @@ func TestReadDaemonLog(t *testing.T) {
 	})
 }
 
+func TestPrepareDaemonCmd_KeepsNewLogAvailable(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+
+	key := "newdaemonlog"
+	sessDir := filepath.Join(home, ".crit", "sessions")
+	if err := os.MkdirAll(sessDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, key+".json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, key+".log"), []byte("old error"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, readEnd, writeEnd, logFile, err := prepareDaemonCmd(key, nil)
+	if err != nil {
+		t.Fatalf("prepareDaemonCmd: %v", err)
+	}
+	readEnd.Close()
+	writeEnd.Close()
+	logFile.Close()
+
+	logPath := filepath.Join(sessDir, key+".log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("new daemon log should remain accessible: %v", err)
+	}
+	if got := ReadDaemonLog(key); got != "" {
+		t.Errorf("ReadDaemonLog = %q, want cleared new log", got)
+	}
+}
+
 func TestOpenReadyPipe_NoEnvVar(t *testing.T) {
 	t.Setenv("_CRIT_READY_STDOUT", "")
 	os.Unsetenv("_CRIT_READY_STDOUT")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
@@ -988,6 +989,29 @@ func TestReadDaemonLog(t *testing.T) {
 			t.Errorf("ReadDaemonLog = %q, want empty", msg)
 		}
 	})
+}
+
+func TestCleanOrphanedSessions_ExpiresOldDaemonFailures(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+
+	key := "expirederror"
+	if err := WriteDaemonFailure(key, 123, fmt.Errorf("initialization failed")); err != nil {
+		t.Fatal(err)
+	}
+	path, err := daemonFailurePath(key, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expired := time.Now().Add(-daemonFailureRetention - time.Second)
+	if err := os.Chtimes(path, expired, expired); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanOrphanedSessions()
+	if got := ReadDaemonFailure(key, 123); got != "" {
+		t.Errorf("ReadDaemonFailure = %q, want expired failure removed", got)
+	}
 }
 
 func TestPrepareDaemonCmd_KeepsNewLogAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve post-readiness daemon initialization failures for the originating client.
- Retain generation-scoped diagnostics through stale-session cleanup in both CLI and plan-hook flows.
- Cover shutdown, stale cleanup, expiry, generation isolation, and immediate 500 responses.

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (Go daemon lifecycle only)

## Test plan
- mise exec -- go test -race -count=1 ./...
- mise exec -- golangci-lint run ./...

Closes #740