### PR TITLE
fix: make the agent reply flow usable end to end

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2672,13 +2672,19 @@ func (s *Server) handleAgentRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	comment, filePath, found := s.session.Load().FindCommentByID(body.CommentID, body.FilePath)
-	if !found {
-		http.Error(w, "Comment not found", http.StatusNotFound)
-		return
+	sess := s.session.Load()
+	comment, filePath, found := sess.FindCommentByID(body.CommentID, body.FilePath)
+	if found {
+		sess.SetCommentLive(filePath, comment.ID)
+	} else {
+		comment, found = sess.FindReviewCommentByID(body.CommentID)
+		if !found {
+			http.Error(w, "Comment not found", http.StatusNotFound)
+			return
+		}
+		filePath = ""
+		sess.SetReviewCommentLive(comment.ID)
 	}
-
-	s.session.Load().SetCommentLive(filePath, comment.ID)
 
 	prompt := buildAgentPrompt(comment, filePath)
 
@@ -2702,12 +2708,16 @@ func (s *Server) handleAgentRequest(w http.ResponseWriter, r *http.Request) {
 // buildAgentPrompt constructs a prompt string from a comment for the agent.
 func buildAgentPrompt(c Comment, filePath string) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("A reviewer left a comment on %s", filePath))
-	if c.StartLine > 0 {
-		if c.EndLine > c.StartLine {
-			b.WriteString(fmt.Sprintf(" (lines %d-%d)", c.StartLine, c.EndLine))
-		} else {
-			b.WriteString(fmt.Sprintf(" (line %d)", c.StartLine))
+	if filePath == "" {
+		b.WriteString("A reviewer left a general comment on this review")
+	} else {
+		b.WriteString(fmt.Sprintf("A reviewer left a comment on %s", filePath))
+		if c.StartLine > 0 {
+			if c.EndLine > c.StartLine {
+				b.WriteString(fmt.Sprintf(" (lines %d-%d)", c.StartLine, c.EndLine))
+			} else {
+				b.WriteString(fmt.Sprintf(" (line %d)", c.StartLine))
+			}
 		}
 	}
 	b.WriteString(":\n\n")
@@ -2788,6 +2798,9 @@ func (s *Server) runAgentCmd(prompt string, commentID string, filePath string) {
 				filePath = actualPath
 			}
 		}
+	}
+	if !ok {
+		_, ok = sess.AddReviewCommentReply(commentID, response, author, "")
 	}
 	if !ok {
 		log.Printf("agent-request %s: failed to add reply (comment not found in file %q)", commentID, filePath)

--- a/internal/server/server_agent_test.go
+++ b/internal/server/server_agent_test.go
@@ -163,6 +163,74 @@ func TestBuildAgentPrompt_ReviewLevel(t *testing.T) {
 	}
 }
 
+// Empty file_path still resolves a normal file comment via the all-files scan
+// before the review-level fallback.
+func TestHandleAgentRequest_EmptyPathFindsFileComment(t *testing.T) {
+	s, session := newTestServer(t)
+	s.agentCmd = "echo test"
+
+	session.Lock()
+	session.Files[0].Comments = []Comment{
+		{ID: "c_file1", StartLine: 1, EndLine: 1, Body: "file note", Author: "reviewer", Scope: "line"},
+	}
+	session.Unlock()
+
+	body := `{"comment_id":"c_file1","file_path":""}`
+	req := httptest.NewRequest("POST", "/api/agent/request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["file_path"] == "" {
+		t.Error("expected resolved file_path for a file comment even when request path was empty")
+	}
+	if !session.Files[0].Comments[0].Live {
+		t.Error("expected file comment Live after agent request")
+	}
+}
+
+// Deliberate ID collision: AddReply scans file comments before the review
+// fallback. Production IDs are namespaced (c_ vs r_); this locks prefer-file.
+func TestRunAgentCmd_IDCollisionPrefersFileComment(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, session := newTestServer(t)
+	session.RepoRoot = dir
+	s.agentCmd = "echo collision-reply"
+
+	rc := session.AddReviewComment("review side", "reviewer", "")
+	session.Lock()
+	session.Files[0].Comments = []Comment{
+		{ID: rc.ID, StartLine: 1, EndLine: 1, Body: "file side", Author: "reviewer", Scope: "line"},
+	}
+	session.Unlock()
+
+	s.runAgentCmd("hello collision", rc.ID, "")
+
+	if len(session.Files[0].Comments[0].Replies) == 0 {
+		t.Fatal("expected reply on the file comment (prefer-file on collision)")
+	}
+	if !strings.Contains(session.Files[0].Comments[0].Replies[0].Body, "collision-reply") {
+		t.Errorf("file reply body = %q", session.Files[0].Comments[0].Replies[0].Body)
+	}
+	rcs := session.GetReviewComments()
+	if len(rcs) != 1 {
+		t.Fatalf("expected 1 review comment, got %d", len(rcs))
+	}
+	if len(rcs[0].Replies) != 0 {
+		t.Errorf("review thread unexpectedly got %d replies on ID collision", len(rcs[0].Replies))
+	}
+}
+
 func TestAgentName_Codex(t *testing.T) {
 	tests := []struct {
 		cmd  string

--- a/internal/server/server_agent_test.go
+++ b/internal/server/server_agent_test.go
@@ -82,6 +82,87 @@ func TestHandleAgentRequest_Success(t *testing.T) {
 	}
 }
 
+// Review-level comments carry no file path and must still reach the agent.
+func TestHandleAgentRequest_ReviewLevelComment(t *testing.T) {
+	s, session := newTestServer(t)
+	s.agentCmd = "echo test"
+
+	c := session.AddReviewComment("Describe the problem and how we fix it", "reviewer", "")
+
+	body := `{"comment_id":"` + c.ID + `","file_path":""}`
+	req := httptest.NewRequest("POST", "/api/agent/request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["status"] != "accepted" {
+		t.Errorf("status = %v, want accepted", resp["status"])
+	}
+	if resp["file_path"] != "" {
+		t.Errorf("file_path = %v, want empty for a review-level comment", resp["file_path"])
+	}
+
+	comments := session.GetReviewComments()
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 review comment, got %d", len(comments))
+	}
+	if !comments[0].Live {
+		t.Error("expected review comment Live to be true after agent request")
+	}
+}
+
+// The answer must land in the review thread; there is no file to fall back on.
+func TestRunAgentCmd_ReviewLevelReply(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, session := newTestServer(t)
+	session.RepoRoot = dir
+	s.agentCmd = "echo {prompt}"
+
+	c := session.AddReviewComment("general feedback", "reviewer", "")
+
+	s.runAgentCmd("hello review level", c.ID, "")
+
+	comments := session.GetReviewComments()
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 review comment, got %d", len(comments))
+	}
+	replies := comments[0].Replies
+	if len(replies) == 0 {
+		t.Fatal("expected a reply from agent on the review-level comment, got none")
+	}
+	if !strings.Contains(replies[0].Body, "hello review level") {
+		t.Errorf("reply body = %q, want it to contain the prompt text", replies[0].Body)
+	}
+	if replies[0].Author != "echo" {
+		t.Errorf("reply author = %q, want 'echo'", replies[0].Author)
+	}
+}
+
+// With no file path the prompt must not claim the comment sits on a file.
+func TestBuildAgentPrompt_ReviewLevel(t *testing.T) {
+	c := Comment{ID: "r_1", Body: "tighten the summary", Author: "reviewer", Scope: "review"}
+	got := buildAgentPrompt(c, "")
+	if strings.Contains(got, "comment on :") || strings.Contains(got, "comment on \n") {
+		t.Errorf("prompt names an empty file path:\n%s", got)
+	}
+	if !strings.Contains(got, "tighten the summary") {
+		t.Errorf("prompt is missing the comment body:\n%s", got)
+	}
+	if !strings.Contains(got, "review") {
+		t.Errorf("prompt does not say the comment is about the review as a whole:\n%s", got)
+	}
+}
+
 func TestAgentName_Codex(t *testing.T) {
 	tests := []struct {
 		cmd  string

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1343,6 +1343,33 @@ func (s *Session) ResolveReviewComment(id string, resolved bool) (Comment, bool)
 	return Comment{}, false
 }
 
+// FindReviewCommentByID looks up a review-level comment by ID. Unlike
+// GetReviewComments it does not filter by focus.
+func (s *Session) FindReviewCommentByID(id string) (Comment, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, c := range s.reviewComments {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return Comment{}, false
+}
+
+// SetReviewCommentLive marks a review-level comment as live (sent to an agent).
+func (s *Session) SetReviewCommentLive(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, c := range s.reviewComments {
+		if c.ID == id {
+			s.reviewComments[i].Live = true
+			s.scheduleWrite()
+			return true
+		}
+	}
+	return false
+}
+
 // AddReviewCommentReply adds a reply to a review-level comment.
 func (s *Session) AddReviewCommentReply(commentID, body, author, userID string) (Reply, bool) {
 	s.mu.Lock()

--- a/test/e2e/tests/agent-request.spec.ts
+++ b/test/e2e/tests/agent-request.spec.ts
@@ -69,6 +69,41 @@ test.describe('Send to Agent', () => {
     expect(body.comment_id).toBe(comment.id);
   });
 
+  // Used to run the file-scoped submit path with an empty path and bail silently.
+  test('Send now submits a review-level comment and sends it to agent', async ({ page }) => {
+    await loadPage(page);
+    await page.keyboard.press('Shift+G');
+
+    const textarea = page.locator('#reviewConversation .comment-form textarea');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('Describe the problem and how we fix it');
+
+    await page.locator('#reviewConversation .btn-agent').click();
+
+    const cards = page.locator('#reviewConversation .comment-card');
+    await expect(cards).toHaveCount(1);
+    await expect(cards.first()).toContainText('Describe the problem and how we fix it');
+
+    await expect(page.locator('.mini-toast')).toContainText('Sent to agent');
+    await expect(page.locator('#reviewConversation .agent-pending-reply')).toBeVisible();
+    await expect(page.locator('#reviewConversation .agent-pending-author')).toHaveText('@echo');
+  });
+
+  test('POST /api/agent/request accepts a review-level comment', async ({ request }) => {
+    const commentRes = await request.post('/api/comments', {
+      data: { body: 'General note about this review' },
+    });
+    const comment = await commentRes.json();
+
+    const res = await request.post('/api/agent/request', {
+      data: { comment_id: comment.id, file_path: '' },
+    });
+    expect(res.status()).toBe(202);
+    const body = await res.json();
+    expect(body.status).toBe('accepted');
+    expect(body.file_path).toBe('');
+  });
+
   test('POST /api/agent/request returns 404 for unknown comment', async ({ request }) => {
     const res = await request.post('/api/agent/request', {
       data: { comment_id: 'nonexistent', file_path: 'plan.md' },

--- a/test/e2e/tests/agent-request.spec.ts
+++ b/test/e2e/tests/agent-request.spec.ts
@@ -43,8 +43,17 @@ test.describe('Send to Agent', () => {
     const textarea = page.locator('.comment-form textarea');
     await textarea.fill('Please review this section');
 
+    // Guard against scope inversion: line Send now must not post empty file_path.
+    const agentReq = page.waitForRequest((req) =>
+      req.url().includes('/api/agent/request') && req.method() === 'POST'
+    );
+
     const sendBtn = page.locator('.btn-agent');
     await sendBtn.click();
+
+    const posted = await agentReq;
+    const postedBody = posted.postDataJSON();
+    expect(postedBody.file_path).toBeTruthy();
 
     // Verify toast and pending reply indicator appear
     await expect(page.locator('.mini-toast')).toContainText('Sent to agent');

--- a/test/e2e/tests/threading.spec.ts
+++ b/test/e2e/tests/threading.spec.ts
@@ -49,10 +49,49 @@ test.describe('Comment Threading', () => {
     await expect(card.locator('.reply-textarea')).toBeFocused();
     await expect(card.locator('.reply-form-buttons')).toBeVisible();
 
-    // Escape collapses back to compact input
+    // Escape collapses back to the compact input, but the buttons stay put.
     await card.locator('.reply-textarea').press('Escape');
     await expect(card.locator('.reply-input')).toBeVisible();
-    await expect(card.locator('.reply-form-buttons')).toHaveCount(0);
+    await expect(card.locator('.reply-textarea')).toHaveCount(0);
+    await expect(card.locator('.reply-form-buttons')).toBeVisible();
+  });
+
+  test('send buttons are visible on an open card and hidden with a collapsed one', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Review this');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    await expect(card.locator('.reply-form-buttons .btn-primary')).toBeVisible();
+
+    await card.locator('.comment-collapse-btn').click();
+    await expect(card).toHaveClass(/collapsed/);
+    await expect(card.locator('.reply-form-buttons')).toBeHidden();
+
+    await card.locator('.comment-collapse-btn').click();
+    await expect(card.locator('.reply-form-buttons .btn-primary')).toBeVisible();
+  });
+
+  test('can send a reply without expanding the box', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Review this');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    await card.locator('.reply-input').fill('sent without expanding');
+    await card.locator('.reply-form-buttons .btn-primary').click();
+
+    await expect(section.locator('.comment-reply')).toHaveCount(1);
+    await expect(section.locator('.reply-body')).toContainText('sent without expanding');
+    await expect(card.locator('.reply-input')).toHaveValue('');
   });
 
   test('submitting reply form adds reply to thread', async ({ page, request }) => {
@@ -213,6 +252,79 @@ test.describe('Comment Threading', () => {
     // Should collapse back to compact input, no reply added
     await expect(card.locator('.reply-input')).toBeVisible();
     await expect(section.locator('.comment-reply')).toHaveCount(0);
+  });
+
+  // Expanding used to push Reply off screen with nothing scrolling it back.
+  test('expanding a reply near the bottom edge keeps Reply on screen', async ({ page, request }) => {
+    // Pinned: the bug is geometric, so don't depend on the default window size.
+    await page.setViewportSize({ width: 1200, height: 500 });
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Reply to me');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Park the collapsed reply input just above the bottom edge.
+    await page.evaluate(() => {
+      const el = document.querySelector('.comment-card .reply-input');
+      if (!el) throw new Error('no reply input');
+      const r = el.getBoundingClientRect();
+      window.scrollBy(0, r.top - (window.innerHeight - 60));
+    });
+
+    // locator.click() and boundingBox() scroll the target into view first,
+    // which would move the page out of the state under test.
+    const point = await page.evaluate(() => {
+      const el = document.querySelector('.comment-card .reply-input');
+      if (!el) throw new Error('no reply input');
+      const r = el.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    });
+    await page.mouse.click(point.x, point.y);
+
+    await expect(card.locator('.reply-textarea')).toBeVisible();
+    const replyBtn = card.locator('.reply-form-buttons .btn-primary');
+    await expect(replyBtn).toBeVisible();
+
+    // Measured in-page for the same reason. Retried because html has
+    // scroll-behavior: smooth, so the scroll is animated.
+    await expect(async () => {
+      const geom = await page.evaluate(() => {
+        const btn = document.querySelector('.comment-card .reply-form-buttons .btn-primary');
+        if (!btn) throw new Error('no Reply button');
+        const r = btn.getBoundingClientRect();
+        return { bottom: Math.round(r.bottom), viewportHeight: window.innerHeight };
+      });
+      expect(geom.bottom).toBeLessThanOrEqual(geom.viewportHeight);
+    }).toPass({ timeout: 5000 });
+  });
+
+  // Closing an empty form re-renders the file, which used to detach the very
+  // reply form being expanded — the box stayed one line tall.
+  test('reply form still expands when an empty comment form is open on the same file', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Reply to me');
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const section = mdSection(page);
+    const card = section.locator('.comment-card');
+    await expect(card).toBeVisible();
+
+    // Open a second, empty comment form on the same file via the gutter.
+    await section.locator('.line-block').nth(2).hover();
+    await section.locator('.line-comment-gutter').nth(2).click();
+    await expect(section.locator('.comment-form')).toHaveCount(1);
+
+    // Now expand the thread's reply box.
+    await card.locator('.reply-input').click();
+
+    await expect(card.locator('.reply-form.expanded')).toHaveCount(1);
+    await expect(card.locator('.reply-textarea')).toBeVisible();
+    await expect(card.locator('.reply-form-buttons .btn-primary')).toBeVisible();
   });
 
   test('panel shows replies inline', async ({ page, request }) => {

--- a/web/app.js
+++ b/web/app.js
@@ -1994,7 +1994,7 @@
         const card = expandedForms[i].closest('.comment-card');
         if (card && card.dataset.commentId) {
           const ta = expandedForms[i].querySelector('.reply-textarea');
-          activeReplyForms.set(card.dataset.commentId, { text: ta ? ta.value : '' });
+          activeReplyForms.set(card.dataset.commentId, { text: ta ? ta.value : '', expanded: true });
         }
       }
     }
@@ -4885,7 +4885,8 @@
     actions.appendChild(cancelBtn);
     actions.appendChild(submitBtn);
 
-    if (agentEnabled && !opts.editingId) {
+    // Callers put editingId on formObj, not opts.
+    if (agentEnabled && !opts.editingId && !formObj.editingId) {
       const sendBtn = document.createElement('button');
       sendBtn.className = 'btn btn-sm btn-agent';
       sendBtn.innerHTML = '<svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" style="vertical-align: -1px"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10"/></svg> Send now';
@@ -4893,25 +4894,34 @@
       sendBtn.addEventListener('click', async function() {
         sendBtn.disabled = true;
         submitBtn.disabled = true;
-        const fp = formObj.filePath;
-        const comment = await submitComment(textarea.value, formObj);
-        if (comment) {
-          pendingAgentRequests.add(comment.id);
-          renderFileByPath(fp);
-          try {
-            const res = await fetch('/api/agent/request', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ comment_id: comment.id, file_path: fp }),
-            });
-            if (!res.ok) throw new Error('Server returned ' + res.status);
-            showMiniToast('Sent to agent');
-          } catch (err) {
-            console.error('Error sending to agent:', err);
-            showMiniToast('Failed to send to agent');
-            pendingAgentRequests.delete(comment.id);
-            renderFileByPath(fp);
-          }
+        const isReview = formObj.scope === 'review';
+        const fp = isReview ? '' : formObj.filePath;
+        const rerender = isReview
+          ? renderReviewConversation
+          : function() { renderFileByPath(fp); };
+        const comment = isReview
+          ? await addReviewComment(textarea.value)
+          : await submitComment(textarea.value, formObj);
+        if (!comment) {
+          sendBtn.disabled = false;
+          submitBtn.disabled = false;
+          return;
+        }
+        pendingAgentRequests.add(comment.id);
+        rerender();
+        try {
+          const res = await fetch('/api/agent/request', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ comment_id: comment.id, file_path: fp }),
+          });
+          if (!res.ok) throw new Error('Server returned ' + res.status);
+          showMiniToast('Sent to agent');
+        } catch (err) {
+          console.error('Error sending to agent:', err);
+          showMiniToast('Failed to send to agent');
+          pendingAgentRequests.delete(comment.id);
+          rerender();
         }
       });
       actions.appendChild(sendBtn);
@@ -5642,8 +5652,9 @@
   // ===== Review-Level (General) Comments =====
   let reviewCommentSubmitting = false;
   async function addReviewComment(body) {
-    if (!body.trim() || reviewCommentSubmitting) return;
+    if (!body.trim() || reviewCommentSubmitting) return null;
     reviewCommentSubmitting = true;
+    let newComment;
     try {
       const res = await fetch('/api/comments', {
         method: 'POST',
@@ -5651,14 +5662,14 @@
         body: JSON.stringify({ body: body.trim(), author: configAuthor })
       });
       if (!res.ok) throw new Error('Server returned ' + res.status);
-      const newComment = await res.json();
+      newComment = await res.json();
       reviewComments.push(newComment);
       userActedThisRound = true;
     } catch (err) {
       console.error('Error adding review comment:', err);
       showMiniToast('Failed to add comment');
       reviewCommentSubmitting = false;
-      return;
+      return null;
     }
     reviewCommentSubmitting = false;
     reviewCommentFormActive = false;
@@ -5672,6 +5683,7 @@
     renderReviewConversation();
     renderCommentsPanel();
     renderFileTree();
+    return newComment;
   }
 
   async function updateReviewComment(id, body) {
@@ -6127,6 +6139,17 @@
     refreshAfterReplyChange(filePath);
   }
 
+  // The selector skips the panel copy of the comment, which has no reply form.
+  function focusRebuiltReplyForm(commentId) {
+    requestAnimationFrame(function() {
+      const sel = '.comment-card[data-comment-id="' + commentId + '"] ';
+      const ta = document.querySelector(sel + '.reply-textarea');
+      if (ta) ta.focus();
+      const btns = document.querySelector(sel + '.reply-form-buttons');
+      if (btns) btns.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
   function createReplyInput(commentId, filePath) {
     const form = document.createElement('div');
     form.className = 'reply-form';
@@ -6161,36 +6184,56 @@
 
     buttons.appendChild(cancelBtn);
     buttons.appendChild(submitBtn);
+    // Always mounted; CSS hides the whole form when the card is collapsed.
+    form.appendChild(buttons);
 
     attachFilePicker(textarea);
     attachImageUploads(textarea);
 
+    function activeField() {
+      return form.classList.contains('expanded') ? textarea : input;
+    }
+
     function expand() {
       if (form.classList.contains('expanded')) return;
+      // Set before closing: closeEmptyForms re-renders the file and detaches
+      // the nodes below, and the rebuilt form restores from this.
+      activeReplyForms.set(commentId, { text: input.value, expanded: true });
       closeEmptyReviewForm();
       closeEmptyForms(null);
+      if (!form.isConnected) {
+        // We were replaced by the re-render; hand off to the fresh form.
+        focusRebuiltReplyForm(commentId);
+        return;
+      }
       form.classList.add('expanded');
       textarea.value = input.value;
       input.replaceWith(textarea);
       form.appendChild(buttons);
       textarea.focus();
-      activeReplyForms.set(commentId, { text: textarea.value });
+      activeReplyForms.set(commentId, { text: textarea.value, expanded: true });
+      // The taller textarea can push the actions off screen, and focusing it
+      // does not bring them along.
+      buttons.scrollIntoView({ block: 'nearest' });
     }
 
     function collapse() {
+      textarea.value = '';
+      input.value = '';
+      activeReplyForms.delete(commentId);
       if (!form.classList.contains('expanded')) return;
       form.classList.remove('expanded');
       textarea.replaceWith(input);
-      input.value = '';
-      if (buttons.parentNode) buttons.remove();
-      activeReplyForms.delete(commentId);
     }
 
     input.addEventListener('focus', expand);
 
     // Keep reply form state in sync for surviving re-renders
     textarea.addEventListener('input', function() {
-      activeReplyForms.set(commentId, { text: textarea.value });
+      activeReplyForms.set(commentId, { text: textarea.value, expanded: true });
+    });
+    input.addEventListener('input', function() {
+      activeReplyForms.set(commentId, { text: input.value, expanded: false });
     });
 
     cancelBtn.addEventListener('click', collapse);
@@ -6205,8 +6248,8 @@
     });
 
     submitBtn.addEventListener('click', async function() {
-      const body = textarea.value.trim();
-      if (!body) return;
+      const body = activeField().value.trim();
+      if (!body) { activeField().focus(); return; }
       submitBtn.disabled = true;
       try {
         const payload = { body: body };
@@ -6222,22 +6265,27 @@
         if (!res.ok) throw new Error('Server returned ' + res.status);
         userActedThisRound = true;
 
-        // Live-thread agent dispatch only applies to file-scoped comments.
+        // Keep a live thread talking to the agent.
+        let comment = null;
         if (filePath) {
           const file = getFileByPath(filePath);
-          const comment = file && file.comments ? file.comments.find(function(c) { return c.id === commentId; }) : null;
-          if (comment && (isLiveThread(comment) || pendingAgentRequests.has(commentId))) {
-            pendingAgentRequests.add(commentId);
-            fetch('/api/agent/request', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ comment_id: commentId, file_path: filePath }),
-            }).catch(function(err) {
-              console.error('Error sending reply to agent:', err);
-              pendingAgentRequests.delete(commentId);
-              showMiniToast('Failed to send to agent');
-            });
+          if (file && file.comments) {
+            comment = file.comments.find(function(c) { return c.id === commentId; });
           }
+        } else {
+          comment = reviewComments.find(function(c) { return c.id === commentId; });
+        }
+        if (comment && (isLiveThread(comment) || pendingAgentRequests.has(commentId))) {
+          pendingAgentRequests.add(commentId);
+          fetch('/api/agent/request', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ comment_id: commentId, file_path: filePath }),
+          }).catch(function(err) {
+            console.error('Error sending reply to agent:', err);
+            pendingAgentRequests.delete(commentId);
+            showMiniToast('Failed to send to agent');
+          });
         }
 
         activeReplyForms.delete(commentId);
@@ -6267,11 +6315,15 @@
 
     // Restore saved reply form state after DOM re-render
     const saved = activeReplyForms.get(commentId);
-    if (saved && saved.text) {
-      form.classList.add('expanded');
-      textarea.value = saved.text;
-      input.replaceWith(textarea);
-      form.appendChild(buttons);
+    if (saved && (saved.text || saved.expanded)) {
+      if (saved.expanded) {
+        form.classList.add('expanded');
+        textarea.value = saved.text || '';
+        input.replaceWith(textarea);
+        form.appendChild(buttons);
+      } else {
+        input.value = saved.text || '';
+      }
     }
 
     return form;
@@ -7124,6 +7176,7 @@
           checkAgentReplies(files[i].comments);
           saveOpenFormContent(files[i].path);
         }
+        checkAgentReplies(reviewComments);
         if (storyActive()) {
           for (let i = 0; i < files.length; i++) {
             const before = previousCommentSignatures.get(files[i].path) || '[]';
@@ -10490,9 +10543,10 @@
     renderMermaidBlocks();
     rebuildNavList();
     applyHideResolved();
-    // Keep active rail row visible.
+    // Keep active rail row visible. Instant: a smooth scroll here outlives the
+    // resetStoryScroll() that showStory() runs next.
     const activeRow = document.querySelector('.crit-story-row.active');
-    if (activeRow) activeRow.scrollIntoView({ block: 'nearest' });
+    if (activeRow) activeRow.scrollIntoView({ block: 'nearest', behavior: 'instant' });
   }
 
   function resetStoryScroll() {

--- a/web/style.css
+++ b/web/style.css
@@ -1895,6 +1895,12 @@ body.dragging { user-select: none; cursor: grabbing; }
   border-top: 1px solid var(--crit-border);
 }
 
+/* Compact shape: the form already supplies the padding. */
+.reply-form:not(.expanded) .reply-form-buttons {
+  padding: 8px 0 0;
+  border-top: none;
+}
+
 .comment-textarea {
   width: 100%;
   background: var(--crit-editor-bg);
@@ -5043,7 +5049,8 @@ body.sidebar-resizing * {
 }
 
 .live-thread.agent-pending .reply-input,
-.live-thread.agent-pending .reply-textarea {
+.live-thread.agent-pending .reply-textarea,
+.live-thread.agent-pending .reply-form-buttons {
   opacity: 0.5;
   pointer-events: none;
 }


### PR DESCRIPTION
Three bugs made "Send now" and the reply thread unusable in different ways.

1. "Send now" did nothing on a review-level (general) comment. The handler in createCommentFormUI always ran the file-scoped submitComment(), ignoring the form's own onSubmit. The review conversation form carries filePath: '', so submitComment looked up getFileByPath('') , got undefined and returned early — after clearing the draft and disabling both buttons. Nothing was posted and nothing was reported. The backend could not have served it either: /api/agent/request only searched file comments, so a review-level id returned 404, the prompt read "A reviewer left a comment on :", and the agent's answer had no thread to land in.

   Send now now branches on the form's scope, posts an empty file_path for review-level comments, re-enables the buttons when creation fails, and no longer appears on edit forms (the old !opts.editingId guard was dead — every caller puts editingId on formObj). Server side: FindReviewCommentByID and SetReviewCommentLive, an agent-request fallback to review-level lookup, a prompt that does not name a file when there is none, and AddReviewCommentReply so the reply lands in the right thread. Live review threads keep talking to the agent on reply, and the comments-changed handler clears their pending spinner.

2. The reply box would not open at all if another empty comment form was open on the same file. expand() closes other empty forms first, and closing one calls renderFileByPath(), which rebuilds the card — so expand() then mutated detached nodes. The box took focus and stayed one line tall with no way to send. The intent is now recorded before the close, so the rebuilt form comes up expanded, and expand() hands off to the fresh form when it finds itself detached.

3. Reply/Cancel were built on expand and appended below the textarea, so on a tall card they landed past the bottom edge with nothing scrolling them in. They are now mounted with the form and stay visible for as long as the card is open (a collapsed card still hides the whole form), and sending works straight from the compact box. They dim with the input while an agent request is in flight.

Also makes the story chapter rail scroll instant. html has scroll-behavior: smooth, so the animated scroll that renderStory() started outlived the resetStoryScroll() right after it and settled a pixel below the top; taller comment cards shifted the rail enough for that to start happening.

Tests: 3 Go tests for review-level agent requests, 2 E2E for Send now on a review comment, 5 E2E for the reply form (expansion under a concurrent form, buttons visible on an open card and hidden on a collapsed one, sending without expanding, buttons staying after Escape, buttons on screen near the bottom edge). Each fails on the code before its fix.