### PR TITLE
feat: add ampcode integration for crit install

### DIFF
--- a/cmd/crit/cli_install.go
+++ b/cmd/crit/cli_install.go
@@ -231,6 +231,13 @@ var integrationMap = map[string][]integration{
 		{source: "integrations/grok/skills/crit/SKILL.md", dest: ".grok/skills/crit/SKILL.md", hint: "Run /crit in Grok to start a review loop"},
 		{source: "integrations/grok/skills/crit-cli/SKILL.md", dest: ".grok/skills/crit-cli/SKILL.md", hint: "The crit-cli skill is available to Grok agents when needed"},
 	},
+	"ampcode": {
+		// Amp discovers project skills in .agents/skills/ and global skills in
+		// ~/.config/agents/skills/ (highest priority per Amp's skill precedence).
+		// Different paths between modes, so globalDest redirects the global install.
+		{source: "integrations/ampcode/skills/crit/SKILL.md", dest: ".agents/skills/crit/SKILL.md", globalDest: ".config/agents/skills/crit/SKILL.md", globalDestKind: globalDestRelHome, hint: "Ask Amp to use crit to start a review loop"},
+		{source: "integrations/ampcode/skills/crit-cli/SKILL.md", dest: ".agents/skills/crit-cli/SKILL.md", globalDest: ".config/agents/skills/crit-cli/SKILL.md", globalDestKind: globalDestRelHome, hint: "The crit-cli skill is available to Amp agents when needed"},
+	},
 }
 
 // legacyIntegrationFile describes an obsolete destination that could keep

--- a/cmd/crit/integration_hashes_gen.go
+++ b/cmd/crit/integration_hashes_gen.go
@@ -4,6 +4,8 @@ package main
 
 var integrationHashes = map[string]string{
 	"integrations/aider/CONVENTIONS.md":                             "5e699f6ff2473ffeb3aa194466125f6fd0c9a8dd4f8fa0dc05a63e92a1eea9ed",
+	"integrations/ampcode/skills/crit-cli/SKILL.md":                 "a23a8e1a248ef1ecd436313df6a9c26ba1de3b3d694df02d202f02fa0f93e1af",
+	"integrations/ampcode/skills/crit/SKILL.md":                     "10803bd9ed9d18b9f3f58d0d241f54b3a1bdd2e2279c37f85d5f4788d7dce4dd",
 	"integrations/claude-code/.claude-plugin/plugin.json":           "3d761bfcb89dc90e52f4805287ba492971eafd95d2a272324702a832fc0c3176",
 	"integrations/claude-code/hooks/hooks.json":                     "beba2c8bd252637ff31b57ed868e4d56135e1a3f429f872befbd2d34b834512b",
 	"integrations/claude-code/skills/crit-cli/SKILL.md":             "3e6bf2be5eb2e441b85329e5d8ab44ccaac50220d5f51ed6a7af7c650d7e272f",

--- a/cmd/crit/integration_routing_test.go
+++ b/cmd/crit/integration_routing_test.go
@@ -57,6 +57,8 @@ func TestDestFor_GlobalMode(t *testing.T) {
 		// grok: same-shape .grok/skills/ project-locally and ~/.grok/skills/ globally (no globalDest redirect needed).
 		{"grok", 0, ".grok/skills/crit/SKILL.md"},
 		{"grok", 1, ".grok/skills/crit-cli/SKILL.md"},
+		{"ampcode", 0, filepath.Join(home, ".config/agents/skills/crit/SKILL.md")},
+		{"ampcode", 1, filepath.Join(home, ".config/agents/skills/crit-cli/SKILL.md")},
 		// opencode: command redirects to ~/.config/opencode/commands/; skill redirects to ~/.agents/skills/.
 		{"opencode", 0, filepath.Join(home, ".config/opencode/commands/crit.md")},
 		{"opencode", 1, filepath.Join(home, ".agents/skills/crit-cli/SKILL.md")},
@@ -114,6 +116,7 @@ func TestIntegrationMap_SnapshotGlobalRouting(t *testing.T) {
 		"cline":          {{".cline/data/workflows/crit.md", globalDestRelHome}, {".cline/skills/crit-cli/SKILL.md", globalDestRelHome}},
 		"gemini":         {{".gemini/skills/crit-cli/SKILL.md", globalDestRelHome}, {".gemini/commands/crit.toml", globalDestRelHome}, {".gemini/policies/crit.toml", globalDestRelHome}},
 		"grok":           {{"", globalDestNone}, {"", globalDestNone}},
+		"ampcode":        {{".config/agents/skills/crit/SKILL.md", globalDestRelHome}, {".config/agents/skills/crit-cli/SKILL.md", globalDestRelHome}},
 		"codex-plugin":   {{".codex/plugins/crit/.codex-plugin/plugin.json", globalDestRelHome}, {".codex/plugins/crit/skills/crit/SKILL.md", globalDestRelHome}, {".codex/plugins/crit/skills/crit/agents/openai.yaml", globalDestRelHome}, {".codex/plugins/crit/skills/crit-cli/SKILL.md", globalDestRelHome}, {".codex/plugins/crit/hooks/hooks.json", globalDestRelHome}},
 		"hermes":         {{".hermes/skills/crit/SKILL.md", globalDestRelHome}, {".hermes/skills/crit-cli/SKILL.md", globalDestRelHome}},
 		"pi":             {{".pi/agent/skills/crit/SKILL.md", globalDestRelHome}, {".pi/agent/skills/crit-cli/SKILL.md", globalDestRelHome}},

--- a/cmd/crit/integrations.go
+++ b/cmd/crit/integrations.go
@@ -469,6 +469,7 @@ var agentProbes = []agentProbe{
 	{"hermes", []string{"hermes"}, []string{".hermes"}, "hermes-ai"},
 	{"gemini", []string{"gemini"}, []string{".gemini"}, "google"},
 	{"grok", []string{"grok"}, []string{".grok"}, "xai"},
+	{"ampcode", []string{"amp"}, []string{".config/amp"}, ""},
 }
 
 // detectPresentAgents returns the names of AI coding tools that appear to be

--- a/cmd/crit/invocation_policy_test.go
+++ b/cmd/crit/invocation_policy_test.go
@@ -20,6 +20,7 @@ func TestInteractiveSkillsDisableModelInvocationWhereSupported(t *testing.T) {
 		"integrations/cursor/skills/crit/SKILL.md",
 		"integrations/github-copilot/skills/crit/SKILL.md",
 		"integrations/grok/skills/crit/SKILL.md",
+		"integrations/ampcode/skills/crit/SKILL.md",
 		"integrations/pi/skills/crit/SKILL.md",
 		"integrations/qwen/skills/crit/SKILL.md",
 	}
@@ -68,6 +69,7 @@ func TestCritCLIStaysModelDiscoverableWithoutStartingInteractiveCrit(t *testing.
 		"integrations/gemini/skills/crit-cli/SKILL.md",
 		"integrations/github-copilot/skills/crit-cli/SKILL.md",
 		"integrations/grok/skills/crit-cli/SKILL.md",
+		"integrations/ampcode/skills/crit-cli/SKILL.md",
 		"integrations/hermes/skills/crit-cli/SKILL.md",
 		"integrations/opencode/skills/crit-cli/SKILL.md",
 		"integrations/pi/skills/crit-cli/SKILL.md",

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -29,6 +29,7 @@ Safe to re-run. Existing files are skipped (use `--force` to overwrite).
 | Aider | `crit install aider` | `.crit/aider-conventions.md` + adds entry under `read:` in `.aider.conf.yml` | `~/.crit-conventions.md` + adds entry under `read:` in `~/.aider.conf.yml` |
 | Gemini CLI | `crit install gemini` | `.gemini/skills/crit-cli/SKILL.md` + `.gemini/commands/crit.toml` + `.gemini/policies/crit.toml` + `.gemini/settings.json` (merged) | `~/.gemini/skills/crit-cli/SKILL.md` + `~/.gemini/commands/crit.toml` + `~/.gemini/policies/crit.toml` + `~/.gemini/settings.json` (merged) |
 | Grok | `crit install grok` | `.grok/skills/crit/SKILL.md` + `.grok/skills/crit-cli/SKILL.md` | `~/.grok/skills/crit/SKILL.md` + `~/.grok/skills/crit-cli/SKILL.md` |
+| Amp | `crit install ampcode` | `.agents/skills/crit/SKILL.md` + `.agents/skills/crit-cli/SKILL.md` | `~/.config/agents/skills/crit/SKILL.md` + `~/.config/agents/skills/crit-cli/SKILL.md` |
 
 ## Plugin marketplace (Claude Code)
 

--- a/integrations/ampcode/skills/crit-cli/SKILL.md
+++ b/integrations/ampcode/skills/crit-cli/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: crit-cli
+description: Use when an agent needs to author or reply to crit inline comments programmatically (including multi-agent workflows commenting on shared code/plans/docs/proposals), publish or unpublish a crit review with crit share, sync a crit review to or from a GitHub PR, or read/interpret a crit review JSON file. Covers crit comment, crit share, crit unpublish, crit pull, crit push, review file format, and resolution workflow. Not for invoking an interactive review loop — that's the `crit` skill.
+user-invocable: false
+---
+
+# Crit CLI Reference
+
+> If a plan was just written and the user said "crit" or "review", use the `crit` skill instead — it covers the full review loop. This skill covers CLI operations like `crit comment`, `crit pull/push`, and `crit share`.
+
+Comments have three scopes:
+
+- **Line comments** (`scope: "line"`) — tied to specific lines, stored in `files.<path>.comments`
+- **File comments** (`scope: "file"`) — about a file overall, stored in `files.<path>.comments` with `start_line: 0`
+- **Review comments** (`scope: "review"`) — general feedback, stored in the top-level `review_comments` array
+
+The review file path is shown by `crit status`.
+
+## Reading comments
+
+Prefer finish stdout when available: after a review round, unresolved comments are in the `comments` array of `crit`'s JSON stdout (same schema as `crit comments --json`); `prompt` has brief instructions only.
+
+When you need to read comments separately:
+
+```bash
+crit comments            # human-readable, unresolved only (default)
+crit comments --json     # flat JSON for agents
+crit comments --all      # include resolved comments
+crit comments --plan <slug>   # plan reviews
+crit comments [path]     # explicit review.json or .crit directory
+```
+
+Review-level comments are listed first — easy to miss in raw `review.json`. Uses the same review resolution as `crit comment` (`--output`, `--plan`, daemon session).
+
+## Review file format
+
+```json
+{
+  "review_comments": [
+    {
+      "id": "r_f1e2d3",
+      "body": "Overall the architecture looks good",
+      "scope": "review",
+      "author": "User Name",
+      "resolved": false,
+      "replies": [
+        { "id": "rp_b4a5c6", "body": "Thanks, addressed the minor issues", "author": "Amp" }
+      ]
+    }
+  ],
+  "files": {
+    "path/to/file.go": {
+      "comments": [
+        {
+          "id": "c_a1b2c3",
+          "start_line": 5,
+          "end_line": 10,
+          "body": "Comment text",
+          "quote": "the specific words selected",
+          "anchor": "The sessions table needs a complete rewrite...",
+          "author": "User Name",
+          "resolved": false,
+          "replies": [
+            { "id": "rp_c7d8e9", "body": "Fixed by extracting to helper", "author": "Amp" }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Field rules:
+- `resolved`: `false` or **missing** — both mean unresolved. Only `true` means resolved.
+- `quote` (optional): the specific text the reviewer selected — narrows scope within the line range. Focus changes on the quoted text rather than the entire range.
+- `anchor` (line comments): full text of the commented lines when placed. When edits shift line numbers, locate content by anchor rather than trusting `start_line`/`end_line`.
+- `drifted: true`: original content was removed or heavily rewritten — line numbers are approximate at best.
+- Unresolved comments may have `replies` — read them before acting.
+
+## Authoring comments
+
+```bash
+# Review-level (general feedback)
+crit comment --author 'Amp' '<body>'
+
+# File-level (whole file, no line numbers)
+crit comment --author 'Amp' <path> '<body>'
+
+# Line (single line or range)
+crit comment --author 'Amp' <path>:<line> '<body>'
+crit comment --author 'Amp' <path>:<start>-<end> '<body>'
+
+# Reply to an existing comment
+crit comment --reply-to <id> --author 'Amp' '<body>'
+```
+
+Hard rules:
+- **Always pass `--author 'Amp'`** so comments are attributed correctly.
+- **Always single-quote the body** — double quotes break on backticks and shell metachars.
+- **Line numbers reference the file on disk** (1-indexed), not diff line numbers.
+- **Reply bodies support markdown** — use code fences and inline code where helpful.
+- **Only pass `--resolve` when the user explicitly asks.** Never resolve proactively. Same rule applies to the `resolve` field in `--json` mode.
+
+## Bulk commenting (3+ comments)
+
+Use `--json` for atomicity (single write, no partial state) and speed (one process). The JSON can come from stdin or `--file <path>`:
+
+```bash
+# stdin — fine for short, single-line bodies:
+echo '[
+  {"body": "overall feedback", "scope": "review"},
+  {"path": "session.go", "body": "restructure", "scope": "file"},
+  {"file": "src/auth.go", "line": 42, "body": "Missing null check"},
+  {"file": "src/auth.go", "line": "50-55", "body": "Extract to helper"},
+  {"reply_to": "c_a1b2c3", "body": "Fixed — added null check"},
+  {"reply_to": "r_f1e2d3", "body": "Done"}
+]' | crit comment --json --author 'Amp'
+```
+
+**For multi-paragraph bodies, prefer `--file`.** A literal newline inside a `"body"` string breaks JSON parsing, and shell-quoted heredocs make this easy to introduce by accident. Write the JSON to a temp file (use your file-edit tool), then:
+
+```bash
+crit comment --json --file /tmp/crit-bulk.json --author 'Amp'
+```
+
+`--file -` is an explicit "read stdin" if you ever need it.
+
+Per-entry schema:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `file` / `path` | string | line/file comments | Relative path. `path` alone (no `line`) → file-level. |
+| `line` | int/string | line comments | `42` or `"45-47"` |
+| `end_line` | int | optional | Defaults to `line` |
+| `body` | string | always | |
+| `author` | string | optional | Per-entry override; falls back to `--author` |
+| `scope` | string | optional | `"review"` / `"file"` — usually inferred |
+| `reply_to` | string | replies | Comment ID (`c_…` or `r_…`) |
+| `resolve` | bool | optional | Only when user explicitly asks |
+
+Scope inference (when `scope` omitted): has `reply_to` → reply; no `file`/`path` and no `line` → review-level; `path` but no `line` → file-level; `file`/`path` + `line` → line.
+
+## Multi-file disambiguation
+
+Comment IDs are unique per session, but the same ID can collide across files. If `crit comment` errors with "comment found in multiple files", disambiguate with `--path`:
+
+```bash
+crit comment --reply-to c_a1b2c3 --path src/auth.go --author 'Amp' 'Fixed the null check'
+```
+
+In `--json` mode, set the `file` field on the entry. Review-level IDs (`r_…`) are globally unique and never need this.
+
+## Plan-mode comments
+
+Plan reviews (via `crit plan` or the ExitPlanMode hook) store the review file in `~/.crit/plans/<slug>/`. **Always pass `--plan <slug>`** — without it, `crit comment` looks in the project root and won't find the comments. The slug is shown in the review feedback prompt.
+
+```bash
+crit comment --plan my-plan-2026-03-23 --reply-to c_a1b2c3 --author 'Amp' 'Updated the plan'
+```
+
+## GitHub PR Integration
+
+```bash
+crit pull [pr-number]                                    # Fetch PR review comments into the review file
+crit push [--dry-run] [--event <type>] [-m <msg>] [pr]   # Post review comments as a GitHub PR review
+```
+
+Requires `gh` CLI installed and authenticated. PR number is auto-detected from the current branch.
+
+`--event` values: `comment` (default), `approve`, `request-changes`. `-m` adds a review-level body message.
+
+## Sharing
+
+```bash
+crit share <file> [file...]                          # Upload and print URL
+crit share --qr <file>                               # Also print QR code (terminal only)
+crit share --org <slug> <file>                       # Share under an organization
+crit share --org <slug> --visibility unlisted <file> # Org share with explicit visibility
+crit unpublish [file...]                              # Remove shared review
+```
+
+- **Always relay the output** — copy the URL (and QR if used) into your response. Don't make them dig through tool output.
+- **`--qr` is terminal-only** — skip in mobile apps, web chat UIs, or anywhere Unicode block characters won't render correctly.
+- **`--org <slug>`** shares under an organization. Visibility defaults to `organization` (members only). Override with `--visibility` (`organization`, `unlisted`, `public`).
+- If a review file exists, comments for the shared files are included automatically.
+- **Unpublish uses the persisted delete token** in the review file — no extra args needed.

--- a/integrations/ampcode/skills/crit/SKILL.md
+++ b/integrations/ampcode/skills/crit/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: crit
+description: "Review code changes, a plan, a live page (running dev server), or a local HTML file with crit inline comments. Use when asked to review code, a plan, a diff, a running web app, or when you want structured human feedback on your work."
+disable-model-invocation: true
+---
+
+# Review with Crit
+
+Review and revise code changes, plans, live pages (running dev servers, staging URLs), or local HTML files using `crit` for inline comment review.
+
+## Step 1: Pass arguments to `crit`
+
+The CLI auto-detects the review mode from its arguments. **Do not ask the user which mode to use.** Pass arguments through:
+
+```
+crit <arguments>               # file, dir, URL, .html — CLI auto-detects mode
+crit --pr <num|url>            # GitHub PR (range mode)
+crit --range <base>..<head>    # commit range (range mode)
+crit                           # no args → branch diff
+```
+If no arguments, check conversation context:
+
+1. A plan file was written earlier in this conversation → `crit <plan-file>`
+2. Otherwise → bare `crit` (branch diff)
+
+## Step 2: Launch crit and block until review completes
+
+**CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
+
+Run `crit` in the foreground and block until it exits:
+
+```bash
+crit <plan-file>   # specific file
+crit               # git mode
+```
+
+If a crit server is already running from earlier in this conversation, `crit` automatically connects to it. Starting from scratch, it spawns the daemon, opens the browser, and blocks until the user clicks "Finish Review".
+
+`crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`). Relay it verbatim:
+
+> **"Crit is open at http://localhost:<port>. Leave inline comments, then click Finish Review."**
+
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
+
+## Step 3: Read the review output
+
+When `crit` completes, read **stdout** and follow its instructions. Check **stderr** for `approved: true` or `approved: false`.
+
+When a comment has `quote`, `anchor`, or `drifted`:
+- `quote`: the specific text the reviewer selected — focus your changes on the quoted text rather than the entire line range
+- `anchor`: use it to locate the current position of the content; line numbers may be stale after edits
+- `drifted: true`: original content was removed or heavily rewritten — line numbers are approximate at best
+
+**Fallback** (mid-round re-entry, plan hooks, or headless workflows): `crit comments` / `crit comments --json`. Use `crit comments --plan <slug>` for plan-mode reviews.
+
+## Step 4: Address each review comment
+
+For each unresolved comment:
+
+1. Understand what the comment asks for
+2. If it contains a suggestion block, apply that specific change
+3. Revise the referenced file (plan or code file from the diff)
+4. Reply with what you did: `crit comment --reply-to <id> --author 'Amp' '<what you did>'` (reply bodies support markdown)
+5. **Do not pass `--resolve`.** Resolving is the reviewer's call. Only add `--resolve` if the user explicitly asks.
+
+Editing the plan file triggers Crit's live reload — the user sees changes in the browser immediately.
+
+<important if="you are revising in plan mode">
+Re-emit the revised plan inside `<proposed_plan>...</proposed_plan>` so Crit can review the new version.
+</important>
+
+### When replying to multiple comments
+
+Use `--json` for a single bulk call instead of one invocation per comment:
+
+```bash
+echo '[
+  {"reply_to": "c_a1b2c3", "body": "Fixed"},
+  {"reply_to": "c_d4e5f6", "body": "Refactored as suggested"}
+]' | crit comment --json --author 'Amp'
+```
+
+## Step 5: Signal completion and start next round
+
+**CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
+
+The finish prompt on stdout includes the command to run again — use it to start a new round.
+
+On subsequent calls, `crit` automatically signals round-complete first, then blocks until the next "Finish Review" click.
+
+Tell the user: **"Changes applied. Review the diff in your browser and click Finish Review when ready."**
+
+**Do NOT proceed until `crit` completes.** When it does, return to Step 3. If the user finishes with zero comments, the review is approved — stop the loop and proceed.
+
+## Sharing
+
+If the user asks for a URL, a shareable link, or to share the review:
+
+```bash
+crit share <file>
+```
+
+**Always relay the full output to the user** — copy the URL directly into your response. Don't make them dig through tool output.
+
+To remove a shared review:
+
+```bash
+crit unpublish [file...]
+```
+
+### QR codes
+
+Only use `--qr` in real terminal environments with monospace rendering. Skip it in mobile apps or web chat UIs — Unicode block characters won't render.
+
+```bash
+crit share --qr <file>
+```


### PR DESCRIPTION
## Background

Amp (ampcode.com) is a frontier coding agent for the terminal and editor. It discovers skills in `.agents/skills/` (project) and `~/.config/agents/skills/` (global), the same `.agents/skills/` path that the existing `codex` integration uses for project installs.

Previously, Amp users had to run `crit install codex-plugin` and then manually fix the `--author` string from `Codex` to `Amp`. This PR adds a native `crit install ampcode` command so the integration is discoverable and installs to the correct paths automatically.

## Changes Summary

- **New: `integrations/ampcode/skills/crit/SKILL.md`** — interactive review loop skill with `disable-model-invocation: true` and `--author 'Amp'`
- **New: `integrations/ampcode/skills/crit-cli/SKILL.md`** — model-discoverable CLI reference skill with `user-invocable: false` and `--author 'Amp'`
- **`cmd/crit/cli_install.go`** — add `"ampcode"` entry to `integrationMap` with project dest `.agents/skills/` and global dest `.config/agents/skills/` (`globalDestRelHome`)
- **`cmd/crit/integrations.go`** — add `{"ampcode", []string{"amp"}, []string{".config/amp"}, ""}` to `agentProbes` for auto-detection
- **`cmd/crit/integration_routing_test.go`** — add ampcode cases to `TestDestFor_GlobalMode` and `TestIntegrationMap_SnapshotGlobalRouting`
- **`cmd/crit/invocation_policy_test.go`** — add ampcode skill paths to `TestInteractiveSkillsDisableModelInvocationWhereSupported` and `TestCritCLIStaysModelDiscoverableWithoutStartingInteractiveCrit`
- **`cmd/crit/integration_hashes_gen.go`** — regenerated via `go generate ./cmd/crit`
- **`integrations/README.md`** — add Amp row to the install table

Follows the same pattern as the Grok integration (PR #544): two skill files, one `integrationMap` entry, agent probe, routing tests, invocation policy tests, regenerated hashes, and a README row.

## How to Test

```bash
# Build with the new integration
go build ./cmd/crit

# Project install — should write to .agents/skills/
./crit install ampcode
ls .agents/skills/crit/SKILL.md .agents/skills/crit-cli/SKILL.md

# Global install — should write to ~/.config/agents/skills/
cd ~ && ./crit install ampcode
ls ~/.config/agents/skills/crit/SKILL.md ~/.config/agents/skills/crit-cli/SKILL.md

# Auto-detection should find amp
./crit check

# Run tests
go test ./cmd/crit/
```

## References

- Amp skill discovery paths: https://ampcode.com/manual#plugins (Skills section)
- Previous thread discussing this integration: https://ampcode.com/threads/T-019f8794-3f8a-77c8-bf6b-64ffdc9d15fb
- Grok integration as template: PR #544