### PR TITLE
feat: auto-close review tab after approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,11 +98,12 @@ Two-level JSON config files, merged (project overrides global):
 - **Global**: `~/.crit.config.json` — user-wide defaults
 - **Project**: `.crit.config.json` in repo root — per-project overrides
 
-Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `auto_viewed_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `disable_stats`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`, `live_cookie`, `live_cookie_file`, `live_cdp_url`.
+Config keys: `port`, `host`, `no_open`, `share_url`, `quiet`, `output`, `author`, `base_branch`, `ignore_patterns`, `auto_viewed_patterns`, `agent_cmd`, `auth_token`, `auth_user_name`, `auth_user_email`, `auth_user_id`, `cleanup_on_approve`, `disable_stats`, `no_update_check`, `no_integration_check`, `vcs`, `proxy_auth`, `live_cookie`, `live_cookie_file`, `live_cdp_url`, `close_on_approve_after_ms`.
 
 - `base_branch` overrides auto-detected default branch (used as diff base in git mode, and by `crit pull`/`crit push`/`crit comment`)
 - `author` falls back to the configured VCS user name if not set
-- `agent_cmd`, `auth_token`, `share_url`, and `proxy_auth` are **global config only**; project-level config cannot override (security — prevents malicious repos from hijacking the agent command or redirecting share requests to an attacker-controlled host)
+- `agent_cmd`, `auth_token`, `share_url`, `proxy_auth`, and `close_on_approve_after_ms` are **global config only**; project-level config cannot override (security — prevents malicious repos from hijacking the agent command, redirecting share requests to an attacker-controlled host, or forcing a reviewer's tab to auto-close)
+- `close_on_approve_after_ms` (default: unset/disabled) — auto-close the review tab N ms after Approve with no unresolved comments; negative values are treated as unset. Not included in `crit config --generate` scaffolding.
 - `proxy_auth` (default: `false`) — when `true`, terminal `crit share` / `crit fetch` / `crit unpublish` are blocked (SSO proxy); the browser UI uses a popup relay instead. Global-only for security. See proxy-auth transport rules.
 - `cleanup_on_approve` (default: `true`) — auto-delete review file when reviewer approves with no unresolved comments
 - `disable_stats` (default: `false`) — disable session stats recording to `~/.crit/stats.json`

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | `public_url`           | string   | `""`                       | Advertised base URL for stderr and browser-open (e.g. `https://machine.ts.net` via tailscale serve). Listen address unchanged. |
 | `share_consented`      | bool     | `false`                    | Written automatically to `true` after you confirm the first-time share prompt. Reset to `false` to see the prompt again. Not used when `share_url` is a custom (self-hosted) URL. |
 | `proxy_auth`           | bool     | `false`                    | When `true`, share / pull / unpublish / re-share use the browser popup relay instead of the local Go server contacting crit-web directly. Use when crit-web is behind an SSO reverse proxy that the terminal cannot authenticate against. No flag or env var — this is a property of the deployment, not a per-invocation choice. |
+| `close_on_approve_after_ms` | int | unset (disabled)          | Auto-close the review tab this many milliseconds after you Approve with no unresolved comments. Unset means no auto-close (current behavior); negative values are treated as unset. A Cancel button during the countdown skips the close for that approval. |
 
 ### CLI flags
 

--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -188,9 +188,11 @@ Available keys:
   open_cmd               string    Custom browser/open command
   agent_cmd              string    Shell command to send comments to an AI agent (e.g. "claude -p")
   auth_token             string    Authentication token for crit-web share service
+  close_on_approve_after_ms int    Auto-close the review tab N ms after Approve (default: unset/disabled)
 
-Note: agent_cmd, auth_token, host, open_cmd, and share_url are global-only (~/.crit.config.json).
-Project-level .crit.config.json cannot override them for security reasons.
+Note: agent_cmd, auth_token, host, open_cmd, share_url, and close_on_approve_after_ms
+are global-only (~/.crit.config.json). Project-level .crit.config.json cannot
+override them for security reasons.
 
 Ignore pattern syntax:
   *.lock            Match files by extension (anywhere in tree)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,34 +20,39 @@ const defaultShareURL = DefaultShareURL
 
 // Config holds all configuration values from config files.
 type Config struct {
-	Port               int               `json:"port,omitempty"`
-	Host               string            `json:"host,omitempty"`       // listen host (default 127.0.0.1)
-	PublicURL          string            `json:"public_url,omitempty"` // advertised base URL (global-only; e.g. tailscale serve)
-	NoOpen             bool              `json:"no_open,omitempty"`
-	OpenCmd            string            `json:"open_cmd,omitempty"`
-	ShareURL           string            `json:"share_url,omitempty"`
-	ProxyAuth          bool              `json:"proxy_auth,omitempty"`
-	Quiet              bool              `json:"quiet,omitempty"`
-	Output             string            `json:"output,omitempty"`
-	Author             string            `json:"author,omitempty"`
-	BaseBranch         string            `json:"base_branch,omitempty"`
-	IgnorePatterns     []string          `json:"ignore_patterns,omitempty"`
-	AutoViewedPatterns []string          `json:"auto_viewed_patterns,omitempty"`
-	NoIntegrationCheck bool              `json:"no_integration_check,omitempty"`
-	NoUpdateCheck      bool              `json:"no_update_check,omitempty"`
-	AgentCmd           string            `json:"agent_cmd,omitempty"`
-	AuthToken          string            `json:"auth_token,omitempty"`
-	AuthUserName       string            `json:"auth_user_name,omitempty"`
-	AuthUserEmail      string            `json:"auth_user_email,omitempty"`
-	AuthUserID         string            `json:"auth_user_id,omitempty"`
-	CleanupOnApprove   *bool             `json:"cleanup_on_approve,omitempty"`
-	DisableStats       bool              `json:"disable_stats,omitempty"`
-	VCS                string            `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl", "jj"
-	ShareConsented     bool              `json:"share_consented,omitempty"`
-	LiveCookie         string            `json:"live_cookie,omitempty"`
-	LiveCookieFile     string            `json:"live_cookie_file,omitempty"`
-	LiveCDPURL         string            `json:"live_cdp_url,omitempty"`
-	Prompts            map[string]string `json:"prompts,omitempty"`
+	Port               int      `json:"port,omitempty"`
+	Host               string   `json:"host,omitempty"`       // listen host (default 127.0.0.1)
+	PublicURL          string   `json:"public_url,omitempty"` // advertised base URL (global-only; e.g. tailscale serve)
+	NoOpen             bool     `json:"no_open,omitempty"`
+	OpenCmd            string   `json:"open_cmd,omitempty"`
+	ShareURL           string   `json:"share_url,omitempty"`
+	ProxyAuth          bool     `json:"proxy_auth,omitempty"`
+	Quiet              bool     `json:"quiet,omitempty"`
+	Output             string   `json:"output,omitempty"`
+	Author             string   `json:"author,omitempty"`
+	BaseBranch         string   `json:"base_branch,omitempty"`
+	IgnorePatterns     []string `json:"ignore_patterns,omitempty"`
+	AutoViewedPatterns []string `json:"auto_viewed_patterns,omitempty"`
+	NoIntegrationCheck bool     `json:"no_integration_check,omitempty"`
+	NoUpdateCheck      bool     `json:"no_update_check,omitempty"`
+	AgentCmd           string   `json:"agent_cmd,omitempty"`
+	AuthToken          string   `json:"auth_token,omitempty"`
+	AuthUserName       string   `json:"auth_user_name,omitempty"`
+	AuthUserEmail      string   `json:"auth_user_email,omitempty"`
+	AuthUserID         string   `json:"auth_user_id,omitempty"`
+	CleanupOnApprove   *bool    `json:"cleanup_on_approve,omitempty"`
+	DisableStats       bool     `json:"disable_stats,omitempty"`
+	// CloseOnApproveAfterMs, when set, auto-closes the review tab this many
+	// milliseconds after an Approve. Global-only (like open_cmd/agent_cmd) so
+	// a project repo cannot force tabs to close. Nil means disabled; the CLI
+	// treats negative values as disabled too (see CloseOnApproveAfterMsEnabled).
+	CloseOnApproveAfterMs *int              `json:"close_on_approve_after_ms,omitempty"`
+	VCS                   string            `json:"vcs,omitempty"` // preferred VCS backend: "git", "sl", "jj"
+	ShareConsented        bool              `json:"share_consented,omitempty"`
+	LiveCookie            string            `json:"live_cookie,omitempty"`
+	LiveCookieFile        string            `json:"live_cookie_file,omitempty"`
+	LiveCDPURL            string            `json:"live_cdp_url,omitempty"`
+	Prompts               map[string]string `json:"prompts,omitempty"`
 	// Hooks are shell commands/scripts executed at the same finish lifecycle
 	// points as prompt templates (on_finish_unresolved / on_finish_approved,
 	// optionally mode-suffixed :files/:diff/:live/:preview). Values use the
@@ -76,6 +81,19 @@ func (c Config) CleanupOnApproveEnabled() bool {
 		return *c.CleanupOnApprove
 	}
 	return true
+}
+
+// CloseOnApproveAfterMsEnabled reports whether auto-close-after-approve is
+// enabled and, if so, the configured delay in milliseconds. Disabled when the
+// key is absent (nil) or set to a negative value.
+func (c Config) CloseOnApproveAfterMsEnabled() (ms int, enabled bool) {
+	if c.CloseOnApproveAfterMs == nil {
+		return 0, false
+	}
+	if *c.CloseOnApproveAfterMs < 0 {
+		return 0, false
+	}
+	return *c.CloseOnApproveAfterMs, true
 }
 
 // String returns a human-readable JSON representation of the resolved config.
@@ -261,14 +279,17 @@ func mergeConfigs(global, project Config, projectPresence ConfigPresence) Config
 	if project.LiveCDPURL != "" {
 		merged.LiveCDPURL = project.LiveCDPURL
 	}
-	// Security: agent_cmd, auth_token, share_url, public_url, proxy_auth, and open_cmd are intentionally
-	// NOT merged from project config. They must remain global-only: agent_cmd to
+	// Security: agent_cmd, auth_token, share_url, public_url, proxy_auth, open_cmd,
+	// and close_on_approve_after_ms are intentionally NOT merged from project
+	// config. They must remain global-only: agent_cmd to
 	// prevent untrusted repos from hijacking the agent command; open_cmd to prevent
 	// untrusted repos from hijacking browser launches; auth_token and
 	// share_url and public_url to prevent a malicious repo's .crit.config.json from
 	// redirecting share requests (and the bearer token) or advertised URLs to an
 	// attacker-controlled host;
-	// proxy_auth to prevent a repo from silently changing the transport mode.
+	// proxy_auth to prevent a repo from silently changing the transport mode;
+	// close_on_approve_after_ms so a project repo cannot force the reviewer's
+	// tab to auto-close — that's a personal preference, not a repo policy.
 	// live_cookie/live_cookie_file/live_cdp_url DO merge from project config — common for local
 	// dev auth. Prefer live_cookie_file pointing at a gitignored path (e.g.
 	// .crit/live-cookies.txt) over committing live_cookie inline. live_cdp_url

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
@@ -924,5 +925,100 @@ func TestMergeConfigs_ProjectHooksOverride(t *testing.T) {
 	merged := mergeConfigs(global, project, ConfigPresence{})
 	if merged.Hooks["on_finish_approved"] != "inline:project" {
 		t.Fatalf("hooks = %v", merged.Hooks)
+	}
+}
+
+func TestCloseOnApproveAfterMsEnabled(t *testing.T) {
+	ms500 := 500
+	msZero := 0
+	msNegative := -1
+
+	tests := []struct {
+		name       string
+		cfg        Config
+		wantMs     int
+		wantEnable bool
+	}{
+		{"nil pointer disables", Config{CloseOnApproveAfterMs: nil}, 0, false},
+		{"positive value enables", Config{CloseOnApproveAfterMs: &ms500}, 500, true},
+		{"zero enables (close immediately)", Config{CloseOnApproveAfterMs: &msZero}, 0, true},
+		{"negative value treated as disabled", Config{CloseOnApproveAfterMs: &msNegative}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMs, gotEnabled := tt.cfg.CloseOnApproveAfterMsEnabled()
+			if gotEnabled != tt.wantEnable || gotMs != tt.wantMs {
+				t.Errorf("CloseOnApproveAfterMsEnabled() = (%d, %v), want (%d, %v)", gotMs, gotEnabled, tt.wantMs, tt.wantEnable)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFile_CloseOnApproveAfterMs(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crit.config.json")
+	if err := os.WriteFile(configPath, []byte(`{"close_on_approve_after_ms": 3000}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _, err := LoadConfigFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CloseOnApproveAfterMs == nil || *cfg.CloseOnApproveAfterMs != 3000 {
+		t.Errorf("CloseOnApproveAfterMs = %v, want 3000", cfg.CloseOnApproveAfterMs)
+	}
+}
+
+func TestMergeConfigs_CloseOnApproveAfterMsGlobalOnly(t *testing.T) {
+	// Project config must not be able to force a reviewer's tab to auto-close.
+	globalMs := 2000
+	projectMs := 0
+	global := Config{CloseOnApproveAfterMs: &globalMs}
+	project := Config{CloseOnApproveAfterMs: &projectMs}
+	merged := mergeConfigs(global, project, ConfigPresence{})
+	if merged.CloseOnApproveAfterMs == nil || *merged.CloseOnApproveAfterMs != 2000 {
+		t.Errorf("CloseOnApproveAfterMs = %v, want global value 2000 (project must not override)", merged.CloseOnApproveAfterMs)
+	}
+}
+
+func TestLoadConfig_CloseOnApproveAfterMs_ProjectCannotEnable(t *testing.T) {
+	// Only global config may set close_on_approve_after_ms — a project-level
+	// .crit.config.json setting it must be ignored entirely.
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"close_on_approve_after_ms": 1500}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig(projectDir)
+	if ms, enabled := cfg.CloseOnApproveAfterMsEnabled(); enabled {
+		t.Errorf("close_on_approve_after_ms enabled from project config (ms=%d), want disabled", ms)
+	}
+}
+
+func TestLoadConfig_CloseOnApproveAfterMs_GlobalWorks(t *testing.T) {
+	homeDir := t.TempDir()
+	testutil.SetHome(t, homeDir)
+	if err := os.WriteFile(filepath.Join(homeDir, ".crit.config.json"),
+		[]byte(`{"close_on_approve_after_ms": 4000}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+
+	cfg := LoadConfig(projectDir)
+	ms, enabled := cfg.CloseOnApproveAfterMsEnabled()
+	if !enabled || ms != 4000 {
+		t.Errorf("CloseOnApproveAfterMsEnabled() = (%d, %v), want (4000, true)", ms, enabled)
+	}
+}
+
+func TestDefaultConfig_DoesNotIncludeCloseOnApproveAfterMs(t *testing.T) {
+	// Scaffolding (`crit config --generate`) must not accidentally enable
+	// auto-close — the generated template omits this key entirely.
+	s := DefaultConfigString()
+	if strings.Contains(s, "close_on_approve_after_ms") {
+		t.Errorf("DefaultConfigString() contains close_on_approve_after_ms, want omitted:\n%s", s)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -452,6 +452,12 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"integrations_available": availableIntegrations(),
 	}
 
+	// Auto-close-after-approve delay, in ms. Omitted entirely when unset (or
+	// negative) so the frontend's "key absent" check stays simple.
+	if ms, enabled := s.cfg.CloseOnApproveAfterMsEnabled(); enabled {
+		resp["close_on_approve_after_ms"] = ms
+	}
+
 	// Integration detection
 	s.addIntegrationStatus(resp)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2413,6 +2413,60 @@ func TestHandleConfig_AuthNotLoggedIn(t *testing.T) {
 	}
 }
 
+func TestHandleConfig_CloseOnApproveAfterMs_OmittedWhenUnset(t *testing.T) {
+	s, _ := newTestServer(t)
+	// s.cfg.CloseOnApproveAfterMs is nil by default (zero value Config).
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp["close_on_approve_after_ms"]; ok {
+		t.Errorf("close_on_approve_after_ms = %v, want omitted when unset", resp["close_on_approve_after_ms"])
+	}
+}
+
+func TestHandleConfig_CloseOnApproveAfterMs_IncludedWhenSet(t *testing.T) {
+	s, _ := newTestServer(t)
+	ms := 2500
+	s.cfg = Config{CloseOnApproveAfterMs: &ms}
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := resp["close_on_approve_after_ms"].(float64)
+	if !ok || int(got) != 2500 {
+		t.Errorf("close_on_approve_after_ms = %v, want 2500", resp["close_on_approve_after_ms"])
+	}
+}
+
+func TestHandleConfig_CloseOnApproveAfterMs_OmittedWhenNegative(t *testing.T) {
+	s, _ := newTestServer(t)
+	ms := -1
+	s.cfg = Config{CloseOnApproveAfterMs: &ms}
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp["close_on_approve_after_ms"]; ok {
+		t.Errorf("close_on_approve_after_ms = %v, want omitted for negative value", resp["close_on_approve_after_ms"])
+	}
+}
+
 func TestHandleConfig_NoIntegrationCheck(t *testing.T) {
 	s, _ := newTestServer(t)
 	s.cfg = Config{NoIntegrationCheck: true}

--- a/web/__tests__/crit-shared.test.js
+++ b/web/__tests__/crit-shared.test.js
@@ -516,6 +516,232 @@ test('runFinishReview onError catches and returns null', async () => {
   assert.match(String(captured), /HTTP 500/);
 });
 
+// ----- close_on_approve_after_ms (auto-close after approve) -----
+// A richer DOM stub than makeFinishSandbox: elements form a real parent/child
+// tree (so ensureCloseCancelBtn's `messageEl.parentNode.insertBefore(...)`
+// works, and a dynamically-inserted #waitingCloseCancel can be found by a
+// later document.getElementById lookup) plus fake setTimeout/clearTimeout so
+// the countdown can be driven deterministically without real delays.
+function makeAutoCloseSandbox(fetchImpl) {
+  function makeNode(tag) {
+    return {
+      tagName: (tag || 'div').toUpperCase(),
+      id: '',
+      style: {},
+      _attrs: {},
+      _children: [],
+      textContent: '',
+      innerHTML: '',
+      offsetWidth: 0,
+      onclick: null,
+      parentNode: null,
+      nextSibling: null,
+      classList: {
+        _set: new Set(),
+        add(...c) { c.forEach((x) => this._set.add(x)); },
+        remove(...c) { c.forEach((x) => this._set.delete(x)); },
+        contains(c) { return this._set.has(c); },
+      },
+      setAttribute(k, v) { this._attrs[k] = v; },
+      getAttribute(k) { return Object.prototype.hasOwnProperty.call(this._attrs, k) ? this._attrs[k] : null; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      appendChild(child) {
+        child.parentNode = this;
+        this._children.push(child);
+        relink(this);
+        return child;
+      },
+      insertBefore(newNode, referenceNode) {
+        let idx = this._children.indexOf(referenceNode);
+        if (idx === -1) idx = this._children.length;
+        this._children.splice(idx, 0, newNode);
+        newNode.parentNode = this;
+        relink(this);
+        return newNode;
+      },
+    };
+  }
+  function relink(parent) {
+    const kids = parent._children;
+    for (let i = 0; i < kids.length; i++) kids[i].nextSibling = kids[i + 1] || null;
+  }
+  function findById(node, id) {
+    if (!node) return null;
+    if (node.id === id) return node;
+    for (const child of node._children || []) {
+      const found = findById(child, id);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  const messageEl = makeNode('p'); messageEl.id = 'waitingMessage';
+  const headingEl = makeNode('h3'); headingEl.id = 'waitingHeading';
+  const header = makeNode('div'); header.id = 'waitingHeader';
+  header.appendChild(headingEl);
+  header.appendChild(messageEl);
+
+  const copyLabel = makeNode('span'); copyLabel.textContent = 'Copy';
+  const clipEl = makeNode('button'); clipEl.id = 'waitingClipboard';
+  clipEl._attrs['aria-label'] = 'Copy prompt to clipboard';
+  clipEl.querySelector = (sel) => (sel === '.copy-label' ? copyLabel : null);
+
+  const dialog = makeNode('div'); dialog.id = 'waitingDialog';
+  dialog.appendChild(header);
+
+  const promptEl = makeNode('div'); promptEl.id = 'waitingPrompt';
+  const previewEl = makeNode('span'); previewEl.id = 'promptPreview';
+
+  const root = makeNode('body');
+  root.appendChild(dialog);
+  root.appendChild(promptEl);
+  root.appendChild(previewEl);
+  root.appendChild(clipEl);
+
+  const doc = {
+    cookie: '',
+    getElementById: (id) => findById(root, id),
+    createElement: (tag) => makeNode(tag),
+  };
+
+  // Deterministic fake clock: setTimeout/clearTimeout only (matches
+  // scheduleAutoClose, which never uses setInterval).
+  const timers = [];
+  let now = 0;
+  const fakeSetTimeout = (cb, ms) => { const t = { at: now + (ms || 0), cb, fired: false, cancelled: false }; timers.push(t); return t; };
+  const fakeClearTimeout = (t) => { if (t) t.cancelled = true; };
+  function flush(ms) {
+    now += (ms || 0);
+    let progress = true;
+    while (progress) {
+      progress = false;
+      for (const t of timers) {
+        if (!t.cancelled && !t.fired && t.at <= now) {
+          t.fired = true;
+          progress = true;
+          t.cb();
+        }
+      }
+    }
+  }
+
+  const win = { close: () => { win.closeCalls = (win.closeCalls || 0) + 1; }, closeCalls: 0 };
+  win.navigator = { clipboard: { writeText: async () => {} } };
+  const fn = new Function(
+    'window', 'document', 'setTimeout', 'clearTimeout',
+    src + '\nreturn window;',
+  );
+  fn(win, doc, fakeSetTimeout, fakeClearTimeout);
+  globalThis.fetch = fetchImpl;
+  globalThis.navigator = win.navigator;
+  return { shared: win.crit.shared, win, doc, els: { messageEl, headingEl, dialog, promptEl, previewEl, clipEl }, flush };
+}
+
+test('scheduleAutoClose: counts down then calls window.close() after the configured delay', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  assert.equal(els.messageEl.textContent, 'Closing in 3s…');
+  assert.equal(win.closeCalls, 0);
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 2s…');
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 1s…');
+  assert.equal(win.closeCalls, 0);
+  flush(1000);
+  assert.equal(win.closeCalls, 1, 'window.close() called once the countdown reaches zero');
+});
+
+test('scheduleAutoClose: negative or non-numeric ms is a no-op (disabled)', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(-1, els.messageEl);
+  s.scheduleAutoClose(undefined, els.messageEl);
+  s.scheduleAutoClose('not-a-number', els.messageEl);
+  flush(60000);
+  assert.equal(win.closeCalls, 0);
+  assert.equal(els.messageEl.textContent, '');
+});
+
+test('scheduleAutoClose: Cancel button stops the countdown, hides itself, and no close happens', () => {
+  const { shared: s, win, els, doc, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  const cancelBtn = doc.getElementById('waitingCloseCancel');
+  assert.ok(cancelBtn, 'Cancel button was created');
+  assert.equal(cancelBtn.style.display, '');
+
+  flush(1000); // one tick in, then cancel
+  cancelBtn.onclick();
+
+  assert.equal(cancelBtn.style.display, 'none');
+  assert.equal(els.messageEl.style.display, 'none');
+  assert.equal(els.messageEl.textContent, '');
+
+  flush(60000); // no further scheduled close, even well past the original delay
+  assert.equal(win.closeCalls, 0);
+});
+
+test('scheduleAutoClose: reuses the same Cancel button across approvals instead of duplicating it', () => {
+  const { shared: s, doc } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(5000, doc.getElementById('waitingMessage'));
+  const first = doc.getElementById('waitingCloseCancel');
+  s.scheduleAutoClose(5000, doc.getElementById('waitingMessage'));
+  const second = doc.getElementById('waitingCloseCancel');
+  assert.equal(first, second, 'Cancel button element is reused, not recreated');
+});
+
+test('scheduleAutoClose: after window.close(), shows "you can close this tab" if the tab is still open', () => {
+  const { shared: s, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(1000, els.messageEl);
+  flush(1000); // triggers window.close() (a no-op in this stub — tab "stays open")
+  flush(50);   // the post-close fallback message tick
+  assert.equal(els.messageEl.textContent, 'Approved — you can close this tab');
+});
+
+test('runFinishReview: approved + close_on_approve_after_ms set schedules the countdown and eventual close', async () => {
+  const fetch = async (url) => {
+    if (url === '/api/finish') return { ok: true, json: async () => ({ approved: true, prompt: 'ok' }) };
+    if (url === '/api/config') return { ok: true, json: async () => ({ close_on_approve_after_ms: 2000 }) };
+    throw new Error('unexpected fetch ' + url);
+  };
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(fetch);
+  const result = await s.runFinishReview({});
+  assert.equal(result.approved, true);
+  assert.equal(els.messageEl.textContent, 'Closing in 2s…');
+  // Ticks chain one setTimeout at a time (each scheduled relative to "now"
+  // at fire time), so advance the fake clock one tick at a time rather than
+  // jumping straight to the total delay.
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 1s…');
+  flush(1000);
+  assert.equal(win.closeCalls, 1);
+});
+
+test('runFinishReview: approved + no close_on_approve_after_ms in config skips auto-close entirely', async () => {
+  const fetch = async (url) => {
+    if (url === '/api/finish') return { ok: true, json: async () => ({ approved: true, prompt: 'ok' }) };
+    if (url === '/api/config') return { ok: true, json: async () => ({}) }; // key absent
+    throw new Error('unexpected fetch ' + url);
+  };
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(fetch);
+  await s.runFinishReview({});
+  // approved path already hides the message when auto-close is disabled.
+  assert.equal(els.messageEl.style.display, 'none');
+  flush(60000);
+  assert.equal(win.closeCalls, 0);
+});
+
+test('runFinishReview: not-approved path never schedules an auto-close, regardless of config', async () => {
+  const fetch = async (url) => {
+    if (url === '/api/finish') return { ok: true, json: async () => ({ approved: false, prompt: 'p' }) };
+    if (url === '/api/config') return { ok: true, json: async () => ({ close_on_approve_after_ms: 500 }) };
+    throw new Error('unexpected fetch ' + url);
+  };
+  const { shared: s, win, flush } = makeAutoCloseSandbox(fetch);
+  await s.runFinishReview({ onWaiting: () => {} });
+  flush(60000);
+  assert.equal(win.closeCalls, 0, '/api/config is never even consulted on the not-approved path');
+});
+
 // ----- waitForSession -----
 test('waitForSession: 503 then 200 resolves with payload, fires onProgress', async () => {
   let n = 0;

--- a/web/__tests__/crit-shared.test.js
+++ b/web/__tests__/crit-shared.test.js
@@ -626,7 +626,11 @@ function makeAutoCloseSandbox(fetchImpl) {
     }
   }
 
-  const win = { close: () => { win.closeCalls = (win.closeCalls || 0) + 1; }, closeCalls: 0 };
+  const win = {
+    closed: false,
+    close: () => { win.closeCalls = (win.closeCalls || 0) + 1; },
+    closeCalls: 0,
+  };
   win.navigator = { clipboard: { writeText: async () => {} } };
   const fn = new Function(
     'window', 'document', 'setTimeout', 'clearTimeout',
@@ -695,6 +699,16 @@ test('scheduleAutoClose: after window.close(), shows "you can close this tab" if
   flush(1000); // triggers window.close() (a no-op in this stub — tab "stays open")
   flush(50);   // the post-close fallback message tick
   assert.equal(els.messageEl.textContent, 'Approved — you can close this tab');
+});
+
+test('scheduleAutoClose: after window.close(), skips fallback message when the tab actually closed', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  win.close = () => { win.closeCalls = (win.closeCalls || 0) + 1; win.closed = true; };
+  s.scheduleAutoClose(1000, els.messageEl);
+  flush(1000);
+  flush(50);
+  assert.equal(win.closeCalls, 1);
+  assert.notEqual(els.messageEl.textContent, 'Approved — you can close this tab');
 });
 
 test('runFinishReview: approved + close_on_approve_after_ms set schedules the countdown and eventual close', async () => {

--- a/web/crit-shared.js
+++ b/web/crit-shared.js
@@ -339,7 +339,7 @@
         // If the tab is still open (window.close() is a no-op on tabs the
         // browser didn't open via script), tell the user how to proceed.
         var closedCheckId = setTimeout(function () {
-          if (cancelled) return;
+          if (cancelled || window.closed) return;
           if (messageEl) {
             messageEl.style.display = '';
             messageEl.textContent = 'Approved — you can close this tab';

--- a/web/crit-shared.js
+++ b/web/crit-shared.js
@@ -267,6 +267,99 @@
     }
   }
 
+  // ===== Auto-close after approve =====
+  // When `close_on_approve_after_ms` is configured (global-only, see
+  // internal/config/config.go), runFinishReview counts down on the waiting
+  // dialog's message line and calls window.close() once the delay elapses.
+  // A Cancel button (created lazily, reused across approvals) stops the
+  // countdown and leaves the Approved dialog as-is. Ticks once per second
+  // via chained setTimeout so tests can drive it with a fake clock (only
+  // setTimeout/clearTimeout are needed, matching the showToast sandbox).
+  var CLOSE_COUNTDOWN_TICK_MS = 1000;
+  var _autoCloseTimers = null; // array of pending timer ids, or null when idle
+
+  function clearAutoCloseTimers() {
+    if (!_autoCloseTimers) return;
+    _autoCloseTimers.forEach(function (id) { clearTimeout(id); });
+    _autoCloseTimers = null;
+  }
+
+  // Creates (once) or reuses the Cancel button, inserted right after
+  // messageEl so it shows up under the "Closing in Ns…" text. Dynamic
+  // creation avoids template churn across index.html / live-mode markup.
+  function ensureCloseCancelBtn(messageEl) {
+    var existing = document.getElementById('waitingCloseCancel');
+    if (existing) return existing;
+    if (!messageEl || !messageEl.parentNode || typeof messageEl.parentNode.insertBefore !== 'function') return null;
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'waitingCloseCancel';
+    btn.className = 'btn btn-sm waiting-close-cancel';
+    btn.textContent = 'Cancel';
+    messageEl.parentNode.insertBefore(btn, messageEl.nextSibling);
+    return btn;
+  }
+
+  // Starts (or no-ops) the auto-close countdown for this approval. `ms` is
+  // the resolved `close_on_approve_after_ms` value — undefined/negative
+  // means disabled (matches CloseOnApproveAfterMsEnabled on the Go side).
+  function scheduleAutoClose(ms, messageEl) {
+    clearAutoCloseTimers();
+    if (typeof ms !== 'number' || !isFinite(ms) || ms < 0) return;
+
+    var cancelled = false;
+    var remaining = ms;
+    var timers = [];
+    _autoCloseTimers = timers;
+    var cancelBtn = ensureCloseCancelBtn(messageEl);
+
+    function showCountdown() {
+      if (!messageEl) return;
+      messageEl.style.display = '';
+      messageEl.textContent = 'Closing in ' + Math.ceil(remaining / 1000) + 's…';
+    }
+
+    function onCancel() {
+      if (cancelled) return;
+      cancelled = true;
+      clearAutoCloseTimers();
+      if (cancelBtn) cancelBtn.style.display = 'none';
+      if (messageEl) { messageEl.style.display = 'none'; messageEl.textContent = ''; }
+    }
+
+    if (cancelBtn) {
+      cancelBtn.style.display = '';
+      cancelBtn.onclick = onCancel;
+    }
+
+    function tick() {
+      if (cancelled) return;
+      if (remaining <= 0) {
+        try { window.close(); } catch (_) {}
+        // If the tab is still open (window.close() is a no-op on tabs the
+        // browser didn't open via script), tell the user how to proceed.
+        var closedCheckId = setTimeout(function () {
+          if (cancelled) return;
+          if (messageEl) {
+            messageEl.style.display = '';
+            messageEl.textContent = 'Approved — you can close this tab';
+          }
+          if (cancelBtn) cancelBtn.style.display = 'none';
+        }, 50);
+        timers.push(closedCheckId);
+        return;
+      }
+      showCountdown();
+      var nextId = setTimeout(function () {
+        remaining -= CLOSE_COUNTDOWN_TICK_MS;
+        tick();
+      }, Math.min(CLOSE_COUNTDOWN_TICK_MS, remaining));
+      timers.push(nextId);
+    }
+
+    tick();
+  }
+
   // ===== runFinishReview =====
   // Shared finish-review flow used by both code-review (app.js) and
   // live-mode (live-mode.js). POSTs /api/finish, parses
@@ -365,6 +458,22 @@
       }
 
       try { await navigator.clipboard.writeText(prompt); } catch (_) {}
+
+      if (approved) {
+        // close_on_approve_after_ms is global-only and off by default; read
+        // it fresh from /api/config rather than requiring every caller to
+        // thread a cached copy through. Best-effort — a config fetch failure
+        // just means no auto-close, never blocks the approval itself.
+        var closeMs;
+        try {
+          var cfgResp = await fetch('/api/config');
+          if (cfgResp && cfgResp.ok) {
+            var cfgData = await cfgResp.json();
+            closeMs = cfgData && cfgData.close_on_approve_after_ms;
+          }
+        } catch (_) { /* best effort */ }
+        scheduleAutoClose(closeMs, messageEl);
+      }
 
       if (approved && typeof o.onApproved === 'function') o.onApproved(prompt);
       else if (!approved && typeof o.onWaiting === 'function') o.onWaiting();
@@ -904,6 +1013,7 @@
     updateCommentCountIndicator,
     showToast,
     runFinishReview,
+    scheduleAutoClose,
     waitForSession,
     installSidebarResize,
     computeResizeDelta,

--- a/web/style.css
+++ b/web/style.css
@@ -2384,6 +2384,13 @@ textarea.drag-active {
   margin-top: 12px;
 }
 
+/* Cancel button for the auto-close-after-approve countdown (close_on_approve_after_ms).
+   Created dynamically in crit-shared.js right after #waitingMessage. */
+.waiting-close-cancel {
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
 /* -- Prompt copy row -- */
 .prompt-copy-row {
   margin: 16px 24px 0;


### PR DESCRIPTION
## Summary
- Adds global-only `close_on_approve_after_ms` — when set in `~/.crit.config.json`, the Approved dialog counts down and calls `window.close()` after Approve (zero unresolved comments)
- Cancel button during the countdown skips the close for that approval; if the browser ignores `window.close()`, falls back to “Approved — you can close this tab”
- Key absent/negative = current behavior; deliberately excluded from `crit config --generate`; project config cannot enable it

Closes #752

## Test plan
- [ ] Set `"close_on_approve_after_ms": 2000` in `~/.crit.config.json`, approve a plan/file review, confirm countdown + tab closes (or fallback message)
- [ ] Click Cancel during countdown — tab stays open, no later close
- [ ] Unset the key — Approve leaves the tab open as before
- [ ] Confirm project `.crit.config.json` cannot enable auto-close
- [ ] CI green


Made with [Cursor](https://cursor.com)