### PR TITLE
fix: avoid duplicate browser tab on live cold start

### DIFF
--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -63,9 +63,12 @@ func detectFrameworks(body []byte) []string {
 var smokeClient = &http.Client{Timeout: 10 * time.Second}
 
 var (
-	startLiveDaemon = daemon.StartDaemon
-	runLiveClient   = daemon.RunReviewClient
-	openLiveBrowser = browser.OpenBrowserWithCommand
+	startLiveDaemon                = daemon.StartDaemon
+	runLiveClient                  = daemon.RunReviewClient
+	installLiveDaemonSignalHandler = installDaemonSignalHandler
+	launchLiveBrowser              = func(url, openCmd string) {
+		go browser.OpenBrowserWithCommand(url, openCmd)
+	}
 )
 
 func runSmokeTest(origin, cookies string) smokeResult {
@@ -155,7 +158,7 @@ func connectToLiveDaemon(key, openCmd string) bool {
 		entry.BaseURL(), entry.Port+1)
 	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.BaseURL())
 	if !daemon.DaemonHasBrowser(entry) {
-		go openLiveBrowser(entry.BaseURL()+"/live", openCmd)
+		launchLiveBrowser(entry.BaseURL()+"/live", openCmd)
 	}
 	runLiveClient(entry, key)
 	return true
@@ -275,7 +278,7 @@ func RunLive(args []string) {
 		entry.Port, entry.Port+1)
 	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.BaseURL())
 
-	installDaemonSignalHandler(entry.PID)
+	installLiveDaemonSignalHandler(entry.PID)
 
 	runLiveClient(entry, key)
 }

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -62,6 +62,12 @@ func detectFrameworks(body []byte) []string {
 
 var smokeClient = &http.Client{Timeout: 10 * time.Second}
 
+var (
+	startLiveDaemon = daemon.StartDaemon
+	runLiveClient   = daemon.RunReviewClient
+	openLiveBrowser = browser.OpenBrowserWithCommand
+)
+
 func runSmokeTest(origin, cookies string) smokeResult {
 	req, err := http.NewRequest(http.MethodGet, origin, nil)
 	if err != nil {
@@ -149,9 +155,9 @@ func connectToLiveDaemon(key, openCmd string) bool {
 		entry.BaseURL(), entry.Port+1)
 	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.BaseURL())
 	if !daemon.DaemonHasBrowser(entry) {
-		go browser.OpenBrowserWithCommand(entry.BaseURL()+"/live", openCmd)
+		go openLiveBrowser(entry.BaseURL()+"/live", openCmd)
 	}
-	daemon.RunReviewClient(entry, key)
+	runLiveClient(entry, key)
 	return true
 }
 
@@ -259,7 +265,7 @@ func RunLive(args []string) {
 	}
 
 	noOpenResolved := f.noOpen || cfg.NoOpen
-	entry, err := daemon.StartDaemon(key, buildLiveDaemonArgs(f.origin, liveCookies, f, cfg, noOpenResolved))
+	entry, err := startLiveDaemon(key, buildLiveDaemonArgs(f.origin, liveCookies, f, cfg, noOpenResolved))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start live daemon: %v\n", err)
 		os.Exit(1)
@@ -271,11 +277,7 @@ func RunLive(args []string) {
 
 	installDaemonSignalHandler(entry.PID)
 
-	if !noOpenResolved {
-		go browser.OpenBrowserWithCommand(entry.BaseURL()+"/live", cfg.OpenCmd)
-	}
-
-	daemon.RunReviewClient(entry, key)
+	runLiveClient(entry, key)
 }
 
 func checkLiveSmoke(origin, cookies string) {

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -66,8 +66,9 @@ var (
 	startLiveDaemon                = daemon.StartDaemon
 	runLiveClient                  = daemon.RunReviewClient
 	installLiveDaemonSignalHandler = installDaemonSignalHandler
+	openLiveBrowser                = browser.OpenBrowserWithCommand
 	launchLiveBrowser              = func(url, openCmd string) {
-		go browser.OpenBrowserWithCommand(url, openCmd)
+		go openLiveBrowser(url, openCmd)
 	}
 )
 

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -535,11 +536,13 @@ func TestRunLive_ColdStartBrowserOwnership(t *testing.T) {
 	originalStart := startLiveDaemon
 	originalRunClient := runLiveClient
 	originalInstallSignalHandler := installLiveDaemonSignalHandler
+	originalOpenBrowser := openLiveBrowser
 	originalLaunchBrowser := launchLiveBrowser
 	t.Cleanup(func() {
 		startLiveDaemon = originalStart
 		runLiveClient = originalRunClient
 		installLiveDaemonSignalHandler = originalInstallSignalHandler
+		openLiveBrowser = originalOpenBrowser
 		launchLiveBrowser = originalLaunchBrowser
 	})
 
@@ -605,6 +608,69 @@ func TestRunLive_ColdStartBrowserOwnership(t *testing.T) {
 				t.Fatalf("cold-start client launched the browser %d times; the daemon owns the initial browser open", browserOpenCalls)
 			}
 		})
+	}
+}
+
+func TestConnectToLiveDaemon_LaunchesBrowserWhenNoneAttached(t *testing.T) {
+	originalRunClient := runLiveClient
+	originalOpenBrowser := openLiveBrowser
+	t.Cleanup(func() {
+		runLiveClient = originalRunClient
+		openLiveBrowser = originalOpenBrowser
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "browser_clients": false})
+	}))
+	defer srv.Close()
+
+	serverURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	const key = "live-connect-test"
+	entry := daemon.SessionEntry{PID: os.Getpid(), Port: port}
+	if err := daemon.WriteSessionFile(key, entry); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	type browserCall struct {
+		url     string
+		openCmd string
+	}
+	browserCalls := make(chan browserCall, 1)
+	openLiveBrowser = func(url, openCmd string) {
+		browserCalls <- browserCall{url: url, openCmd: openCmd}
+	}
+	clientRan := false
+	runLiveClient = func(gotEntry daemon.SessionEntry, gotKey string) bool {
+		clientRan = true
+		if gotEntry.Port != entry.Port || gotKey != key {
+			t.Fatalf("run client with entry/key = %+v/%q, want %+v/%q", gotEntry, gotKey, entry, key)
+		}
+		return false
+	}
+
+	if !connectToLiveDaemon(key, "custom-open") {
+		t.Fatal("connectToLiveDaemon returned false")
+	}
+	if !clientRan {
+		t.Fatal("review client did not run")
+	}
+	select {
+	case got := <-browserCalls:
+		wantURL := entry.BaseURL() + "/live"
+		if got.url != wantURL || got.openCmd != "custom-open" {
+			t.Fatalf("browser call = %+v, want URL %q with custom-open", got, wantURL)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("browser launch was not dispatched")
 	}
 }
 

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -534,11 +534,13 @@ func TestBuildLiveDaemonArgs(t *testing.T) {
 func TestRunLive_ColdStartLeavesBrowserOpeningToDaemon(t *testing.T) {
 	originalStart := startLiveDaemon
 	originalRunClient := runLiveClient
-	originalOpenBrowser := openLiveBrowser
+	originalInstallSignalHandler := installLiveDaemonSignalHandler
+	originalLaunchBrowser := launchLiveBrowser
 	t.Cleanup(func() {
 		startLiveDaemon = originalStart
 		runLiveClient = originalRunClient
-		openLiveBrowser = originalOpenBrowser
+		installLiveDaemonSignalHandler = originalInstallSignalHandler
+		launchLiveBrowser = originalLaunchBrowser
 	})
 
 	home := t.TempDir()
@@ -561,23 +563,28 @@ func TestRunLive_ColdStartLeavesBrowserOpeningToDaemon(t *testing.T) {
 		clientRan = true
 		return false
 	}
-	browserOpened := make(chan string, 1)
-	openLiveBrowser = func(url, _ string) {
-		browserOpened <- url
+	signalHandlerInstalled := false
+	installLiveDaemonSignalHandler = func(int) {
+		signalHandlerInstalled = true
+	}
+	browserOpenCalls := 0
+	launchLiveBrowser = func(string, string) {
+		browserOpenCalls++
 	}
 
 	RunLive([]string{upstream.URL})
 
+	if !signalHandlerInstalled {
+		t.Fatal("daemon signal handler was not installed")
+	}
 	if !clientRan {
 		t.Fatal("review client did not run")
 	}
 	if containsArgPair(daemonArgs, "--no-open", "") {
 		t.Fatalf("cold-start daemon args unexpectedly disable browser opening: %v", daemonArgs)
 	}
-	select {
-	case openedURL := <-browserOpened:
-		t.Fatalf("cold-start client opened %s; the daemon owns the initial browser open", openedURL)
-	case <-time.After(100 * time.Millisecond):
+	if browserOpenCalls != 0 {
+		t.Fatalf("cold-start client launched the browser %d times; the daemon owns the initial browser open", browserOpenCalls)
 	}
 }
 

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/focus"
 )
 
@@ -527,6 +528,56 @@ func TestBuildLiveDaemonArgs(t *testing.T) {
 	fromCfg := buildLiveDaemonArgs("http://localhost:3000", "", liveCLIFlags{}, Config{PublicURL: "https://cfg.ts.net"}, false)
 	if !containsArgPair(fromCfg, "--public-url", "https://cfg.ts.net") {
 		t.Fatalf("missing config public-url: %v", fromCfg)
+	}
+}
+
+func TestRunLive_ColdStartLeavesBrowserOpeningToDaemon(t *testing.T) {
+	originalStart := startLiveDaemon
+	originalRunClient := runLiveClient
+	originalOpenBrowser := openLiveBrowser
+	t.Cleanup(func() {
+		startLiveDaemon = originalStart
+		runLiveClient = originalRunClient
+		openLiveBrowser = originalOpenBrowser
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+
+	var daemonArgs []string
+	startLiveDaemon = func(_ string, args []string) (daemon.SessionEntry, error) {
+		daemonArgs = append([]string(nil), args...)
+		return daemon.SessionEntry{PID: os.Getpid(), Port: 43123}, nil
+	}
+	clientRan := false
+	runLiveClient = func(daemon.SessionEntry, string) bool {
+		clientRan = true
+		return false
+	}
+	browserOpened := make(chan string, 1)
+	openLiveBrowser = func(url, _ string) {
+		browserOpened <- url
+	}
+
+	RunLive([]string{upstream.URL})
+
+	if !clientRan {
+		t.Fatal("review client did not run")
+	}
+	if containsArgPair(daemonArgs, "--no-open", "") {
+		t.Fatalf("cold-start daemon args unexpectedly disable browser opening: %v", daemonArgs)
+	}
+	select {
+	case openedURL := <-browserOpened:
+		t.Fatalf("cold-start client opened %s; the daemon owns the initial browser open", openedURL)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -531,7 +531,7 @@ func TestBuildLiveDaemonArgs(t *testing.T) {
 	}
 }
 
-func TestRunLive_ColdStartLeavesBrowserOpeningToDaemon(t *testing.T) {
+func TestRunLive_ColdStartBrowserOwnership(t *testing.T) {
 	originalStart := startLiveDaemon
 	originalRunClient := runLiveClient
 	originalInstallSignalHandler := installLiveDaemonSignalHandler
@@ -553,38 +553,58 @@ func TestRunLive_ColdStartLeavesBrowserOpeningToDaemon(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	var daemonArgs []string
-	startLiveDaemon = func(_ string, args []string) (daemon.SessionEntry, error) {
-		daemonArgs = append([]string(nil), args...)
-		return daemon.SessionEntry{PID: os.Getpid(), Port: 43123}, nil
-	}
-	clientRan := false
-	runLiveClient = func(daemon.SessionEntry, string) bool {
-		clientRan = true
-		return false
-	}
-	signalHandlerInstalled := false
-	installLiveDaemonSignalHandler = func(int) {
-		signalHandlerInstalled = true
-	}
-	browserOpenCalls := 0
-	launchLiveBrowser = func(string, string) {
-		browserOpenCalls++
+	tests := []struct {
+		name             string
+		args             []string
+		wantDaemonNoOpen bool
+	}{
+		{
+			name: "default leaves opening to daemon",
+			args: []string{upstream.URL},
+		},
+		{
+			name:             "no-open disables daemon opening",
+			args:             []string{"--no-open", upstream.URL},
+			wantDaemonNoOpen: true,
+		},
 	}
 
-	RunLive([]string{upstream.URL})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var daemonArgs []string
+			startLiveDaemon = func(_ string, args []string) (daemon.SessionEntry, error) {
+				daemonArgs = append([]string(nil), args...)
+				return daemon.SessionEntry{PID: os.Getpid(), Port: 43123}, nil
+			}
+			clientRan := false
+			runLiveClient = func(daemon.SessionEntry, string) bool {
+				clientRan = true
+				return false
+			}
+			signalHandlerInstalled := false
+			installLiveDaemonSignalHandler = func(int) {
+				signalHandlerInstalled = true
+			}
+			browserOpenCalls := 0
+			launchLiveBrowser = func(string, string) {
+				browserOpenCalls++
+			}
 
-	if !signalHandlerInstalled {
-		t.Fatal("daemon signal handler was not installed")
-	}
-	if !clientRan {
-		t.Fatal("review client did not run")
-	}
-	if containsArgPair(daemonArgs, "--no-open", "") {
-		t.Fatalf("cold-start daemon args unexpectedly disable browser opening: %v", daemonArgs)
-	}
-	if browserOpenCalls != 0 {
-		t.Fatalf("cold-start client launched the browser %d times; the daemon owns the initial browser open", browserOpenCalls)
+			RunLive(tt.args)
+
+			if !signalHandlerInstalled {
+				t.Fatal("daemon signal handler was not installed")
+			}
+			if !clientRan {
+				t.Fatal("review client did not run")
+			}
+			if got := containsArgPair(daemonArgs, "--no-open", ""); got != tt.wantDaemonNoOpen {
+				t.Fatalf("daemon --no-open = %v, want %v; args: %v", got, tt.wantDaemonNoOpen, daemonArgs)
+			}
+			if browserOpenCalls != 0 {
+				t.Fatalf("cold-start client launched the browser %d times; the daemon owns the initial browser open", browserOpenCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the foreground live client’s redundant cold-start browser launch
- leave the initial `/live` browser open to the daemon while preserving reconnect behavior
- cover default and `--no-open` ownership paths with deterministic regression tests

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (local Go CLI only)
- [x] Red-team checks: passed

## Test plan
- `mise exec -- go test ./internal/live -run TestRunLive_ColdStartBrowserOwnership -count=20`
- `mise exec -- go test -race ./internal/live -count=1`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`

Closes #766