### PR TITLE
Adapt OpenCode reviews to shell capabilities

### DIFF
--- a/cmd/crit/integration_hashes_gen.go
+++ b/cmd/crit/integration_hashes_gen.go
@@ -36,7 +36,7 @@ var integrationHashes = map[string]string{
 	"integrations/grok/skills/crit/SKILL.md":                        "343e2920e5de9be0a96067e8c29f9b16c24ee2e108da2bb805018a4649ebf728",
 	"integrations/hermes/skills/crit-cli/SKILL.md":                  "bb78303077d690e73f57d17cffa895f80aa1632413bd7f749659c5f2f95d288c",
 	"integrations/hermes/skills/crit/SKILL.md":                      "a22cade9cda7a573b910cec4a245435fff524e1197ffe084f4b17558ee3f5c37",
-	"integrations/opencode/crit.md":                                 "c4726311422505b55ea2e19f5b76dfdf0e86c7536c985315f3d67377808c175e",
+	"integrations/opencode/crit.md":                                 "066cdd4d8a3761bdbf5fbef4e2a23a4b0b400ec0521893463865787ab94f15c1",
 	"integrations/opencode/plugin/crit.ts":                          "bbb6b53ead31f811b46c51055e4c225536f91f52a4eca1667b7e14d600e30958",
 	"integrations/opencode/plugin/lib/crit-wait-notify.js":          "95f4b82ebfc9ee60b2595bda3a260069aa6f34edea6c5b9eb9b503b7c6a58edb",
 	"integrations/opencode/plugin/lib/crit-wait-notify.test.js":     "9ac621e93e99e1a68c536f9e05535914b691107fb0e4d7d95a93b635d3855991",

--- a/integrations/opencode/crit.md
+++ b/integrations/opencode/crit.md
@@ -16,24 +16,59 @@ Pick whichever applies — don't ask for confirmation:
 3. **Branch review** — otherwise → bare `crit`. Auto-detects uncommitted changes or branch-vs-default-branch diff. Works on clean branches.
 4. **PR / commit range** — user asked to review a specific GitHub PR or a commit range → `crit --pr <num|url>` or `crit --range <baseSHA>..<headSHA>` (boots crit in *range mode*, scoping the review to a fixed range of commits rather than the working tree).
 
-## Step 2: Launch crit and block until review completes
+## Step 2: Launch crit and wait for review completion
 
 **CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
 
-Run `crit` in the foreground and block until it exits:
+Inspect the available Bash/shell tool schema. Use the same strategy for the initial review and every subsequent round.
 
-```bash
-crit <plan-file>   # specific file
-crit               # git mode
+### Background-capable shell
+
+If the Bash/shell tool exposes a `background` boolean, launch `crit` with `background: true` and no `timeout` argument. Background commands default to no timeout. Do not append `&`, use `nohup`, or wrap the command in another backgrounding mechanism.
+
+```text
+Shell tool call:
+- command: crit <plan-file>   # specific file
+- background: true
+
+Shell tool call:
+- command: crit               # git mode
+- background: true
 ```
 
-If a crit server is already running from earlier in this conversation, `crit` automatically connects to it. Starting from scratch, it spawns the daemon, opens the browser, and blocks until the user clicks "Finish Review".
+The tool returns immediately and notifies you automatically when `crit` finishes. Do not poll, sleep, read the review file early, or launch a duplicate command while it is running.
 
-`crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`). Relay it verbatim:
+Tell the user:
+
+> **"Crit is running in the background and will open in your browser. Leave inline comments, then click Finish Review."**
+
+End the current response after launching it. When the completion notification arrives, continue at Step 3.
+
+### Foreground-only shell
+
+If the Bash/shell tool does not expose `background`, run `crit` in the foreground with an explicit 24-hour timeout. The timeout is a tool argument in milliseconds, not part of the shell command:
+
+```text
+Bash tool call:
+- command: crit <plan-file>   # specific file
+- timeout: 86400000
+
+Bash tool call:
+- command: crit               # git mode
+- timeout: 86400000
+```
+
+Always pass `timeout: 86400000` to every blocking `crit` invocation. Do not rely on the shell tool's default timeout. Wait for the command to exit before continuing.
+
+If a crit server is already running from earlier in this conversation, `crit` automatically connects to it. Starting from scratch, it spawns the daemon, opens the browser, and waits until the user clicks "Finish Review".
+
+In foreground mode, `crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`). Relay it verbatim:
 
 > **"Crit is open at http://localhost:<port>. Leave inline comments, then click Finish Review."**
 
-**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Do NOT read the review file early. Wait for the foreground command to finish — that is how you know the human is done reviewing.
+In background mode, intermediate output may not be available before completion; rely on Crit opening the browser automatically rather than polling for the URL.
+
+**Do NOT proceed until `crit` completes.** Do NOT ask the user to type anything. Command completion is how you know the human is done reviewing.
 
 ## Step 3: Read the review output
 
@@ -91,6 +126,13 @@ crit comment --json --file /tmp/replies.json --author 'OpenCode'
 The finish prompt on stdout includes the command to run again — use it to start a new round.
 
 On subsequent calls, `crit` automatically signals round-complete first, then blocks until the next "Finish Review" click.
+
+Use the same shell strategy selected in Step 2:
+
+- Background-capable shell: invoke the next `crit` round with `background: true` and no `timeout`, then end the response and wait for the automatic completion notification.
+- Foreground-only shell: invoke the next `crit` round with `timeout: 86400000` and block until it completes.
+
+Never run more than one `crit` invocation for the same review round.
 
 Tell the user: **"Changes applied. Review the diff in your browser and click Finish Review when ready."**
 


### PR DESCRIPTION
Tested this with both V1 and V2, seems to be working as expected.

---

## Summary

- run Crit through managed background shell execution when the available OpenCode shell tool supports it
- fall back to foreground execution with an explicit 24-hour timeout when background execution is unavailable
- select behavior from the exposed shell schema rather than assuming a particular OpenCode version
- reuse the selected strategy for every subsequent review round
- regenerate the integration source hash

## Why

OpenCode v1.17.20 defaults shell commands to a two-minute timeout and does not expose managed background execution by default. Since Crit waits for a human to finish reviewing, relying on that default can interrupt an otherwise valid review.

OpenCode V2 is in beta now, and its current shell supports managed background commands with automatic completion delivery and no default background timeout. Because the V2 tool contract may continue to evolve during beta, the integration does not select behavior from the OpenCode version. Instead, it checks the shell capabilities exposed to the agent:

- when `background` is available, Crit runs as a managed background command;
- otherwise, Crit remains in the foreground with an explicit 24-hour timeout.

The same strategy is used for later review rounds. In background mode, Crit opens the browser automatically; the integration does not poll for the startup URL because the current V2 beta shell delivers captured output with the completion notification.