### PR TITLE
fix: honor legacy --output reviews and close browser-open gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ All keys are optional — omit any you don't need.
 | `host`                 | string   | `"127.0.0.1"`              | Listen host. Set to `"0.0.0.0"` to expose the server on your LAN. There is no auth, so any non-loopback bind is an explicit opt-in.                                                     |
 | `no_open`              | bool     | `false`                    | Don't auto-open the browser when starting a review.                                                                                                                                     |
 | `quiet`                | bool     | `false`                    | Suppress terminal status output.                                                                                                                                                        |
-| `output`               | string   | `~/.crit`                  | Crit data root for reviews. Reviews live in `<root>/reviews/<key>/` (same layout as the default).                                                                                         |
+| `output`               | string   | `~/.crit`                  | Crit data root for reviews. Reviews live in `<root>/reviews/<key>/` (same layout as the default). A leftover `<root>/.crit` from when `output` named a single review folder is still used (with a warning) until you move or remove it. |
 | `author`               | string   | VCS user name              | Author name shown on comments. Falls back to your configured VCS user name.                                                                                                            |
 | `base_branch`          | string   | auto-detected              | Base branch to diff against (e.g. `"main"`, `"develop"`). Overrides auto-detection.                                                                                                     |
 | `ignore_patterns`      | string[] | `[".crit/"]` | File patterns to exclude from git-mode file lists. Global and project patterns are merged.                                                                                              |
@@ -368,7 +368,7 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | `--public-url`  |       | `public_url`          | Advertised review URL (listen unchanged) |
 | `--no-open`     |       | `no_open`             | Don't auto-open browser                |
 | `--share-url`   |       | `share_url`           | Share service URL                      |
-| `--output`      | `-o`  | `output`              | Crit data root for reviews (`<root>/reviews/<key>/`) |
+| `--output`      | `-o`  | `output`              | Crit data root for reviews (`<root>/reviews/<key>/`). Honors a leftover `<root>/.crit` from older crit versions until removed. |
 | `--quiet`       | `-q`  | `quiet`               | Suppress status output                 |
 | `--base-branch` |       | `base_branch`         | Base branch to diff against            |
 | `--vcs`         |       | `vcs`                 | VCS backend (`git`, `sl`, or `jj`)     |

--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/tomasz-tomczyk/crit/internal/config"
 )
 
 type commandDescriptor struct {
@@ -25,7 +27,7 @@ var commandRegistry = []commandDescriptor{
 Share files to crit-web and print the review URL.
 
 Options:
-  -o, --output <dir>       Review output directory
+  -o, --output <dir>       Crit data root for reviews
       --share-url <url>    Share service URL
       --org <slug>         Organization slug
       --visibility <level> Review visibility
@@ -39,12 +41,10 @@ Fetch comments from a shared crit-web review.`},
 Remove a shared review from crit-web.
 
 Options:
-  -o, --output <dir>       Review output directory
+  -o, --output <dir>       Crit data root for reviews
       --share-url <url>    Share service URL`},
 	{name: "install", handler: runInstall, helpFn: printInstallUsage},
-	{name: "config", handler: runConfig, bareHelp: true, help: `Usage: crit config [--generate|-g]
-
-Show resolved configuration, or print a starter config with --generate.`},
+	{name: "config", handler: runConfig, bareHelp: true, helpFn: config.PrintConfigHelp},
 	{name: "check", handler: func([]string) { runCheck() }, help: `Usage: crit check
 
 Check installed integrations for missing or stale configuration.`},
@@ -62,7 +62,7 @@ Options:
       --dry-run          Preview without posting
   -e, --event <type>     comment, approve, or request-changes
   -m, --message <text>   Review-level message
-  -o, --output <dir>     Review output directory`},
+  -o, --output <dir>     Crit data root for reviews`},
 	{name: "comment", handler: runComment, help: `Usage: crit comment [options] <body>
        crit comment [options] <path> <body>
        crit comment [options] <path>:<line[-end]> <body>
@@ -73,7 +73,7 @@ Options:
 Add, reply to, bulk import, or clear review comments.
 
 Options:
-  -o, --output <dir>   Review output directory
+  -o, --output <dir>   Crit data root for reviews
       --author <name>  Comment author
       --plan <name>    Target a stored plan review
       --reply-to <id>  Reply to an existing comment
@@ -94,7 +94,7 @@ Options:
       --range <base>..<head>  Review a commit range
       --base-branch <branch>  Override the diff base
       --no-open               Do not open a browser
-  -o, --output <dir>          Review output directory`},
+  -o, --output <dir>          Crit data root for reviews`},
 	{name: "live", handler: runLive, help: `Usage: crit live [options] <url>
 
 Review a running web application in live mode.
@@ -371,69 +371,6 @@ func runPlanHookCommand(args []string) {
 		fmt.Fprintf(os.Stderr, "Unknown plan-hook mode: %s\n", mode)
 		os.Exit(1)
 	}
-}
-
-func printConfigHelp() {
-	fmt.Fprintf(os.Stderr, `crit config — show resolved configuration
-
-Prints the merged configuration from global and project config files as JSON.
-CLI flags and environment variables are not reflected in this output.
-
-Config files:
-  ~/.crit.config.json          Global config (applies to all projects)
-  .crit.config.json            Project config (in repo root)
-
-Precedence (highest to lowest):
-  1. CLI flags / env vars
-  2. Project config
-  3. Global config
-  4. Built-in defaults
-
-Available keys:
-  port              int       Port to listen on (default: random)
-  host              string    Listen host (default: 127.0.0.1; e.g. 0.0.0.0 for LAN)
-  no_open           bool      Don't auto-open browser (default: false)
-  share_url         string    Share service URL (global config only)
-  proxy_auth        bool      Proxy auth mode (config-only, no flag/env). false (default) —
-                              local server contacts crit-web directly. true — browser opens
-                              crit-web in a popup, authenticates there (e.g. via SSO), and
-                              proxies share/pull/unpublish/re-share through a MessagePort.
-                              Use when crit-web is behind an SSO reverse proxy.
-  quiet             bool      Suppress status output (default: false)
-  output            string    Crit data root for reviews (default: ~/.crit; reviews in <root>/reviews/<key>/)
-  author            string    Your name for comments (default: git config user.name)
-  base_branch       string    Base branch to diff against (overrides auto-detection)
-  vcs                    string    Preferred VCS backend: git, sl, or jj (default: auto-detect)
-  ignore_patterns        []string  Gitignore-style patterns to exclude files from review
-  auto_viewed_patterns   []string  Patterns whose files are auto-marked viewed once per launch
-  no_integration_check   bool      Skip integration staleness check (default: false)
-  no_update_check        bool      Disable update check on startup (default: false)
-  cleanup_on_approve     bool      Auto-delete review file when approved (default: true)
-  notify_on_round_ready  bool      Desktop notification when a round is ready (default: false)
-  disable_stats          bool      Disable session stats recording (default: false)
-  open_cmd               string    Custom browser/open command
-  agent_cmd              string    Shell command to send comments to an AI agent (e.g. "claude -p")
-  auth_token             string    Authentication token for crit-web share service
-  plan_approve_mode      string    Claude Code mode after plan approval (default: unset)
-  close_on_approve_after_ms int    Auto-close the review tab N ms after Approve (default: unset/disabled)
-
-Note: agent_cmd, auth_token, host, open_cmd, share_url, plan_approve_mode, and
-close_on_approve_after_ms are global-only (~/.crit.config.json). Project-level
-.crit.config.json cannot override them for security reasons.
-
-Ignore pattern syntax:
-  *.lock            Match files by extension (anywhere in tree)
-  vendor/           Match all files under a directory
-  package-lock.json Match exact filename (anywhere in tree)
-  generated/*.pb.go Match with path prefix (filepath.Match syntax)
-
-Example config:
-  {
-    "port": 3456,
-    "share_url": "https://crit.md",
-    "ignore_patterns": ["*.lock", "*.min.js", "vendor/", "generated/"]
-  }
-`)
 }
 
 func printVersion() {

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -90,10 +90,7 @@ func resolveServeReviewPath(outputDir, planDir, sessionKey string) (string, erro
 	switch {
 	case outputDir != "":
 		// --output / config output is a crit data root (like ~/.crit).
-		if reviewpath.HasLegacyIdentity(outputDir) {
-			fmt.Fprintf(os.Stderr, "crit: warning: %s still has a legacy .crit review from when --output meant a fixed review folder; output is now a data root and reviews live under %s/reviews/<key>/\n", outputDir, outputDir)
-		}
-		return reviewpath.Identity(outputDir, sessionKey)
+		return reviewpath.IdentityUnderDataRoot(outputDir, sessionKey)
 	case planDir != "":
 		abs, err := serveAbsPath(planDir)
 		if err != nil {

--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -117,7 +117,7 @@ func TestResolveServeReviewPath(t *testing.T) {
 		}
 	})
 
-	t.Run("outputDir warns on legacy identity", func(t *testing.T) {
+	t.Run("outputDir keeps a legacy identity and warns", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(dir, ".crit"), 0o755); err != nil {
 			t.Fatal(err)
@@ -127,7 +127,9 @@ func TestResolveServeReviewPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("resolveServeReviewPath: %v", err)
 			}
-			want := filepath.Join(dir, "reviews", "deadbeef1234")
+			// The daemon must land on the same folder the headless commands
+			// resolve to, or `crit comment` would write to a sibling review.
+			want := filepath.Join(dir, ".crit")
 			if got != want {
 				t.Fatalf("got %q, want %q", got, want)
 			}

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -3,51 +3,54 @@ package config
 import (
 	"fmt"
 	"os"
-
-	"github.com/tomasz-tomczyk/crit/internal/clicmd"
-	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 func RunConfig(args []string) error {
 	for _, arg := range args {
-		if arg == "--help" || arg == "-h" || arg == "help" {
-			printConfigHelp()
-			return nil
-		}
 		if arg == "--generate" || arg == "-g" {
 			fmt.Print(DefaultConfigString())
 			return nil
 		}
 	}
-	configDir := ""
-	if vc := vcs.DetectVCS(""); vc != nil {
-		configDir, _ = vc.RepoRoot()
+	cfg, err := LoadCurrentConfig()
+	if err != nil {
+		return err
 	}
-	if configDir == "" {
-		var err error
-		configDir, err = mustGetwd()
-		if err != nil {
-			return err
-		}
-	}
-	cfg := LoadConfig(configDir)
 	fmt.Print(cfg.String())
 	return nil
 }
 
-func printConfigHelp() {
-	fmt.Fprintf(os.Stderr, `crit config — show resolved configuration
+// PrintConfigHelp is the single help text for `crit config`. The command
+// registry wires it as the command's helpFn, so `crit config --help`,
+// `crit config help`, and `crit help config` all reach this one copy.
+func PrintConfigHelp() {
+	fmt.Fprint(os.Stderr, `Usage: crit config [--generate|-g]
 
-Prints the merged configuration from global and project config files as JSON.
-CLI flags and environment variables are not reflected in this output.
+Show the configuration merged from ~/.crit.config.json and the project
+.crit.config.json as JSON, or print a template with every key and its default
+using --generate. CLI flags and environment variables are not reflected in the
+resolved output.
 
-Usage:
-  crit config              Show resolved config
-  crit config --generate   Print a config template with all keys
+Keys worth knowing:
+  output <dir>
+      Crit data root for reviews. Reviews live in <dir>/reviews/<key>/, keyed
+      per working directory and branch, the same layout as the default
+      ~/.crit. A <dir>/.crit folder left over from when output named a single
+      review folder keeps being used, with a warning, until you move it.
 
+  plan_approve_mode <mode>
+      Claude Code permission mode to switch to after a plan-hook approval, for
+      example "acceptEdits". Global-only, so a repository cannot weaken your
+      permission policy. Unset leaves Claude Code's behavior unchanged.
+
+  notify_on_round_ready <bool>
+      Send a desktop notification when a review round is ready for you.
+      Opt-in: defaults to false.
+
+  close_on_approve_after_ms <int>
+      Auto-close the review tab this many milliseconds after an Approve.
+      Global-only. Omit it, or use a negative value, to keep the tab open.
+
+Run 'crit config --generate' for the full key list with default values.
 `)
-}
-
-func mustGetwd() (string, error) {
-	return clicmd.MustGetwd()
 }

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -12,9 +12,38 @@ import (
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
-func TestRunConfig_Help(t *testing.T) {
-	err := RunConfig([]string{"--help"})
+func TestPrintConfigHelp(t *testing.T) {
+	old := os.Stderr
+	r, w, err := os.Pipe()
 	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	PrintConfigHelp()
+	_ = w.Close()
+	os.Stderr = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"crit config",
+		"output <dir>",
+		"plan_approve_mode",
+		"notify_on_round_ready",
+		"close_on_approve_after_ms",
+		"reviews/<key>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PrintConfigHelp missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunConfig_HelpFlagIsNoOp(t *testing.T) {
+	// Help is handled by the command registry helpFn, not RunConfig.
+	if err := RunConfig([]string{"--help"}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -150,7 +150,7 @@ func LooksLikeLiveArgs(args []string) bool {
 	return u.Scheme == "http" || u.Scheme == "https"
 }
 
-func connectToLiveDaemon(key, openCmd string) bool {
+func connectToLiveDaemon(key string, noOpen bool, openCmd string) bool {
 	entry, alive := daemon.FindAliveSession(key)
 	if !alive {
 		return false
@@ -158,7 +158,7 @@ func connectToLiveDaemon(key, openCmd string) bool {
 	fmt.Fprintf(os.Stderr, "[crit] connected to live daemon at %s (proxy :%d)\n",
 		entry.BaseURL(), entry.Port+1)
 	fmt.Fprintf(os.Stderr, "[crit] open %s/live\n", entry.BaseURL())
-	if !daemon.DaemonHasBrowser(entry) {
+	if !noOpen && !daemon.DaemonHasBrowser(entry) {
 		launchLiveBrowser(entry.BaseURL()+"/live", openCmd)
 	}
 	runLiveClient(entry, key)
@@ -252,7 +252,8 @@ func RunLive(args []string) {
 	}
 	cfg := config.LoadConfig(cwd)
 	key := daemon.LiveSessionKey(cwd, f.origin)
-	if connectToLiveDaemon(key, cfg.OpenCmd) {
+	noOpenResolved := f.noOpen || cfg.NoOpen
+	if connectToLiveDaemon(key, noOpenResolved, cfg.OpenCmd) {
 		return
 	}
 
@@ -264,11 +265,10 @@ func RunLive(args []string) {
 
 	checkLiveSmoke(f.origin, liveCookies)
 
-	if connectToLiveDaemon(key, cfg.OpenCmd) {
+	if connectToLiveDaemon(key, noOpenResolved, cfg.OpenCmd) {
 		return
 	}
 
-	noOpenResolved := f.noOpen || cfg.NoOpen
 	entry, err := startLiveDaemon(key, buildLiveDaemonArgs(f.origin, liveCookies, f, cfg, noOpenResolved))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: could not start live daemon: %v\n", err)

--- a/internal/live/live_test.go
+++ b/internal/live/live_test.go
@@ -657,7 +657,7 @@ func TestConnectToLiveDaemon_LaunchesBrowserWhenNoneAttached(t *testing.T) {
 		return false
 	}
 
-	if !connectToLiveDaemon(key, "custom-open") {
+	if !connectToLiveDaemon(key, false, "custom-open") {
 		t.Fatal("connectToLiveDaemon returned false")
 	}
 	if !clientRan {
@@ -671,6 +671,49 @@ func TestConnectToLiveDaemon_LaunchesBrowserWhenNoneAttached(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("browser launch was not dispatched")
+	}
+}
+
+func TestConnectToLiveDaemon_RespectsNoOpen(t *testing.T) {
+	originalRunClient := runLiveClient
+	originalLaunchBrowser := launchLiveBrowser
+	t.Cleanup(func() {
+		runLiveClient = originalRunClient
+		launchLiveBrowser = originalLaunchBrowser
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "browser_clients": false})
+	}))
+	defer srv.Close()
+
+	serverURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	const key = "live-connect-no-open"
+	entry := daemon.SessionEntry{PID: os.Getpid(), Port: port}
+	if err := daemon.WriteSessionFile(key, entry); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	browserOpenCalls := 0
+	launchLiveBrowser = func(string, string) {
+		browserOpenCalls++
+	}
+	runLiveClient = func(daemon.SessionEntry, string) bool { return false }
+
+	if !connectToLiveDaemon(key, true, "custom-open") {
+		t.Fatal("connectToLiveDaemon returned false")
+	}
+	if browserOpenCalls != 0 {
+		t.Fatalf("noOpen reconnect launched the browser %d times", browserOpenCalls)
 	}
 }
 

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -116,10 +116,8 @@ func RunPreview(args []string) {
 
 	installDaemonSignalHandler(entry.PID)
 
-	if !noOpenResolved {
-		go browser.OpenBrowserWithCommand(entry.BaseURL()+"/preview", cfg.OpenCmd)
-	}
-
+	// Daemon owns the initial browser open (same as crit live after #768).
+	// Opening here too doubles the tab on cold start.
 	daemon.RunReviewClient(entry, key)
 }
 

--- a/internal/review/review_file.go
+++ b/internal/review/review_file.go
@@ -90,21 +90,22 @@ func ResolveReviewPathWithArgs(outputDir string, fileArgs []string) (string, err
 }
 
 // identityUnderDataRoot maps --output / config output (a crit data root) to
-// {dataRoot}/reviews/<key>, matching default ~/.crit/reviews/<key> layout.
+// {dataRoot}/reviews/<key>, matching default ~/.crit/reviews/<key> layout. A
+// pre-data-root {dataRoot}/.crit review still wins — see
+// reviewpath.IdentityUnderDataRoot.
 //
 // When a daemon is alive for this cwd, its session key wins — file/live/PR/range
 // reviews key differently from plain git mode, and re-deriving from local
 // context would fork a sibling review under the same data root.
 func identityUnderDataRoot(dataRoot string, fileArgs []string) (string, error) {
-	warnLegacyOutputLayout(dataRoot)
 	cwd, err := daemon.ResolvedCWD()
 	if err != nil {
 		return "", err
 	}
 	if key := sessionKeyFromDaemon(cwd); key != "" {
-		return reviewpath.Identity(dataRoot, key)
+		return reviewpath.IdentityUnderDataRoot(dataRoot, key)
 	}
-	return reviewpath.Identity(dataRoot, sessionKeyForArgs(cwd, fileArgs))
+	return reviewpath.IdentityUnderDataRoot(dataRoot, sessionKeyForArgs(cwd, fileArgs))
 }
 
 // sessionKeyFromDaemon returns the registry key of the best matching live
@@ -134,13 +135,6 @@ func sessionKeyForArgs(cwd string, fileArgs []string) string {
 		branch = vc.CurrentBranch()
 	}
 	return daemon.SessionKey(cwd, branch, nil)
-}
-
-func warnLegacyOutputLayout(dataRoot string) {
-	if !reviewpath.HasLegacyIdentity(dataRoot) {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "crit: warning: %s still has a legacy .crit review from when --output meant a fixed review folder; output is now a data root and reviews live under %s/reviews/<key>/\n", dataRoot, dataRoot)
 }
 
 // ResolveReviewPathFromDaemon checks the daemon registry for a running session

--- a/internal/review/review_file_test.go
+++ b/internal/review/review_file_test.go
@@ -495,16 +495,23 @@ func TestResolveCommandReviewPathPrecedence(t *testing.T) {
 		}
 	})
 
-	t.Run("warns on legacy output layout", func(t *testing.T) {
+	t.Run("keeps using a legacy output layout and warns", func(t *testing.T) {
 		dataRoot := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(dataRoot, ".crit"), 0o755); err != nil {
 			t.Fatal(err)
 		}
+		var got string
 		stderr := captureStderr(t, func() {
-			if _, err := ResolveReviewPathWithArgs(dataRoot, nil); err != nil {
+			var err error
+			got, err = ResolveReviewPathWithArgs(dataRoot, nil)
+			if err != nil {
 				t.Fatalf("ResolveReviewPathWithArgs: %v", err)
 			}
 		})
+		want := filepath.Join(dataRoot, ".crit")
+		if got != want {
+			t.Fatalf("review path = %q, want pre-existing legacy path %q", got, want)
+		}
 		if !strings.Contains(stderr, "legacy .crit review") {
 			t.Fatalf("stderr = %q, want legacy warning", stderr)
 		}

--- a/internal/reviewpath/output.go
+++ b/internal/reviewpath/output.go
@@ -1,6 +1,7 @@
 package reviewpath
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -33,8 +34,29 @@ func Identity(dataRoot, key string) (string, error) {
 	return filepath.Join(dir, key), nil
 }
 
+// IdentityUnderDataRoot resolves a session key under a crit data root,
+// preferring a pre-existing legacy {dataRoot}/.crit review when one is there.
+//
+// Before --output meant a data root it named one fixed review folder, so roots
+// written by older versions already hold review.json, the share URL and the
+// delete token at {dataRoot}/.crit. Keying underneath such a root would strand
+// that review: `crit share` would publish a duplicate and `crit fetch` /
+// `crit unpublish` would report no review file. The legacy folder therefore
+// keeps winning, with a warning, until the user moves or removes it.
+func IdentityUnderDataRoot(dataRoot, key string) (string, error) {
+	if HasLegacyIdentity(dataRoot) {
+		legacy, err := LegacyIdentityPath(dataRoot)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(os.Stderr, "crit: warning: using the legacy .crit review in %s, from when --output named a single review folder; output is now a data root, so move or remove it to get keyed, per-branch reviews under %s\n",
+			dataRoot, filepath.Join(dataRoot, "reviews"))
+		return legacy, nil
+	}
+	return Identity(dataRoot, key)
+}
+
 // LegacyIdentityPath is the pre-data-root layout: {dataRoot}/.crit.
-// Used only to detect leftover reviews after the semantics change.
 func LegacyIdentityPath(dataRoot string) (string, error) {
 	abs, err := absPath(dataRoot)
 	if err != nil {
@@ -43,8 +65,8 @@ func LegacyIdentityPath(dataRoot string) (string, error) {
 	return filepath.Join(abs, ".crit"), nil
 }
 
-// HasLegacyIdentity reports whether dataRoot still contains the old
-// fixed-identity folder or flat file from before output meant "data root".
+// HasLegacyIdentity reports whether dataRoot contains the old fixed-identity
+// folder or flat file from before output meant "data root".
 func HasLegacyIdentity(dataRoot string) bool {
 	legacy, err := LegacyIdentityPath(dataRoot)
 	if err != nil {

--- a/internal/reviewpath/output_test.go
+++ b/internal/reviewpath/output_test.go
@@ -67,6 +67,50 @@ func TestLegacyIdentityPath(t *testing.T) {
 	}
 }
 
+func TestIdentityUnderDataRoot(t *testing.T) {
+	t.Run("keys under reviews when the root is clean", func(t *testing.T) {
+		root := t.TempDir()
+		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, "reviews", "deadbeef1234")
+		if got != want {
+			t.Fatalf("IdentityUnderDataRoot = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("honors a legacy .crit folder", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".crit"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, ".crit")
+		if got != want {
+			t.Fatalf("IdentityUnderDataRoot = %q, want legacy path %q", got, want)
+		}
+	})
+
+	t.Run("honors a legacy .crit.json flat file", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, ".crit.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, ".crit")
+		if got != want {
+			t.Fatalf("IdentityUnderDataRoot = %q, want legacy path %q", got, want)
+		}
+	})
+}
+
 func TestReviewsDirAbsError(t *testing.T) {
 	orig := absPath
 	t.Cleanup(func() { absPath = orig })

--- a/internal/session/status_cli.go
+++ b/internal/session/status_cli.go
@@ -81,7 +81,7 @@ func resolveStatusReviewPath(cwd, branch string, matchedSession *daemon.SessionE
 		return "", err
 	}
 	if cfg.Output != "" {
-		return reviewpath.Identity(cfg.Output, daemon.SessionKey(cwd, branch, nil))
+		return reviewpath.IdentityUnderDataRoot(cfg.Output, daemon.SessionKey(cwd, branch, nil))
 	}
 	key := daemon.SessionKey(cwd, branch, nil)
 	return daemon.ReviewFilePath(key)

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -337,7 +337,13 @@ func reviewRoundFromAPI(t *testing.T, baseURL, token string) int {
 }
 
 // writeTestCritJSON writes a CritJSON to .crit/review.json in dir.
-// NOTE: readCritJSON is defined in github_test.go and shared across test files.
+//
+// `--output <dir>` names a crit data root, so a fresh root would key the review
+// as <dir>/reviews/<key>/. Seeding <dir>/.crit puts the tests on the
+// pre-data-root layout that crit still honors for existing users, which is what
+// keeps every helper below (and readCritJSON) pointed at one review folder.
+// NOTE: readCritJSON is defined in integration_export_test.go and shared across
+// test files.
 func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 	t.Helper()
 	d, err := json.MarshalIndent(cj, "", "  ")
@@ -354,7 +360,8 @@ func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 }
 
 // critShareCmd runs `crit share` and returns stdout. Fails the test on error.
-// Uses --output to point at the temp dir so crit reads/writes .crit.json there.
+// Uses --output to point at the temp dir seeded by writeTestCritJSON, so crit
+// reads/writes .crit/review.json there.
 func critShareCmd(t *testing.T, binary, baseURL, dir string, files ...string) string {
 	t.Helper()
 	args := append([]string{"share", "--share-url", baseURL, "--output", dir}, files...)
@@ -2103,14 +2110,14 @@ func TestShareReceiver_LegacyShareStillWorks(t *testing.T) {
 		t.Errorf("expected output to contain stub review URL, got: %s", out)
 	}
 
-	// .crit.json should now record the share URL + delete token.
-	data, err := os.ReadFile(filepath.Join(dir, ".crit.json"))
+	// The review file should now record the share URL + delete token.
+	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
 	if err != nil {
-		t.Fatalf("read .crit.json: %v", err)
+		t.Fatalf("read .crit/review.json: %v", err)
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
-		t.Fatalf("decode .crit.json: %v", err)
+		t.Fatalf("decode .crit/review.json: %v", err)
 	}
 	if cj.ShareURL != "https://crit.stub/r/stubtoken" {
 		t.Errorf("share_url = %q, want https://crit.stub/r/stubtoken", cj.ShareURL)


### PR DESCRIPTION
## Summary
- Prefer an existing `{root}/.crit` when `--output` is a data root so share/fetch/unpublish keep working for pre-#771 layouts (with a warning).
- Wire `crit config --help` to a single help text for the new config keys / output semantics.
- Honor `--no-open` when reconnecting to a live daemon; stop preview from opening a second cold-start tab.

## Review
- [x] Code review: passed (independent post-fix)
- [x] Parity audit: N/A

## Test plan
- [x] `go test ./...`, golangci-lint
- [x] `make e2e-share` (all TestShareSync* green)
- [x] focused live/preview/config tests


Made with [Cursor](https://cursor.com)