### PR TITLE
fix: skip hidden resolved comments during navigation

### DIFF
--- a/test/e2e/tests/hide-resolved.spec.ts
+++ b/test/e2e/tests/hide-resolved.spec.ts
@@ -3,9 +3,9 @@ import * as fs from 'fs';
 import { clearAllComments, loadPage, getMdPath, addComment, getReviewFilePath } from './helpers';
 
 // Create a resolved comment by finishing a round, marking resolved, and round-completing.
-async function setupResolvedComment(request: APIRequestContext) {
+async function setupResolvedComment(request: APIRequestContext, line = 1) {
   const mdPath = await getMdPath(request);
-  await addComment(request, mdPath, 1, 'Resolved comment');
+  await addComment(request, mdPath, line, 'Resolved comment');
 
   // Finish to write the review file
   await request.post('/api/finish');
@@ -82,6 +82,40 @@ test.describe('Hide Resolved', () => {
     // Press h again to show
     await page.keyboard.press('h');
     await expect(resolvedBlock.first()).toBeVisible();
+  });
+
+  test('comment arrows skip hidden resolved comments in both directions', async ({ page, request }) => {
+    await setupResolvedComment(request, 3);
+    const mdPath = await getMdPath(request);
+    await addComment(request, mdPath, 1, 'Open A');
+    await addComment(request, mdPath, 5, 'Open C');
+    await loadPage(page);
+
+    const openA = page.locator('.comment-card:not(.resolved-card)').filter({ hasText: 'Open A' });
+    const resolvedCard = page.locator('.comment-card.resolved-card').first();
+    const openC = page.locator('.comment-card:not(.resolved-card)').filter({ hasText: 'Open C' });
+
+    await page.locator('#commentNavNext').click();
+    await expect(openA).toHaveClass(/comment-nav-highlight/);
+    await page.locator('#commentNavNext').click();
+    await expect(resolvedCard).toHaveClass(/comment-nav-highlight/);
+
+    await page.keyboard.press('h');
+    await expect(resolvedCard).toBeHidden();
+
+    await page.locator('#commentNavPrev').click();
+    await expect(openA).toHaveClass(/comment-nav-highlight/);
+    await expect(openC).not.toHaveClass(/comment-nav-highlight/);
+    await expect(resolvedCard).not.toHaveClass(/comment-nav-highlight/);
+
+    await page.keyboard.press('h');
+    await page.locator('#commentNavNext').click();
+    await expect(resolvedCard).toHaveClass(/comment-nav-highlight/);
+
+    await page.keyboard.press('h');
+    await page.locator('#commentNavNext').click();
+    await expect(openC).toHaveClass(/comment-nav-highlight/);
+    await expect(resolvedCard).not.toHaveClass(/comment-nav-highlight/);
   });
 
   test('hide resolved persists via localStorage across reload', async ({ page, request }) => {

--- a/web/app.js
+++ b/web/app.js
@@ -8339,39 +8339,48 @@
   function navigateToComment(direction) {
     const panel = document.getElementById('commentsPanel');
     const container = document.querySelector('.main-content');
-    const cards = Array.from(container.querySelectorAll('.comment-card')).filter(function(card) {
+    const allCards = Array.from(container.querySelectorAll('.comment-card')).filter(function(card) {
       return !panel || !panel.contains(card);
     });
+    const isEligible = function(card) {
+      return !isHideResolved() || !card.classList.contains('resolved-card');
+    };
+    const cards = allCards.filter(isEligible);
     if (cards.length === 0) return;
 
     const header = document.querySelector('.header');
     const headerHeight = header ? header.offsetHeight : 52;
 
-    // Find current position by stored comment ID (immune to smooth-scroll race conditions)
+    // Keep the current position in the full order even when that card becomes
+    // hidden, then scan in the requested direction for the next eligible card.
     let idx = -1;
     if (navCommentId) {
-      for (let i = 0; i < cards.length; i++) {
-        if (cards[i].dataset.commentId === navCommentId) { idx = i; break; }
+      for (let i = 0; i < allCards.length; i++) {
+        if (allCards[i].dataset.commentId === navCommentId) { idx = i; break; }
       }
     }
 
-    let targetIdx;
-    if (direction === 1) {
-      if (idx < 0) {
-        // First use: pick first card below the header area by viewport position
-        targetIdx = -1;
-        for (let j = 0; j < cards.length; j++) {
-          if (cards[j].getBoundingClientRect().top > headerHeight + 8) { targetIdx = j; break; }
+    let target;
+    if (idx >= 0) {
+      for (let step = 1; step <= allCards.length; step++) {
+        const candidateIdx = (idx + direction * step + allCards.length) % allCards.length;
+        if (isEligible(allCards[candidateIdx])) {
+          target = allCards[candidateIdx];
+          break;
         }
-        if (targetIdx < 0) targetIdx = 0;
-      } else {
-        targetIdx = idx >= cards.length - 1 ? 0 : idx + 1;
       }
+    } else if (direction === 1) {
+      // First use: pick first card below the header area by viewport position
+      let targetIdx = -1;
+      for (let j = 0; j < cards.length; j++) {
+        if (cards[j].getBoundingClientRect().top > headerHeight + 8) { targetIdx = j; break; }
+      }
+      if (targetIdx < 0) targetIdx = 0;
+      target = cards[targetIdx];
     } else {
-      targetIdx = idx <= 0 ? cards.length - 1 : idx - 1;
+      target = cards[cards.length - 1];
     }
 
-    const target = cards[targetIdx];
     navCommentId = target.dataset.commentId;
 
     if (navHighlightTimer) {


### PR DESCRIPTION
## Summary
- skip resolved cards during previous/next comment navigation when Hide resolved is enabled
- preserve directional continuity when the current resolved comment becomes hidden
- add multi-card state-transition browser coverage

## Review
- [x] Code review: passed
- [x] Parity audit: passed
- [x] Intent audit: passed

## Test plan
- pre-commit formatting, lint, Go, JavaScript, and CSS checks
- full race-enabled Go suite
- focused comment navigation and hide-resolved Playwright coverage

See also: https://github.com/tomasz-tomczyk/crit-web/pull/322