### PR TITLE
fix(cli): add command-scoped help

### DIFF
--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -6,36 +6,248 @@ import (
 	"strings"
 )
 
-// commandDispatch maps subcommand names to handler functions.
-var commandDispatch = map[string]func([]string){
-	"help":      func([]string) { printHelp() },
-	"--help":    func([]string) { printHelp() },
-	"-h":        func([]string) { printHelp() },
-	"--version": func([]string) { printVersion() },
-	"-v":        func([]string) { printVersion() },
-	"share":     runShare,
-	"fetch":     runFetch,
-	"unpublish": runUnpublish,
-	"install":   runInstall,
-	"config":    runConfig,
-	"check":     func([]string) { runCheck() },
-	"pr":        runPR,
-	"pull":      runPull,
-	"push":      runPush,
-	"comment":   runComment,
-	"comments":  runComments,
-	"review":    runReview,
-	"live":      runLive,
-	"preview":   runPreview,
-	"plan":      runPlan,
-	"plan-hook": runPlanHookCommand,
-	"story":     runStory,
-	"auth":      runAuth,
-	"stop":      runStop,
-	"status":    runStatus,
-	"stats":     runStats,
-	"cleanup":   runCleanup,
-	"_serve":    runServe,
+type commandDescriptor struct {
+	name        string
+	handler     func([]string)
+	help        string
+	helpFn      func()
+	hidden      bool
+	bareHelp    bool
+	subcommands []commandDescriptor
+}
+
+// commandRegistry is the single source of truth for command dispatch, help,
+// ordering, and public visibility.
+var commandRegistry = []commandDescriptor{
+	{name: "share", handler: runShare, help: `Usage: crit share [options] <file> [file...]
+       crit share [options] --preview <file.html>
+
+Share files to crit-web and print the review URL.
+
+Options:
+  -o, --output <dir>       Review output directory
+      --share-url <url>    Share service URL
+      --org <slug>         Organization slug
+      --visibility <level> Review visibility
+      --preview <file>     Share a local HTML preview
+      --qr                 Print a QR code`},
+	{name: "fetch", handler: runFetch, help: `Usage: crit fetch [--output <dir>]
+
+Fetch comments from a shared crit-web review.`},
+	{name: "unpublish", handler: runUnpublish, help: `Usage: crit unpublish [options] [file...]
+
+Remove a shared review from crit-web.
+
+Options:
+  -o, --output <dir>       Review output directory
+      --share-url <url>    Share service URL`},
+	{name: "install", handler: runInstall, helpFn: printInstallUsage},
+	{name: "config", handler: runConfig, bareHelp: true, help: `Usage: crit config [--generate|-g]
+
+Show resolved configuration, or print a starter config with --generate.`},
+	{name: "check", handler: func([]string) { runCheck() }, help: `Usage: crit check
+
+Check installed integrations for missing or stale configuration.`},
+	{name: "pr", handler: runPR, help: `Usage: crit pr <num|url>
+
+Open a GitHub pull request for review.`},
+	{name: "pull", handler: runPull, help: `Usage: crit pull [--output <dir>] [pr-number]
+
+Fetch GitHub pull-request comments into the local review file.`},
+	{name: "push", handler: runPush, help: `Usage: crit push [options] [pr-number]
+
+Post local comments as a GitHub pull-request review.
+
+Options:
+      --dry-run          Preview without posting
+  -e, --event <type>     comment, approve, or request-changes
+  -m, --message <text>   Review-level message
+  -o, --output <dir>     Review output directory`},
+	{name: "comment", handler: runComment, help: `Usage: crit comment [options] <body>
+       crit comment [options] <path> <body>
+       crit comment [options] <path>:<line[-end]> <body>
+       crit comment --reply-to <id> [--resolve] <body>
+       crit comment --json [--file <path>]
+       crit comment --clear
+
+Add, reply to, bulk import, or clear review comments.
+
+Options:
+  -o, --output <dir>   Review output directory
+      --author <name>  Comment author
+      --plan <name>    Target a stored plan review
+      --reply-to <id>  Reply to an existing comment
+      --resolve        Resolve the parent after replying
+      --path <path>    File path for a reply
+      --json           Read bulk comments as JSON
+  -f, --file <path>    Read JSON from a file
+      --scope <mode>   Override comment focus scope`},
+	{name: "comments", handler: runComments, help: `Usage: crit comments [--json] [--all] [review]
+
+List unresolved comments, with review-level comments first.`},
+	{name: "review", handler: runReview, help: `Usage: crit review [options] [file|dir...]
+
+Open an inline review for git changes, a commit range, a PR, or files.
+
+Options:
+      --pr <num|url>          Review a GitHub pull request
+      --range <base>..<head>  Review a commit range
+      --base-branch <branch>  Override the diff base
+      --no-open               Do not open a browser
+  -o, --output <dir>          Review output directory`},
+	{name: "live", handler: runLive, help: `Usage: crit live [options] <url>
+
+Review a running web application in live mode.
+
+Options:
+  -p, --port <port>        Port to listen on
+      --host <host>        Host to listen on
+      --public-url <url>   Advertised base URL
+      --cookie <value>     Forward a Cookie header
+      --cookie-file <path> Read cookies from a file
+      --cdp-url <url>      Reuse cookies from Chrome DevTools
+      --share-url <url>    Share service URL
+      --no-open            Do not open a browser
+  -q, --quiet              Suppress status output`},
+	{name: "preview", handler: runPreview, help: `Usage: crit preview [options] <file.html>
+
+Review a local HTML file in preview mode.
+
+Options:
+  -p, --port <port>       Port to listen on
+      --host <host>       Host to listen on
+      --public-url <url>  Advertised base URL
+      --share-url <url>   Share service URL
+      --no-open           Do not open a browser
+  -q, --quiet             Suppress status output`},
+	{name: "plan", handler: runPlan, help: `Usage: crit plan [--name <slug>] <file>
+       echo "content" | crit plan [--name <slug>]
+
+Create or continue a plan-file review. If --name is omitted, crit derives it
+from the plan content.`},
+	{name: "story", handler: runStory, helpFn: printStoryUsage, bareHelp: true},
+	{name: "auth", handler: runAuth, help: `Usage: crit auth <login|logout|whoami>
+
+Manage crit-web authentication.
+
+Commands:
+  login     Log in to crit-web
+  logout    Log out and revoke the saved token
+  whoami    Show the current user`, subcommands: []commandDescriptor{
+		{name: "login", help: `Usage: crit auth login [--force]
+
+Log in to crit-web with the device authorization flow.
+
+Options:
+      --force  Reauthenticate even when already logged in`},
+		{name: "logout", help: `Usage: crit auth logout
+
+Revoke the current token and remove saved credentials.`},
+		{name: "whoami", help: `Usage: crit auth whoami
+
+Show the currently authenticated crit-web user.`},
+	}},
+	{name: "stop", handler: runStop, help: `Usage: crit stop [--all] [file...]
+
+Stop the review daemon for the current session. Specify files to target an
+exact file-mode session, or use --all to stop every daemon.`},
+	{name: "status", handler: runStatus, help: `Usage: crit status [--json]
+
+Show the review path, daemon status, and comment counts.`},
+	{name: "stats", handler: runStats, help: `Usage: crit stats [--json]
+
+Show lifetime review statistics.`},
+	{name: "cleanup", handler: runCleanup, help: `Usage: crit cleanup [--days N] [--force]
+
+Delete stale review files. The default age is seven days.`},
+	{name: "plan-hook", handler: runPlanHookCommand, help: `Usage: crit plan-hook [--mode claude|codex]
+
+Run the internal plan hook.`, hidden: true},
+	{name: "_serve", handler: runServe, help: `Usage: crit _serve [options]
+
+Run the internal foreground review server.`, hidden: true},
+}
+
+func dispatchCLI(args []string) (bool, error) {
+	return dispatchWithRegistry(args, commandRegistry)
+}
+
+func dispatchWithRegistry(args []string, registry []commandDescriptor) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	switch args[0] {
+	case "--help", "-h":
+		printHelp()
+		return true, nil
+	case "--version", "-v":
+		printVersion()
+		return true, nil
+	case "help":
+		return true, printRequestedHelp(args[1:], registry)
+	}
+
+	command, ok := findCommand(registry, args[0])
+	if !ok {
+		return false, nil
+	}
+	commandArgs := args[1:]
+	if len(commandArgs) > 0 && (isHelpFlag(commandArgs[0]) || command.bareHelp && commandArgs[0] == "help") {
+		printCommandHelp(command)
+		return true, nil
+	}
+	if len(command.subcommands) > 0 && len(commandArgs) >= 2 {
+		if subcommand, found := findCommand(command.subcommands, commandArgs[0]); found && isHelpFlag(commandArgs[1]) {
+			printCommandHelp(subcommand)
+			return true, nil
+		}
+	}
+	command.handler(commandArgs)
+	return true, nil
+}
+
+func printRequestedHelp(args []string, registry []commandDescriptor) error {
+	if len(args) == 0 {
+		printHelp()
+		return nil
+	}
+	command, ok := findCommand(registry, args[0])
+	if !ok {
+		return fmt.Errorf("unknown help topic %q", strings.Join(args, " "))
+	}
+	if len(args) > 1 {
+		if subcommand, found := findCommand(command.subcommands, args[1]); found {
+			if len(args) > 2 {
+				return fmt.Errorf("unknown help topic %q", strings.Join(args, " "))
+			}
+			printCommandHelp(subcommand)
+			return nil
+		}
+		return fmt.Errorf("unknown help topic %q", strings.Join(args, " "))
+	}
+	printCommandHelp(command)
+	return nil
+}
+
+func findCommand(registry []commandDescriptor, name string) (commandDescriptor, bool) {
+	for _, command := range registry {
+		if command.name == name {
+			return command, true
+		}
+	}
+	return commandDescriptor{}, false
+}
+
+func isHelpFlag(arg string) bool {
+	return arg == "--help" || arg == "-h"
+}
+
+func printCommandHelp(command commandDescriptor) {
+	if command.helpFn != nil {
+		command.helpFn()
+		return
+	}
+	fmt.Fprintln(os.Stderr, command.help)
 }
 
 func printHelp() {
@@ -44,6 +256,9 @@ func printHelp() {
 Getting started:
   crit install <agent>                       Set up crit for your AI coding tool
   crit                                       Review your current changes (auto-detects git)
+
+Commands:
+  %s
 
 Review:
   crit                                       Auto-detect changed files via git
@@ -114,7 +329,17 @@ Configuration:
   Run 'crit config' to see all keys and resolved values.
 
 Learn more: https://crit.md
-`, strings.Join(availableIntegrations(), ", "))
+`, strings.Join(visibleCommandNames(), ", "), strings.Join(availableIntegrations(), ", "))
+}
+
+func visibleCommandNames() []string {
+	var names []string
+	for _, command := range commandRegistry {
+		if !command.hidden {
+			names = append(names, command.name)
+		}
+	}
+	return names
 }
 
 func runPlanHookCommand(args []string) {

--- a/cmd/crit/cli_dispatch_test.go
+++ b/cmd/crit/cli_dispatch_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+var publicCommandNames = []string{
+	"share", "fetch", "unpublish", "install", "config", "check", "pr", "pull",
+	"push", "comment", "comments", "review", "live", "preview", "plan", "story",
+	"auth", "stop", "status", "stats", "cleanup",
+}
+
+func TestCommandRegistry_PublicInventory(t *testing.T) {
+	got := visibleCommandNames()
+	if !slices.Equal(got, publicCommandNames) {
+		t.Fatalf("public commands = %v, want %v", got, publicCommandNames)
+	}
+}
+
+func TestCommandRegistry_Invariants(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, command := range commandRegistry {
+		if seen[command.name] {
+			t.Errorf("duplicate command %q", command.name)
+		}
+		seen[command.name] = true
+		if command.handler == nil {
+			t.Errorf("command %q has no handler", command.name)
+		}
+		if command.help == "" && command.helpFn == nil {
+			t.Errorf("command %q has no help", command.name)
+		}
+		for _, subcommand := range command.subcommands {
+			if subcommand.help == "" && subcommand.helpFn == nil {
+				t.Errorf("subcommand %q %q has no help", command.name, subcommand.name)
+			}
+		}
+	}
+}
+
+func TestCommandHelpFlagsDoNotInvokeHandlers(t *testing.T) {
+	for _, name := range publicCommandNames {
+		for _, flag := range []string{"--help", "-h"} {
+			t.Run(name+"/"+flag, func(t *testing.T) {
+				registry := append([]commandDescriptor(nil), commandRegistry...)
+				invoked := false
+				for i := range registry {
+					if registry[i].name == name {
+						registry[i].handler = func([]string) { invoked = true }
+					}
+				}
+
+				out := captureStderr(t, func() {
+					handled, err := dispatchWithRegistry([]string{name, flag}, registry)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !handled {
+						t.Fatal("command was not dispatched")
+					}
+				})
+				if invoked {
+					t.Fatal("help invoked the command handler")
+				}
+				if !strings.Contains(out, "Usage: crit "+name) {
+					t.Fatalf("command help missing scoped usage:\n%s", out)
+				}
+			})
+		}
+	}
+}
+
+func TestHelpCommand(t *testing.T) {
+	for _, name := range publicCommandNames {
+		t.Run(name, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				handled, err := dispatchWithRegistry([]string{"help", name}, commandRegistry)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !handled {
+					t.Fatal("help command was not dispatched")
+				}
+			})
+			if !strings.Contains(out, "Usage: crit "+name) {
+				t.Fatalf("help output missing command usage:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestNestedAuthHelpDoesNotInvokeHandler(t *testing.T) {
+	for _, subcommand := range []string{"login", "logout", "whoami"} {
+		t.Run("help/"+subcommand, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				if _, err := dispatchWithRegistry([]string{"help", "auth", subcommand}, commandRegistry); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if !strings.Contains(out, "Usage: crit auth "+subcommand) {
+				t.Fatalf("nested help missing usage:\n%s", out)
+			}
+		})
+		for _, flag := range []string{"--help", "-h"} {
+			t.Run(subcommand+"/"+flag, func(t *testing.T) {
+				registry := append([]commandDescriptor(nil), commandRegistry...)
+				invoked := false
+				for i := range registry {
+					if registry[i].name == "auth" {
+						registry[i].handler = func([]string) { invoked = true }
+					}
+				}
+				out := captureStderr(t, func() {
+					if _, err := dispatchWithRegistry([]string{"auth", subcommand, flag}, registry); err != nil {
+						t.Fatal(err)
+					}
+				})
+				if invoked {
+					t.Fatal("nested auth help invoked the auth handler")
+				}
+				if !strings.Contains(out, "Usage: crit auth "+subcommand) {
+					t.Fatalf("nested auth help missing usage:\n%s", out)
+				}
+			})
+		}
+	}
+}
+
+func TestRootHelpAliasesAndHiddenOmission(t *testing.T) {
+	for _, alias := range []string{"help", "--help", "-h"} {
+		t.Run(alias, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				if _, err := dispatchWithRegistry([]string{alias}, commandRegistry); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if !strings.Contains(out, "crit — inline code review") {
+				t.Fatalf("root help missing heading:\n%s", out)
+			}
+			for _, hidden := range []string{"plan-hook", "_serve"} {
+				if strings.Contains(out, hidden) {
+					t.Fatalf("root help unexpectedly lists hidden command %q:\n%s", hidden, out)
+				}
+			}
+		})
+	}
+}
+
+func TestHelpInterceptionOnlyUsesLeadingCommandArgument(t *testing.T) {
+	for _, args := range [][]string{
+		{"comment", "--", "--help"},
+		{"comment", "--output", "--help"},
+		{"story", "--story-file", "--help"},
+	} {
+		t.Run(strings.Join(args, "/"), func(t *testing.T) {
+			registry := append([]commandDescriptor(nil), commandRegistry...)
+			var received []string
+			for i := range registry {
+				if registry[i].name == args[0] {
+					registry[i].handler = func(args []string) {
+						received = append([]string(nil), args...)
+					}
+				}
+			}
+			if _, err := dispatchWithRegistry(args, registry); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(received, args[1:]) {
+				t.Fatalf("handler args = %v, want %v", received, args[1:])
+			}
+		})
+	}
+}
+
+func TestLegacyBareHelpUsesRegistryRenderer(t *testing.T) {
+	for _, name := range []string{"config", "story"} {
+		t.Run(name, func(t *testing.T) {
+			flagHelp := captureStderr(t, func() {
+				if _, err := dispatchWithRegistry([]string{name, "--help"}, commandRegistry); err != nil {
+					t.Fatal(err)
+				}
+			})
+			bareHelp := captureStderr(t, func() {
+				if _, err := dispatchWithRegistry([]string{name, "help"}, commandRegistry); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if bareHelp != flagHelp {
+				t.Fatalf("bare and flag help differ:\n--- bare ---\n%s\n--- flag ---\n%s", bareHelp, flagHelp)
+			}
+		})
+	}
+}
+
+func TestCommandHelpDocumentsKeyOptions(t *testing.T) {
+	tests := map[string][]string{
+		"install": {"--force", "all"},
+		"comment": {"--reply-to", "--resolve", "--json", "--scope"},
+		"plan":    {"[--name <slug>]"},
+		"story":   {"--no-open", "--pr", "--range", "--scope", "--vcs"},
+		"stop":    {"[file...]"},
+	}
+	for name, expected := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				if _, err := dispatchWithRegistry([]string{name, "--help"}, commandRegistry); err != nil {
+					t.Fatal(err)
+				}
+			})
+			for _, want := range expected {
+				if !strings.Contains(out, want) {
+					t.Errorf("help missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestInvalidHelpTopicReturnsError(t *testing.T) {
+	for _, args := range [][]string{
+		{"help", "unknown"},
+		{"help", "auth", "unknown"},
+		{"help", "auth", "login", "extra"},
+	} {
+		t.Run(strings.Join(args, "/"), func(t *testing.T) {
+			handled, err := dispatchWithRegistry(args, commandRegistry)
+			if !handled {
+				t.Fatal("help command was not dispatched")
+			}
+			if err == nil || !strings.Contains(err.Error(), strings.Join(args[1:], " ")) {
+				t.Fatalf("error = %v, want unknown topic containing %q", err, strings.Join(args[1:], " "))
+			}
+		})
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}

--- a/cmd/crit/cli_dispatch_test.go
+++ b/cmd/crit/cli_dispatch_test.go
@@ -246,17 +246,37 @@ func captureStderr(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	os.Stderr = w
+	var out strings.Builder
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&out, r)
+		done <- copyErr
+	}()
+	writerClosed := false
+	copyDone := false
+	defer func() {
+		os.Stderr = old
+		if !writerClosed {
+			_ = w.Close()
+		}
+		if !copyDone {
+			<-done
+		}
+		_ = r.Close()
+	}()
+
 	fn()
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
+	writerClosed = true
 	os.Stderr = old
-	out, err := io.ReadAll(r)
-	if err != nil {
+	if err := <-done; err != nil {
 		t.Fatal(err)
 	}
+	copyDone = true
 	if err := r.Close(); err != nil {
 		t.Fatal(err)
 	}
-	return string(out)
+	return out.String()
 }

--- a/cmd/crit/cli_handlers_story.go
+++ b/cmd/crit/cli_handlers_story.go
@@ -107,6 +107,8 @@ Diff scope options:
       --range <base>..<head> Generate for a commit range
       --base-branch <branch> Override auto-detected base branch
       --output, -o <dir>     Output directory for the review file
+      --scope <mode>         PR diff scope: layer or full-stack
+      --vcs <name>           VCS backend: git, sl, or jj
 
 Default generation uses global agent_cmd from ~/.crit.config.json. The agent
 must be able to read the generated prep file and print raw story JSON.`)
@@ -241,12 +243,7 @@ func clearStory(f storyFlags, critPath string, cj review.CritJSON) error {
 }
 
 func wantsStoryHelp(args []string) bool {
-	for _, arg := range args {
-		if arg == "help" || arg == "--help" || arg == "-h" {
-			return true
-		}
-	}
-	return false
+	return len(args) > 0 && (args[0] == "help" || isHelpFlag(args[0]))
 }
 
 func runStoryNoSpend(f storyFlags, cj review.CritJSON) error {

--- a/cmd/crit/cli_install.go
+++ b/cmd/crit/cli_install.go
@@ -46,7 +46,10 @@ func parseInstallArgs(args []string) (target string, force bool) {
 }
 
 func printInstallUsage() {
-	fmt.Fprintln(os.Stderr, "Usage: crit install <agent|prompts|story-prompts>")
+	fmt.Fprintln(os.Stderr, "Usage: crit install [--force|-f] <agent|all|prompts|story-prompts>")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Options:")
+	fmt.Fprintln(os.Stderr, "  -f, --force  Overwrite existing integration files")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Available agents:")
 	for _, a := range availableIntegrations() {

--- a/cmd/crit/main.go
+++ b/cmd/crit/main.go
@@ -23,8 +23,8 @@ func main() {
 		clicmd.Exit(session.RunReview(nil))
 		return
 	}
-	if handler, ok := commandDispatch[os.Args[1]]; ok {
-		handler(os.Args[2:])
+	if handled, err := dispatchCLI(os.Args[1:]); handled {
+		clicmd.Exit(err)
 		return
 	}
 	args := resolveAtPrefixedArgs(os.Args[1:])


### PR DESCRIPTION
## Summary
- centralize public CLI commands and command-scoped help in one ordered registry
- make `--help` and `-h` return before command handlers can cause side effects
- support `crit help <command>` and nested auth command help while keeping internal commands hidden
- preserve literal and later-position help tokens as command data

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (CLI-only)

## Test plan
- `mise exec -- gofmt -l .`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go test -race -count=1 ./...`
- built-binary smoke across all 21 public commands and `auth login/logout/whoami`
- invalid help-topic exit-code and handler-bypass regression tests

Closes #767