### PR TITLE
fix: restore Claude Code plan approval hooks

### DIFF
--- a/internal/session/codex_plan_test.go
+++ b/internal/session/codex_plan_test.go
@@ -210,6 +210,15 @@ func TestRunCodexPlanHookBlocksOnMalformedInput(t *testing.T) {
 	}
 }
 
+func TestEmitCodexStopDecision_ApprovalRemainsSilent(t *testing.T) {
+	output := captureHookDecision(t, func() {
+		emitCodexStopDecision(true, "")
+	})
+	if len(output) != 0 {
+		t.Fatalf("approved Codex hook output = %q, want no output", output)
+	}
+}
+
 func runCodexPlanHookWithInput(t *testing.T, event codexStopHookEvent) {
 	t.Helper()
 

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -152,10 +152,8 @@ func RunPlan(args []string) error {
 }
 
 type planHookEvent struct {
-	SessionID string `json:"session_id"`
-	ToolInput struct {
-		Plan string `json:"plan"`
-	} `json:"tool_input"`
+	SessionID string          `json:"session_id"`
+	ToolInput json.RawMessage `json:"tool_input"`
 }
 
 func resolveHookSlug(sessionID string, content []byte) string {
@@ -172,12 +170,15 @@ func resolveHookSlug(sessionID string, content []byte) string {
 	return ResolveSlug(content)
 }
 
-func emitHookDecision(approved bool, prompt string) {
+func emitHookDecision(approved bool, prompt string, toolInput json.RawMessage) {
 	if approved {
 		out, _ := json.Marshal(map[string]any{
 			"hookSpecificOutput": map[string]any{
 				"hookEventName": "PermissionRequest",
-				"decision":      map[string]any{"behavior": "allow"},
+				"decision": map[string]any{
+					"behavior":     "allow",
+					"updatedInput": toolInput,
+				},
 			},
 		})
 		fmt.Println(string(out))
@@ -279,14 +280,29 @@ func RunPlanHook() error {
 	var event planHookEvent
 	if err := json.NewDecoder(os.Stdin).Decode(&event); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: could not parse stdin: %v\n", err)
-		emitHookDecision(false, "Crit could not parse the plan hook input; plan was not reviewed.")
+		emitHookDecision(false, "Crit could not parse the plan hook input; plan was not reviewed.", nil)
 		return nil
 	}
-	if strings.TrimSpace(event.ToolInput.Plan) == "" {
+	if len(event.ToolInput) == 0 {
 		return nil
 	}
 
-	runPlanReviewHook("crit plan-hook", event.SessionID, []byte(event.ToolInput.Plan), emitHookDecision)
+	var toolInput struct {
+		Plan string `json:"plan"`
+	}
+	if err := json.Unmarshal(event.ToolInput, &toolInput); err != nil {
+		fmt.Fprintf(os.Stderr, "crit plan-hook: could not parse tool input: %v\n", err)
+		emitHookDecision(false, "Crit could not parse the plan hook input; plan was not reviewed.", nil)
+		return nil
+	}
+	if strings.TrimSpace(toolInput.Plan) == "" {
+		return nil
+	}
+
+	emitDecision := func(approved bool, prompt string) {
+		emitHookDecision(approved, prompt, event.ToolInput)
+	}
+	runPlanReviewHook("crit plan-hook", event.SessionID, []byte(toolInput.Plan), emitDecision)
 	return nil
 }
 

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -218,6 +218,10 @@ var runCodexPlanReviewHook = func(sessionID string, content []byte) {
 	runPlanReviewHook("crit plan-hook --mode codex", sessionID, content, emitCodexStopDecision)
 }
 
+var runClaudePlanReviewHook = func(sessionID string, content []byte, emitDecision func(bool, string)) {
+	runPlanReviewHook("crit plan-hook", sessionID, content, emitDecision)
+}
+
 func runPlanReviewHook(logPrefix, sessionID string, content []byte, emitDecision func(bool, string)) {
 	slug := resolveHookSlug(sessionID, content)
 
@@ -302,7 +306,7 @@ func RunPlanHook() error {
 	emitDecision := func(approved bool, prompt string) {
 		emitHookDecision(approved, prompt, event.ToolInput)
 	}
-	runPlanReviewHook("crit plan-hook", event.SessionID, []byte(toolInput.Plan), emitDecision)
+	runClaudePlanReviewHook(event.SessionID, []byte(toolInput.Plan), emitDecision)
 	return nil
 }
 

--- a/internal/session/plan_cli_main_test.go
+++ b/internal/session/plan_cli_main_test.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -49,4 +52,106 @@ func TestResolvePlanSlug_DerivesFromContent(t *testing.T) {
 	if !strings.Contains(slug, "auth-flow") {
 		t.Errorf("slug = %q, expected to contain 'auth-flow'", slug)
 	}
+}
+
+func TestEmitHookDecision_ApprovalEchoesCompleteToolInput(t *testing.T) {
+	toolInput := json.RawMessage(`{
+		"plan": "# Auth Flow\n\nImplement the auth flow.",
+		"planFilePath": "/tmp/auth-flow.md",
+		"futureOption": {"enabled": true}
+	}`)
+
+	output := captureHookDecision(t, func() {
+		emitHookDecision(true, "", toolInput)
+	})
+
+	var response struct {
+		HookSpecificOutput struct {
+			HookEventName string `json:"hookEventName"`
+			Decision      struct {
+				Behavior     string         `json:"behavior"`
+				UpdatedInput map[string]any `json:"updatedInput"`
+			} `json:"decision"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(output, &response); err != nil {
+		t.Fatalf("decode hook response: %v", err)
+	}
+	if response.HookSpecificOutput.HookEventName != "PermissionRequest" {
+		t.Errorf("hookEventName = %q, want PermissionRequest", response.HookSpecificOutput.HookEventName)
+	}
+	if response.HookSpecificOutput.Decision.Behavior != "allow" {
+		t.Errorf("behavior = %q, want allow", response.HookSpecificOutput.Decision.Behavior)
+	}
+
+	var expectedInput map[string]any
+	if err := json.Unmarshal(toolInput, &expectedInput); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(response.HookSpecificOutput.Decision.UpdatedInput, expectedInput) {
+		t.Fatalf(
+			"decision.updatedInput = %#v, want complete original tool_input %#v",
+			response.HookSpecificOutput.Decision.UpdatedInput,
+			expectedInput,
+		)
+	}
+}
+
+func TestEmitHookDecision_DenyBehaviorUnchanged(t *testing.T) {
+	toolInput := json.RawMessage(`{"plan":"# Auth Flow","futureOption":true}`)
+	output := captureHookDecision(t, func() {
+		emitHookDecision(false, "Address the review comments.", toolInput)
+	})
+
+	var response struct {
+		HookSpecificOutput struct {
+			HookEventName string `json:"hookEventName"`
+			Decision      struct {
+				Behavior     string          `json:"behavior"`
+				Message      string          `json:"message"`
+				UpdatedInput json.RawMessage `json:"updatedInput"`
+			} `json:"decision"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(output, &response); err != nil {
+		t.Fatalf("decode hook response: %v", err)
+	}
+
+	if response.HookSpecificOutput.HookEventName != "PermissionRequest" {
+		t.Errorf("hookEventName = %q, want PermissionRequest", response.HookSpecificOutput.HookEventName)
+	}
+	if response.HookSpecificOutput.Decision.Behavior != "deny" {
+		t.Errorf("behavior = %q, want deny", response.HookSpecificOutput.Decision.Behavior)
+	}
+	if response.HookSpecificOutput.Decision.Message != "Address the review comments." {
+		t.Errorf("message = %q, want review feedback", response.HookSpecificOutput.Decision.Message)
+	}
+	if response.HookSpecificOutput.Decision.UpdatedInput != nil {
+		t.Errorf("deny response unexpectedly included updatedInput: %s", response.HookSpecificOutput.Decision.UpdatedInput)
+	}
+}
+
+func captureHookDecision(t *testing.T, emit func()) []byte {
+	t.Helper()
+
+	previousStdout := os.Stdout
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = stdoutWriter
+	t.Cleanup(func() {
+		os.Stdout = previousStdout
+	})
+
+	emit()
+
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return output
 }

--- a/internal/session/plan_cli_main_test.go
+++ b/internal/session/plan_cli_main_test.go
@@ -64,7 +64,11 @@ func TestRunPlanHook_ApprovalEchoesCompleteToolInput(t *testing.T) {
 		"tool_input": {
 			"plan": "# Auth Flow\n\nImplement the auth flow.",
 			"planFilePath": "/tmp/auth-flow.md",
-			"futureOption": {"enabled": true}
+			"futureOption": {
+				"enabled": true,
+				"largeNumber": 9007199254740993,
+				"escaped": "\u003cfuture\u003e"
+			}
 		}
 	}`)
 	setPlanHookStdin(t, hookInput)
@@ -93,8 +97,8 @@ func TestRunPlanHook_ApprovalEchoesCompleteToolInput(t *testing.T) {
 		HookSpecificOutput struct {
 			HookEventName string `json:"hookEventName"`
 			Decision      struct {
-				Behavior     string         `json:"behavior"`
-				UpdatedInput map[string]any `json:"updatedInput"`
+				Behavior     string          `json:"behavior"`
+				UpdatedInput json.RawMessage `json:"updatedInput"`
 			} `json:"decision"`
 		} `json:"hookSpecificOutput"`
 	}
@@ -108,23 +112,33 @@ func TestRunPlanHook_ApprovalEchoesCompleteToolInput(t *testing.T) {
 		t.Errorf("behavior = %q, want allow", response.HookSpecificOutput.Decision.Behavior)
 	}
 
-	var expectedInput map[string]any
 	var event struct {
 		ToolInput json.RawMessage `json:"tool_input"`
 	}
 	if err := json.Unmarshal(hookInput, &event); err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(event.ToolInput, &expectedInput); err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(response.HookSpecificOutput.Decision.UpdatedInput, expectedInput) {
+	expectedInput := decodeJSONUseNumber(t, event.ToolInput)
+	actualInput := decodeJSONUseNumber(t, response.HookSpecificOutput.Decision.UpdatedInput)
+	if !reflect.DeepEqual(actualInput, expectedInput) {
 		t.Fatalf(
 			"decision.updatedInput = %#v, want complete original tool_input %#v",
-			response.HookSpecificOutput.Decision.UpdatedInput,
+			actualInput,
 			expectedInput,
 		)
 	}
+}
+
+func decodeJSONUseNumber(t *testing.T, input []byte) any {
+	t.Helper()
+
+	decoder := json.NewDecoder(strings.NewReader(string(input)))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
 }
 
 func setPlanHookStdin(t *testing.T, input []byte) {

--- a/internal/session/plan_cli_main_test.go
+++ b/internal/session/plan_cli_main_test.go
@@ -54,15 +54,39 @@ func TestResolvePlanSlug_DerivesFromContent(t *testing.T) {
 	}
 }
 
-func TestEmitHookDecision_ApprovalEchoesCompleteToolInput(t *testing.T) {
-	toolInput := json.RawMessage(`{
-		"plan": "# Auth Flow\n\nImplement the auth flow.",
-		"planFilePath": "/tmp/auth-flow.md",
-		"futureOption": {"enabled": true}
+func TestRunPlanHook_ApprovalEchoesCompleteToolInput(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	hookInput := json.RawMessage(`{
+		"session_id": "session-737",
+		"hook_event_name": "PermissionRequest",
+		"tool_name": "ExitPlanMode",
+		"tool_input": {
+			"plan": "# Auth Flow\n\nImplement the auth flow.",
+			"planFilePath": "/tmp/auth-flow.md",
+			"futureOption": {"enabled": true}
+		}
 	}`)
+	setPlanHookStdin(t, hookInput)
+
+	previousReviewHook := runClaudePlanReviewHook
+	runClaudePlanReviewHook = func(sessionID string, content []byte, emitDecision func(bool, string)) {
+		if sessionID != "session-737" {
+			t.Errorf("sessionID = %q, want session-737", sessionID)
+		}
+		if got, want := string(content), "# Auth Flow\n\nImplement the auth flow."; got != want {
+			t.Errorf("plan content = %q, want %q", got, want)
+		}
+		emitDecision(true, "")
+	}
+	t.Cleanup(func() {
+		runClaudePlanReviewHook = previousReviewHook
+	})
 
 	output := captureHookDecision(t, func() {
-		emitHookDecision(true, "", toolInput)
+		if err := RunPlanHook(); err != nil {
+			t.Fatalf("RunPlanHook() error = %v", err)
+		}
 	})
 
 	var response struct {
@@ -85,7 +109,13 @@ func TestEmitHookDecision_ApprovalEchoesCompleteToolInput(t *testing.T) {
 	}
 
 	var expectedInput map[string]any
-	if err := json.Unmarshal(toolInput, &expectedInput); err != nil {
+	var event struct {
+		ToolInput json.RawMessage `json:"tool_input"`
+	}
+	if err := json.Unmarshal(hookInput, &event); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(event.ToolInput, &expectedInput); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(response.HookSpecificOutput.Decision.UpdatedInput, expectedInput) {
@@ -95,6 +125,27 @@ func TestEmitHookDecision_ApprovalEchoesCompleteToolInput(t *testing.T) {
 			expectedInput,
 		)
 	}
+}
+
+func setPlanHookStdin(t *testing.T, input []byte) {
+	t.Helper()
+
+	previousStdin := os.Stdin
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdinWriter.Write(input); err != nil {
+		t.Fatal(err)
+	}
+	if err := stdinWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = stdinReader
+	t.Cleanup(func() {
+		os.Stdin = previousStdin
+		stdinReader.Close()
+	})
 }
 
 func TestEmitHookDecision_DenyBehaviorUnchanged(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve the complete Claude Code `ExitPlanMode` tool input during Crit plan review
- echo the approved input as `decision.updatedInput` so Claude Code skips its duplicate terminal chooser
- cover the full Claude hook path, unchanged denial output, and unchanged Codex approval behavior

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (Claude Code hook backend only)

## Test plan
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`

Closes #737

Upstream: https://github.com/anthropics/claude-code/issues/74256
Crit issue: https://github.com/tomasz-tomczyk/crit/issues/737