### PR TITLE
fix: reject cross-site browser POSTs via Sec-Fetch-Site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,7 @@ Static: `GET /files/<path>` — serve files from repo root (path traversal prote
 <important if="you are modifying server security, request handling, or path-validation logic">
 
 - Server binds to `127.0.0.1` by default; user can opt into a different host via `--host` / `CRIT_HOST` / `host` config key. There is no auth, so any non-loopback bind exposes file content + comment-write API to anyone who can reach the port — that's why it's an explicit opt-in (CLI flag / env var / config key).
+- State-changing requests (POST/PUT/PATCH/DELETE) with a `Sec-Fetch-Site` header must be `same-origin`. Missing header is allowed (CLI/curl/agent). `cross-site` is rejected — CSRF defense against malicious pages posting to loopback. Complements `checkHost` (DNS-rebinding), does not replace auth on non-loopback binds.
 - `/files/` validates paths, blocks `..` traversal, verifies resolved path stays within repo root
 - Body size: 10MB for comments, 1MB for share-url via `http.MaxBytesReader`
 - HTTP server: `ReadTimeout: 15s`, `IdleTimeout: 60s` (no `WriteTimeout` — SSE needs open connections)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -263,7 +263,32 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
+	// CSRF defense for browser clients: modern browsers always send
+	// Sec-Fetch-Site on requests they initiate. Cross-site values mean the
+	// request came from another origin (e.g. evil.com → 127.0.0.1). Missing
+	// header = non-browser client (CLI, curl, agent) — allow. same-origin =
+	// Crit UI on this port — allow. DNS-rebinding is handled by checkHost.
+	if !checkSecFetchSite(r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	s.mux.ServeHTTP(w, r)
+}
+
+// checkSecFetchSite reports whether a request is allowed under the CSRF policy.
+// Safe methods (GET/HEAD/OPTIONS) always pass. For state-changing methods:
+// absent Sec-Fetch-Site is allowed (CLI/curl); "same-origin" is allowed (UI);
+// any other value (notably "cross-site") is rejected.
+func checkSecFetchSite(r *http.Request) bool {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	site := r.Header.Get("Sec-Fetch-Site")
+	if site == "" {
+		return true
+	}
+	return site == "same-origin"
 }
 
 // requireReady returns false and writes a 503 or 500 response if the server

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -183,6 +183,94 @@ func TestHostCheckDefaultWiring(t *testing.T) {
 	}
 }
 
+func TestCheckSecFetchSite(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		site   string // empty = omit header
+		want   bool
+	}{
+		{"GET ignores cross-site", http.MethodGet, "cross-site", true},
+		{"HEAD ignores cross-site", http.MethodHead, "cross-site", true},
+		{"OPTIONS ignores cross-site", http.MethodOptions, "cross-site", true},
+		{"POST missing header (CLI)", http.MethodPost, "", true},
+		{"PUT missing header (CLI)", http.MethodPut, "", true},
+		{"DELETE missing header (CLI)", http.MethodDelete, "", true},
+		{"POST same-origin (UI)", http.MethodPost, "same-origin", true},
+		{"PUT same-origin (UI)", http.MethodPut, "same-origin", true},
+		{"DELETE same-origin (UI)", http.MethodDelete, "same-origin", true},
+		{"POST cross-site (CSRF)", http.MethodPost, "cross-site", false},
+		{"PUT cross-site (CSRF)", http.MethodPut, "cross-site", false},
+		{"PATCH cross-site (CSRF)", http.MethodPatch, "cross-site", false},
+		{"DELETE cross-site (CSRF)", http.MethodDelete, "cross-site", false},
+		{"POST same-site rejected", http.MethodPost, "same-site", false},
+		{"POST none rejected", http.MethodPost, "none", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/finish", nil)
+			if tt.site != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.site)
+			}
+			if got := checkSecFetchSite(req); got != tt.want {
+				t.Errorf("checkSecFetchSite = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSecFetchSiteCSRF_RejectsCrossSiteCommentPOST pins Vector A: a browser on
+// evil.com POSTing to 127.0.0.1 with Host: loopback (so checkHost passes) must
+// still be rejected when Sec-Fetch-Site is cross-site. The comment must not
+// be written.
+func TestSecFetchSiteCSRF_RejectsCrossSiteCommentPOST(t *testing.T) {
+	s, session := newTestServer(t)
+	s.SetListenHost("127.0.0.1")
+	before := len(session.GetComments("test.md"))
+
+	body := `{"start_line":1,"end_line":1,"body":"run attacker command","author":"evil"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/file/comments?path=test.md", strings.NewReader(body))
+	req.Host = "127.0.0.1:9"
+	req.Header.Set("Content-Type", "text/plain") // simple-request CSRF shape
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if got := len(session.GetComments("test.md")); got != before {
+		t.Fatalf("comment count = %d, want %d (cross-site POST must not write)", got, before)
+	}
+}
+
+func TestSecFetchSiteCSRF_AllowsSameOriginAndCLI(t *testing.T) {
+	s, session := newTestServer(t)
+	s.SetListenHost("127.0.0.1")
+
+	post := func(t *testing.T, site string) {
+		t.Helper()
+		body := `{"start_line":1,"end_line":1,"body":"ok","author":"me"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/file/comments?path=test.md", strings.NewReader(body))
+		req.Host = "127.0.0.1:9"
+		req.Header.Set("Content-Type", "application/json")
+		if site != "" {
+			req.Header.Set("Sec-Fetch-Site", site)
+		}
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("site=%q status = %d, want 201; body=%s", site, w.Code, w.Body.String())
+		}
+	}
+
+	before := len(session.GetComments("test.md"))
+	post(t, "")            // CLI / curl
+	post(t, "same-origin") // Crit UI
+	if got := len(session.GetComments("test.md")); got != before+2 {
+		t.Fatalf("comment count = %d, want %d", got, before+2)
+	}
+}
+
 func TestSetPublicURL(t *testing.T) {
 	s, _ := newTestServer(t)
 	s.SetPublicURL("https://mymac.ts.net/design")


### PR DESCRIPTION
## Summary
- Close CSRF against the local mutating API by rejecting state-changing requests whose `Sec-Fetch-Site` is present and not `same-origin`.
- Missing header still allowed (CLI/curl/agent); Crit UI same-origin fetches unchanged. Complements existing DNS-rebinding `checkHost` guard.

## Test plan
- [x] `go test ./internal/server/ -run 'TestCheckSecFetchSite|TestSecFetchSiteCSRF|TestHostCheck'`
- [x] Full `go test ./internal/server/`
- [ ] CI green
- [ ] Manual: open Crit UI, add comment / Finish Review still works
- [ ] Manual: `curl -X POST` to `/api/file/comments` without Sec-Fetch-Site still works


Made with [Cursor](https://cursor.com)