### PR TITLE
fix: correct opencode sub-command from 'ask' to 'run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ After the first agent interaction, the comment becomes a **live thread**:
 | Agent                 | `agent_cmd` value        |
 | --------------------- | ------------------------ |
 | Claude Code           | `claude -p`              |
-| OpenCode              | `opencode ask`           |
+| OpenCode              | `opencode run`           |
 | Cline                 | `cline --pipe`           |
 | Aider                 | `aider --message-file -` |
 | Cursor (experimental) | `cursor --pipe`          |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -570,7 +570,7 @@ func TestMergeConfigs_AgentCmd(t *testing.T) {
 	}
 
 	// project-level agent_cmd must be ignored — only global config may set it
-	project2 := Config{AgentCmd: "opencode ask"}
+	project2 := Config{AgentCmd: "opencode run"}
 	merged2 := mergeConfigs(global, project2, ConfigPresence{})
 	if merged2.AgentCmd != "claude -p" {
 		t.Fatalf("expected project agent_cmd to be ignored, got %q", merged2.AgentCmd)

--- a/web/app.js
+++ b/web/app.js
@@ -8604,7 +8604,7 @@
       html += '<span class="config-card-title">Agent Command</span>';
       html += '</div>';
       html += '<div class="config-card-body">Edit <code>~/.crit.config.json</code> and set <code>agent_cmd</code> to send comments directly to your AI agent. <a href="https://github.com/tomasz-tomczyk/crit#send-to-agent-experimental" target="_blank" rel="noopener" style="color:var(--crit-brand)">Learn more</a></div>';
-      html += '<div class="config-card-snippet">{"agent_cmd": "claude -p"}\n// Also: "opencode ask", "aider --message"</div>';
+      html += '<div class="config-card-snippet">{"agent_cmd": "claude -p"}\n// Also: "opencode run", "aider --message"</div>';
       html += '</div>';
     }
 

--- a/web/crit-settings-panes.js
+++ b/web/crit-settings-panes.js
@@ -361,7 +361,7 @@
           html += '<span class="config-card-title">Agent Command</span>';
           html += '</div>';
           html += '<div class="config-card-body">Edit <code>~/.crit.config.json</code> and set <code>agent_cmd</code> to send comments directly to your AI agent. <a href="https://github.com/tomasz-tomczyk/crit#send-to-agent-experimental" target="_blank" rel="noopener" style="color:var(--crit-brand)">Learn more</a></div>';
-          html += '<div class="config-card-snippet">{"agent_cmd": "claude -p"}\n// Also: "opencode ask", "aider --message"</div>';
+          html += '<div class="config-card-snippet">{"agent_cmd": "claude -p"}\n// Also: "opencode run", "aider --message"</div>';
           html += '</div>';
         }
       }


### PR DESCRIPTION
I corrected the sub-command to invoke opencode for `Send now`.
As far as I know, opencode does not provided the sub-command named `ask`, and the sub-command that you may intent is `run`

> [run](https://opencode.ai/docs/cli/#run-1)
> Run opencode in non-interactive mode by passing a prompt directly.

https://opencode.ai/docs/cli/#run-1

I confirmed the the response invoked via `send now` from opencode is shown in crit comments when `agent_cmd` is set to `opencode run`.

<img width="1401" height="1041" alt="image" src="https://github.com/user-attachments/assets/68f741d4-9b3e-4187-9e0e-ea6fedcba783" />
