### PR TITLE
fix: clear auto-close on dismiss and drop inert notifications

### DIFF
--- a/web/__tests__/auto-close-dismiss-wiring.test.js
+++ b/web/__tests__/auto-close-dismiss-wiring.test.js
@@ -1,0 +1,30 @@
+'use strict';
+// Regression: dismissing the waiting overlay ("Back to editing", backdrop)
+// must call clearAutoCloseTimers — otherwise the Approve countdown keeps
+// running and closes the tab while the reviewer is editing again.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+const liveJs = fs.readFileSync(path.join(__dirname, '..', 'live-mode.js'), 'utf8');
+
+test('setUIState("reviewing") clears any auto-close countdown', () => {
+  const start = appJs.indexOf('function setUIState(state)');
+  assert.ok(start >= 0, 'app.js setUIState must exist');
+  assert.match(
+    appJs.slice(start, start + 600),
+    /state === 'reviewing'[\s\S]*?clearAutoCloseTimers\(\)/,
+    'app.js: dismissing the waiting overlay must stop the countdown'
+  );
+
+  const liveStart = liveJs.indexOf('function setUIState(s)');
+  assert.ok(liveStart >= 0, 'live-mode.js setUIState must exist');
+  assert.match(
+    liveJs.slice(liveStart, liveStart + 600),
+    /s === 'reviewing'[\s\S]*?clearAutoCloseTimers\(\)/,
+    'live-mode.js: dismissing the waiting overlay must stop the countdown'
+  );
+});

--- a/web/__tests__/crit-shared.test.js
+++ b/web/__tests__/crit-shared.test.js
@@ -523,6 +523,7 @@ test('runFinishReview onError catches and returns null', async () => {
 // later document.getElementById lookup) plus fake setTimeout/clearTimeout so
 // the countdown can be driven deterministically without real delays.
 function makeAutoCloseSandbox(fetchImpl) {
+  const focusLog = [];
   function makeNode(tag) {
     return {
       tagName: (tag || 'div').toUpperCase(),
@@ -544,6 +545,8 @@ function makeAutoCloseSandbox(fetchImpl) {
       },
       setAttribute(k, v) { this._attrs[k] = v; },
       getAttribute(k) { return Object.prototype.hasOwnProperty.call(this._attrs, k) ? this._attrs[k] : null; },
+      removeAttribute(k) { delete this._attrs[k]; },
+      focus() { focusLog.push(this); },
       querySelector() { return null; },
       querySelectorAll() { return []; },
       appendChild(child) {
@@ -592,12 +595,14 @@ function makeAutoCloseSandbox(fetchImpl) {
 
   const promptEl = makeNode('div'); promptEl.id = 'waitingPrompt';
   const previewEl = makeNode('span'); previewEl.id = 'promptPreview';
+  const copyStatusEl = makeNode('div'); copyStatusEl.id = 'copyStatus';
 
   const root = makeNode('body');
   root.appendChild(dialog);
   root.appendChild(promptEl);
   root.appendChild(previewEl);
   root.appendChild(clipEl);
+  root.appendChild(copyStatusEl);
 
   const doc = {
     cookie: '',
@@ -639,7 +644,14 @@ function makeAutoCloseSandbox(fetchImpl) {
   fn(win, doc, fakeSetTimeout, fakeClearTimeout);
   globalThis.fetch = fetchImpl;
   globalThis.navigator = win.navigator;
-  return { shared: win.crit.shared, win, doc, els: { messageEl, headingEl, dialog, promptEl, previewEl, clipEl }, flush };
+  return {
+    shared: win.crit.shared,
+    win,
+    doc,
+    els: { messageEl, headingEl, dialog, promptEl, previewEl, clipEl, copyStatusEl },
+    focusLog,
+    flush,
+  };
 }
 
 test('scheduleAutoClose: counts down then calls window.close() after the configured delay', () => {
@@ -694,11 +706,16 @@ test('scheduleAutoClose: reuses the same Cancel button across approvals instead 
 });
 
 test('scheduleAutoClose: after window.close(), shows "you can close this tab" if the tab is still open', () => {
-  const { shared: s, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  const { shared: s, els, doc, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
   s.scheduleAutoClose(1000, els.messageEl);
   flush(1000); // triggers window.close() (a no-op in this stub — tab "stays open")
   flush(50);   // the post-close fallback message tick
   assert.equal(els.messageEl.textContent, 'Approved — you can close this tab');
+  // The spent countdown must not leave an idle timer or a dead Cancel behind,
+  // and role="timer" is aria-live "off" so the new text needs a real announce.
+  assert.equal(els.messageEl.getAttribute('role'), null);
+  assert.equal(doc.getElementById('waitingCloseCancel').style.display, 'none');
+  assert.equal(els.copyStatusEl.textContent, 'Approved — you can close this tab.');
 });
 
 test('scheduleAutoClose: after window.close(), skips fallback message when the tab actually closed', () => {
@@ -709,6 +726,16 @@ test('scheduleAutoClose: after window.close(), skips fallback message when the t
   flush(50);
   assert.equal(win.closeCalls, 1);
   assert.notEqual(els.messageEl.textContent, 'Approved — you can close this tab');
+  assert.notEqual(els.copyStatusEl.textContent, 'Approved — you can close this tab.');
+});
+
+test('scheduleAutoClose: announcement says "1 second", not "1 seconds"', () => {
+  const { shared: s, els } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(1000, els.messageEl);
+  assert.equal(
+    els.copyStatusEl.textContent,
+    'Approved. This tab closes in 1 second. Press Cancel to stay.',
+  );
 });
 
 test('runFinishReview: approved + close_on_approve_after_ms set schedules the countdown and eventual close', async () => {
@@ -754,6 +781,113 @@ test('runFinishReview: not-approved path never schedules an auto-close, regardle
   await s.runFinishReview({ onWaiting: () => {} });
   flush(60000);
   assert.equal(win.closeCalls, 0, '/api/config is never even consulted on the not-approved path');
+});
+
+// ----- clearAutoCloseTimers (dismissing the waiting overlay) -----
+// Regression: "Back to editing" / backdrop click only removed .active from the
+// overlay, so a running countdown kept ticking behind the dismissed dialog and
+// eventually called window.close() out from under the reviewer.
+
+test('clearAutoCloseTimers: stops a running countdown so window.close() never fires', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 2s…');
+
+  s.clearAutoCloseTimers();
+
+  flush(60000);
+  assert.equal(win.closeCalls, 0, 'no close after the countdown was cleared');
+});
+
+test('clearAutoCloseTimers: hides the Cancel button and drops role="timer"', () => {
+  const { shared: s, els, doc } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  assert.equal(els.messageEl.getAttribute('role'), 'timer');
+  const cancelBtn = doc.getElementById('waitingCloseCancel');
+  assert.equal(cancelBtn.style.display, '');
+
+  s.clearAutoCloseTimers();
+
+  assert.equal(cancelBtn.style.display, 'none');
+  assert.equal(els.messageEl.getAttribute('role'), null);
+});
+
+test('clearAutoCloseTimers: is an idempotent no-op when no countdown is running', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.clearAutoCloseTimers();
+  s.clearAutoCloseTimers();
+  assert.equal(els.messageEl.getAttribute('role'), null);
+  flush(60000);
+  assert.equal(win.closeCalls, 0);
+});
+
+test('clearAutoCloseTimers: a cleared countdown does not resume when a later one is scheduled', () => {
+  const { shared: s, win, els, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  s.clearAutoCloseTimers();
+  s.scheduleAutoClose(2000, els.messageEl);
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 1s…');
+  flush(1000);
+  assert.equal(win.closeCalls, 1, 'only the newest countdown closes the tab, and only once');
+  flush(60000);
+  assert.equal(win.closeCalls, 1);
+});
+
+test('runFinishReview: a not-approved finish clears a countdown left over from a prior approval', async () => {
+  let approved = true;
+  const fetch = async (url) => {
+    if (url === '/api/finish') return { ok: true, json: async () => ({ approved, prompt: 'p' }) };
+    if (url === '/api/config') return { ok: true, json: async () => ({ close_on_approve_after_ms: 3000 }) };
+    throw new Error('unexpected fetch ' + url);
+  };
+  const { shared: s, win, els, doc, flush } = makeAutoCloseSandbox(fetch);
+  await s.runFinishReview({});
+  assert.equal(els.messageEl.textContent, 'Closing in 3s…');
+
+  approved = false;
+  await s.runFinishReview({ onWaiting: () => {} });
+  assert.match(els.messageEl.textContent, /^Agent notified\./);
+  assert.equal(els.messageEl.getAttribute('role'), null);
+  assert.equal(doc.getElementById('waitingCloseCancel').style.display, 'none');
+
+  flush(60000);
+  assert.equal(win.closeCalls, 0, 'the inherited countdown never closes the tab');
+});
+
+// ----- auto-close accessibility -----
+
+test('scheduleAutoClose: focuses Cancel and announces the countdown once, not per tick', () => {
+  const { shared: s, els, doc, focusLog, flush } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+
+  assert.equal(focusLog[focusLog.length - 1], doc.getElementById('waitingCloseCancel'));
+  assert.equal(
+    els.copyStatusEl.textContent,
+    'Approved. This tab closes in 3 seconds. Press Cancel to stay.',
+  );
+
+  // The per-second text lives on a role="timer" element (implicit aria-live
+  // "off") and the live region is left untouched by subsequent ticks.
+  assert.equal(els.messageEl.getAttribute('role'), 'timer');
+  assert.equal(els.messageEl.getAttribute('aria-live'), null);
+  flush(1000);
+  assert.equal(els.messageEl.textContent, 'Closing in 2s…');
+  assert.equal(
+    els.copyStatusEl.textContent,
+    'Approved. This tab closes in 3 seconds. Press Cancel to stay.',
+  );
+});
+
+test('scheduleAutoClose: Cancel announces and moves focus off the button it hides', () => {
+  const { shared: s, els, doc, focusLog } = makeAutoCloseSandbox(async () => ({ ok: true, json: async () => ({}) }));
+  s.scheduleAutoClose(3000, els.messageEl);
+  doc.getElementById('waitingCloseCancel').onclick();
+
+  assert.equal(focusLog[focusLog.length - 1], els.clipEl, 'focus lands on the Copy prompt button');
+  assert.equal(els.copyStatusEl.textContent, 'Auto-close cancelled. This tab will stay open.');
+  assert.equal(els.messageEl.getAttribute('role'), null);
 });
 
 // ----- waitForSession -----

--- a/web/__tests__/crit-tab-ready.test.js
+++ b/web/__tests__/crit-tab-ready.test.js
@@ -12,47 +12,66 @@ function fakeDocument(visibility) {
 
 test('notifyRoundReady badges when tab is hidden', () => {
   const doc = fakeDocument('hidden');
-  const ready = create({ document: doc, Notification: null, baseTitle: 'Crit Review' });
-  const result = ready.notifyRoundReady({ body: 'Round 2 is ready' });
+  const ready = create({ document: doc, baseTitle: 'Crit Review' });
+  const result = ready.notifyRoundReady();
   assert.equal(result.badged, true);
-  assert.equal(result.notified, false);
   assert.equal(ready.isBadgeActive(), true);
   assert.ok(doc.title.startsWith(ready.BADGE_PREFIX));
 });
 
 test('notifyRoundReady is a no-op when tab is visible', () => {
   const doc = fakeDocument('visible');
-  const ready = create({ document: doc, Notification: null, baseTitle: 'Crit Review' });
+  const ready = create({ document: doc, baseTitle: 'Crit Review' });
   const result = ready.notifyRoundReady();
   assert.equal(result.badged, false);
   assert.equal(ready.isBadgeActive(), false);
   assert.equal(doc.title, 'Crit Review');
 });
 
-test('notifyRoundReady fires Notification when permission granted', () => {
-  const constructed = [];
-  function FakeNotification(title, opts) {
-    constructed.push({ title, opts });
-    this.title = title;
-    this.opts = opts;
-  }
-  FakeNotification.permission = 'granted';
+test('notifyRoundReady with force badges even when the tab is visible', () => {
+  const doc = fakeDocument('visible');
+  const ready = create({ document: doc, baseTitle: 'Crit Review' });
+  const result = ready.notifyRoundReady({ force: true });
+  assert.equal(result.badged, true);
+  assert.equal(ready.isBadgeActive(), true);
+});
 
-  const doc = fakeDocument('hidden');
-  const ready = create({ document: doc, Notification: FakeNotification, baseTitle: 'Crit Review' });
-  const result = ready.notifyRoundReady({ title: 'Crit', body: 'Round 3 is ready for review' });
-  assert.equal(result.notified, true);
-  assert.equal(constructed.length, 1);
-  assert.equal(constructed[0].title, 'Crit');
-  assert.equal(constructed[0].opts.body, 'Round 3 is ready for review');
-  assert.equal(constructed[0].opts.tag, 'crit-round-ready');
+// The browser Notification path was removed on purpose: crit serves on an
+// ephemeral localhost port, so a permission grant never survives to the next
+// run. Desktop notifications are server-side (notify_on_round_ready).
+test('no browser Notification is constructed, even when one is granted globally', () => {
+  const constructed = [];
+  function FakeNotification(title, opts) { constructed.push({ title, opts }); }
+  FakeNotification.permission = 'granted';
+  const prior = globalThis.Notification;
+  globalThis.Notification = FakeNotification;
+  try {
+    const ready = create({ document: fakeDocument('hidden'), baseTitle: 'Crit Review' });
+    ready.notifyRoundReady();
+    assert.equal(constructed.length, 0);
+    assert.equal(ready.requestPermission, undefined);
+    assert.equal(ready.lastNotification, undefined);
+  } finally {
+    if (prior === undefined) delete globalThis.Notification;
+    else globalThis.Notification = prior;
+  }
 });
 
 test('clearTabBadge restores title', () => {
   const doc = fakeDocument('hidden');
-  const ready = create({ document: doc, Notification: null, baseTitle: 'Crit Review' });
+  const ready = create({ document: doc, baseTitle: 'Crit Review' });
   ready.notifyRoundReady();
   ready.clearTabBadge();
   assert.equal(ready.isBadgeActive(), false);
   assert.equal(doc.title, 'Crit Review');
+});
+
+test('setDocumentTitle keeps the badge prefix while the badge is active', () => {
+  const doc = fakeDocument('hidden');
+  const ready = create({ document: doc, baseTitle: 'Crit Review' });
+  ready.notifyRoundReady();
+  ready.setDocumentTitle('Crit Review — app.js');
+  assert.equal(doc.title, ready.BADGE_PREFIX + 'Crit Review — app.js');
+  ready.clearTabBadge();
+  assert.equal(doc.title, 'Crit Review — app.js');
 });

--- a/web/app.js
+++ b/web/app.js
@@ -180,8 +180,8 @@
   }
 
   // ===== Tab-Ready Indicator =====
-  // Prepends a bullet to document.title (and optionally a browser Notification)
-  // when a review round completes while the tab is hidden.
+  // Prepends a bullet to document.title when a review round completes while
+  // the tab is hidden. Desktop notifications are server-side (notify_on_round_ready).
   const tabReady = (window.crit && window.crit.createTabReady)
     ? window.crit.createTabReady()
     : null;
@@ -191,14 +191,7 @@
   const noop = function() { /* tabReady unavailable */ };
   const setTabBadge = tabReady ? tabReady.setTabBadge : noop;
   const clearTabBadge = tabReady ? tabReady.clearTabBadge : noop;
-  const notifyRoundReady = tabReady
-    ? function() {
-        tabReady.notifyRoundReady({
-          title: 'Crit',
-          body: 'A review round is ready',
-        });
-      }
-    : setTabBadge;
+  const notifyRoundReady = tabReady ? tabReady.notifyRoundReady : setTabBadge;
 
   document.addEventListener('visibilitychange', function() {
     if (document.visibilityState === 'visible') clearTabBadge();
@@ -6818,7 +6811,14 @@
 
   function setUIState(state) {
     uiState = state;
-    if (state === 'reviewing') { waitingNotApproved = false; stopTipRotation(); }
+    if (state === 'reviewing') {
+      waitingNotApproved = false;
+      stopTipRotation();
+      // Leaving the waiting dialog ("Back to editing", backdrop click, a new
+      // round arriving) must kill any auto-close countdown — otherwise it
+      // keeps ticking behind the dismissed overlay and closes the tab.
+      window.crit.shared.clearAutoCloseTimers();
+    }
     const finishBtn = document.getElementById('finishBtn');
     const waitingOverlay = document.getElementById('waitingOverlay');
 
@@ -7064,8 +7064,8 @@
         // current chapter still exists (storyFromHash re-reads the hash).
         applyStoryPresence();
         setUIState('reviewing');
-        // Signal "ready" in the tab bar (and browser Notification if granted)
-        // if the user has tabbed away. Cleared on visibilitychange → visible.
+        // Signal "ready" in the tab bar if the user has tabbed away.
+        // Cleared on visibilitychange → visible.
         if (document.visibilityState !== 'visible') notifyRoundReady();
       } catch (err) {
         console.error('Error handling file-changed:', err);

--- a/web/crit-shared.js
+++ b/web/crit-shared.js
@@ -276,12 +276,37 @@
   // via chained setTimeout so tests can drive it with a fake clock (only
   // setTimeout/clearTimeout are needed, matching the showToast sandbox).
   var CLOSE_COUNTDOWN_TICK_MS = 1000;
-  var _autoCloseTimers = null; // array of pending timer ids, or null when idle
+  // In-flight countdown: { cancelled, timers, messageEl, cancelBtn }, or null
+  // when idle. Held at module scope so clearAutoCloseTimers can abort a
+  // countdown started by an earlier call.
+  var _autoCloseRun = null;
 
+  // Announce on the shared polite live region. The per-second countdown text
+  // deliberately does NOT live here — repeating it every tick would flood a
+  // screen reader; callers announce once when state changes.
+  function announceAutoClose(text) {
+    var el = document.getElementById('copyStatus');
+    if (!el) return;
+    el.textContent = '';
+    el.textContent = text;
+  }
+
+  // Aborts any in-flight auto-close countdown and undoes its UI: clears the
+  // pending ticks, marks the run cancelled so already-scheduled callbacks bail
+  // out, hides the Cancel button and drops the timer role from the message
+  // line. Callers must invoke this whenever the reviewer leaves the waiting
+  // dialog ("Back to editing", overlay backdrop) — otherwise the countdown
+  // keeps running behind the dismissed overlay and closes the tab.
   function clearAutoCloseTimers() {
-    if (!_autoCloseTimers) return;
-    _autoCloseTimers.forEach(function (id) { clearTimeout(id); });
-    _autoCloseTimers = null;
+    var run = _autoCloseRun;
+    _autoCloseRun = null;
+    if (!run) return;
+    run.cancelled = true;
+    run.timers.forEach(function (id) { clearTimeout(id); });
+    if (run.cancelBtn) run.cancelBtn.style.display = 'none';
+    if (run.messageEl && typeof run.messageEl.removeAttribute === 'function') {
+      run.messageEl.removeAttribute('role');
+    }
   }
 
   // Creates (once) or reuses the Cancel button, inserted right after
@@ -307,11 +332,10 @@
     clearAutoCloseTimers();
     if (typeof ms !== 'number' || !isFinite(ms) || ms < 0) return;
 
-    var cancelled = false;
     var remaining = ms;
-    var timers = [];
-    _autoCloseTimers = timers;
     var cancelBtn = ensureCloseCancelBtn(messageEl);
+    var run = { cancelled: false, timers: [], messageEl: messageEl, cancelBtn: cancelBtn };
+    _autoCloseRun = run;
 
     function showCountdown() {
       if (!messageEl) return;
@@ -320,33 +344,55 @@
     }
 
     function onCancel() {
-      if (cancelled) return;
-      cancelled = true;
+      if (run.cancelled) return;
       clearAutoCloseTimers();
-      if (cancelBtn) cancelBtn.style.display = 'none';
       if (messageEl) { messageEl.style.display = 'none'; messageEl.textContent = ''; }
+      // The Cancel button was focused and is now hidden — hand focus to the
+      // Copy-prompt button so keyboard/AT users don't get dropped on <body>.
+      var clip = document.getElementById('waitingClipboard');
+      if (clip && typeof clip.focus === 'function') clip.focus();
+      announceAutoClose('Auto-close cancelled. This tab will stay open.');
     }
 
     if (cancelBtn) {
       cancelBtn.style.display = '';
       cancelBtn.onclick = onCancel;
     }
+    // role="timer" has an implicit aria-live of "off", so the per-second text
+    // updates stay silent while still being exposed as a timer to AT.
+    if (messageEl && typeof messageEl.setAttribute === 'function') {
+      messageEl.setAttribute('role', 'timer');
+    }
+    // Move focus to Cancel so the escape hatch is reachable without hunting,
+    // and announce the countdown once (never per tick).
+    if (cancelBtn && typeof cancelBtn.focus === 'function') cancelBtn.focus();
+    var totalSecs = Math.ceil(ms / 1000);
+    announceAutoClose(
+      'Approved. This tab closes in ' + totalSecs +
+      (totalSecs === 1 ? ' second' : ' seconds') + '. Press Cancel to stay.',
+    );
 
     function tick() {
-      if (cancelled) return;
+      if (run.cancelled) return;
       if (remaining <= 0) {
         try { window.close(); } catch (_) {}
         // If the tab is still open (window.close() is a no-op on tabs the
         // browser didn't open via script), tell the user how to proceed.
         var closedCheckId = setTimeout(function () {
-          if (cancelled || window.closed) return;
+          if (run.cancelled || window.closed) return;
+          // The countdown is spent, so tear it down: drop role="timer" (an
+          // idle timer AT can still read) and hide Cancel, which no longer
+          // cancels anything.
+          clearAutoCloseTimers();
           if (messageEl) {
             messageEl.style.display = '';
             messageEl.textContent = 'Approved — you can close this tab';
           }
-          if (cancelBtn) cancelBtn.style.display = 'none';
+          // role="timer" is aria-live "off", so the new text is silent on its
+          // own; announce the terminal state on the polite region instead.
+          announceAutoClose('Approved — you can close this tab.');
         }, 50);
-        timers.push(closedCheckId);
+        run.timers.push(closedCheckId);
         return;
       }
       showCountdown();
@@ -354,7 +400,7 @@
         remaining -= CLOSE_COUNTDOWN_TICK_MS;
         tick();
       }, Math.min(CLOSE_COUNTDOWN_TICK_MS, remaining));
-      timers.push(nextId);
+      run.timers.push(nextId);
     }
 
     tick();
@@ -422,6 +468,10 @@
         }
       }
       if (headingEl) headingEl.textContent = approved ? 'Approved' : 'Review Complete';
+      // A countdown from a previous approval must not survive into this
+      // finish: on the non-approved path nothing else would stop it, and the
+      // message line we're about to rewrite is the countdown's own output.
+      clearAutoCloseTimers();
       if (messageEl) {
         if (approved) {
           messageEl.style.display = 'none';
@@ -459,12 +509,12 @@
 
       try { await navigator.clipboard.writeText(prompt); } catch (_) {}
 
+      var closeMs;
       if (approved) {
         // close_on_approve_after_ms is global-only and off by default; read
         // it fresh from /api/config rather than requiring every caller to
         // thread a cached copy through. Best-effort — a config fetch failure
         // just means no auto-close, never blocks the approval itself.
-        var closeMs;
         try {
           var cfgResp = await fetch('/api/config');
           if (cfgResp && cfgResp.ok) {
@@ -472,11 +522,15 @@
             closeMs = cfgData && cfgData.close_on_approve_after_ms;
           }
         } catch (_) { /* best effort */ }
-        scheduleAutoClose(closeMs, messageEl);
       }
 
       if (approved && typeof o.onApproved === 'function') o.onApproved(prompt);
       else if (!approved && typeof o.onWaiting === 'function') o.onWaiting();
+
+      // Must run after onApproved: the waiting overlay is display:none until
+      // the caller flips uiState to 'waiting', and focus() on a hidden Cancel
+      // button is a silent no-op.
+      if (approved) scheduleAutoClose(closeMs, messageEl);
 
       return { approved: approved, prompt: prompt };
     } catch (err) {
@@ -1014,6 +1068,7 @@
     showToast,
     runFinishReview,
     scheduleAutoClose,
+    clearAutoCloseTimers,
     waitForSession,
     installSidebarResize,
     computeResizeDelta,

--- a/web/crit-tab-ready.js
+++ b/web/crit-tab-ready.js
@@ -1,5 +1,11 @@
-// crit-tab-ready.js — tab title badge + browser Notification when a review
-// round becomes ready while the page is hidden.
+// crit-tab-ready.js — tab title badge when a review round becomes ready
+// while the page is hidden.
+//
+// Deliberately no browser Notification API: crit serves on an ephemeral
+// localhost port, so a permission grant never carries over to the next run
+// and Notification.permission is effectively always 'default'. Desktop
+// notifications are the server's job instead, gated by the
+// `notify_on_round_ready` config key (see internal/notify).
 //
 // Browser: attach via window.crit.createTabReady / window.crit.tabReady.
 // Node path: module.exports for unit tests.
@@ -8,14 +14,9 @@
 function createTabReady(deps) {
   deps = deps || {};
   var documentRef = deps.document || (typeof document !== 'undefined' ? document : null);
-  var NotificationCtor = deps.Notification;
-  if (NotificationCtor === undefined && typeof Notification !== 'undefined') {
-    NotificationCtor = Notification;
-  }
   var BADGE_PREFIX = '\u25CF ';
   var baseTitle = deps.baseTitle || (documentRef && documentRef.title) || '';
   var badgeActive = false;
-  var lastNotification = null;
 
   function setDocumentTitle(nextBase) {
     baseTitle = nextBase;
@@ -44,33 +45,9 @@ function createTabReady(deps) {
 
   function notifyRoundReady(opts) {
     opts = opts || {};
-    if (visibilityState() !== 'hidden' && !opts.force) return { badged: false, notified: false };
-
+    if (visibilityState() !== 'hidden' && !opts.force) return { badged: false };
     setTabBadge();
-
-    var notified = false;
-    if (NotificationCtor && NotificationCtor.permission === 'granted') {
-      try {
-        var title = opts.title || 'Crit';
-        var body = opts.body || 'A review round is ready';
-        lastNotification = new NotificationCtor(title, {
-          body: body,
-          tag: opts.tag || 'crit-round-ready',
-        });
-        notified = true;
-      } catch (_) {
-        notified = false;
-      }
-    }
-
-    return { badged: true, notified: notified };
-  }
-
-  function requestPermission() {
-    if (!NotificationCtor || typeof NotificationCtor.requestPermission !== 'function') {
-      return Promise.resolve('denied');
-    }
-    return Promise.resolve(NotificationCtor.requestPermission());
+    return { badged: true };
   }
 
   return {
@@ -78,9 +55,7 @@ function createTabReady(deps) {
     setTabBadge: setTabBadge,
     clearTabBadge: clearTabBadge,
     notifyRoundReady: notifyRoundReady,
-    requestPermission: requestPermission,
     isBadgeActive: function () { return badgeActive; },
-    lastNotification: function () { return lastNotification; },
     BADGE_PREFIX: BADGE_PREFIX,
   };
 }

--- a/web/index.html
+++ b/web/index.html
@@ -455,7 +455,7 @@
       var shr = document.createElement('script'); shr.src = 'crit-share.js'; shr.async = false; document.body.appendChild(shr);
       // Glob matcher for auto-viewed-patterns (window.crit.globMatch). Must load before app.js.
       var gm = document.createElement('script'); gm.src = 'crit-glob-match.js'; gm.async = false; document.body.appendChild(gm);
-      // Tab badge + browser Notification when a round becomes ready while hidden.
+      // Tab title badge when a round becomes ready while the tab is hidden.
       var tr = document.createElement('script'); tr.src = 'crit-tab-ready.js'; tr.async = false; document.body.appendChild(tr);
       var a = document.createElement('script'); a.src = 'app.js'; a.async = false; document.body.appendChild(a);
     }

--- a/web/live-mode.js
+++ b/web/live-mode.js
@@ -56,8 +56,8 @@
   var inflightAPI = (window.crit && window.crit.live && window.crit.live.inflight) || null;
 
   // ===== Tab-Ready Indicator =====
-  // Same pattern as app.js: ● in the title + browser Notification when a new
-  // round starts while the tab is hidden.
+  // Same pattern as app.js: ● in the title when a new round starts while the
+  // tab is hidden. Desktop notifications are server-side (notify_on_round_ready).
   var tabReady = (window.crit && window.crit.createTabReady)
     ? window.crit.createTabReady()
     : null;
@@ -72,11 +72,8 @@
     if (tabReady) tabReady.clearTabBadge();
   }
   function notifyRoundReady() {
-    if (tabReady) {
-      tabReady.notifyRoundReady({ title: 'Crit', body: 'A review round is ready' });
-    } else {
-      setTabBadge();
-    }
+    if (tabReady) tabReady.notifyRoundReady();
+    else setTabBadge();
   }
 
   document.addEventListener('visibilitychange', function () {
@@ -755,6 +752,10 @@
     var overlay = document.getElementById('waitingOverlay');
     if (s === 'reviewing') {
       stopLiveTipRotation();
+      // Leaving the waiting dialog ("Back to editing", backdrop click, a new
+      // round arriving) must kill any auto-close countdown — otherwise it
+      // keeps ticking behind the dismissed overlay and closes the tab.
+      shared.clearAutoCloseTimers();
       if (btn) {
         btn.disabled = false;
         btn.classList.add('btn-primary');


### PR DESCRIPTION
## Summary
- Clear the approve auto-close countdown when dismissing the waiting overlay (Back to editing / backdrop).
- Drop the inert browser Notification path; keep the tab-title badge (OS notify stays server-side).
- Focus Cancel and announce once for screen readers; pluralize the countdown announcement.

## Review
- [x] Code review: passed (independent post-fix PASS)
- [x] Parity audit: N/A (CLI-only)

## Test plan
- [x] `node --test` wiring + crit-shared + crit-tab-ready (69 pass)
- [x] pre-commit ESLint/stylelint


Made with [Cursor](https://cursor.com)