### PR TITLE
fix: honor configured output across review commands

### DIFF
--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -181,7 +181,7 @@ func TestResolveServeReviewPath(t *testing.T) {
 
 func TestResolveServeReviewPathPlanBeatsConfiguredOutput(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(dir)
 	if err := os.WriteFile(
 		filepath.Join(dir, ".crit.config.json"),

--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -179,6 +179,33 @@ func TestResolveServeReviewPath(t *testing.T) {
 	})
 }
 
+func TestResolveServeReviewPathPlanBeatsConfiguredOutput(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(dir)
+	if err := os.WriteFile(
+		filepath.Join(dir, ".crit.config.json"),
+		[]byte(`{"output":"/tmp/configured"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	planDir := filepath.Join(dir, "plan")
+	sc, err := server.ResolveDaemonCLIConfig([]string{"--plan-dir", planDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveServeReviewPath(sc.OutputDir, sc.PlanDir, "deadbeef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(planDir, ".crit")
+	if got != want {
+		t.Fatalf("review path = %q, want plan review path %q", got, want)
+	}
+}
+
 func TestServeSessionKey_Override(t *testing.T) {
 	sc := &server.DaemonCLIConfig{SessionKeyOverride: "839f3b4cd5d6"}
 	if got := serveSessionKey(sc); got != "839f3b4cd5d6" {

--- a/internal/comment/comment_cli.go
+++ b/internal/comment/comment_cli.go
@@ -193,7 +193,10 @@ func addCommentToCritJSONScoped(filePath string, startLine, endLine int, body, a
 	if err != nil {
 		return err
 	}
+	return addCommentToCritJSONAtPath(filePath, startLine, endLine, body, author, userID, critPath, scope)
+}
 
+func addCommentToCritJSONAtPath(filePath string, startLine, endLine int, body, author, userID, critPath string, scope session.InheritedScope) error {
 	if isAbsoluteOrTraversal(filePath) {
 		return fmt.Errorf("path %q must be relative and within the repository", filePath)
 	}
@@ -218,7 +221,10 @@ func addReplyToCritJSON(commentID, body, author, userID string, resolve bool, ou
 	if err != nil {
 		return err
 	}
+	return addReplyToCritJSONAtPath(commentID, body, author, userID, resolve, critPath, filterPath)
+}
 
+func addReplyToCritJSONAtPath(commentID, body, author, userID string, resolve bool, critPath string, filterPath string) error {
 	cj, err := review.LoadCritJSON(critPath)
 	if err != nil {
 		return err
@@ -427,15 +433,17 @@ func parseLineSpec(spec string) (start, end int, err error) {
 //
 //nolint:unparam // globalUserID is part of the public contract; tests don't exercise it
 func bulkAddCommentsToCritJSONScoped(entries []BulkCommentEntry, globalAuthor, globalUserID string, outputDir string, scope session.InheritedScope) error {
-	if len(entries) == 0 {
-		return fmt.Errorf("no comment entries provided")
-	}
-
 	primaryPath, err := review.ResolveReviewPath(outputDir)
 	if err != nil {
 		return err
 	}
+	return bulkAddCommentsToCritJSONAtPath(entries, globalAuthor, globalUserID, primaryPath, scope)
+}
 
+func bulkAddCommentsToCritJSONAtPath(entries []BulkCommentEntry, globalAuthor, globalUserID, primaryPath string, scope session.InheritedScope) error {
+	if len(entries) == 0 {
+		return fmt.Errorf("no comment entries provided")
+	}
 	primary, err := review.LoadCritJSON(primaryPath)
 	if err != nil {
 		return err
@@ -531,7 +539,10 @@ func addReviewCommentToCritJSONScoped(body, author, userID, outputDir string, sc
 	if err != nil {
 		return err
 	}
+	return addReviewCommentToCritJSONAtPath(body, author, userID, critPath, scope)
+}
 
+func addReviewCommentToCritJSONAtPath(body, author, userID, critPath string, scope session.InheritedScope) error {
 	cj, err := review.LoadCritJSON(critPath)
 	if err != nil {
 		return err
@@ -548,7 +559,10 @@ func addFileCommentToCritJSONScoped(filePath, body, author, userID, outputDir st
 	if err != nil {
 		return err
 	}
+	return addFileCommentToCritJSONAtPath(filePath, body, author, userID, critPath, scope)
+}
 
+func addFileCommentToCritJSONAtPath(filePath, body, author, userID, critPath string, scope session.InheritedScope) error {
 	if isAbsoluteOrTraversal(filePath) {
 		return fmt.Errorf("path %q must be relative and within the repository", filePath)
 	}

--- a/internal/comment/comment_json_input_test.go
+++ b/internal/comment/comment_json_input_test.go
@@ -11,6 +11,13 @@ import (
 	"testing"
 )
 
+func TestBulkAddCommentsAtPathEmptyInput(t *testing.T) {
+	err := bulkAddCommentsToCritJSONAtPath(nil, "", "", filepath.Join(t.TempDir(), ".crit"), inheritedScope{})
+	if err == nil || !strings.Contains(err.Error(), "no comment entries") {
+		t.Fatalf("error = %v, want no comment entries", err)
+	}
+}
+
 func TestReadCommentJSONInputFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bulk.json")

--- a/internal/comment/comment_scope_test.go
+++ b/internal/comment/comment_scope_test.go
@@ -28,6 +28,16 @@ func writeReviewFileWithScope(t *testing.T, dir, scope string) {
 	}
 }
 
+func TestLoadCritJSONForOutputDir(t *testing.T) {
+	outputDir := t.TempDir()
+	writeReviewFileWithScope(t, outputDir, "layer")
+
+	cj, ok := loadCritJSONForOutputDir(outputDir)
+	if !ok || cj.ActiveDiffScope != "layer" {
+		t.Fatalf("review = %+v, ok = %v; want layer scope", cj, ok)
+	}
+}
+
 func TestResolveCommentScope(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/comment/daemon_config_precedence_test.go
+++ b/internal/comment/daemon_config_precedence_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func TestRunCommentDaemonThenConfiguredOutputPrecedence(t *testing.T) {
 	projectDir := t.TempDir()
 	daemonOutput := filepath.Join(projectDir, "daemon-output")
 	configuredOutput := filepath.Join(projectDir, "configured-output")
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),

--- a/internal/comment/daemon_config_precedence_test.go
+++ b/internal/comment/daemon_config_precedence_test.go
@@ -1,0 +1,98 @@
+package comment
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/review"
+	"github.com/tomasz-tomczyk/crit/internal/session"
+)
+
+func TestRunCommentDaemonThenConfiguredOutputPrecedence(t *testing.T) {
+	projectDir := t.TempDir()
+	daemonOutput := filepath.Join(projectDir, "daemon-output")
+	configuredOutput := filepath.Join(projectDir, "configured-output")
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(fmt.Sprintf(`{"output":%q}`, configuredOutput)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonReviewPath := filepath.Join(daemonOutput, ".crit")
+	if err := review.SaveCritJSON(daemonReviewPath, session.CritJSON{
+		ReviewRound: 1,
+		Files:       map[string]session.CritJSONFile{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/health" {
+			fmt.Fprint(w, `{"status":"ok"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(health.Close)
+	parsed, err := url.Parse(health.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := daemon.ResolvedCWD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sessionKey = "comment-precedence"
+	if err := daemon.WriteSessionFile(sessionKey, daemon.SessionEntry{
+		PID:        os.Getpid(),
+		Port:       port,
+		CWD:        cwd,
+		ReviewPath: daemonReviewPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { daemon.RemoveSessionFile(sessionKey) })
+
+	if err := RunComment([]string{"--author", "bot", "active daemon"}); err != nil {
+		t.Fatal(err)
+	}
+	daemonReview, err := review.LoadCritJSON(daemonReviewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(daemonReview.ReviewComments) != 1 || daemonReview.ReviewComments[0].Body != "active daemon" {
+		t.Fatalf("daemon review comments = %+v, want active daemon comment", daemonReview.ReviewComments)
+	}
+	if _, err := os.Stat(filepath.Join(configuredOutput, ".crit", "review.json")); !os.IsNotExist(err) {
+		t.Fatalf("configured review unexpectedly written while daemon active: %v", err)
+	}
+
+	health.Close()
+	daemon.RemoveSessionFile(sessionKey)
+	if err := RunComment([]string{"--author", "bot", "configured fallback"}); err != nil {
+		t.Fatal(err)
+	}
+	configuredReview, err := review.LoadCritJSON(filepath.Join(configuredOutput, ".crit"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configuredReview.ReviewComments) != 1 || configuredReview.ReviewComments[0].Body != "configured fallback" {
+		t.Fatalf("configured review comments = %+v, want fallback comment", configuredReview.ReviewComments)
+	}
+}

--- a/internal/comment/flags.go
+++ b/internal/comment/flags.go
@@ -5,17 +5,19 @@ import (
 )
 
 type commentFlags struct {
-	outputDir string
-	author    string
-	userID    string
-	replyTo   string
-	resolve   bool
-	path      string
-	json      bool
-	file      string
-	plan      string
-	scope     CommentFocusOverride
-	args      []string
+	outputDir        string
+	configuredOutput string
+	reviewPath       string
+	author           string
+	userID           string
+	replyTo          string
+	resolve          bool
+	path             string
+	json             bool
+	file             string
+	plan             string
+	scope            CommentFocusOverride
+	args             []string
 }
 
 func parseCommentFlags(args []string) (commentFlags, error) { //nolint:gocyclo // CLI flag parser

--- a/internal/comment/flags_main_test.go
+++ b/internal/comment/flags_main_test.go
@@ -1,10 +1,20 @@
 package comment
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func outputConfigJSON(t *testing.T, output string) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]string{"output": output})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
 
 func TestParseCommentFlags(t *testing.T) {
 	tests := []struct {
@@ -114,7 +124,7 @@ func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
 	t.Chdir(projectDir)
 
 	configuredOutput := filepath.Join(projectDir, "reviews")
-	configData := []byte(`{"output":` + `"` + configuredOutput + `"` + `}`)
+	configData := outputConfigJSON(t, configuredOutput)
 	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), configData, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/comment/flags_main_test.go
+++ b/internal/comment/flags_main_test.go
@@ -127,8 +127,11 @@ func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
 		if err := resolveCommentFlags(&f); err != nil {
 			t.Fatal(err)
 		}
-		if f.outputDir != configuredOutput {
-			t.Fatalf("outputDir = %q, want configured output %q", f.outputDir, configuredOutput)
+		if f.configuredOutput != configuredOutput {
+			t.Fatalf("configuredOutput = %q, want %q", f.configuredOutput, configuredOutput)
+		}
+		if f.reviewPath != filepath.Join(configuredOutput, ".crit") {
+			t.Fatalf("reviewPath = %q, want configured review path", f.reviewPath)
 		}
 	})
 
@@ -144,6 +147,9 @@ func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
 		if f.outputDir != explicitOutput {
 			t.Fatalf("outputDir = %q, want explicit output %q", f.outputDir, explicitOutput)
 		}
+		if f.reviewPath != filepath.Join(explicitOutput, ".crit") {
+			t.Fatalf("reviewPath = %q, want explicit review path", f.reviewPath)
+		}
 	})
 
 	t.Run("plan storage wins without conflict", func(t *testing.T) {
@@ -156,6 +162,9 @@ func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
 		}
 		if f.outputDir == "" || f.outputDir == configuredOutput {
 			t.Fatalf("outputDir = %q, want plan storage", f.outputDir)
+		}
+		if f.reviewPath != filepath.Join(f.outputDir, ".crit") {
+			t.Fatalf("reviewPath = %q, want plan review path", f.reviewPath)
 		}
 	})
 }

--- a/internal/comment/flags_main_test.go
+++ b/internal/comment/flags_main_test.go
@@ -1,6 +1,8 @@
 package comment
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -104,4 +106,56 @@ func TestParseCommentFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+
+	configuredOutput := filepath.Join(projectDir, "reviews")
+	configData := []byte(`{"output":` + `"` + configuredOutput + `"` + `}`)
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), configData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("configured output", func(t *testing.T) {
+		f, err := parseCommentFlags([]string{"body"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := resolveCommentFlags(&f); err != nil {
+			t.Fatal(err)
+		}
+		if f.outputDir != configuredOutput {
+			t.Fatalf("outputDir = %q, want configured output %q", f.outputDir, configuredOutput)
+		}
+	})
+
+	t.Run("explicit output wins", func(t *testing.T) {
+		explicitOutput := filepath.Join(projectDir, "explicit")
+		f, err := parseCommentFlags([]string{"--output", explicitOutput, "body"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := resolveCommentFlags(&f); err != nil {
+			t.Fatal(err)
+		}
+		if f.outputDir != explicitOutput {
+			t.Fatalf("outputDir = %q, want explicit output %q", f.outputDir, explicitOutput)
+		}
+	})
+
+	t.Run("plan storage wins without conflict", func(t *testing.T) {
+		f, err := parseCommentFlags([]string{"--plan", "my-plan", "body"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := resolveCommentFlags(&f); err != nil {
+			t.Fatal(err)
+		}
+		if f.outputDir == "" || f.outputDir == configuredOutput {
+			t.Fatalf("outputDir = %q, want plan storage", f.outputDir)
+		}
+	})
 }

--- a/internal/comment/flags_main_test.go
+++ b/internal/comment/flags_main_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func outputConfigJSON(t *testing.T, output string) []byte {
@@ -120,7 +122,7 @@ func TestParseCommentFlags(t *testing.T) {
 
 func TestResolveCommentFlagsOutputPrecedence(t *testing.T) {
 	projectDir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 
 	configuredOutput := filepath.Join(projectDir, "reviews")

--- a/internal/comment/list_cli.go
+++ b/internal/comment/list_cli.go
@@ -12,11 +12,12 @@ import (
 )
 
 type commentsListFlags struct {
-	outputDir    string
-	plan         string
-	jsonOutput   bool
-	all          bool
-	explicitPath string
+	outputDir        string
+	configuredOutput string
+	plan             string
+	jsonOutput       bool
+	all              bool
+	explicitPath     string
 }
 
 func parseCommentsListFlags(args []string) (commentsListFlags, error) {
@@ -69,11 +70,14 @@ func resolveCommentsListFlags(f *commentsListFlags) error {
 			return err
 		}
 	}
+	if f.explicitPath != "" {
+		return nil
+	}
 	cfg, err := config.LoadCurrentConfig()
 	if err != nil {
 		return err
 	}
-	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.configuredOutput = cfg.Output
 	return nil
 }
 
@@ -81,7 +85,7 @@ func resolveCommentsCritPath(f commentsListFlags) (string, error) {
 	if f.explicitPath != "" {
 		return resolveExplicitReviewPath(f.explicitPath)
 	}
-	return review.ResolveReviewPath(f.outputDir)
+	return review.ResolveCommandReviewPath(f.outputDir, f.configuredOutput)
 }
 
 func resolveExplicitReviewPath(path string) (string, error) {

--- a/internal/comment/list_cli.go
+++ b/internal/comment/list_cli.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 )
@@ -68,6 +69,11 @@ func resolveCommentsListFlags(f *commentsListFlags) error {
 			return err
 		}
 	}
+	cfg, err := config.LoadCurrentConfig()
+	if err != nil {
+		return err
+	}
+	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
 	return nil
 }
 

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func writeTestReview(t *testing.T, dir string, cj CritJSON) string {
@@ -274,7 +276,7 @@ func TestRunComments_PlanAndOutputConflict(t *testing.T) {
 
 func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 	projectDir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 
 	configuredOutput := filepath.Join(projectDir, "reviews")
@@ -321,7 +323,7 @@ func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 
 func TestResolveCommentsCritPathExplicitPathWinsConfiguredOutput(t *testing.T) {
 	projectDir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -278,7 +278,7 @@ func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 	t.Chdir(projectDir)
 
 	configuredOutput := filepath.Join(projectDir, "reviews")
-	configData := []byte(`{"output":` + `"` + configuredOutput + `"` + `}`)
+	configData := outputConfigJSON(t, configuredOutput)
 	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), configData, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -272,6 +272,64 @@ func TestRunComments_PlanAndOutputConflict(t *testing.T) {
 	}
 }
 
+func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+
+	configuredOutput := filepath.Join(projectDir, "reviews")
+	configData := []byte(`{"output":` + `"` + configuredOutput + `"` + `}`)
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), configData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantOutput string
+		wantPlan   bool
+	}{
+		{name: "configured output", args: []string{"--json"}, wantOutput: configuredOutput},
+		{name: "explicit output wins", args: []string{"--output", "explicit", "--json"}, wantOutput: "explicit"},
+		{name: "plan storage wins without conflict", args: []string{"--plan", "my-plan", "--json"}, wantPlan: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := parseCommentsListFlags(tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := resolveCommentsListFlags(&f); err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantPlan {
+				if f.outputDir == "" || f.outputDir == configuredOutput {
+					t.Fatalf("outputDir = %q, want plan storage", f.outputDir)
+				}
+				return
+			}
+			if f.outputDir != tt.wantOutput {
+				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestResolveCommentsCritPathExplicitPathWinsConfiguredOutput(t *testing.T) {
+	explicitPath := writeTestReview(t, t.TempDir(), CritJSON{})
+	f := commentsListFlags{
+		outputDir:    filepath.Join(t.TempDir(), "configured"),
+		explicitPath: explicitPath,
+	}
+	got, err := resolveCommentsCritPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != explicitPath {
+		t.Fatalf("crit path = %q, want explicit review path %q", got, explicitPath)
+	}
+}
+
 func TestResolveExplicitReviewPath(t *testing.T) {
 	tmp := t.TempDir()
 	critPath := filepath.Join(tmp, ".crit")

--- a/internal/comment/list_test.go
+++ b/internal/comment/list_test.go
@@ -284,13 +284,14 @@ func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		args       []string
-		wantOutput string
-		wantPlan   bool
+		name           string
+		args           []string
+		wantOutput     string
+		wantConfigured string
+		wantPlan       bool
 	}{
-		{name: "configured output", args: []string{"--json"}, wantOutput: configuredOutput},
-		{name: "explicit output wins", args: []string{"--output", "explicit", "--json"}, wantOutput: "explicit"},
+		{name: "configured output", args: []string{"--json"}, wantConfigured: configuredOutput},
+		{name: "explicit output wins", args: []string{"--output", "explicit", "--json"}, wantOutput: "explicit", wantConfigured: configuredOutput},
 		{name: "plan storage wins without conflict", args: []string{"--plan", "my-plan", "--json"}, wantPlan: true},
 	}
 	for _, tt := range tests {
@@ -308,6 +309,9 @@ func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 				}
 				return
 			}
+			if f.configuredOutput != tt.wantConfigured {
+				t.Fatalf("configuredOutput = %q, want %q", f.configuredOutput, tt.wantConfigured)
+			}
 			if f.outputDir != tt.wantOutput {
 				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.wantOutput)
 			}
@@ -316,10 +320,26 @@ func TestResolveCommentsListFlagsOutputPrecedence(t *testing.T) {
 }
 
 func TestResolveCommentsCritPathExplicitPathWinsConfiguredOutput(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"output":"configured"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
 	explicitPath := writeTestReview(t, t.TempDir(), CritJSON{})
-	f := commentsListFlags{
-		outputDir:    filepath.Join(t.TempDir(), "configured"),
-		explicitPath: explicitPath,
+	f, err := parseCommentsListFlags([]string{filepath.Join(explicitPath, "review.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := resolveCommentsListFlags(&f); err != nil {
+		t.Fatal(err)
+	}
+	if f.configuredOutput != "" {
+		t.Fatalf("configured output was loaded despite explicit review path: %q", f.configuredOutput)
 	}
 	got, err := resolveCommentsCritPath(f)
 	if err != nil {

--- a/internal/comment/run.go
+++ b/internal/comment/run.go
@@ -197,14 +197,6 @@ func commentUsageError() error {
 	return clicmd.Usage("invalid comment usage")
 }
 
-func runCommentLineLevelScoped(loc string, commentArgs []string, author, userID, outputDir string, scope session.InheritedScope) error {
-	critPath, err := review.ResolveReviewPath(outputDir)
-	if err != nil {
-		return err
-	}
-	return runCommentLineLevelAtPath(loc, commentArgs, author, userID, critPath, scope)
-}
-
 func runCommentLineLevelAtPath(loc string, commentArgs []string, author, userID, critPath string, scope session.InheritedScope) error {
 	colonIdx := strings.LastIndex(loc, ":")
 	lineSpec := loc[colonIdx+1:]

--- a/internal/comment/run.go
+++ b/internal/comment/run.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
-	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 // RunComment is the crit comment subcommand implementation.
@@ -91,16 +90,11 @@ func resolveCommentFlags(f *commentFlags) error {
 		}
 	}
 
-	cfgDir, err := os.Getwd()
+	cfg, err := config.LoadCurrentConfig()
 	if err != nil {
 		return err
 	}
-	if v := vcs.DetectVCS(""); v != nil {
-		if root, rootErr := v.RepoRoot(); rootErr == nil {
-			cfgDir = root
-		}
-	}
-	cfg := config.LoadConfig(cfgDir)
+	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
 	if f.author == "" {
 		f.author = cfg.Author
 	}

--- a/internal/comment/run.go
+++ b/internal/comment/run.go
@@ -21,7 +21,7 @@ func RunComment(args []string) error { //nolint:gocyclo // CLI dispatcher
 		return err
 	}
 
-	scope, err := ResolveCommentScope(f.scope, f.outputDir)
+	scope, err := resolveCommentScopeAtPath(f.scope, f.reviewPath)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func RunComment(args []string) error { //nolint:gocyclo // CLI dispatcher
 	}
 
 	if len(f.args) >= 1 && f.args[0] == "--clear" {
-		return runCommentClear(f.outputDir)
+		return runCommentClear(f.reviewPath)
 	}
 
 	if len(f.args) < 1 {
@@ -44,7 +44,7 @@ func RunComment(args []string) error { //nolint:gocyclo // CLI dispatcher
 
 	if len(f.args) == 1 {
 		body := f.args[0]
-		if err := addReviewCommentToCritJSONScoped(body, f.author, f.userID, f.outputDir, scope); err != nil {
+		if err := addReviewCommentToCritJSONAtPath(body, f.author, f.userID, f.reviewPath, scope); err != nil {
 			return err
 		}
 		fmt.Println("Added review comment")
@@ -54,14 +54,14 @@ func RunComment(args []string) error { //nolint:gocyclo // CLI dispatcher
 	loc := f.args[0]
 	colonIdx := strings.LastIndex(loc, ":")
 	if colonIdx > 0 && looksLikeLineSpec(loc[colonIdx+1:]) {
-		return runCommentLineLevelScoped(loc, f.args, f.author, f.userID, f.outputDir, scope)
+		return runCommentLineLevelAtPath(loc, f.args, f.author, f.userID, f.reviewPath, scope)
 	}
 
 	if len(f.args) >= 2 {
 		candidatePath := f.args[0]
-		if fileExistsOnDiskOrSession(candidatePath, f.outputDir) {
+		if fileExistsOnDiskOrReview(candidatePath, f.reviewPath) {
 			body := strings.Join(f.args[1:], " ")
-			if err := addFileCommentToCritJSONScoped(candidatePath, body, f.author, f.userID, f.outputDir, scope); err != nil {
+			if err := addFileCommentToCritJSONAtPath(candidatePath, body, f.author, f.userID, f.reviewPath, scope); err != nil {
 				return err
 			}
 			fmt.Printf("Added file comment on %s\n", candidatePath)
@@ -94,7 +94,11 @@ func resolveCommentFlags(f *commentFlags) error {
 	if err != nil {
 		return err
 	}
-	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.configuredOutput = cfg.Output
+	f.reviewPath, err = review.ResolveCommandReviewPath(f.outputDir, f.configuredOutput)
+	if err != nil {
+		return err
+	}
 	if f.author == "" {
 		f.author = cfg.Author
 	}
@@ -115,7 +119,7 @@ func runCommentJSONScoped(f commentFlags, scope session.InheritedScope) error {
 		return err
 	}
 
-	if err := bulkAddCommentsToCritJSONScoped(entries, f.author, f.userID, f.outputDir, scope); err != nil {
+	if err := bulkAddCommentsToCritJSONAtPath(entries, f.author, f.userID, f.reviewPath, scope); err != nil {
 		return err
 	}
 
@@ -148,7 +152,7 @@ func runCommentReply(f commentFlags) error {
 		return clicmd.Usage("Usage: crit comment --reply-to <comment-id> [--resolve] <body>")
 	}
 	replyBody := strings.Join(f.args, " ")
-	if err := addReplyToCritJSON(f.replyTo, replyBody, f.author, f.userID, f.resolve, f.outputDir, f.path); err != nil {
+	if err := addReplyToCritJSONAtPath(f.replyTo, replyBody, f.author, f.userID, f.resolve, f.reviewPath, f.path); err != nil {
 		return err
 	}
 	if f.resolve {
@@ -159,8 +163,8 @@ func runCommentReply(f commentFlags) error {
 	return nil
 }
 
-func runCommentClear(outputDir string) error {
-	if err := review.ClearCritJSON(outputDir); err != nil {
+func runCommentClear(reviewPath string) error {
+	if err := review.ClearReviewPath(reviewPath); err != nil {
 		return err
 	}
 	fmt.Println("Cleared review file")
@@ -194,6 +198,14 @@ func commentUsageError() error {
 }
 
 func runCommentLineLevelScoped(loc string, commentArgs []string, author, userID, outputDir string, scope session.InheritedScope) error {
+	critPath, err := review.ResolveReviewPath(outputDir)
+	if err != nil {
+		return err
+	}
+	return runCommentLineLevelAtPath(loc, commentArgs, author, userID, critPath, scope)
+}
+
+func runCommentLineLevelAtPath(loc string, commentArgs []string, author, userID, critPath string, scope session.InheritedScope) error {
 	colonIdx := strings.LastIndex(loc, ":")
 	lineSpec := loc[colonIdx+1:]
 	filePath := loc[:colonIdx]
@@ -202,12 +214,10 @@ func runCommentLineLevelScoped(loc string, commentArgs []string, author, userID,
 		return fmt.Errorf("invalid line spec in %q", loc)
 	}
 	body := strings.Join(commentArgs[1:], " ")
-	if critPath, pathErr := review.ResolveReviewPath(outputDir); pathErr == nil {
-		if guardErr := checkCommentCLIAllowed(critPath); guardErr != nil {
-			return guardErr
-		}
+	if guardErr := checkCommentCLIAllowed(critPath); guardErr != nil {
+		return guardErr
 	}
-	if err := addCommentToCritJSONScoped(filePath, startLine, endLine, body, author, userID, outputDir, scope); err != nil {
+	if err := addCommentToCritJSONAtPath(filePath, startLine, endLine, body, author, userID, critPath, scope); err != nil {
 		return err
 	}
 	fmt.Printf("Added comment on %s:%s\n", filePath, lineSpec)
@@ -235,6 +245,17 @@ func fileExistsOnDiskOrSession(path string, outputDir string) bool {
 	if err != nil {
 		return false
 	}
+	return fileExistsInReview(path, critPath)
+}
+
+func fileExistsOnDiskOrReview(path, critPath string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return fileExistsInReview(path, critPath)
+}
+
+func fileExistsInReview(path, critPath string) bool {
 	cj, err := review.LoadCritJSON(critPath)
 	if err != nil {
 		return false

--- a/internal/comment/run_cli_test.go
+++ b/internal/comment/run_cli_test.go
@@ -118,6 +118,37 @@ func TestRunComment_Clear(t *testing.T) {
 	}
 }
 
+func TestRunComment_ReplyUsesResolvedReviewPath(t *testing.T) {
+	outputDir := t.TempDir()
+	reviewPath := filepath.Join(outputDir, ".crit")
+	if err := saveCritJSON(reviewPath, CritJSON{
+		ReviewComments: []Comment{{ID: "r_reply", Body: "parent", Scope: "review"}},
+		Files:          map[string]CritJSONFile{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunComment([]string{
+		"--output", outputDir,
+		"--reply-to", "r_reply",
+		"--author", "bot",
+		"done",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cj, err := loadCritJSON(reviewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cj.ReviewComments) != 1 || len(cj.ReviewComments[0].Replies) != 1 {
+		t.Fatalf("review comments = %+v, want one reply", cj.ReviewComments)
+	}
+	if cj.ReviewComments[0].Replies[0].Body != "done" {
+		t.Fatalf("reply body = %q, want done", cj.ReviewComments[0].Replies[0].Body)
+	}
+}
+
 func TestRunComment_ReplyMissingBody(t *testing.T) {
 	err := RunComment([]string{"--reply-to", "c_abc"})
 	if err == nil {

--- a/internal/comment/run_cli_test.go
+++ b/internal/comment/run_cli_test.go
@@ -149,6 +149,61 @@ func TestRunComment_ReplyUsesResolvedReviewPath(t *testing.T) {
 	}
 }
 
+func TestRunComment_InvalidReviewReturnsErrors(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
+	if err := os.WriteFile(filepath.Join(projectDir, "file.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputDir := filepath.Join(projectDir, "output")
+	reviewPath := filepath.Join(outputDir, ".crit")
+	if err := os.MkdirAll(reviewPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviewPath, "review.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "review comment", args: []string{"body"}},
+		{name: "file comment", args: []string{"file.go", "body"}},
+		{name: "line comment", args: []string{"file.go:1", "body"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"--output", outputDir}, tt.args...)
+			if err := RunComment(args); err == nil {
+				t.Fatal("expected invalid review error")
+			}
+		})
+	}
+}
+
+func TestRunCommentLineLevelRejectsLiveReview(t *testing.T) {
+	reviewPath := filepath.Join(t.TempDir(), ".crit")
+	if err := saveCritJSON(reviewPath, CritJSON{
+		ReviewType: "live",
+		Files:      map[string]CritJSONFile{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCommentLineLevelAtPath(
+		"file.go:1",
+		[]string{"file.go:1", "body"},
+		"bot",
+		"",
+		reviewPath,
+		inheritedScope{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "not supported for live reviews") {
+		t.Fatalf("error = %v, want live review rejection", err)
+	}
+}
+
 func TestRunComment_ReplyMissingBody(t *testing.T) {
 	err := RunComment([]string{"--reply-to", "c_abc"})
 	if err == nil {

--- a/internal/comment/scope.go
+++ b/internal/comment/scope.go
@@ -58,6 +58,10 @@ func loadCritJSONForOutputDir(outputDir string) (session.CritJSON, bool) {
 		fmt.Fprintf(os.Stderr, "Warning: cannot resolve review path: %v\n", err)
 		return session.CritJSON{}, false
 	}
+	return loadCritJSONForPath(critPath)
+}
+
+func loadCritJSONForPath(critPath string) (session.CritJSON, bool) {
 	cj, err := review.LoadCritJSON(critPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -73,24 +77,32 @@ func loadCritJSONForOutputDir(outputDir string) (session.CritJSON, bool) {
 // based on the --scope flag, a running daemon's Focus, and the on-disk
 // ActiveDiffScope.
 func ResolveCommentScope(override CommentFocusOverride, outputDir string) (session.InheritedScope, error) {
+	critPath, err := review.ResolveReviewPath(outputDir)
+	if err != nil {
+		return session.InheritedScope{}, err
+	}
+	return resolveCommentScopeAtPath(override, critPath)
+}
+
+func resolveCommentScopeAtPath(override CommentFocusOverride, critPath string) (session.InheritedScope, error) {
 	daemonFocus := session.ProbeDaemonFocus()
 
 	switch override {
 	case ScopeOverrideWorkingTree:
 		return session.InheritedScope{}, nil
 	case ScopeOverrideFullStack:
-		return resolveExplicitCommentScope(daemonFocus, outputDir, session.DiffScopeFullStack, "full_stack",
+		return resolveExplicitCommentScope(daemonFocus, critPath, session.DiffScopeFullStack, "full_stack",
 			"--scope=full-stack: no active full-stack focus to attach to (start `crit --pr <n> --scope=full-stack` first)")
 	case ScopeOverrideLayer:
-		return resolveExplicitCommentScope(daemonFocus, outputDir, session.DiffScopeLayer, "layer",
+		return resolveExplicitCommentScope(daemonFocus, critPath, session.DiffScopeLayer, "layer",
 			"--scope=layer: no active layer focus to attach to (start `crit --pr <n>` first)")
 	case ScopeOverrideUnset:
-		return resolveAutoCommentScope(daemonFocus, outputDir), nil
+		return resolveAutoCommentScope(daemonFocus, critPath), nil
 	}
 	return session.InheritedScope{}, fmt.Errorf("invalid --scope value %q", override)
 }
 
-func resolveExplicitCommentScope(daemonFocus *session.Focus, outputDir string, want session.DiffScope, wantStr, errMsg string) (session.InheritedScope, error) {
+func resolveExplicitCommentScope(daemonFocus *session.Focus, critPath string, want session.DiffScope, wantStr, errMsg string) (session.InheritedScope, error) {
 	if daemonFocus != nil && daemonFocus.Kind == session.FocusRange && daemonFocus.DiffScope == want {
 		return session.InheritedScope{
 			HeadSHA:   daemonFocus.HeadSHA,
@@ -99,13 +111,13 @@ func resolveExplicitCommentScope(daemonFocus *session.Focus, outputDir string, w
 			DiffScope: wantStr,
 		}, nil
 	}
-	if cj, ok := loadCritJSONForOutputDir(outputDir); ok && cj.ActiveDiffScope == wantStr {
+	if cj, ok := loadCritJSONForPath(critPath); ok && cj.ActiveDiffScope == wantStr {
 		return session.InheritedScope{DiffScope: wantStr}, nil
 	}
 	return session.InheritedScope{}, fmt.Errorf("%s", errMsg)
 }
 
-func resolveAutoCommentScope(daemonFocus *session.Focus, outputDir string) session.InheritedScope {
+func resolveAutoCommentScope(daemonFocus *session.Focus, critPath string) session.InheritedScope {
 	if daemonFocus != nil && daemonFocus.Kind == session.FocusRange {
 		return session.InheritedScope{
 			HeadSHA:   daemonFocus.HeadSHA,
@@ -114,7 +126,7 @@ func resolveAutoCommentScope(daemonFocus *session.Focus, outputDir string) sessi
 			DiffScope: string(daemonFocus.DiffScope),
 		}
 	}
-	if cj, ok := loadCritJSONForOutputDir(outputDir); ok && cj.ActiveDiffScope != "" {
+	if cj, ok := loadCritJSONForPath(critPath); ok && cj.ActiveDiffScope != "" {
 		fmt.Fprintf(os.Stderr,
 			"Note: stamping comment with diff_scope=%q from review file (no daemon running; head_sha unknown)\n",
 			cj.ActiveDiffScope)

--- a/internal/config/cli_resolve.go
+++ b/internal/config/cli_resolve.go
@@ -2,10 +2,22 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
+
+// LoadConfigForCommands loads merged config and anchors a relative configured
+// output to the project/config directory. Explicit CLI outputs are normalized
+// later by review-path resolution and remain relative to the invoking CWD.
+func LoadConfigForCommands(configDir string) Config {
+	cfg := LoadConfig(configDir)
+	if cfg.Output != "" && !filepath.IsAbs(cfg.Output) {
+		cfg.Output = filepath.Join(configDir, cfg.Output)
+	}
+	return cfg
+}
 
 // LoadCurrentConfig loads merged global and project config for the current
 // repository, falling back to the current directory outside a repository.
@@ -19,7 +31,7 @@ func LoadCurrentConfig() (Config, error) {
 			configDir = root
 		}
 	}
-	return LoadConfig(configDir), nil
+	return LoadConfigForCommands(configDir), nil
 }
 
 // ResolveOutputDir returns the explicit CLI/plan output when set, otherwise

--- a/internal/config/cli_resolve.go
+++ b/internal/config/cli_resolve.go
@@ -3,7 +3,33 @@ package config
 import (
 	"os"
 	"strconv"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
+
+// LoadCurrentConfig loads merged global and project config for the current
+// repository, falling back to the current directory outside a repository.
+func LoadCurrentConfig() (Config, error) {
+	configDir, err := os.Getwd()
+	if err != nil {
+		return Config{}, err
+	}
+	if v := vcs.DetectVCS(""); v != nil {
+		if root, rootErr := v.RepoRoot(); rootErr == nil {
+			configDir = root
+		}
+	}
+	return LoadConfig(configDir), nil
+}
+
+// ResolveOutputDir returns the explicit CLI/plan output when set, otherwise
+// the output from merged config.
+func ResolveOutputDir(explicit string, cfg Config) string {
+	if explicit != "" {
+		return explicit
+	}
+	return cfg.Output
+}
 
 // ResolvePort returns the effective listen port (flag > env > config).
 func ResolvePort(flagPort, cfgPort int) int {

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func TestRunConfig_Help(t *testing.T) {
@@ -76,6 +78,46 @@ func TestCurrentConfigOutputPrecedence(t *testing.T) {
 	}
 	if got := ResolveOutputDir("/explicit", cfg); got != "/explicit" {
 		t.Fatalf("explicit output = %q, want /explicit", got)
+	}
+}
+
+func TestCurrentConfigRelativeOutputAnchoredToRepoRoot(t *testing.T) {
+	repoDir := testutil.InitTestRepo(t)
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(
+		filepath.Join(repoDir, ".crit.config.json"),
+		[]byte(`{"output":"reviews"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(repoDir)
+	rootCfg, err := LoadCurrentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nestedDir := filepath.Join(repoDir, "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nestedDir)
+	nestedCfg, err := LoadCurrentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalRepo, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(canonicalRepo, "reviews")
+	if rootCfg.Output != want {
+		t.Fatalf("root output = %q, want %q", rootCfg.Output, want)
+	}
+	if nestedCfg.Output != want {
+		t.Fatalf("nested output = %q, want %q", nestedCfg.Output, want)
 	}
 }
 

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -46,9 +47,14 @@ func TestCurrentConfigOutputPrecedence(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Chdir(projectDir)
 
+	globalOutput := filepath.Join(t.TempDir(), "global")
+	globalData, err := json.Marshal(map[string]string{"output": globalOutput})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(
 		filepath.Join(homeDir, ".crit.config.json"),
-		[]byte(`{"output":"/global"}`),
+		globalData,
 		0o644,
 	); err != nil {
 		t.Fatal(err)
@@ -58,13 +64,18 @@ func TestCurrentConfigOutputPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := ResolveOutputDir("", cfg); got != "/global" {
-		t.Fatalf("global output = %q, want /global", got)
+	if got := ResolveOutputDir("", cfg); got != globalOutput {
+		t.Fatalf("global output = %q, want %q", got, globalOutput)
 	}
 
+	projectOutput := filepath.Join(t.TempDir(), "project")
+	projectData, err := json.Marshal(map[string]string{"output": projectOutput})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),
-		[]byte(`{"output":"/project"}`),
+		projectData,
 		0o644,
 	); err != nil {
 		t.Fatal(err)
@@ -73,11 +84,12 @@ func TestCurrentConfigOutputPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := ResolveOutputDir("", cfg); got != "/project" {
-		t.Fatalf("project output = %q, want /project", got)
+	if got := ResolveOutputDir("", cfg); got != projectOutput {
+		t.Fatalf("project output = %q, want %q", got, projectOutput)
 	}
-	if got := ResolveOutputDir("/explicit", cfg); got != "/explicit" {
-		t.Fatalf("explicit output = %q, want /explicit", got)
+	explicitOutput := t.TempDir()
+	if got := ResolveOutputDir(explicitOutput, cfg); got != explicitOutput {
+		t.Fatalf("explicit output = %q, want %q", got, explicitOutput)
 	}
 }
 

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -44,7 +44,7 @@ func TestRunConfig_ShowResolved(t *testing.T) {
 func TestCurrentConfigOutputPrecedence(t *testing.T) {
 	homeDir := t.TempDir()
 	projectDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	testutil.SetHome(t, homeDir)
 	t.Chdir(projectDir)
 
 	globalOutput := filepath.Join(t.TempDir(), "global")
@@ -95,7 +95,7 @@ func TestCurrentConfigOutputPrecedence(t *testing.T) {
 
 func TestCurrentConfigRelativeOutputAnchoredToRepoRoot(t *testing.T) {
 	repoDir := testutil.InitTestRepo(t)
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	if err := os.WriteFile(
 		filepath.Join(repoDir, ".crit.config.json"),
 		[]byte(`{"output":"reviews"}`),

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -34,6 +35,47 @@ func TestRunConfig_ShowResolved(t *testing.T) {
 	})
 	if !strings.Contains(out, "{") {
 		t.Errorf("expected JSON config output, got: %s", out[:min(100, len(out))])
+	}
+}
+
+func TestCurrentConfigOutputPrecedence(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Chdir(projectDir)
+
+	if err := os.WriteFile(
+		filepath.Join(homeDir, ".crit.config.json"),
+		[]byte(`{"output":"/global"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadCurrentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveOutputDir("", cfg); got != "/global" {
+		t.Fatalf("global output = %q, want /global", got)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"output":"/project"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = LoadCurrentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveOutputDir("", cfg); got != "/project" {
+		t.Fatalf("project output = %q, want /project", got)
+	}
+	if got := ResolveOutputDir("/explicit", cfg); got != "/explicit" {
+		t.Fatalf("explicit output = %q, want /explicit", got)
 	}
 }
 

--- a/internal/github/pull_cli.go
+++ b/internal/github/pull_cli.go
@@ -16,8 +16,9 @@ import (
 )
 
 type pullFlags struct {
-	prFlag    int
-	outputDir string
+	prFlag           int
+	outputDir        string
+	configuredOutput string
 }
 
 func parsePullFlags(args []string) (pullFlags, error) {
@@ -48,12 +49,12 @@ func resolvePullFlags(f *pullFlags) error {
 	if err != nil {
 		return err
 	}
-	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.configuredOutput = cfg.Output
 	return nil
 }
 
-func shouldRedirectReviewForPR(prFlag int, outputDir string) bool {
-	return prFlag != 0 && outputDir == ""
+func shouldRedirectReviewForPR(prFlag int, pinnedOutput bool) bool {
+	return prFlag != 0 && !pinnedOutput
 }
 
 func RunPull(args []string) error { //nolint:gocyclo
@@ -87,7 +88,7 @@ func RunPull(args []string) error { //nolint:gocyclo
 		threadResolved = nil
 	}
 
-	critPath, err := review.ResolveReviewPath(f.outputDir)
+	critPath, err := review.ResolveCommandReviewPath(f.outputDir, f.configuredOutput)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func RunPull(args []string) error { //nolint:gocyclo
 		}
 	}
 
-	if shouldRedirectReviewForPR(f.prFlag, f.outputDir) {
+	if shouldRedirectReviewForPR(f.prFlag, f.outputDir != "" || f.configuredOutput != "") {
 		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ

--- a/internal/github/pull_cli.go
+++ b/internal/github/pull_cli.go
@@ -43,6 +43,19 @@ func parsePullFlags(args []string) (pullFlags, error) {
 	return f, nil
 }
 
+func resolvePullFlags(f *pullFlags) error {
+	cfg, err := config.LoadCurrentConfig()
+	if err != nil {
+		return err
+	}
+	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	return nil
+}
+
+func shouldRedirectReviewForPR(prFlag int, outputDir string) bool {
+	return prFlag != 0 && outputDir == ""
+}
+
 func RunPull(args []string) error { //nolint:gocyclo
 	if err := RequireGH(); err != nil {
 		return err
@@ -50,6 +63,9 @@ func RunPull(args []string) error { //nolint:gocyclo
 
 	f, err := parsePullFlags(args)
 	if err != nil {
+		return err
+	}
+	if err := resolvePullFlags(&f); err != nil {
 		return err
 	}
 
@@ -82,7 +98,7 @@ func RunPull(args []string) error { //nolint:gocyclo
 		}
 	}
 
-	if f.prFlag != 0 && f.outputDir == "" {
+	if shouldRedirectReviewForPR(f.prFlag, f.outputDir) {
 		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ

--- a/internal/github/pull_cli.go
+++ b/internal/github/pull_cli.go
@@ -53,6 +53,17 @@ func resolvePullFlags(f *pullFlags) error {
 	return nil
 }
 
+func parseResolvedPullFlags(args []string) (pullFlags, error) {
+	f, err := parsePullFlags(args)
+	if err != nil {
+		return pullFlags{}, err
+	}
+	if err := resolvePullFlags(&f); err != nil {
+		return pullFlags{}, err
+	}
+	return f, nil
+}
+
 func shouldRedirectReviewForPR(prFlag int, pinnedOutput bool) bool {
 	return prFlag != 0 && !pinnedOutput
 }
@@ -62,11 +73,8 @@ func RunPull(args []string) error { //nolint:gocyclo
 		return err
 	}
 
-	f, err := parsePullFlags(args)
+	f, err := parseResolvedPullFlags(args)
 	if err != nil {
-		return err
-	}
-	if err := resolvePullFlags(&f); err != nil {
 		return err
 	}
 

--- a/internal/github/pull_cli_test.go
+++ b/internal/github/pull_cli_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -15,7 +16,10 @@ func configureOutputForTest(t *testing.T) string {
 	t.Setenv("HOME", t.TempDir())
 	t.Chdir(projectDir)
 	configuredOutput := filepath.Join(projectDir, "configured")
-	data := []byte(`{"output":"` + configuredOutput + `"}`)
+	data, err := json.Marshal(map[string]string{"output": configuredOutput})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -58,13 +62,14 @@ func TestParsePullFlags(t *testing.T) {
 
 func TestResolvePullFlagsOutputPrecedence(t *testing.T) {
 	configuredOutput := configureOutputForTest(t)
+	explicitOutput := t.TempDir()
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{name: "configured output", want: configuredOutput},
-		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+		{name: "explicit output wins", in: explicitOutput, want: explicitOutput},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,6 +86,26 @@ func TestResolvePullFlagsOutputPrecedence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseResolvedPullFlags(t *testing.T) {
+	configuredOutput := configureOutputForTest(t)
+
+	t.Run("success loads configured output", func(t *testing.T) {
+		f, err := parseResolvedPullFlags([]string{"42"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.prFlag != 42 || f.configuredOutput != configuredOutput {
+			t.Fatalf("flags = %+v, want PR 42 and configured output %q", f, configuredOutput)
+		}
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		if _, err := parseResolvedPullFlags([]string{"--output"}); err == nil {
+			t.Fatal("expected missing output value error")
+		}
+	})
 }
 
 func TestShouldRedirectReviewForPR(t *testing.T) {

--- a/internal/github/pull_cli_test.go
+++ b/internal/github/pull_cli_test.go
@@ -2,10 +2,25 @@ package github
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 )
+
+func configureOutputForTest(t *testing.T) string {
+	t.Helper()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+	configuredOutput := filepath.Join(projectDir, "configured")
+	data := []byte(`{"output":"` + configuredOutput + `"}`)
+	if err := os.WriteFile(filepath.Join(projectDir, ".crit.config.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return configuredOutput
+}
 
 func TestParsePullFlags(t *testing.T) {
 	tests := []struct {
@@ -36,6 +51,49 @@ func TestParsePullFlags(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("parsePullFlags(%v) = %+v, want %+v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePullFlagsOutputPrecedence(t *testing.T) {
+	configuredOutput := configureOutputForTest(t)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "configured output", want: configuredOutput},
+		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := pullFlags{outputDir: tt.in}
+			if err := resolvePullFlags(&f); err != nil {
+				t.Fatal(err)
+			}
+			if f.outputDir != tt.want {
+				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRedirectReviewForPR(t *testing.T) {
+	tests := []struct {
+		name      string
+		prFlag    int
+		outputDir string
+		want      bool
+	}{
+		{name: "explicit PR without pinned output redirects", prFlag: 42, want: true},
+		{name: "auto-detected PR does not redirect", want: false},
+		{name: "explicit PR with CLI or configured output stays pinned", prFlag: 42, outputDir: "/pinned", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRedirectReviewForPR(tt.prFlag, tt.outputDir); got != tt.want {
+				t.Fatalf("shouldRedirectReviewForPR(%d, %q) = %v, want %v", tt.prFlag, tt.outputDir, got, tt.want)
 			}
 		})
 	}

--- a/internal/github/pull_cli_test.go
+++ b/internal/github/pull_cli_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func configureOutputForTest(t *testing.T) string {
 	t.Helper()
 	projectDir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 	configuredOutput := filepath.Join(projectDir, "configured")
 	data, err := json.Marshal(map[string]string{"output": configuredOutput})

--- a/internal/github/pull_cli_test.go
+++ b/internal/github/pull_cli_test.go
@@ -72,8 +72,12 @@ func TestResolvePullFlagsOutputPrecedence(t *testing.T) {
 			if err := resolvePullFlags(&f); err != nil {
 				t.Fatal(err)
 			}
-			if f.outputDir != tt.want {
-				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
+			got := f.configuredOutput
+			if f.outputDir != "" {
+				got = f.outputDir
+			}
+			if got != tt.want {
+				t.Fatalf("resolved output = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -81,19 +85,19 @@ func TestResolvePullFlagsOutputPrecedence(t *testing.T) {
 
 func TestShouldRedirectReviewForPR(t *testing.T) {
 	tests := []struct {
-		name      string
-		prFlag    int
-		outputDir string
-		want      bool
+		name         string
+		prFlag       int
+		pinnedOutput bool
+		want         bool
 	}{
 		{name: "explicit PR without pinned output redirects", prFlag: 42, want: true},
 		{name: "auto-detected PR does not redirect", want: false},
-		{name: "explicit PR with CLI or configured output stays pinned", prFlag: 42, outputDir: "/pinned", want: false},
+		{name: "explicit PR with CLI or configured output stays pinned", prFlag: 42, pinnedOutput: true, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldRedirectReviewForPR(tt.prFlag, tt.outputDir); got != tt.want {
-				t.Fatalf("shouldRedirectReviewForPR(%d, %q) = %v, want %v", tt.prFlag, tt.outputDir, got, tt.want)
+			if got := shouldRedirectReviewForPR(tt.prFlag, tt.pinnedOutput); got != tt.want {
+				t.Fatalf("shouldRedirectReviewForPR(%d, %v) = %v, want %v", tt.prFlag, tt.pinnedOutput, got, tt.want)
 			}
 		})
 	}

--- a/internal/github/push_cli.go
+++ b/internal/github/push_cli.go
@@ -16,11 +16,12 @@ import (
 )
 
 type pushFlags struct {
-	prFlag    int
-	dryRun    bool
-	message   string
-	outputDir string
-	eventFlag string
+	prFlag           int
+	dryRun           bool
+	message          string
+	outputDir        string
+	configuredOutput string
+	eventFlag        string
 }
 
 func parsePushFlags(args []string) (pushFlags, error) {
@@ -70,8 +71,19 @@ func resolvePushFlags(f *pushFlags) error {
 	if err != nil {
 		return err
 	}
-	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.configuredOutput = cfg.Output
 	return nil
+}
+
+func parseResolvedPushFlags(args []string) (pushFlags, error) {
+	f, err := parsePushFlags(args)
+	if err != nil {
+		return pushFlags{}, err
+	}
+	if err := resolvePushFlags(&f); err != nil {
+		return pushFlags{}, err
+	}
+	return f, nil
 }
 
 // postPushReplies posts each reply via `gh api`. On the first auth-rotation
@@ -125,11 +137,8 @@ func loadPushContext(args []string) (pushContext, error) {
 		return pushContext{}, err
 	}
 
-	f, err := parsePushFlags(args)
+	f, err := parseResolvedPushFlags(args)
 	if err != nil {
-		return pushContext{}, err
-	}
-	if err := resolvePushFlags(&f); err != nil {
 		return pushContext{}, err
 	}
 
@@ -147,7 +156,7 @@ func loadPushContext(args []string) (pushContext, error) {
 		return pushContext{}, err
 	}
 
-	critPath, err := review.ResolveReviewPath(f.outputDir)
+	critPath, err := review.ResolveCommandReviewPath(f.outputDir, f.configuredOutput)
 	if err != nil {
 		return pushContext{}, err
 	}
@@ -171,7 +180,7 @@ func loadPushContext(args []string) (pushContext, error) {
 	// review file is for a different branch (or is missing) — pushing the wrong
 	// comments to a PR is destructive, so honor the explicit intent first. Same
 	// pattern as PR #424's findReviewFileByCommentID fallback for `crit comment`.
-	if shouldRedirectReviewForPR(f.prFlag, f.outputDir) {
+	if shouldRedirectReviewForPR(f.prFlag, f.outputDir != "" || f.configuredOutput != "") {
 		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ

--- a/internal/github/push_cli.go
+++ b/internal/github/push_cli.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/share"
@@ -62,6 +63,15 @@ func parsePushFlags(args []string) (pushFlags, error) {
 		f.prFlag = n
 	}
 	return f, nil
+}
+
+func resolvePushFlags(f *pushFlags) error {
+	cfg, err := config.LoadCurrentConfig()
+	if err != nil {
+		return err
+	}
+	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	return nil
 }
 
 // postPushReplies posts each reply via `gh api`. On the first auth-rotation
@@ -119,6 +129,9 @@ func loadPushContext(args []string) (pushContext, error) {
 	if err != nil {
 		return pushContext{}, err
 	}
+	if err := resolvePushFlags(&f); err != nil {
+		return pushContext{}, err
+	}
 
 	event, err := ParsePushEvent(f.eventFlag)
 	if err != nil {
@@ -158,7 +171,7 @@ func loadPushContext(args []string) (pushContext, error) {
 	// review file is for a different branch (or is missing) — pushing the wrong
 	// comments to a PR is destructive, so honor the explicit intent first. Same
 	// pattern as PR #424's findReviewFileByCommentID fallback for `crit comment`.
-	if f.prFlag != 0 && f.outputDir == "" {
+	if shouldRedirectReviewForPR(f.prFlag, f.outputDir) {
 		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ

--- a/internal/github/push_cli_flags_test.go
+++ b/internal/github/push_cli_flags_test.go
@@ -67,8 +67,12 @@ func TestResolvePushFlagsOutputPrecedence(t *testing.T) {
 			if err := resolvePushFlags(&f); err != nil {
 				t.Fatal(err)
 			}
-			if f.outputDir != tt.want {
-				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
+			got := f.configuredOutput
+			if f.outputDir != "" {
+				got = f.outputDir
+			}
+			if got != tt.want {
+				t.Fatalf("resolved output = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/github/push_cli_flags_test.go
+++ b/internal/github/push_cli_flags_test.go
@@ -53,13 +53,14 @@ func TestParsePushFlags(t *testing.T) {
 
 func TestResolvePushFlagsOutputPrecedence(t *testing.T) {
 	configuredOutput := configureOutputForTest(t)
+	explicitOutput := t.TempDir()
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{name: "configured output", want: configuredOutput},
-		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+		{name: "explicit output wins", in: explicitOutput, want: explicitOutput},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,6 +77,29 @@ func TestResolvePushFlagsOutputPrecedence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseResolvedPushFlags(t *testing.T) {
+	configuredOutput := configureOutputForTest(t)
+
+	t.Run("success loads configured output", func(t *testing.T) {
+		f, err := parseResolvedPushFlags([]string{"--dry-run", "42"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !f.dryRun || f.prFlag != 42 {
+			t.Fatalf("flags = %+v, want dry-run PR 42", f)
+		}
+		if f.configuredOutput != configuredOutput {
+			t.Fatalf("configuredOutput = %q, want %q", f.configuredOutput, configuredOutput)
+		}
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		if _, err := parseResolvedPushFlags([]string{"--output"}); err == nil {
+			t.Fatal("expected missing output value error")
+		}
+	})
 }
 
 func TestParsePushFlags_NonNumericExitCode(t *testing.T) {

--- a/internal/github/push_cli_flags_test.go
+++ b/internal/github/push_cli_flags_test.go
@@ -51,6 +51,29 @@ func TestParsePushFlags(t *testing.T) {
 	}
 }
 
+func TestResolvePushFlagsOutputPrecedence(t *testing.T) {
+	configuredOutput := configureOutputForTest(t)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "configured output", want: configuredOutput},
+		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := pushFlags{outputDir: tt.in}
+			if err := resolvePushFlags(&f); err != nil {
+				t.Fatal(err)
+			}
+			if f.outputDir != tt.want {
+				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
+			}
+		})
+	}
+}
+
 func TestParsePushFlags_NonNumericExitCode(t *testing.T) {
 	_, err := parsePushFlags([]string{"bogus"})
 	var exitErr clicmd.ExitError

--- a/internal/review/export.go
+++ b/internal/review/export.go
@@ -25,6 +25,11 @@ func ClearCritJSON(outputDir string) error {
 	return clearCritJSON(outputDir)
 }
 
+// ClearReviewPath removes a resolved review identity folder.
+func ClearReviewPath(reviewPath string) error {
+	return clearReviewFolder(reviewPath)
+}
+
 // LoadSnapshotsFile reads snapshots.json from the given path.
 func LoadSnapshotsFile(snapshotsPath string) (SnapshotsFile, error) {
 	return loadSnapshotsFile(snapshotsPath)

--- a/internal/review/review_file.go
+++ b/internal/review/review_file.go
@@ -62,6 +62,37 @@ func ResolveReviewPath(outputDir string) (string, error) {
 	return path, nil
 }
 
+// ResolveCommandReviewPath resolves a headless command's review identity.
+// Explicit output belongs to the current invocation and wins first. A live
+// daemon then preserves the identity selected when the review was launched,
+// followed by configured output and finally centralized storage.
+func ResolveCommandReviewPath(explicitOutput, configuredOutput string) (string, error) {
+	return resolveCommandReviewPathWithArgs(explicitOutput, configuredOutput, nil)
+}
+
+// ResolveCommandReviewPathWithArgs applies command-path precedence while
+// retaining file arguments for the centralized fallback session key.
+func ResolveCommandReviewPathWithArgs(explicitOutput, configuredOutput string, fileArgs []string) (string, error) {
+	return resolveCommandReviewPathWithArgs(explicitOutput, configuredOutput, fileArgs)
+}
+
+func resolveCommandReviewPathWithArgs(explicitOutput, configuredOutput string, fileArgs []string) (string, error) {
+	if explicitOutput != "" {
+		return reviewpath.FromOutputDir(explicitOutput)
+	}
+	cwd, err := daemon.ResolvedCWD()
+	if err != nil {
+		return "", err
+	}
+	if path := ResolveReviewPathFromDaemon(cwd); path != "" {
+		return path, nil
+	}
+	if configuredOutput != "" {
+		return reviewpath.FromOutputDir(configuredOutput)
+	}
+	return ResolveReviewPathWithArgs("", fileArgs)
+}
+
 // resolveReviewPathWithArgs is like ResolveReviewPath but includes file args
 // in the session key, matching the key that file-mode sessions use.
 func ResolveReviewPathWithArgs(outputDir string, fileArgs []string) (string, error) {

--- a/internal/review/review_file.go
+++ b/internal/review/review_file.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/reviewpath"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
@@ -35,11 +36,7 @@ var errReviewFileAmbiguousForBranch = errors.New("multiple review files match br
 //  5. If no daemon found, compute the centralized path: ~/.crit/reviews/<key>
 func ResolveReviewPath(outputDir string) (string, error) {
 	if outputDir != "" {
-		abs, err := filepath.Abs(outputDir)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(abs, ".crit"), nil
+		return reviewpath.FromOutputDir(outputDir)
 	}
 
 	cwd, err := daemon.ResolvedCWD()
@@ -72,11 +69,7 @@ func ResolveReviewPathWithArgs(outputDir string, fileArgs []string) (string, err
 		return ResolveReviewPath(outputDir)
 	}
 	if outputDir != "" {
-		abs, err := filepath.Abs(outputDir)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(abs, ".crit"), nil
+		return reviewpath.FromOutputDir(outputDir)
 	}
 
 	cwd, err := daemon.ResolvedCWD()

--- a/internal/review/review_file_test.go
+++ b/internal/review/review_file_test.go
@@ -250,6 +250,24 @@ func TestResolveReviewPathWithArgs(t *testing.T) {
 	})
 }
 
+func TestResolveCommandReviewPathExplicitRelativeOutputUsesCurrentDirectory(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+
+	got, err := ResolveCommandReviewPath("reviews", filepath.Join(root, "configured"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(nested, "reviews", ".crit")
+	if got != want {
+		t.Fatalf("review path = %q, want explicit CWD-relative path %q", got, want)
+	}
+}
+
 func withFetchPRHeadInfo(t *testing.T, fn func(int) (*PRHeadInfo, error)) {
 	t.Helper()
 	prev := FetchPRHeadInfoFn

--- a/internal/review/review_file_test.go
+++ b/internal/review/review_file_test.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -265,6 +270,94 @@ func TestResolveCommandReviewPathExplicitRelativeOutputUsesCurrentDirectory(t *t
 	want := filepath.Join(nested, "reviews", ".crit")
 	if got != want {
 		t.Fatalf("review path = %q, want explicit CWD-relative path %q", got, want)
+	}
+}
+
+func TestResolveCommandReviewPathPrecedence(t *testing.T) {
+	cwd := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(cwd)
+	resolvedCWD, err := daemon.ResolvedCWD()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("configured output before centralized", func(t *testing.T) {
+		configuredOutput := t.TempDir()
+		got, err := ResolveCommandReviewPath("", configuredOutput)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(configuredOutput, ".crit")
+		if got != want {
+			t.Fatalf("review path = %q, want configured path %q", got, want)
+		}
+	})
+
+	t.Run("file args retained for centralized fallback", func(t *testing.T) {
+		args := []string{"plan.md"}
+		got, err := ResolveCommandReviewPathWithArgs("", "", args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, err := ResolveReviewPathWithArgs("", args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("review path = %q, want centralized path %q", got, want)
+		}
+	})
+
+	t.Run("active daemon before configured output", func(t *testing.T) {
+		health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"status":"ok"}`)
+		}))
+		t.Cleanup(health.Close)
+		parsed, err := url.Parse(health.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		port, err := strconv.Atoi(parsed.Port())
+		if err != nil {
+			t.Fatal(err)
+		}
+		daemonPath := filepath.Join(t.TempDir(), ".crit")
+		const key = "review-command-path"
+		if err := daemon.WriteSessionFile(key, daemon.SessionEntry{
+			PID:        os.Getpid(),
+			Port:       port,
+			CWD:        resolvedCWD,
+			ReviewPath: daemonPath,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { daemon.RemoveSessionFile(key) })
+
+		got, err := ResolveCommandReviewPath("", t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != daemonPath {
+			t.Fatalf("review path = %q, want daemon path %q", got, daemonPath)
+		}
+	})
+}
+
+func TestClearReviewPath(t *testing.T) {
+	reviewPath := filepath.Join(t.TempDir(), ".crit")
+	if err := os.MkdirAll(reviewPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reviewPath, "review.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearReviewPath(reviewPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(reviewPath); !os.IsNotExist(err) {
+		t.Fatalf("review path still exists or stat failed unexpectedly: %v", err)
 	}
 }
 

--- a/internal/review/review_file_test.go
+++ b/internal/review/review_file_test.go
@@ -275,7 +275,7 @@ func TestResolveCommandReviewPathExplicitRelativeOutputUsesCurrentDirectory(t *t
 
 func TestResolveCommandReviewPathPrecedence(t *testing.T) {
 	cwd := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(cwd)
 	resolvedCWD, err := daemon.ResolvedCWD()
 	if err != nil {

--- a/internal/reviewpath/output.go
+++ b/internal/reviewpath/output.go
@@ -1,0 +1,12 @@
+package reviewpath
+
+import "path/filepath"
+
+// FromOutputDir resolves an output directory to its v4 review identity folder.
+func FromOutputDir(outputDir string) (string, error) {
+	abs, err := filepath.Abs(outputDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(abs, ".crit"), nil
+}

--- a/internal/reviewpath/output_test.go
+++ b/internal/reviewpath/output_test.go
@@ -1,0 +1,19 @@
+package reviewpath
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFromOutputDir(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "reviews")
+	got, err := FromOutputDir(nested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(nested, ".crit")
+	if got != want {
+		t.Fatalf("review path = %q, want %q", got, want)
+	}
+}

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -204,7 +204,7 @@ func ResolveDaemonCLIConfig(args []string) (*DaemonCLIConfig, error) {
 	if configDir == "" {
 		configDir = daemonMustGetwd()
 	}
-	cfg := config.LoadConfig(configDir)
+	cfg := config.LoadConfigForCommands(configDir)
 
 	applyDaemonConfigDefaults(&sf, cfg)
 

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -154,7 +154,9 @@ func applyDaemonConfigDefaults(sf *daemonFlagSet, cfg config.Config) {
 	if !sf.quiet && cfg.Quiet {
 		sf.quiet = true
 	}
-	sf.outputDir = config.ResolveOutputDir(sf.outputDir, cfg)
+	if sf.outputDir == "" && sf.planDir == "" {
+		sf.outputDir = cfg.Output
+	}
 	if sf.baseBranch == "" && cfg.BaseBranch != "" {
 		sf.baseBranch = cfg.BaseBranch
 	}

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -154,9 +154,7 @@ func applyDaemonConfigDefaults(sf *daemonFlagSet, cfg config.Config) {
 	if !sf.quiet && cfg.Quiet {
 		sf.quiet = true
 	}
-	if sf.outputDir == "" && cfg.Output != "" {
-		sf.outputDir = cfg.Output
-	}
+	sf.outputDir = config.ResolveOutputDir(sf.outputDir, cfg)
 	if sf.baseBranch == "" && cfg.BaseBranch != "" {
 		sf.baseBranch = cfg.BaseBranch
 	}

--- a/internal/server/daemon_cli_config_test.go
+++ b/internal/server/daemon_cli_config_test.go
@@ -670,6 +670,52 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 			t.Errorf("outputDir = %q, want /tmp/cfg-out (from config)", sc.OutputDir)
 		}
 	})
+
+	t.Run("plan dir wins over config output", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"output": "/tmp/cfg-out"}`), 0644)
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		planDir := filepath.Join(dir, "plan")
+		sc, err := ResolveDaemonCLIConfig([]string{"--plan-dir", planDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.OutputDir != "" {
+			t.Errorf("outputDir = %q, want empty so plan dir remains authoritative", sc.OutputDir)
+		}
+		if sc.PlanDir != planDir {
+			t.Errorf("planDir = %q, want %q", sc.PlanDir, planDir)
+		}
+	})
+
+	t.Run("explicit output wins over plan dir and config", func(t *testing.T) {
+		vcs.SetDefaultBranchOverride("")
+
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"output": "/tmp/cfg-out"}`), 0644)
+		homeDir := t.TempDir()
+		testutil.SetHome(t, homeDir)
+
+		origDir, _ := os.Getwd()
+		os.Chdir(dir)
+		defer os.Chdir(origDir)
+
+		sc, err := ResolveDaemonCLIConfig([]string{"--output", "/tmp/explicit", "--plan-dir", "/tmp/plan"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc.OutputDir != "/tmp/explicit" {
+			t.Errorf("outputDir = %q, want /tmp/explicit", sc.OutputDir)
+		}
+	})
 }
 
 func TestResolveDaemonCLIConfig_NotifyOnRoundReady(t *testing.T) {

--- a/internal/server/daemon_cli_config_test.go
+++ b/internal/server/daemon_cli_config_test.go
@@ -718,6 +718,38 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 	})
 }
 
+func TestResolveDaemonCLIConfigRelativeOutputAnchoredToRepoRoot(t *testing.T) {
+	defer resetBranchOverride(t)
+	vcs.SetDefaultBranchOverride("")
+	repoDir := testutil.InitTestRepo(t)
+	testutil.SetHome(t, t.TempDir())
+	if err := os.WriteFile(
+		filepath.Join(repoDir, ".crit.config.json"),
+		[]byte(`{"output":"reviews"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	nestedDir := filepath.Join(repoDir, "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nestedDir)
+
+	sc, err := ResolveDaemonCLIConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalRepo, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(canonicalRepo, "reviews")
+	if sc.OutputDir != want {
+		t.Fatalf("outputDir = %q, want repo-relative %q", sc.OutputDir, want)
+	}
+}
+
 func TestResolveDaemonCLIConfig_NotifyOnRoundReady(t *testing.T) {
 	vcs.SetDefaultBranchOverride("")
 	dir := t.TempDir()

--- a/internal/server/daemon_cli_config_test.go
+++ b/internal/server/daemon_cli_config_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,17 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
+
+func writeDaemonOutputConfig(t *testing.T, dir, output string) {
+	t.Helper()
+	data, err := json.Marshal(map[string]string{"output": output})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".crit.config.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func resetBranchOverride(t *testing.T) {
 	t.Helper()
@@ -654,7 +666,8 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 		vcs.SetDefaultBranchOverride("")
 
 		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"output": "/tmp/cfg-out"}`), 0644)
+		configuredOutput := t.TempDir()
+		writeDaemonOutputConfig(t, dir, configuredOutput)
 		homeDir := t.TempDir()
 		testutil.SetHome(t, homeDir)
 
@@ -666,8 +679,8 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if sc.OutputDir != "/tmp/cfg-out" {
-			t.Errorf("outputDir = %q, want /tmp/cfg-out (from config)", sc.OutputDir)
+		if sc.OutputDir != configuredOutput {
+			t.Errorf("outputDir = %q, want %q (from config)", sc.OutputDir, configuredOutput)
 		}
 	})
 
@@ -675,7 +688,7 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 		vcs.SetDefaultBranchOverride("")
 
 		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"output": "/tmp/cfg-out"}`), 0644)
+		writeDaemonOutputConfig(t, dir, t.TempDir())
 		homeDir := t.TempDir()
 		testutil.SetHome(t, homeDir)
 
@@ -700,7 +713,7 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 		vcs.SetDefaultBranchOverride("")
 
 		dir := t.TempDir()
-		os.WriteFile(filepath.Join(dir, ".crit.config.json"), []byte(`{"output": "/tmp/cfg-out"}`), 0644)
+		writeDaemonOutputConfig(t, dir, t.TempDir())
 		homeDir := t.TempDir()
 		testutil.SetHome(t, homeDir)
 
@@ -708,12 +721,14 @@ func TestResolveServerConfig_OutputDir(t *testing.T) {
 		os.Chdir(dir)
 		defer os.Chdir(origDir)
 
-		sc, err := ResolveDaemonCLIConfig([]string{"--output", "/tmp/explicit", "--plan-dir", "/tmp/plan"})
+		explicitOutput := t.TempDir()
+		planDir := t.TempDir()
+		sc, err := ResolveDaemonCLIConfig([]string{"--output", explicitOutput, "--plan-dir", planDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if sc.OutputDir != "/tmp/explicit" {
-			t.Errorf("outputDir = %q, want /tmp/explicit", sc.OutputDir)
+		if sc.OutputDir != explicitOutput {
+			t.Errorf("outputDir = %q, want %q", sc.OutputDir, explicitOutput)
 		}
 	})
 }

--- a/internal/session/status_cli.go
+++ b/internal/session/status_cli.go
@@ -26,20 +26,21 @@ func RunStatus(args []string) error {
 
 	vcsName := ""
 	branch := ""
-	if vcs := vcs.DetectVCS(""); vcs != nil {
-		vcsName = vcs.Name()
-		branch = vcs.CurrentBranch()
+	var backend vcs.VCS
+	if backend = vcs.DetectVCS(""); backend != nil {
+		vcsName = backend.Name()
+		branch = backend.CurrentBranch()
 	}
 
 	sessions, err := daemon.ListSessionsForCWD(cwd)
 	if err != nil {
 		return err
 	}
-	var matchedSession *daemon.SessionEntry
-	for i, s := range sessions {
-		if s.Branch == branch || (branch == "" && len(sessions) == 1) {
-			matchedSession = &sessions[i]
-			break
+	matchedSession := selectStatusSession(sessions, branch)
+	if matchedSession == nil && backend != nil {
+		if repoRoot, rootErr := backend.RepoRoot(); rootErr == nil {
+			repoSessions, _ := daemon.ListSessionsForRepoRoot(repoRoot)
+			matchedSession = selectStatusSession(repoSessions, branch)
 		}
 	}
 
@@ -59,6 +60,15 @@ func RunStatus(args []string) error {
 	}
 
 	printStatusHuman(vcsName, branch, revPath, revExists, matchedSession)
+	return nil
+}
+
+func selectStatusSession(sessions []daemon.SessionEntry, branch string) *daemon.SessionEntry {
+	for i, s := range sessions {
+		if s.Branch == branch || (branch == "" && len(sessions) == 1) {
+			return &sessions[i]
+		}
+	}
 	return nil
 }
 

--- a/internal/session/status_cli.go
+++ b/internal/session/status_cli.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/reviewpath"
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
@@ -41,12 +43,9 @@ func RunStatus(args []string) error {
 		}
 	}
 
-	var revPath string
-	if matchedSession != nil && matchedSession.ReviewPath != "" {
-		revPath = matchedSession.ReviewPath
-	} else {
-		key := daemon.SessionKey(cwd, branch, nil)
-		revPath, _ = daemon.ReviewFilePath(key)
+	revPath, err := resolveStatusReviewPath(cwd, branch, matchedSession)
+	if err != nil {
+		return err
 	}
 
 	revExists := false
@@ -61,6 +60,21 @@ func RunStatus(args []string) error {
 
 	printStatusHuman(vcsName, branch, revPath, revExists, matchedSession)
 	return nil
+}
+
+func resolveStatusReviewPath(cwd, branch string, matchedSession *daemon.SessionEntry) (string, error) {
+	if matchedSession != nil && matchedSession.ReviewPath != "" {
+		return matchedSession.ReviewPath, nil
+	}
+	cfg, err := config.LoadCurrentConfig()
+	if err != nil {
+		return "", err
+	}
+	if cfg.Output != "" {
+		return reviewpath.FromOutputDir(cfg.Output)
+	}
+	key := daemon.SessionKey(cwd, branch, nil)
+	return daemon.ReviewFilePath(key)
 }
 
 func printStatusJSON(vcsName, branch, revPath string, revExists bool, session *daemon.SessionEntry) {

--- a/internal/session/status_cli_test.go
+++ b/internal/session/status_cli_test.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
+)
+
+func captureStatusJSON(t *testing.T) map[string]interface{} {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = original })
+
+	if err := RunStatus([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = original
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("decoding status JSON %q: %v", data, err)
+	}
+	return result
+}
+
+func writeStatusReview(t *testing.T, reviewPath string) {
+	t.Helper()
+	if err := os.MkdirAll(reviewPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		ReviewPathsFor(reviewPath).Review,
+		[]byte(`{"version":4,"review_round":1,"files":{}}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunStatusUsesConfiguredOutputWithoutDaemon(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := filepath.Join(projectDir, "configured-output")
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(fmt.Sprintf(`{"output":%q}`, outputDir)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeStatusReview(t, filepath.Join(outputDir, ".crit"))
+
+	result := captureStatusJSON(t)
+	want := filepath.Join(outputDir, ".crit", "review.json")
+	if result["review_file"] != want {
+		t.Fatalf("review_file = %q, want %q", result["review_file"], want)
+	}
+	if result["review_file_exists"] != true {
+		t.Fatalf("review_file_exists = %v, want true", result["review_file_exists"])
+	}
+}
+
+func TestRunStatusLiveSessionWinsOverConfiguredOutput(t *testing.T) {
+	projectDir := t.TempDir()
+	configuredOutput := filepath.Join(projectDir, "configured-output")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Chdir(projectDir)
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(fmt.Sprintf(`{"output":%q}`, configuredOutput)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeStatusReview(t, filepath.Join(configuredOutput, ".crit"))
+
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	t.Cleanup(health.Close)
+	parsed, err := url.Parse(health.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	liveReviewPath := filepath.Join(t.TempDir(), ".crit")
+	writeStatusReview(t, liveReviewPath)
+	cwd, err := daemon.ResolvedCWD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.WriteSessionFile("status-live", daemon.SessionEntry{
+		PID:        os.Getpid(),
+		Port:       port,
+		CWD:        cwd,
+		ReviewPath: liveReviewPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := captureStatusJSON(t)
+	want := filepath.Join(liveReviewPath, "review.json")
+	if result["review_file"] != want {
+		t.Fatalf("review_file = %q, want live session path %q", result["review_file"], want)
+	}
+}

--- a/internal/session/status_cli_test.go
+++ b/internal/session/status_cli_test.go
@@ -87,6 +87,29 @@ func TestRunStatusUsesConfiguredOutputWithoutDaemon(t *testing.T) {
 	}
 }
 
+func TestResolveStatusReviewPathCentralizedFallback(t *testing.T) {
+	cwd := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(cwd)
+	resolvedCWD, err := daemon.ResolvedCWD()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveStatusReviewPath(resolvedCWD, "feature", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := daemon.SessionKey(resolvedCWD, "feature", nil)
+	want, err := daemon.ReviewFilePath(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("review path = %q, want centralized path %q", got, want)
+	}
+}
+
 func TestRunStatusLiveSessionWinsOverConfiguredOutput(t *testing.T) {
 	projectDir := t.TempDir()
 	configuredOutput := filepath.Join(projectDir, "configured-output")

--- a/internal/session/status_cli_test.go
+++ b/internal/session/status_cli_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 func captureStatusJSON(t *testing.T) map[string]interface{} {
@@ -133,5 +135,91 @@ func TestRunStatusLiveSessionWinsOverConfiguredOutput(t *testing.T) {
 	want := filepath.Join(liveReviewPath, "review.json")
 	if result["review_file"] != want {
 		t.Fatalf("review_file = %q, want live session path %q", result["review_file"], want)
+	}
+}
+
+func TestRunStatusFindsRepoRootSessionFromNestedDirectory(t *testing.T) {
+	repoDir := testutil.InitTestRepo(t)
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	configuredOutput := filepath.Join(repoDir, "configured-output")
+	if err := os.WriteFile(
+		filepath.Join(repoDir, ".crit.config.json"),
+		[]byte(fmt.Sprintf(`{"output":%q}`, configuredOutput)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeStatusReview(t, filepath.Join(configuredOutput, ".crit"))
+
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	t.Cleanup(health.Close)
+	parsed, err := url.Parse(health.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(repoDir)
+	backend := vcs.DetectVCS("")
+	if backend == nil {
+		t.Fatal("expected git repository")
+	}
+	repoRoot, err := backend.RepoRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootReviewPath := filepath.Join(t.TempDir(), ".crit")
+	writeStatusReview(t, rootReviewPath)
+	const sessionKey = "status-repo-root"
+	if err := daemon.WriteSessionFile(sessionKey, daemon.SessionEntry{
+		PID:        os.Getpid(),
+		Port:       port,
+		CWD:        repoRoot,
+		Branch:     backend.CurrentBranch(),
+		ReviewPath: rootReviewPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { daemon.RemoveSessionFile(sessionKey) })
+
+	nestedDir := filepath.Join(repoDir, "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nestedDir)
+	nestedCWD, err := daemon.ResolvedCWD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wrongBranchSessionKey = "status-nested-wrong-branch"
+	if err := daemon.WriteSessionFile(wrongBranchSessionKey, daemon.SessionEntry{
+		PID:        os.Getpid(),
+		Port:       port,
+		CWD:        nestedCWD,
+		Branch:     "different-branch",
+		ReviewPath: filepath.Join(t.TempDir(), ".crit"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { daemon.RemoveSessionFile(wrongBranchSessionKey) })
+
+	result := captureStatusJSON(t)
+	want := filepath.Join(rootReviewPath, "review.json")
+	if result["review_file"] != want {
+		t.Fatalf("review_file = %q, want root daemon path %q", result["review_file"], want)
+	}
+	daemonStatus, ok := result["daemon"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("daemon status = %#v, want object", result["daemon"])
+	}
+	if daemonStatus["running"] != true {
+		t.Fatalf("daemon.running = %v, want true", daemonStatus["running"])
 	}
 }

--- a/internal/session/status_cli_test.go
+++ b/internal/session/status_cli_test.go
@@ -66,7 +66,7 @@ func writeStatusReview(t *testing.T, reviewPath string) {
 func TestRunStatusUsesConfiguredOutputWithoutDaemon(t *testing.T) {
 	projectDir := t.TempDir()
 	outputDir := filepath.Join(projectDir, "configured-output")
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),
@@ -89,7 +89,7 @@ func TestRunStatusUsesConfiguredOutputWithoutDaemon(t *testing.T) {
 
 func TestResolveStatusReviewPathCentralizedFallback(t *testing.T) {
 	cwd := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(cwd)
 	resolvedCWD, err := daemon.ResolvedCWD()
 	if err != nil {
@@ -114,7 +114,7 @@ func TestRunStatusLiveSessionWinsOverConfiguredOutput(t *testing.T) {
 	projectDir := t.TempDir()
 	configuredOutput := filepath.Join(projectDir, "configured-output")
 	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	testutil.SetHome(t, homeDir)
 	t.Chdir(projectDir)
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),
@@ -164,7 +164,7 @@ func TestRunStatusLiveSessionWinsOverConfiguredOutput(t *testing.T) {
 func TestRunStatusFindsRepoRootSessionFromNestedDirectory(t *testing.T) {
 	repoDir := testutil.InitTestRepo(t)
 	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	testutil.SetHome(t, homeDir)
 	configuredOutput := filepath.Join(repoDir, "configured-output")
 	if err := os.WriteFile(
 		filepath.Join(repoDir, ".crit.config.json"),

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -23,19 +23,21 @@ import (
 )
 
 type shareFlags struct {
-	outputDir  string
-	svcURL     string
-	showQR     bool
-	org        string
-	visibility string
-	preview    string
-	files      []string
+	outputDir        string
+	configuredOutput string
+	svcURL           string
+	showQR           bool
+	org              string
+	visibility       string
+	preview          string
+	files            []string
 }
 
 type unpublishFlags struct {
-	outputDir string
-	svcURL    string
-	files     []string
+	outputDir        string
+	configuredOutput string
+	svcURL           string
+	files            []string
 }
 
 func postPreviewShare(htmlPath, svcURL, authToken string) (string, error) {
@@ -126,7 +128,7 @@ func parseShareFlags(args []string) (shareFlags, error) {
 }
 
 func applyShareConfigDefaults(sf *shareFlags, cfg config.Config) {
-	sf.outputDir = config.ResolveOutputDir(sf.outputDir, cfg)
+	sf.configuredOutput = cfg.Output
 	sf.svcURL = ResolveShareURL(sf.svcURL, cfg, config.DefaultShareURL)
 }
 
@@ -333,7 +335,7 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 		return err
 	}
 
-	critPath, err := review.ResolveReviewPath(sf.outputDir)
+	critPath, err := review.ResolveCommandReviewPath(sf.outputDir, sf.configuredOutput)
 	if err != nil {
 		return err
 	}
@@ -407,12 +409,13 @@ func parseFetchOutputDir(args []string) (string, error) {
 	return outputDir, nil
 }
 
-func resolveFetchOutputDir(args []string) (string, error) {
+func resolveFetchReviewPath(args []string) (string, error) {
 	outputDir, err := parseFetchOutputDir(args)
 	if err != nil {
 		return "", err
 	}
-	return config.ResolveOutputDir(outputDir, LoadShareConfig()), nil
+	cfg := LoadShareConfig()
+	return review.ResolveCommandReviewPath(outputDir, cfg.Output)
 }
 
 func printFetchedComments(webComments []WebComment) {
@@ -436,12 +439,7 @@ func RunFetch(args []string) error {
 	if err := checkProxyAuthCLIAllowed("crit fetch"); err != nil {
 		return err
 	}
-	outputDir, err := resolveFetchOutputDir(args)
-	if err != nil {
-		return err
-	}
-
-	critPath, err := review.ResolveReviewPath(outputDir)
+	critPath, err := resolveFetchReviewPath(args)
 	if err != nil {
 		return err
 	}
@@ -524,7 +522,7 @@ func parseUnpublishFlags(args []string) (unpublishFlags, error) {
 }
 
 func applyUnpublishConfigDefaults(f *unpublishFlags, cfg config.Config) {
-	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.configuredOutput = cfg.Output
 	f.svcURL = ResolveShareURL(f.svcURL, cfg, config.DefaultShareURL)
 }
 
@@ -542,7 +540,7 @@ func RunUnpublish(args []string) error {
 	applyUnpublishConfigDefaults(&f, unpubCfg)
 	unpubAuthToken := ResolveAuthToken(unpubCfg)
 
-	critPath, err := review.ResolveReviewPathWithArgs(f.outputDir, f.files)
+	critPath, err := review.ResolveCommandReviewPathWithArgs(f.outputDir, f.configuredOutput, f.files)
 	if err != nil {
 		return err
 	}

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -32,6 +32,12 @@ type shareFlags struct {
 	files      []string
 }
 
+type unpublishFlags struct {
+	outputDir string
+	svcURL    string
+	files     []string
+}
+
 func postPreviewShare(htmlPath, svcURL, authToken string) (string, error) {
 	files, err := session.CrawlPreview(htmlPath)
 	if err != nil {
@@ -117,6 +123,11 @@ func parseShareFlags(args []string) (shareFlags, error) {
 		}
 	}
 	return sf, nil
+}
+
+func applyShareConfigDefaults(sf *shareFlags, cfg config.Config) {
+	sf.outputDir = config.ResolveOutputDir(sf.outputDir, cfg)
+	sf.svcURL = ResolveShareURL(sf.svcURL, cfg, config.DefaultShareURL)
 }
 
 func runSharePreview(sf shareFlags) error {
@@ -312,7 +323,7 @@ func RunShare(args []string) error { //nolint:gocyclo // CLI dispatcher
 	flagURL := sf.svcURL != ""
 
 	cfg := LoadShareConfig()
-	sf.svcURL = ResolveShareURL(sf.svcURL, cfg, config.DefaultShareURL)
+	applyShareConfigDefaults(&sf, cfg)
 	cfg.AuthToken = ResolveAuthToken(cfg)
 	auth.LazyBackfillAuthUserID(&cfg, sf.svcURL)
 	authToken := cfg.AuthToken
@@ -396,6 +407,14 @@ func parseFetchOutputDir(args []string) (string, error) {
 	return outputDir, nil
 }
 
+func resolveFetchOutputDir(args []string) (string, error) {
+	outputDir, err := parseFetchOutputDir(args)
+	if err != nil {
+		return "", err
+	}
+	return config.ResolveOutputDir(outputDir, LoadShareConfig()), nil
+}
+
 func printFetchedComments(webComments []WebComment) {
 	fmt.Printf("Fetched %d new comment(s) into review file\n", len(webComments))
 	for _, wc := range webComments {
@@ -417,7 +436,7 @@ func RunFetch(args []string) error {
 	if err := checkProxyAuthCLIAllowed("crit fetch"); err != nil {
 		return err
 	}
-	outputDir, err := parseFetchOutputDir(args)
+	outputDir, err := resolveFetchOutputDir(args)
 	if err != nil {
 		return err
 	}
@@ -480,39 +499,50 @@ func runFetchUnderLock(critPath string) error {
 	return nil
 }
 
-// RunUnpublish removes a shared review from crit-web.
-func RunUnpublish(args []string) error {
-	if err := checkProxyAuthCLIAllowed("crit unpublish"); err != nil {
-		return err
-	}
-	unpubOutputDir := ""
-	unpubSvcURL := ""
-	var unpubFiles []string
+func parseUnpublishFlags(args []string) (unpublishFlags, error) {
+	var f unpublishFlags
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--output" || arg == "-o":
 			if i+1 >= len(args) {
-				return clicmd.Usage(fmt.Sprintf("Error: %s requires a value", arg))
+				return f, clicmd.Usage(fmt.Sprintf("Error: %s requires a value", arg))
 			}
 			i++
-			unpubOutputDir = args[i]
+			f.outputDir = args[i]
 		case arg == "--share-url":
 			if i+1 >= len(args) {
-				return clicmd.Usage("Error: --share-url requires a value")
+				return f, clicmd.Usage("Error: --share-url requires a value")
 			}
 			i++
-			unpubSvcURL = args[i]
+			f.svcURL = args[i]
 		default:
-			unpubFiles = append(unpubFiles, arg)
+			f.files = append(f.files, arg)
 		}
+	}
+	return f, nil
+}
+
+func applyUnpublishConfigDefaults(f *unpublishFlags, cfg config.Config) {
+	f.outputDir = config.ResolveOutputDir(f.outputDir, cfg)
+	f.svcURL = ResolveShareURL(f.svcURL, cfg, config.DefaultShareURL)
+}
+
+// RunUnpublish removes a shared review from crit-web.
+func RunUnpublish(args []string) error {
+	if err := checkProxyAuthCLIAllowed("crit unpublish"); err != nil {
+		return err
+	}
+	f, err := parseUnpublishFlags(args)
+	if err != nil {
+		return err
 	}
 
 	unpubCfg := LoadShareConfig()
-	unpubSvcURL = ResolveShareURL(unpubSvcURL, unpubCfg, config.DefaultShareURL)
+	applyUnpublishConfigDefaults(&f, unpubCfg)
 	unpubAuthToken := ResolveAuthToken(unpubCfg)
 
-	critPath, err := review.ResolveReviewPathWithArgs(unpubOutputDir, unpubFiles)
+	critPath, err := review.ResolveReviewPathWithArgs(f.outputDir, f.files)
 	if err != nil {
 		return err
 	}
@@ -529,7 +559,7 @@ func RunUnpublish(args []string) error {
 		return nil
 	}
 
-	if err := UnpublishFromWeb(unpubSvcURL, cj.DeleteToken, unpubAuthToken); err != nil {
+	if err := UnpublishFromWeb(f.svcURL, cj.DeleteToken, unpubAuthToken); err != nil {
 		return err
 	}
 

--- a/internal/share/cli_fetch_test.go
+++ b/internal/share/cli_fetch_test.go
@@ -249,6 +249,15 @@ func TestRunShare_MissingFiles(t *testing.T) {
 	}
 }
 
+func TestRunShare_MissingFile(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+	t.Chdir(t.TempDir())
+	err := RunShare([]string{"missing.md"})
+	if err == nil || !strings.Contains(err.Error(), "reading missing.md") {
+		t.Fatalf("error = %v, want missing file error", err)
+	}
+}
+
 func TestRunShare_OutputFlagMissingValue(t *testing.T) {
 	err := RunShare([]string{"--output"})
 	if err == nil {

--- a/internal/share/cli_main_test.go
+++ b/internal/share/cli_main_test.go
@@ -77,7 +77,7 @@ func TestRunUnpublish_NoReviewFile(t *testing.T) {
 }
 
 func TestRunUnpublish_ParseError(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(t.TempDir())
 	if err := RunUnpublish([]string{"--output"}); err == nil {
 		t.Fatal("expected missing output value error")
@@ -265,7 +265,7 @@ func TestParseUnpublishFlags(t *testing.T) {
 
 func TestLoadShareConfigRelativeOutputAnchoredToRepoRoot(t *testing.T) {
 	repoDir := testutil.InitTestRepo(t)
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	if err := os.WriteFile(
 		filepath.Join(repoDir, ".crit.config.json"),
 		[]byte(`{"output":"reviews"}`),

--- a/internal/share/cli_main_test.go
+++ b/internal/share/cli_main_test.go
@@ -76,6 +76,14 @@ func TestRunUnpublish_NoReviewFile(t *testing.T) {
 	}
 }
 
+func TestRunUnpublish_ParseError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	if err := RunUnpublish([]string{"--output"}); err == nil {
+		t.Fatal("expected missing output value error")
+	}
+}
+
 func TestParseShareFlags(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -162,13 +170,14 @@ func TestParseShareFlags(t *testing.T) {
 
 func TestApplyShareConfigDefaultsOutputPrecedence(t *testing.T) {
 	cfg := config.Config{Output: "/configured", ShareURL: "https://configured.example"}
+	explicitOutput := t.TempDir()
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{name: "configured output", want: "/configured"},
-		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+		{name: "explicit output wins", in: explicitOutput, want: explicitOutput},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -187,13 +196,14 @@ func TestApplyShareConfigDefaultsOutputPrecedence(t *testing.T) {
 
 func TestApplyUnpublishConfigDefaultsOutputPrecedence(t *testing.T) {
 	cfg := config.Config{Output: "/configured", ShareURL: "https://configured.example"}
+	explicitOutput := t.TempDir()
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{name: "configured output", want: "/configured"},
-		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+		{name: "explicit output wins", in: explicitOutput, want: explicitOutput},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -205,6 +215,49 @@ func TestApplyUnpublishConfigDefaultsOutputPrecedence(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("resolved output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseUnpublishFlags(t *testing.T) {
+	outputDir := t.TempDir()
+	tests := []struct {
+		name    string
+		args    []string
+		want    unpublishFlags
+		wantErr bool
+	}{
+		{name: "empty"},
+		{
+			name: "all values",
+			args: []string{"--output", outputDir, "--share-url", "https://example.test", "one.md", "two.md"},
+			want: unpublishFlags{
+				outputDir: outputDir,
+				svcURL:    "https://example.test",
+				files:     []string{"one.md", "two.md"},
+			},
+		},
+		{name: "missing output", args: []string{"--output"}, wantErr: true},
+		{name: "missing share URL", args: []string{"--share-url"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUnpublishFlags(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.outputDir != tt.want.outputDir || got.svcURL != tt.want.svcURL {
+				t.Fatalf("flags = %+v, want %+v", got, tt.want)
+			}
+			if strings.Join(got.files, ",") != strings.Join(tt.want.files, ",") {
+				t.Fatalf("files = %v, want %v", got.files, tt.want.files)
 			}
 		})
 	}

--- a/internal/share/cli_main_test.go
+++ b/internal/share/cli_main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/config"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func TestPromptShareConsent(t *testing.T) {
@@ -173,8 +174,12 @@ func TestApplyShareConfigDefaultsOutputPrecedence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sf := shareFlags{outputDir: tt.in}
 			applyShareConfigDefaults(&sf, cfg)
-			if sf.outputDir != tt.want {
-				t.Fatalf("outputDir = %q, want %q", sf.outputDir, tt.want)
+			got := sf.configuredOutput
+			if sf.outputDir != "" {
+				got = sf.outputDir
+			}
+			if got != tt.want {
+				t.Fatalf("resolved output = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -194,10 +199,41 @@ func TestApplyUnpublishConfigDefaultsOutputPrecedence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := unpublishFlags{outputDir: tt.in}
 			applyUnpublishConfigDefaults(&f, cfg)
-			if f.outputDir != tt.want {
-				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
+			got := f.configuredOutput
+			if f.outputDir != "" {
+				got = f.outputDir
+			}
+			if got != tt.want {
+				t.Fatalf("resolved output = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLoadShareConfigRelativeOutputAnchoredToRepoRoot(t *testing.T) {
+	repoDir := testutil.InitTestRepo(t)
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(
+		filepath.Join(repoDir, ".crit.config.json"),
+		[]byte(`{"output":"reviews"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	nestedDir := filepath.Join(repoDir, "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nestedDir)
+
+	cfg := LoadShareConfig()
+	canonicalRepo, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(canonicalRepo, "reviews")
+	if cfg.Output != want {
+		t.Fatalf("share output = %q, want repo-relative %q", cfg.Output, want)
 	}
 }
 

--- a/internal/share/cli_main_test.go
+++ b/internal/share/cli_main_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/config"
 )
 
 func TestPromptShareConsent(t *testing.T) {
@@ -152,6 +154,48 @@ func TestParseShareFlags(t *testing.T) {
 				if sf.files[i] != tt.files[i] {
 					t.Errorf("files[%d] = %q, want %q", i, sf.files[i], tt.files[i])
 				}
+			}
+		})
+	}
+}
+
+func TestApplyShareConfigDefaultsOutputPrecedence(t *testing.T) {
+	cfg := config.Config{Output: "/configured", ShareURL: "https://configured.example"}
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "configured output", want: "/configured"},
+		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sf := shareFlags{outputDir: tt.in}
+			applyShareConfigDefaults(&sf, cfg)
+			if sf.outputDir != tt.want {
+				t.Fatalf("outputDir = %q, want %q", sf.outputDir, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyUnpublishConfigDefaultsOutputPrecedence(t *testing.T) {
+	cfg := config.Config{Output: "/configured", ShareURL: "https://configured.example"}
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "configured output", want: "/configured"},
+		{name: "explicit output wins", in: "/explicit", want: "/explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := unpublishFlags{outputDir: tt.in}
+			applyUnpublishConfigDefaults(&f, cfg)
+			if f.outputDir != tt.want {
+				t.Fatalf("outputDir = %q, want %q", f.outputDir, tt.want)
 			}
 		})
 	}

--- a/internal/share/fetch_flags_test.go
+++ b/internal/share/fetch_flags_test.go
@@ -1,6 +1,7 @@
 package share
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -57,21 +58,26 @@ func TestResolveFetchOutputDirOutputPrecedence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Chdir(projectDir)
 	configuredOutput := filepath.Join(projectDir, "configured")
+	configData, err := json.Marshal(map[string]string{"output": configuredOutput})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(
 		filepath.Join(projectDir, ".crit.config.json"),
-		[]byte(`{"output":"`+configuredOutput+`"}`),
+		configData,
 		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}
 
+	explicitOutput := t.TempDir()
 	tests := []struct {
 		name string
 		args []string
 		want string
 	}{
 		{name: "configured output", want: configuredOutput},
-		{name: "explicit output wins", args: []string{"--output", "/explicit"}, want: "/explicit"},
+		{name: "explicit output wins", args: []string{"--output", explicitOutput}, want: explicitOutput},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -84,5 +90,11 @@ func TestResolveFetchOutputDirOutputPrecedence(t *testing.T) {
 				t.Fatalf("review path = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestResolveFetchReviewPathParseError(t *testing.T) {
+	if _, err := resolveFetchReviewPath([]string{"--output"}); err == nil {
+		t.Fatal("expected missing output value error")
 	}
 }

--- a/internal/share/fetch_flags_test.go
+++ b/internal/share/fetch_flags_test.go
@@ -2,6 +2,8 @@ package share
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
@@ -47,5 +49,39 @@ func TestParseFetchOutputDir_UnknownArg(t *testing.T) {
 	_, err := parseFetchOutputDir([]string{"--bogus"})
 	if err == nil {
 		t.Fatal("expected error for unknown arg")
+	}
+}
+
+func TestResolveFetchOutputDirOutputPrecedence(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(projectDir)
+	configuredOutput := filepath.Join(projectDir, "configured")
+	if err := os.WriteFile(
+		filepath.Join(projectDir, ".crit.config.json"),
+		[]byte(`{"output":"`+configuredOutput+`"}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "configured output", want: configuredOutput},
+		{name: "explicit output wins", args: []string{"--output", "/explicit"}, want: "/explicit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveFetchOutputDir(tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("outputDir = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/share/fetch_flags_test.go
+++ b/internal/share/fetch_flags_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
 func TestParseFetchOutputDir(t *testing.T) {
@@ -55,7 +56,7 @@ func TestParseFetchOutputDir_UnknownArg(t *testing.T) {
 
 func TestResolveFetchOutputDirOutputPrecedence(t *testing.T) {
 	projectDir := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	testutil.SetHome(t, t.TempDir())
 	t.Chdir(projectDir)
 	configuredOutput := filepath.Join(projectDir, "configured")
 	configData, err := json.Marshal(map[string]string{"output": configuredOutput})

--- a/internal/share/fetch_flags_test.go
+++ b/internal/share/fetch_flags_test.go
@@ -75,12 +75,13 @@ func TestResolveFetchOutputDirOutputPrecedence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveFetchOutputDir(tt.args)
+			got, err := resolveFetchReviewPath(tt.args)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != tt.want {
-				t.Fatalf("outputDir = %q, want %q", got, tt.want)
+			want := filepath.Join(tt.want, ".crit")
+			if got != want {
+				t.Fatalf("review path = %q, want %q", got, want)
 			}
 		})
 	}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -20,7 +20,6 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/focus"
 	"github.com/tomasz-tomczyk/crit/internal/session"
-	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 // DefaultShareURL is the production crit-web service URL, used as the fallback
@@ -1004,18 +1003,11 @@ proxy_auth is set in ~/.crit.config.json (global config only)`, command)
 // loadShareConfig loads the merged config.Config from the current directory context.
 // Used by share/fetch/unpublish commands to avoid redundant config parsing.
 func loadShareConfig() config.Config {
-	cfgDir := ""
-	if vcs := vcs.DetectVCS(""); vcs != nil {
-		cfgDir, _ = vcs.RepoRoot()
+	cfg, err := config.LoadCurrentConfig()
+	if err != nil {
+		return config.Config{}
 	}
-	if cfgDir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return config.Config{}
-		}
-		cfgDir = cwd
-	}
-	return config.LoadConfig(cfgDir)
+	return cfg
 }
 
 // resolveShareURL resolves the share service URL from flag > env > config > fallback.


### PR DESCRIPTION
## Summary
- honor merged project/global `output` config in comment, status, GitHub sync, and share lifecycle commands
- preserve precedence for explicit output, plan storage, active daemons, configured output, and centralized fallback
- anchor relative configured output to the project root and keep status resolution consistent from subdirectories

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (Go CLI only)

## Test plan
- `mise exec -- go test -race -count=1 ./...`
- `CRIT_WEB_DIR=/Users/tomasztomczyk/Server/side/crit-mono/crit-web make e2e-share`
- focused command/config/daemon/status precedence regression tests

Closes #763