### PR TITLE
fix: align story review paths and daemon errors

### DIFF
--- a/cmd/crit/cli_handlers_story.go
+++ b/cmd/crit/cli_handlers_story.go
@@ -281,9 +281,9 @@ func resolveStoryReviewPath(scopeArgs []string) (string, error) {
 	if entry, alive := storyDaemonAlive(key); alive && entry.ReviewPath != "" {
 		return entry.ReviewPath, nil
 	}
-	path, err := daemon.ReviewFilePath(key)
+	path, err := resolveServeReviewPath(reviewCfg.OutputDir, reviewCfg.PlanDir, key)
 	if err != nil {
-		return "", clicmd.ExitError{Code: 1, Err: err}
+		return "", clicmd.ExitError{Code: 1, Err: fmt.Errorf("resolve story review path: %w", err)}
 	}
 	return path, nil
 }

--- a/cmd/crit/cli_handlers_story_test.go
+++ b/cmd/crit/cli_handlers_story_test.go
@@ -337,6 +337,56 @@ func TestResolveStoryReviewPathIgnoresOtherScopedDaemon(t *testing.T) {
 	}
 }
 
+func TestResolveStoryReviewPathUsesExplicitOutputWithoutDaemon(t *testing.T) {
+	setupStoryRepo(t)
+	origAlive := storyDaemonAlive
+	t.Cleanup(func() { storyDaemonAlive = origAlive })
+	storyDaemonAlive = func(string) (daemon.SessionEntry, bool) {
+		return daemon.SessionEntry{}, false
+	}
+
+	for _, flag := range []string{"--output", "-o"} {
+		t.Run(flag, func(t *testing.T) {
+			outputDir := filepath.Join(t.TempDir(), "review-output")
+			path, err := resolveStoryReviewPath([]string{flag, outputDir})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join(outputDir, ".crit")
+			if path != want {
+				t.Fatalf("path = %q, want %q", path, want)
+			}
+		})
+	}
+}
+
+func TestResolveStoryReviewPathUsesConfiguredOutputWithoutDaemon(t *testing.T) {
+	repoDir, _, _ := setupStoryRepo(t)
+	origAlive := storyDaemonAlive
+	t.Cleanup(func() { storyDaemonAlive = origAlive })
+	storyDaemonAlive = func(string) (daemon.SessionEntry, bool) {
+		return daemon.SessionEntry{}, false
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "configured-output")
+	configJSON, err := json.Marshal(map[string]string{"output": outputDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".crit.config.json"), configJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := resolveStoryReviewPath(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(outputDir, ".crit")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+}
+
 func TestStorySkipLLMWritesStub(t *testing.T) {
 	setupStoryRepo(t)
 	if err := runStoryE([]string{"--skip-llm"}); err != nil {

--- a/cmd/crit/cli_handlers_story_test.go
+++ b/cmd/crit/cli_handlers_story_test.go
@@ -387,6 +387,26 @@ func TestResolveStoryReviewPathUsesConfiguredOutputWithoutDaemon(t *testing.T) {
 	}
 }
 
+func TestResolveStoryReviewPathPreservesOutputPathError(t *testing.T) {
+	setupStoryRepo(t)
+	origAlive, origAbsPath := storyDaemonAlive, serveAbsPath
+	t.Cleanup(func() {
+		storyDaemonAlive = origAlive
+		serveAbsPath = origAbsPath
+	})
+	storyDaemonAlive = func(string) (daemon.SessionEntry, bool) {
+		return daemon.SessionEntry{}, false
+	}
+	serveAbsPath = func(string) (string, error) {
+		return "", errors.New("working directory unavailable")
+	}
+
+	_, err := resolveStoryReviewPath([]string{"--output", "review-output"})
+	if err == nil || !strings.Contains(err.Error(), "resolve story review path: working directory unavailable") {
+		t.Fatalf("expected wrapped output path error, got %v", err)
+	}
+}
+
 func TestStorySkipLLMWritesStub(t *testing.T) {
 	setupStoryRepo(t)
 	if err := runStoryE([]string{"--skip-llm"}); err != nil {

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -83,16 +83,18 @@ func bindListener(host string, port int) (net.Listener, error) {
 // resolveServeReviewPath computes the daemon's review folder so that
 // srv.reviewPath, the session-registry entry, session.ReviewFilePath, and
 // session.critJSONPath() all agree on one folder.
+var serveAbsPath = filepath.Abs
+
 func resolveServeReviewPath(outputDir, planDir, sessionKey string) (string, error) {
 	switch {
 	case outputDir != "":
-		abs, err := filepath.Abs(outputDir)
+		abs, err := serveAbsPath(outputDir)
 		if err != nil {
 			return "", err
 		}
 		return filepath.Join(abs, ".crit"), nil
 	case planDir != "":
-		abs, err := filepath.Abs(planDir)
+		abs, err := serveAbsPath(planDir)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -83,17 +83,22 @@ func bindListener(host string, port int) (net.Listener, error) {
 // resolveServeReviewPath computes the daemon's review folder so that
 // srv.reviewPath, the session-registry entry, session.ReviewFilePath, and
 // session.critJSONPath() all agree on one folder.
-func resolveServeReviewPath(outputDir, planDir, sessionKey string) string {
+func resolveServeReviewPath(outputDir, planDir, sessionKey string) (string, error) {
 	switch {
 	case outputDir != "":
-		abs, _ := filepath.Abs(outputDir)
-		return filepath.Join(abs, ".crit")
+		abs, err := filepath.Abs(outputDir)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(abs, ".crit"), nil
 	case planDir != "":
-		abs, _ := filepath.Abs(planDir)
-		return filepath.Join(abs, ".crit")
+		abs, err := filepath.Abs(planDir)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(abs, ".crit"), nil
 	default:
-		path, _ := reviewFilePath(sessionKey)
-		return path
+		return reviewFilePath(sessionKey)
 	}
 }
 
@@ -132,7 +137,10 @@ func runServe(args []string) {
 	if vcs := DetectVCS(sc.VCSOverride); vcs != nil {
 		branch = vcs.CurrentBranch()
 	}
-	sc.ReviewPath = resolveServeReviewPath(sc.OutputDir, sc.PlanDir, key)
+	sc.ReviewPath, err = resolveServeReviewPath(sc.OutputDir, sc.PlanDir, key)
+	if err != nil {
+		daemonFatal(pipe, "Error: resolve review path: %v", err)
+	}
 	var cliArgs []string
 	switch {
 	case sc.LiveOrigin != "":

--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +107,10 @@ func TestPreflightCheck_NotARepo(t *testing.T) {
 func TestResolveServeReviewPath(t *testing.T) {
 	t.Run("outputDir wins", func(t *testing.T) {
 		dir := t.TempDir()
-		got := resolveServeReviewPath(dir, "/some/plan/dir", "deadbeef")
+		got, err := resolveServeReviewPath(dir, "/some/plan/dir", "deadbeef")
+		if err != nil {
+			t.Fatal(err)
+		}
 		want := filepath.Join(dir, ".crit")
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -115,7 +119,10 @@ func TestResolveServeReviewPath(t *testing.T) {
 
 	t.Run("planDir used when outputDir empty", func(t *testing.T) {
 		planDir := t.TempDir()
-		got := resolveServeReviewPath("", planDir, "deadbeef")
+		got, err := resolveServeReviewPath("", planDir, "deadbeef")
+		if err != nil {
+			t.Fatal(err)
+		}
 		want := filepath.Join(planDir, ".crit")
 		if got != want {
 			t.Errorf("plan-mode review path: got %q, want %q (must co-locate with review.json so attachments/ inlining can find them)", got, want)
@@ -123,9 +130,25 @@ func TestResolveServeReviewPath(t *testing.T) {
 	})
 
 	t.Run("centralized path when neither outputDir nor planDir set", func(t *testing.T) {
-		got := resolveServeReviewPath("", "", "deadbeef123")
+		got, err := resolveServeReviewPath("", "", "deadbeef123")
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !strings.Contains(got, "deadbeef123") {
 			t.Errorf("centralized path should embed session key; got %q", got)
+		}
+	})
+
+	t.Run("centralized path errors are preserved", func(t *testing.T) {
+		orig := reviewFilePath
+		t.Cleanup(func() { reviewFilePath = orig })
+		reviewFilePath = func(string) (string, error) {
+			return "", errors.New("home unavailable")
+		}
+
+		if _, err := resolveServeReviewPath("", "", "deadbeef123"); err == nil ||
+			!strings.Contains(err.Error(), "home unavailable") {
+			t.Fatalf("expected centralized path error, got %v", err)
 		}
 	})
 }

--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -151,6 +151,32 @@ func TestResolveServeReviewPath(t *testing.T) {
 			t.Fatalf("expected centralized path error, got %v", err)
 		}
 	})
+
+	t.Run("absolute output path errors are preserved", func(t *testing.T) {
+		orig := serveAbsPath
+		t.Cleanup(func() { serveAbsPath = orig })
+		serveAbsPath = func(string) (string, error) {
+			return "", errors.New("working directory unavailable")
+		}
+
+		if _, err := resolveServeReviewPath("output", "", "deadbeef123"); err == nil ||
+			!strings.Contains(err.Error(), "working directory unavailable") {
+			t.Fatalf("expected output path error, got %v", err)
+		}
+	})
+
+	t.Run("absolute plan path errors are preserved", func(t *testing.T) {
+		orig := serveAbsPath
+		t.Cleanup(func() { serveAbsPath = orig })
+		serveAbsPath = func(string) (string, error) {
+			return "", errors.New("working directory unavailable")
+		}
+
+		if _, err := resolveServeReviewPath("", "plan", "deadbeef123"); err == nil ||
+			!strings.Contains(err.Error(), "working directory unavailable") {
+			t.Fatalf("expected plan path error, got %v", err)
+		}
+	})
 }
 
 func TestServeSessionKey_Override(t *testing.T) {

--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -91,6 +91,7 @@ func init() {
 		return &session.CLIReviewConfig{
 			Files:              sc.Files,
 			Focus:              sc.Focus,
+			OutputDir:          sc.OutputDir,
 			PlanDir:            sc.PlanDir,
 			NoOpen:             sc.NoOpen,
 			OpenCmd:            sc.OpenCmd,

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -2,12 +2,21 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"time"
 )
+
+type daemonInitializationError struct {
+	message string
+}
+
+func (e *daemonInitializationError) Error() string {
+	return e.message
+}
 
 // RunReviewClient connects to a running daemon, blocks until the user finishes
 // reviewing, prints feedback to stdout, and returns whether the review was approved.
@@ -69,6 +78,10 @@ func RunReviewClientRaw(entry SessionEntry, sessionKey string) (approved bool, p
 	statusCode, body, err := waitForDaemonReady(client, entry.Host, entry.Port, sessionKey, entry.StartedAt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook: %v\n", err)
+		var initErr *daemonInitializationError
+		if errors.As(err, &initErr) {
+			return false, "crit daemon failed to initialize: " + initErr.Error()
+		}
 		return false, "crit daemon was unreachable; plan was not reviewed."
 	}
 	if statusCode == http.StatusInternalServerError {
@@ -118,7 +131,7 @@ func waitForDaemonReady(client *http.Client, host string, port int, sessionKey, 
 		if reqErr != nil {
 			if sessionKey != "" {
 				if msg := ReadDaemonFailure(sessionKey, daemonGeneration); msg != "" {
-					return 0, nil, fmt.Errorf("%s", msg)
+					return 0, nil, &daemonInitializationError{message: msg}
 				}
 				if msg := ReadDaemonLog(sessionKey); msg != "" {
 					return 0, nil, fmt.Errorf("%s", msg)

--- a/internal/daemon/client_main_test.go
+++ b/internal/daemon/client_main_test.go
@@ -307,3 +307,65 @@ func TestRunReviewClientRaw_ReturnsInitializationError(t *testing.T) {
 		t.Fatalf("expected initialization error in prompt, got %q", prompt)
 	}
 }
+
+func TestRunReviewClientRaw_ReturnsPreservedDaemonFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	testutil.SetHome(t, t.TempDir())
+	key := "planhookfail"
+	generation := "2026-07-17T12:00:00.123456789Z"
+	cause := "repository initialization failed: invalid base branch"
+	if err := WriteDaemonFailure(key, generation, fmt.Errorf("%s", cause)); err != nil {
+		t.Fatal(err)
+	}
+
+	approved, prompt := RunReviewClientRaw(SessionEntry{
+		Port:      port,
+		StartedAt: generation,
+	}, key)
+	if approved {
+		t.Fatal("expected approved=false")
+	}
+	if !strings.Contains(prompt, cause) {
+		t.Fatalf("expected preserved daemon failure in prompt, got %q", prompt)
+	}
+}
+
+func TestRunReviewClientRaw_DoesNotExposeFallbackDaemonLog(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	testutil.SetHome(t, t.TempDir())
+	key := "planhooklog"
+	sessDir, err := sessionsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContents := "internal daemon detail that must stay on stderr"
+	if err := os.WriteFile(filepath.Join(sessDir, key+".log"), []byte(logContents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	approved, prompt := RunReviewClientRaw(SessionEntry{Port: port}, key)
+	if approved {
+		t.Fatal("expected approved=false")
+	}
+	if strings.Contains(prompt, logContents) {
+		t.Fatalf("agent-facing prompt exposed daemon log: %q", prompt)
+	}
+	if prompt != "crit daemon was unreachable; plan was not reviewed." {
+		t.Fatalf("unexpected fallback prompt: %q", prompt)
+	}
+}

--- a/internal/session/hooks.go
+++ b/internal/session/hooks.go
@@ -6,6 +6,7 @@ import "fmt"
 type CLIReviewConfig struct {
 	Files              []string
 	Focus              *Focus
+	OutputDir          string
 	PlanDir            string
 	NoOpen             bool
 	OpenCmd            string


### PR DESCRIPTION
## Summary
- align Story save paths with explicit and configured daemon output paths
- propagate review-path errors instead of writing into the working directory
- expose generation-scoped initialization failures while keeping fallback daemon logs and transport details out of the agent-facing prompt

## Review
- [x] Code review: passed
- [x] Parity audit: N/A
- [x] Intent audit: passed
- [x] Security scan: passed

## Test plan
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`
- focused Story path and daemon failure provenance tests