### PR TITLE
feat: add customizable keyboard shortcuts

### DIFF
--- a/test/e2e/tests/mobile-chrome.mobile.spec.ts
+++ b/test/e2e/tests/mobile-chrome.mobile.spec.ts
@@ -49,6 +49,34 @@ test.describe('Mobile chrome layout (F1)', () => {
     }).toPass();
   });
 
+  test('custom arrow shortcut does not hijack the mobile file picker', async ({ page }) => {
+    const picker = page.locator('#mobileFilePicker');
+    await expect(async () => {
+      expect(await picker.locator('option').count()).toBeGreaterThanOrEqual(2);
+    }).toPass();
+
+    await page.locator('#settingsToggle').click();
+    await page.locator('.settings-tab[data-tab="shortcuts"]').click();
+    await page.locator('[data-shortcut-id="next_block"]').click();
+    await page.keyboard.press('ArrowDown');
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+
+    await page.evaluate(() => {
+      (window as typeof window & { __pickerDefaultPrevented?: boolean }).__pickerDefaultPrevented = true;
+      document.querySelector('#mobileFilePicker')!.addEventListener('keydown', (event) => {
+        setTimeout(() => {
+          (window as typeof window & { __pickerDefaultPrevented?: boolean }).__pickerDefaultPrevented = event.defaultPrevented;
+        }, 0);
+      }, { once: true });
+    });
+    await picker.focus();
+    await page.keyboard.press('ArrowDown');
+    await expect.poll(() => page.evaluate(() =>
+      (window as typeof window & { __pickerDefaultPrevented?: boolean }).__pickerDefaultPrevented,
+    )).toBe(false);
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(0);
+  });
+
   test('selecting a file scrolls that file section into view', async ({ page }) => {
     const picker = page.locator('#mobileFilePicker');
     await expect(picker).toBeVisible();

--- a/test/e2e/tests/settings-panel.filemode.spec.ts
+++ b/test/e2e/tests/settings-panel.filemode.spec.ts
@@ -59,6 +59,21 @@ test.describe('Settings Panel — File Mode', () => {
     await expect(page.locator('.settings-overlay')).toHaveClass(/active/);
   });
 
+  test('custom shortcut can be set and used in file mode', async ({ page }) => {
+    await page.keyboard.press('?');
+    await page.locator('[data-shortcut-id="next_block"]').click();
+    await page.keyboard.press('ArrowDown');
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press('j');
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(0);
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(1);
+
+    await page.keyboard.press('?');
+    await page.locator('.shortcut-reset-all').click();
+  });
+
   test('theme toggle in settings panel changes theme', async ({ page }) => {
     await page.click('#settingsToggle');
     await page.click('[data-settings-theme="dark"]');

--- a/test/e2e/tests/settings-panel.spec.ts
+++ b/test/e2e/tests/settings-panel.spec.ts
@@ -71,6 +71,60 @@ test.describe('Settings Panel', () => {
     await expect(pane.locator('.shortcuts-group-label').nth(3)).toHaveText('Story');
   });
 
+  test('custom shortcut is applied immediately, persists, and can be reset', async ({ page }) => {
+    await page.keyboard.press('?');
+    const nextBlock = page.locator('[data-shortcut-id="next_block"]');
+    await nextBlock.click();
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('[data-shortcut-id="next_block"]')).toContainText('ArrowDown');
+
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+    await page.keyboard.press('j');
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(0);
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(1);
+
+    // A write through app.js must merge with the freshly saved shortcut,
+    // rather than replacing it with an older cached settings object.
+    await page.keyboard.press('h');
+    await page.reload();
+    await page.keyboard.press('?');
+    await expect(page.locator('[data-shortcut-id="next_block"]')).toContainText('ArrowDown');
+    await page.locator('.shortcut-reset-all').click();
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+    await page.keyboard.press('j');
+    await expect(page.locator('.kb-nav.focused')).toHaveCount(1);
+  });
+
+  test('shortcut conflicts are shown without changing the row height', async ({ page }) => {
+    await page.keyboard.press('?');
+    await page.locator('.settings-dialog').evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    });
+    const previousBlock = page.locator('[data-shortcut-id="previous_block"]');
+    const row = previousBlock.locator('xpath=ancestor::tr');
+    const heightBefore = await row.evaluate((element) => element.getBoundingClientRect().height);
+    await previousBlock.click();
+    const heightWhileEditing = await row.evaluate((element) => element.getBoundingClientRect().height);
+    expect(heightWhileEditing).toBe(heightBefore);
+    await page.keyboard.press('j');
+
+    await expect(page.locator('.mini-toast--error')).toContainText(
+      'already assigned to “Next block”',
+    );
+    await expect(row.locator('.shortcut-inline-feedback')).toHaveCount(0);
+  });
+
+  test('modified submit chords stay reserved', async ({ page }) => {
+    await page.keyboard.press('?');
+    const finishReview = page.locator('[data-shortcut-id="finish_review"]');
+    await finishReview.click();
+    await page.keyboard.press('Control+Shift+Enter');
+
+    await expect(page.locator('.mini-toast--error')).toContainText('is reserved by Crit');
+    await expect(finishReview).toContainText('Shift+F');
+  });
+
   test('settings pane shows display section with theme and width', async ({ page }) => {
     await page.click('#settingsToggle');
     const pane = page.locator('.settings-pane[data-pane="settings"]');

--- a/test/e2e/tests/settings-shortcuts.livemode.spec.ts
+++ b/test/e2e/tests/settings-shortcuts.livemode.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { clearAllLivePins } from './livemode-helpers';
+
+test.describe('Settings shortcuts — Live and Preview controller', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllLivePins(request);
+    await page.goto('/live');
+  });
+
+  test('custom shortcut can be set and used from live mode', async ({ page }) => {
+    await page.locator('#settingsToggle').click();
+    await page.locator('.settings-tab[data-tab="shortcuts"]').click();
+    const togglePinMode = page.locator('[data-shortcut-id="toggle_pin_mode"]');
+    await expect(togglePinMode).toBeVisible();
+    await togglePinMode.click();
+    await page.keyboard.press('x');
+    await page.keyboard.press('x');
+    await expect(page.locator('#liveModeToggle button[data-mode="pin"]')).not.toHaveClass(/active/);
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press('p');
+    await expect(page.locator('#liveModeToggle button[data-mode="pin"]')).not.toHaveClass(/active/);
+    await page.keyboard.press('x');
+    await expect(page.locator('#liveModeToggle button[data-mode="pin"]')).toHaveClass(/active/);
+
+    await page.keyboard.press('?');
+    await page.locator('.shortcut-reset-all').click();
+  });
+});

--- a/web/__tests__/crit-settings-panes.test.js
+++ b/web/__tests__/crit-settings-panes.test.js
@@ -54,6 +54,8 @@ function loadShared() {
   const sandbox = { window: {}, document: { cookie: '', getElementById: () => null } };
   const sharedSrc = fs.readFileSync(path.join(__dirname, '..', 'crit-shared.js'), 'utf8');
   new Function('window', 'document', sharedSrc)(sandbox.window, sandbox.document);
+  const shortcutsSrc = fs.readFileSync(path.join(__dirname, '..', 'crit-shortcuts.js'), 'utf8');
+  new Function('window', 'globalThis', 'module', shortcutsSrc)(sandbox.window, sandbox.window, undefined);
   const panesSrc = fs.readFileSync(path.join(__dirname, '..', 'crit-settings-panes.js'), 'utf8');
   // navigator.clipboard is referenced inside copy-button click handlers but
   // those handlers don't run during render.
@@ -333,7 +335,7 @@ test('renderShortcutsPane: code-review mode shows code-review-only shortcuts', (
   assert.match(html, /<kbd>h<\/kbd>/);
   assert.match(html, /Shift<\/kbd>\+<kbd>F/);
   assert.match(html, /Shift<\/kbd>\+<kbd>C/);
-  assert.match(html, /Switch scope/);
+  assert.match(html, /Switch to all changes/);
   assert.match(html, /Next story chapter/);
   assert.match(html, /Previous story chapter/);
   assert.match(html, /Story prologue/);

--- a/web/__tests__/crit-shortcuts.test.js
+++ b/web/__tests__/crit-shortcuts.test.js
@@ -1,0 +1,64 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function loadShortcuts(initial) {
+  const modulePath = require.resolve('../crit-shortcuts.js');
+  delete require.cache[modulePath];
+  const settings = Object.assign({}, initial || {});
+  global.crit = {
+    shared: {
+      getSetting(key, fallback) { return Object.hasOwn(settings, key) ? settings[key] : fallback; },
+      setSetting(key, value) { settings[key] = value; },
+    },
+  };
+  const shortcuts = require(modulePath);
+  return { shortcuts, settings };
+}
+
+test.afterEach(() => { delete global.crit; });
+
+test('defaults resolve code-review actions from normalized key events', () => {
+  const { shortcuts } = loadShortcuts();
+  assert.equal(shortcuts.actionForEvent({ key: 'j', code: 'KeyJ' }, 'code-review'), 'next_block');
+  assert.equal(shortcuts.actionForEvent({ key: 'F', code: 'KeyF', shiftKey: true }, 'code-review'), 'finish_review');
+  assert.equal(shortcuts.actionForEvent({ key: 'f', shiftKey: true }, 'code-review'), 'finish_review');
+  assert.equal(shortcuts.actionForEvent({ key: '!', code: 'Digit1', shiftKey: true }, 'code-review'), 'scope_all');
+  assert.equal(shortcuts.actionForEvent({ key: '!', code: 'Digit1' }, 'code-review'), 'scope_all');
+  assert.equal(shortcuts.actionForEvent({ key: 'p', code: 'KeyP' }, 'code-review'), '');
+});
+
+test('overrides persist, replace defaults, and can disable actions', () => {
+  const { shortcuts, settings } = loadShortcuts();
+  assert.equal(shortcuts.setBinding('next_block', 'ArrowDown'), true);
+  assert.deepEqual(settings.shortcuts, { next_block: 'ArrowDown' });
+  assert.equal(shortcuts.actionForEvent({ key: 'j', code: 'KeyJ' }, 'code-review'), '');
+  assert.equal(shortcuts.actionForEvent({ key: 'ArrowDown', code: 'ArrowDown' }, 'code-review'), 'next_block');
+
+  shortcuts.setBinding('next_block', '');
+  assert.equal(shortcuts.getBinding('next_block'), '');
+  assert.equal(shortcuts.actionForEvent({ key: 'ArrowDown', code: 'ArrowDown' }, 'code-review'), '');
+});
+
+test('saving the default removes an override and resetAll clears all overrides', () => {
+  const { shortcuts, settings } = loadShortcuts({ shortcuts: { next_block: 'ArrowDown', comment: 'x' } });
+  shortcuts.setBinding('next_block', 'j');
+  assert.deepEqual(settings.shortcuts, { comment: 'x' });
+  shortcuts.resetAll();
+  assert.deepEqual(settings.shortcuts, {});
+});
+
+test('findConflict considers every mode shared by the edited action', () => {
+  const { shortcuts } = loadShortcuts();
+  assert.equal(shortcuts.findConflict('previous_block', 'j').id, 'next_block');
+  assert.equal(shortcuts.findConflict('finish_review', 'p').id, 'toggle_pin_mode');
+  assert.equal(shortcuts.findConflict('next_block', 'p'), null);
+});
+
+test('eventToBinding supports modifier chords and readable special keys', () => {
+  const { shortcuts } = loadShortcuts();
+  assert.equal(shortcuts.eventToBinding({ key: 'K', code: 'KeyK', ctrlKey: true, shiftKey: true }), 'Ctrl+Shift+K');
+  assert.equal(shortcuts.eventToBinding({ key: '?', code: 'Slash', shiftKey: true }), 'Shift+/');
+  assert.equal(shortcuts.eventToBinding({ key: ' ', code: 'Space' }), 'Space');
+  assert.equal(shortcuts.eventToBinding({ key: 'Shift', code: 'ShiftLeft', shiftKey: true }), '');
+});

--- a/web/__tests__/live-mode.shortcut.test.js
+++ b/web/__tests__/live-mode.shortcut.test.js
@@ -29,6 +29,20 @@ test('Esc exits pin only', () => {
   assert.equal(mode, 'navigate');
 });
 
+test('? opens the shortcuts pane', () => {
+  let opened = 0;
+  let prevented = 0;
+  let stopped = 0;
+  handleShortcut({
+    key: '?',
+    preventDefault: () => { prevented++; },
+    stopImmediatePropagation: () => { stopped++; },
+  }, shortcutCtx({ toggleShortcuts: () => { opened++; } }));
+  assert.equal(opened, 1);
+  assert.equal(prevented, 1);
+  assert.equal(stopped, 1);
+});
+
 test('shortcuts suppressed while focusInInput', () => {
   let mode = 'navigate';
   let finished = 0;
@@ -106,4 +120,31 @@ test('Shift+F suppressed while focusInInput', () => {
     shortcutCtx({ focusInInput: true, finishReview: () => { finished++; } })
   );
   assert.equal(finished, 0);
+});
+
+test('resolved actions support customized live-mode bindings', () => {
+  let mode = 'navigate';
+  let prevented = 0;
+  const ctx = shortcutCtx({
+    actionForEvent: (ev) => ev.key === 'x' ? 'toggle_pin_mode' : '',
+    getMode: () => mode,
+    setMode: (next) => { mode = next; },
+  });
+  handleShortcut({ key: 'p' }, ctx);
+  assert.equal(mode, 'navigate', 'old default no longer fires after a rebind');
+  handleShortcut({ key: 'x', preventDefault: () => { prevented++; } }, ctx);
+  assert.equal(mode, 'pin');
+  assert.equal(prevented, 1);
+});
+
+test('resolved actions are suppressed while settings are open', () => {
+  let mode = 'navigate';
+  const ctx = shortcutCtx({
+    settingsOpen: true,
+    actionForEvent: () => 'toggle_pin_mode',
+    getMode: () => mode,
+    setMode: (next) => { mode = next; },
+  });
+  handleShortcut({ key: 'x' }, ctx);
+  assert.equal(mode, 'navigate');
 });

--- a/web/app.js
+++ b/web/app.js
@@ -275,14 +275,11 @@
   // Exception: `crit-templates` stays in its own cookie because it's user-defined
   // and can be longer than the rest combined.
   const SETTINGS_COOKIE = 'crit-settings';
-  let settingsCache = null;
 
   function loadSettings() {
-    if (settingsCache) return settingsCache;
     const raw = getCookie(SETTINGS_COOKIE);
-    try { settingsCache = raw ? JSON.parse(raw) : {}; }
-    catch { settingsCache = {}; }
-    return settingsCache;
+    try { return raw ? JSON.parse(raw) : {}; }
+    catch { return {}; }
   }
 
   function getSetting(key, fallback) {
@@ -8853,7 +8850,7 @@
 
   document.addEventListener('keydown', function(e) {
     const tag = document.activeElement.tagName;
-    if (tag === 'TEXTAREA' || tag === 'INPUT' || document.activeElement.isContentEditable) {
+    if (tag === 'TEXTAREA' || tag === 'INPUT' || tag === 'SELECT' || document.activeElement.isContentEditable) {
       if (e.key === 'Escape' && activeForms.length > 0) {
         e.preventDefault();
         const ta = document.activeElement;
@@ -8877,15 +8874,16 @@
     // short-circuit the rest of the keymap so we don't double-handle.
     if (settingsPanelOpen) return;
 
-    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const shortcutRegistry = window.crit && window.crit.shortcuts;
+    const shortcutAction = shortcutRegistry ? shortcutRegistry.actionForEvent(e, 'code-review') : '';
+    if (!shortcutAction && (e.metaKey || e.ctrlKey || e.altKey)) return;
 
-    // Story navigation keys (chapter nav / overview / jump / help). Scoped to
-    // when the story view is active; uses uppercase J/K so lowercase j/k keep
-    // their in-page block navigation below. Returns early if consumed.
-    if (handleStoryKey(e)) return;
+    // Story navigation actions (chapter nav / overview / jump / help). Scoped
+    // to the active story view. Returns early if consumed.
+    if (handleStoryKey(e, shortcutAction)) return;
 
-    switch (e.key) {
-      case 'j': case 'k': {
+    switch (shortcutAction || e.key) {
+      case 'next_block': case 'previous_block': {
         e.preventDefault();
         const allNav = navElements;
         if (allNav.length === 0) return;
@@ -8895,10 +8893,10 @@
           if (match) curIdx = allNav.indexOf(match);
         }
         if (curIdx === -1) {
-          curIdx = e.key === 'j' ? 0 : allNav.length - 1;
+          curIdx = shortcutAction === 'next_block' ? 0 : allNav.length - 1;
         } else {
-          if (e.key === 'j' && curIdx < allNav.length - 1) curIdx++;
-          if (e.key === 'k' && curIdx > 0) curIdx--;
+          if (shortcutAction === 'next_block' && curIdx < allNav.length - 1) curIdx++;
+          if (shortcutAction === 'previous_block' && curIdx > 0) curIdx--;
         }
         document.querySelectorAll('.kb-nav.focused').forEach(function(el) { el.classList.remove('focused'); });
         focusedElement = allNav[curIdx];
@@ -8919,7 +8917,7 @@
         if (visualMode) extendVisualSelection();
         break;
       }
-      case 'V': {
+      case 'visual_mode': {
         e.preventDefault();
         if (visualMode) {
           // Toggle off — preserve the focus on the current expansion point.
@@ -8929,7 +8927,7 @@
         }
         break;
       }
-      case 'c': {
+      case 'comment': {
         e.preventDefault();
         // Visual mode: comment on the active selection.
         if (visualMode && selectionStart !== null && selectionEnd !== null) {
@@ -8978,8 +8976,8 @@
         }
         break;
       }
-      case 'e':
-      case 'd': {
+      case 'edit_comment':
+      case 'delete_comment': {
         e.preventDefault();
         const loc = getFocusedCommentLocation();
         if (!loc) return;
@@ -8996,28 +8994,28 @@
           comment = file.comments.find(function(c) { return c.end_line === loc.lineNum && (c.side || '') === loc.side; });
         }
         if (!comment) return;
-        if (e.key === 'e') editComment(comment, loc.filePath);
+        if (shortcutAction === 'edit_comment') editComment(comment, loc.filePath);
         else deleteComment(comment.id, loc.filePath);
         break;
       }
-      case 'F': {
+      case 'finish_review': {
         e.preventDefault();
         if (uiState !== 'reviewing') return;
         document.getElementById('finishBtn').click();
         break;
       }
-      case 'G': {
+      case 'general_comment': {
         e.preventDefault();
         openReviewCommentForm();
         break;
       }
-      case 'C': {
+      case 'toggle_comments': {
         e.preventDefault();
         if (storyActive() && tryOpenFormFromSelection()) return;
         toggleCommentsPanel();
         break;
       }
-      case 'h': {
+      case 'toggle_resolved': {
         e.preventDefault();
         setHideResolved(!isHideResolved());
         renderAllFiles();
@@ -9025,39 +9023,39 @@
         if (ht) ht.checked = isHideResolved();
         break;
       }
-      case 't': {
+      case 'toggle_toc': {
         const tocBtn = document.getElementById('tocToggle');
         if (tocBtn.style.display === 'none') return;
         e.preventDefault();
         tocBtn.click();
         break;
       }
-      case ']': {
+      case 'next_comment': {
         e.preventDefault();
         navigateToComment(1);
         break;
       }
-      case '[': {
+      case 'previous_comment': {
         e.preventDefault();
         navigateToComment(-1);
         break;
       }
-      case 'n': {
+      case 'next_change': {
         if (changeGroups.length === 0) break;
         e.preventDefault();
         navigateToChange(1);
         break;
       }
-      case 'N': {
+      case 'previous_change': {
         if (changeGroups.length === 0) break;
         e.preventDefault();
         navigateToChange(-1);
         break;
       }
-      case '!': case '@': case '#': case '$': {
+      case 'scope_all': case 'scope_branch': case 'scope_staged': case 'scope_unstaged': {
         if (session.mode !== 'git') break;
-        const scopeMap = { '!': 'all', '@': 'branch', '#': 'staged', '$': 'unstaged' };
-        const scope = scopeMap[e.key];
+        const scopeMap = { scope_all: 'all', scope_branch: 'branch', scope_staged: 'staged', scope_unstaged: 'unstaged' };
+        const scope = scopeMap[shortcutAction];
         const btn = document.querySelector('#scopeToggle .toggle-btn[data-scope="' + scope + '"]');
         if (btn && !btn.disabled && !btn.classList.contains('active')) {
           e.preventDefault();
@@ -10772,26 +10770,25 @@
   function storyActive() { return !!storyState && document.body.classList.contains('crit-story-active'); }
 
   // Handle a keydown when story view is active. Returns true if consumed.
-  // Uppercase J/K (Shift) drive chapter nav so lowercase j/k keep their
-  // existing in-page block navigation. Scoped keys don't fire when typing.
-  function handleStoryKey(e) {
+  // Scoped story actions don't fire when typing or outside the story view.
+  function handleStoryKey(e, shortcutAction) {
     if (!storyActive()) return false;
     const pages = storyState.pages;
     const curIdx = storyView === 'overview' ? -1 : pages.indexOf(storyPageById(storyView));
-    switch (e.key) {
-      case 'J':
+    switch (shortcutAction || e.key) {
+      case 'story_next':
         e.preventDefault();
         if (curIdx === -1) { if (pages.length) showStory(storyPageId(pages[0])); }
         else if (curIdx < pages.length - 1) showStory(storyPageId(pages[curIdx + 1]));
         return true;
-      case 'K':
+      case 'story_previous':
         e.preventDefault();
         if (curIdx <= 0) showStory('overview');
         else showStory(storyPageId(pages[curIdx - 1]));
         return true;
-      case 'O':
+      case 'story_prologue':
         e.preventDefault(); showStory('overview'); return true;
-      case 'S':
+      case 'story_support':
         e.preventDefault();
         { const sp = storyPageById('support'); if (sp) showStory('support'); }
         return true;
@@ -10802,7 +10799,7 @@
         if (n < chs.length) { e.preventDefault(); showStory(storyPageId(chs[n])); return true; }
         return false;
       }
-      case '\\':
+      case 'story_toggle_list':
         e.preventDefault();
         document.body.classList.toggle('crit-story-rail-open');
         return true;

--- a/web/crit-settings-panes.js
+++ b/web/crit-settings-panes.js
@@ -36,65 +36,34 @@
   // crit-shared.js loads before this file per index.html script order.
   var escapeHTML = window.crit.shared.escapeHTML;
 
-  // Each shortcut declares which modes it actually fires in. The renderer
-  // filters out entries that don't apply to the current mode so live-mode
-  // users aren't shown bindings that do nothing for them. Investigated
-  // bindings:
-  //   - live-mode: Esc, Ctrl+Enter, ? (and `p/P` for pin mode — live-only)
-  //   - code-review: j, k, ], [, n, N, c, e, d, G, Shift+F, Shift+C,
-  //                  Shift+1/2/3/4, t, h, Esc, Ctrl+Enter, ?
-  var BOTH = ['code-review', 'live'];
-  var CODE_REVIEW_ONLY = ['code-review'];
-  var LIVE_ONLY = ['live'];
+  function bindingHTML(binding) {
+    if (!binding) return '<span class="shortcut-unassigned">Unassigned</span>';
+    // En dash is used by the fixed story chapter range and is not a chord.
+    var parts = binding.indexOf('–') !== -1 ? [binding] : binding.split('+');
+    return parts.map(function (part) { return '<kbd>' + escapeHTML(part) + '</kbd>'; }).join('+');
+  }
+
+  function isReservedBinding(binding) {
+    var reserved = ['Esc', 'Shift+/', 'Tab', 'Enter', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+    if (reserved.indexOf(binding) !== -1) return true;
+    var parts = binding.split('+');
+    return parts[parts.length - 1] === 'Enter' &&
+      (parts.indexOf('Ctrl') !== -1 || parts.indexOf('Meta') !== -1);
+  }
 
   function renderShortcutsPane(pane, opts) {
     if (!pane) return;
     opts = opts || {};
     var mode = opts.mode || 'code-review';
+    var shortcuts = window.crit && window.crit.shortcuts;
+    if (!shortcuts) return;
     var html = '';
+    html += '<div class="shortcuts-toolbar">';
+    html += '<span>Click a shortcut, then press its new keys. Backspace disables it.</span>';
+    html += '<button type="button" class="shortcut-reset-all">Reset all</button>';
+    html += '</div>';
 
-    var groups = [
-      { label: 'Navigation', shortcuts: [
-        { key: '<kbd>j</kbd>', action: 'Next block', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>k</kbd>', action: 'Previous block', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Shift</kbd>+<kbd>V</kbd>', action: 'Visual line mode (extend with j/k, then c to comment)', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>]</kbd>', action: 'Next comment', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>[</kbd>', action: 'Previous comment', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>n</kbd>', action: 'Next change', mode: 'file mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>N</kbd>', action: 'Previous change', mode: 'file mode', modes: CODE_REVIEW_ONLY },
-      ]},
-      { label: 'Comments', shortcuts: [
-        { key: '<kbd>c</kbd>', action: 'Comment on focused block (or text selection, with quote)', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>e</kbd>', action: 'Edit comment on focused block', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>d</kbd>', action: 'Delete comment on focused block', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>G</kbd>', action: 'General comment', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Comment', modes: BOTH },
-      ]},
-      { label: 'Review', shortcuts: [
-        { key: '<kbd>Shift</kbd>+<kbd>F</kbd>', action: 'Finish review', modes: BOTH },
-        { key: '<kbd>Shift</kbd>+<kbd>C</kbd>', action: 'Toggle comments panel', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Shift</kbd>+<kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd>/<kbd>4</kbd>', action: 'Switch scope', mode: 'vcs mode', modes: CODE_REVIEW_ONLY },
-      ]},
-      { label: 'Story', shortcuts: [
-        { key: '<kbd>Shift</kbd>+<kbd>J</kbd>', action: 'Next story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Shift</kbd>+<kbd>K</kbd>', action: 'Previous story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Shift</kbd>+<kbd>O</kbd>', action: 'Story prologue', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Shift</kbd>+<kbd>S</kbd>', action: 'Story support', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>1</kbd>-<kbd>9</kbd>', action: 'Jump to story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>\\</kbd>', action: 'Toggle story chapter list', mode: 'story mode', modes: CODE_REVIEW_ONLY },
-      ]},
-      { label: 'Live', shortcuts: [
-        { key: '<kbd>p</kbd>', action: 'Toggle pin mode', modes: LIVE_ONLY },
-      ]},
-      { label: 'View', shortcuts: [
-        { key: '<kbd>t</kbd>', action: 'Toggle table of contents', mode: 'file mode', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>h</kbd>', action: 'Toggle hide resolved', modes: CODE_REVIEW_ONLY },
-        { key: '<kbd>Esc</kbd>', action: 'Cancel / clear focus', modes: BOTH },
-        { key: '<kbd>?</kbd>', action: 'Toggle this panel', modes: BOTH },
-      ]},
-    ];
-
-    groups.forEach(function (group) {
+    shortcuts.groups.forEach(function (group) {
       var visible = group.shortcuts.filter(function (s) {
         return s.modes && s.modes.indexOf(mode) !== -1;
       });
@@ -103,12 +72,72 @@
       html += '<table class="shortcuts-table">';
       visible.forEach(function (s) {
         var modeTag = s.mode ? '<span class="shortcut-mode-badge">' + s.mode + '</span>' : '';
-        html += '<tr><td>' + s.key + '</td><td>' + s.action + modeTag + '</td></tr>';
+        var binding = s.id ? shortcuts.getBinding(s.id) : s.binding;
+        var key = bindingHTML(binding);
+        if (s.id && !s.fixed) {
+          var customized = shortcuts.isCustomized(s.id) ? ' is-customized' : '';
+          key = '<button type="button" class="shortcut-binding' + customized + '" data-shortcut-id="' + escapeHTML(s.id)
+            + '" aria-label="Change shortcut for ' + escapeHTML(s.action) + '">' + key + '</button>';
+        }
+        html += '<tr><td>' + key + '</td><td>' + escapeHTML(s.action) + modeTag + '</td></tr>';
       });
       html += '</table>';
     });
 
     pane.innerHTML = html;
+
+    function rerender() {
+      renderShortcutsPane(pane, opts);
+      if (typeof opts.onChange === 'function') opts.onChange();
+    }
+
+    var reset = pane.querySelector('.shortcut-reset-all');
+    if (reset) reset.addEventListener('click', function () {
+      shortcuts.resetAll();
+      rerender();
+    });
+
+    pane.querySelectorAll('.shortcut-binding').forEach(function (button) {
+      button.addEventListener('click', function () {
+        button.classList.add('is-capturing');
+        // Keep the same <kbd> box while capturing so single-key rows do not
+        // change height when plain button text replaces their binding.
+        button.innerHTML = '<kbd>Press keys…</kbd>';
+      });
+      button.addEventListener('blur', function () {
+        if (button.classList.contains('is-capturing')) rerender();
+      });
+      button.addEventListener('keydown', function (e) {
+        if (!button.classList.contains('is-capturing')) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation();
+        if (e.key === 'Escape') { rerender(); return; }
+
+        var binding = (e.key === 'Backspace' || e.key === 'Delete') ? '' : shortcuts.eventToBinding(e);
+        if (!binding && e.key !== 'Backspace' && e.key !== 'Delete') return;
+        var id = button.dataset.shortcutId;
+
+        function showError(message) {
+          button.classList.remove('is-capturing');
+          button.innerHTML = bindingHTML(shortcuts.getBinding(id));
+          var shared = window.crit && window.crit.shared;
+          if (shared && shared.showToast) shared.showToast(message, { kind: 'error' });
+        }
+
+        if (isReservedBinding(binding)) {
+          showError(binding + ' is reserved by Crit.');
+          return;
+        }
+        var conflict = shortcuts.findConflict(id, binding);
+        if (conflict) {
+          showError(binding + ' is already assigned to “' + conflict.action + '”.');
+          return;
+        }
+        shortcuts.setBinding(id, binding);
+        rerender();
+      });
+    });
   }
 
   function renderAboutPane(pane, cfg, sessionInfo) {

--- a/web/crit-shortcuts.js
+++ b/web/crit-shortcuts.js
@@ -1,0 +1,198 @@
+// crit-shortcuts.js — shared keyboard shortcut registry and persistence.
+//
+// User overrides live under `shortcuts` in the crit-settings cookie:
+//   { "shortcuts": { "next_block": "ArrowDown" } }
+// Empty strings intentionally disable an action. Defaults stay in this module so
+// the settings pane and keyboard handlers cannot drift apart.
+'use strict';
+(function (root, factory) {
+  var api = factory(root);
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else {
+    root.crit = root.crit || {};
+    root.crit.shortcuts = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  var BOTH = ['code-review', 'live'];
+  var CODE_REVIEW_ONLY = ['code-review'];
+  var LIVE_ONLY = ['live'];
+
+  var groups = [
+    { label: 'Navigation', shortcuts: [
+      { id: 'next_block', binding: 'j', action: 'Next block', modes: CODE_REVIEW_ONLY },
+      { id: 'previous_block', binding: 'k', action: 'Previous block', modes: CODE_REVIEW_ONLY },
+      { id: 'visual_mode', binding: 'Shift+V', action: 'Visual line mode (extend with next/previous block, then comment)', modes: CODE_REVIEW_ONLY },
+      { id: 'next_comment', binding: ']', action: 'Next comment', modes: CODE_REVIEW_ONLY },
+      { id: 'previous_comment', binding: '[', action: 'Previous comment', modes: CODE_REVIEW_ONLY },
+      { id: 'next_change', binding: 'n', action: 'Next change', mode: 'file mode', modes: CODE_REVIEW_ONLY },
+      { id: 'previous_change', binding: 'Shift+N', action: 'Previous change', mode: 'file mode', modes: CODE_REVIEW_ONLY },
+    ]},
+    { label: 'Comments', shortcuts: [
+      { id: 'comment', binding: 'c', action: 'Comment on focused block (or text selection, with quote)', modes: CODE_REVIEW_ONLY },
+      { id: 'edit_comment', binding: 'e', action: 'Edit comment on focused block', modes: CODE_REVIEW_ONLY },
+      { id: 'delete_comment', binding: 'd', action: 'Delete comment on focused block', modes: CODE_REVIEW_ONLY },
+      { id: 'general_comment', binding: 'Shift+G', action: 'General comment', modes: CODE_REVIEW_ONLY },
+      { binding: 'Ctrl+Enter', action: 'Comment', modes: BOTH, fixed: true },
+    ]},
+    { label: 'Review', shortcuts: [
+      { id: 'finish_review', binding: 'Shift+F', action: 'Finish review', modes: BOTH },
+      { id: 'toggle_comments', binding: 'Shift+C', action: 'Toggle comments panel', modes: CODE_REVIEW_ONLY },
+      { id: 'scope_all', binding: 'Shift+1', action: 'Switch to all changes', mode: 'vcs mode', modes: CODE_REVIEW_ONLY },
+      { id: 'scope_branch', binding: 'Shift+2', action: 'Switch to branch changes', mode: 'vcs mode', modes: CODE_REVIEW_ONLY },
+      { id: 'scope_staged', binding: 'Shift+3', action: 'Switch to staged changes', mode: 'vcs mode', modes: CODE_REVIEW_ONLY },
+      { id: 'scope_unstaged', binding: 'Shift+4', action: 'Switch to unstaged changes', mode: 'vcs mode', modes: CODE_REVIEW_ONLY },
+    ]},
+    { label: 'Story', shortcuts: [
+      { id: 'story_next', binding: 'Shift+J', action: 'Next story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY },
+      { id: 'story_previous', binding: 'Shift+K', action: 'Previous story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY },
+      { id: 'story_prologue', binding: 'Shift+O', action: 'Story prologue', mode: 'story mode', modes: CODE_REVIEW_ONLY },
+      { id: 'story_support', binding: 'Shift+S', action: 'Story support', mode: 'story mode', modes: CODE_REVIEW_ONLY },
+      { binding: '1–9', action: 'Jump to story chapter', mode: 'story mode', modes: CODE_REVIEW_ONLY, fixed: true },
+      { id: 'story_toggle_list', binding: '\\', action: 'Toggle story chapter list', mode: 'story mode', modes: CODE_REVIEW_ONLY },
+    ]},
+    { label: 'Live', shortcuts: [
+      { id: 'toggle_pin_mode', binding: 'p', action: 'Toggle pin mode', modes: LIVE_ONLY },
+    ]},
+    { label: 'View', shortcuts: [
+      { id: 'toggle_toc', binding: 't', action: 'Toggle table of contents', mode: 'file mode', modes: CODE_REVIEW_ONLY },
+      { id: 'toggle_resolved', binding: 'h', action: 'Toggle hide resolved', modes: CODE_REVIEW_ONLY },
+      { binding: 'Esc', action: 'Cancel / clear focus', modes: BOTH, fixed: true },
+      { binding: '?', action: 'Toggle this panel', modes: BOTH, fixed: true },
+    ]},
+  ];
+
+  var byID = {};
+  groups.forEach(function (group) {
+    group.shortcuts.forEach(function (shortcut) {
+      if (shortcut.id) byID[shortcut.id] = shortcut;
+    });
+  });
+
+  function shared() {
+    return root.crit && root.crit.shared;
+  }
+
+  function overrides() {
+    var helpers = shared();
+    var value = helpers && helpers.getSetting ? helpers.getSetting('shortcuts', {}) : {};
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  }
+
+  function getBinding(id) {
+    var shortcut = byID[id];
+    if (!shortcut) return '';
+    var saved = overrides();
+    return Object.prototype.hasOwnProperty.call(saved, id) ? saved[id] : shortcut.binding;
+  }
+
+  function setBinding(id, binding) {
+    if (!byID[id]) return false;
+    var saved = overrides();
+    if (binding === byID[id].binding) delete saved[id];
+    else saved[id] = binding;
+    var helpers = shared();
+    if (!helpers || !helpers.setSetting) return false;
+    helpers.setSetting('shortcuts', saved);
+    return true;
+  }
+
+  function resetAll() {
+    var helpers = shared();
+    if (helpers && helpers.setSetting) helpers.setSetting('shortcuts', {});
+  }
+
+  function isCustomized(id) {
+    return Object.prototype.hasOwnProperty.call(overrides(), id);
+  }
+
+  function eventToBinding(ev) {
+    var key = ev.key;
+    if (!key || key === 'Shift' || key === 'Control' || key === 'Alt' || key === 'Meta') return '';
+    var names = {
+      ' ': 'Space', Escape: 'Esc', Control: 'Ctrl', ArrowUp: 'ArrowUp',
+      ArrowDown: 'ArrowDown', ArrowLeft: 'ArrowLeft', ArrowRight: 'ArrowRight',
+    };
+    key = names[key] || key;
+
+    // Some synthetic keyboard APIs report the produced glyph but omit
+    // shiftKey. Canonicalize those glyphs to the physical chord shown in UI.
+    var shiftedGlyphs = {
+      '!': '1', '@': '2', '#': '3', '$': '4', '%': '5', '^': '6',
+      '&': '7', '*': '8', '(': '9', ')': '0', '_': '-', '+': '=',
+      '{': '[', '}': ']', ':': ';', '"': "'", '<': ',', '>': '.',
+      '?': '/', '|': '\\', '~': '`',
+    };
+    var shift = !!ev.shiftKey;
+    if (shiftedGlyphs[key]) {
+      key = shiftedGlyphs[key];
+      shift = true;
+    }
+
+    // Shifted number/punctuation keys report the produced glyph in `key`.
+    // Prefer `code` so capture and matching both represent Shift+1 as such.
+    if (shift && /^Digit[0-9]$/.test(ev.code || '')) key = ev.code.slice(5);
+    else if (shift) {
+      var shiftedCodeKeys = {
+        BracketLeft: '[', BracketRight: ']', Semicolon: ';', Quote: "'",
+        Comma: ',', Period: '.', Slash: '/', Backslash: '\\', Backquote: '`',
+        Minus: '-', Equal: '=',
+      };
+      if (shiftedCodeKeys[ev.code]) key = shiftedCodeKeys[ev.code];
+    }
+    if (key.length === 1 && /^[a-zA-Z]$/.test(key)) {
+      key = shift ? key.toUpperCase() : key.toLowerCase();
+    }
+
+    var parts = [];
+    if (ev.ctrlKey) parts.push('Ctrl');
+    if (ev.altKey) parts.push('Alt');
+    if (shift) parts.push('Shift');
+    if (ev.metaKey) parts.push('Meta');
+    parts.push(key);
+    return parts.join('+');
+  }
+
+  function actionForEvent(ev, mode) {
+    var binding = eventToBinding(ev);
+    if (!binding) return '';
+    var found = '';
+    groups.some(function (group) {
+      return group.shortcuts.some(function (shortcut) {
+        if (!shortcut.id || shortcut.modes.indexOf(mode) === -1) return false;
+        if (getBinding(shortcut.id) !== binding) return false;
+        found = shortcut.id;
+        return true;
+      });
+    });
+    return found;
+  }
+
+  function findConflict(id, binding) {
+    if (!binding) return null;
+    var target = byID[id];
+    if (!target) return null;
+    var conflict = null;
+    groups.some(function (group) {
+      return group.shortcuts.some(function (shortcut) {
+        if (!shortcut.id || shortcut.id === id) return false;
+        var sharesMode = shortcut.modes.some(function (mode) { return target.modes.indexOf(mode) !== -1; });
+        if (!sharesMode) return false;
+        if (getBinding(shortcut.id) !== binding) return false;
+        conflict = shortcut;
+        return true;
+      });
+    });
+    return conflict;
+  }
+
+  return {
+    groups: groups,
+    getBinding: getBinding,
+    setBinding: setBinding,
+    resetAll: resetAll,
+    isCustomized: isCustomized,
+    eventToBinding: eventToBinding,
+    actionForEvent: actionForEvent,
+    findConflict: findConflict,
+  };
+});

--- a/web/index.html
+++ b/web/index.html
@@ -338,6 +338,7 @@
         'crit-icons.js',
         'crit-comment-card-helpers.js',
         'crit-comment-card.js',
+        'crit-shortcuts.js',
         'crit-settings-panes.js',
         'crit-settings-overlay.js',
         'crit-share.js',
@@ -441,6 +442,8 @@
       var ch = document.createElement('script'); ch.src = 'crit-comment-card-helpers.js'; ch.async = false; document.body.appendChild(ch);
       // Shared comment-card renderer (used by app.js and live-mode). Must load before app.js.
       var cc = document.createElement('script'); cc.src = 'crit-comment-card.js'; cc.async = false; document.body.appendChild(cc);
+      // Shared shortcut registry, persistence, and key normalization.
+      var ks = document.createElement('script'); ks.src = 'crit-shortcuts.js'; ks.async = false; document.body.appendChild(ks);
       // Shared settings-overlay panes (Shortcuts + About). Must load before app.js.
       var sp = document.createElement('script'); sp.src = 'crit-settings-panes.js'; sp.async = false; document.body.appendChild(sp);
       // Shared settings-overlay shell (open/close/Esc/focus-trap/tab nav). Must load before app.js.

--- a/web/live-mode.js
+++ b/web/live-mode.js
@@ -1564,7 +1564,7 @@
     var overlayApi = window.crit && window.crit.settingsOverlay;
     if (!overlayApi || !overlayApi.install) return;
     var closeBtn = overlay.querySelector && overlay.querySelector('#settingsClose');
-    overlayApi.install({
+    state.settingsOverlay = overlayApi.install({
       overlay: overlay,
       toggle: toggle,
       closeBtn: closeBtn,
@@ -2217,8 +2217,23 @@
     if (!sc) return;
     sc.handleShortcut(ev, {
       focusInInput: !!state.focusInInput,
+      settingsOpen: !!(state.settingsOverlay && state.settingsOverlay.isOpen && state.settingsOverlay.isOpen()),
+      actionForEvent: function (event) {
+        var shortcuts = window.crit && window.crit.shortcuts;
+        return shortcuts ? shortcuts.actionForEvent(event, 'live') : '';
+      },
       getMode: function () { return state.mode; },
       setMode: function (m) { setMode(m); },
+      toggleShortcuts: function () {
+        var settings = state.settingsOverlay;
+        if (!settings) return;
+        if (settings.isOpen && settings.isOpen() &&
+            settings.getActiveTab && settings.getActiveTab() === 'shortcuts') {
+          settings.close();
+        } else if (settings.open) {
+          settings.open('shortcuts');
+        }
+      },
       // Shift+F → click the finishBtn so the "no changes this round"
       // overlay + dedup guard inside the click handler fire just like a
       // mouse click. Skip when the button isn't installed yet or the UI

--- a/web/live-mode.shortcut.js
+++ b/web/live-mode.shortcut.js
@@ -10,20 +10,30 @@
 })(typeof window !== 'undefined' ? window : globalThis, function () {
   function handleShortcut(ev, ctx) {
     if (ctx.focusInInput) return;
+    if (ev.key === '?') {
+      if (typeof ev.preventDefault === 'function') ev.preventDefault();
+      if (typeof ev.stopImmediatePropagation === 'function') ev.stopImmediatePropagation();
+      if (typeof ctx.toggleShortcuts === 'function') ctx.toggleShortcuts();
+      return;
+    }
+    if (ctx.settingsOpen) return;
+    var action = typeof ctx.actionForEvent === 'function' ? ctx.actionForEvent(ev) : '';
     // Shift+F triggers Finish Review for parity with code-review mode.
     // Match against `key` (case-sensitive 'F' arrives when shift is held)
     // AND require shiftKey, so plain 'f' on layouts where shift produces a
     // different glyph still works. Ignore when other modifiers are pressed
     // — we don't want Cmd+Shift+F (browser find-in-page) to be hijacked.
-    if (ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey
-        && (ev.key === 'F' || ev.key === 'f')) {
+    if (action === 'finish_review' || (!ctx.actionForEvent && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey
+        && (ev.key === 'F' || ev.key === 'f'))) {
       if (typeof ctx.finishReview === 'function') {
         if (typeof ev.preventDefault === 'function') ev.preventDefault();
         ctx.finishReview();
       }
       return;
     }
-    if (ev.key === 'p' || ev.key === 'P') {
+    if (action === 'toggle_pin_mode' || (!ctx.actionForEvent && (ev.key === 'p' || ev.key === 'P'))) {
+      if (typeof ev.preventDefault === 'function') ev.preventDefault();
+      if (typeof ev.stopPropagation === 'function') ev.stopPropagation();
       ctx.setMode(ctx.getMode() === 'pin' ? 'navigate' : 'pin');
       return;
     }

--- a/web/style.css
+++ b/web/style.css
@@ -2981,6 +2981,26 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
 }
 
 /* Shortcuts table (inside settings panel) */
+.shortcuts-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.shortcut-reset-all {
+  appearance: none;
+  border: 0;
+  background: none;
+  color: var(--crit-brand);
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+.shortcut-reset-all:hover { text-decoration: underline; }
+.shortcut-reset-all:focus-visible { outline: none; box-shadow: var(--crit-focus); }
 .shortcuts-group-label {
   font-size: 12px;
   text-transform: uppercase;
@@ -3011,12 +3031,41 @@ body.hide-resolved .comment-block:not(.panel-comment-block):has(.resolved-card) 
   background: var(--crit-editor-bg-elevated);
   border: 1px solid var(--crit-border);
   border-radius: 4px;
+  box-sizing: border-box;
+  height: 22px;
+  line-height: 18px;
   padding: 1px 6px;
   font-family: var(--crit-font-mono);
   font-size: 12px;
   color: var(--crit-editor-fg);
   min-width: 24px;
   text-align: center;
+  vertical-align: middle;
+}
+.shortcut-binding {
+  appearance: none;
+  align-items: center;
+  border: 0;
+  box-sizing: border-box;
+  background: none;
+  border-radius: 4px;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  height: 26px;
+  line-height: 1;
+  padding: 2px;
+  vertical-align: middle;
+}
+.shortcut-binding:hover { background: var(--crit-editor-bg-hover); }
+.shortcut-binding:focus-visible,
+.shortcut-binding.is-capturing { outline: none; box-shadow: var(--crit-focus); }
+.shortcut-binding.is-customized kbd { border-color: var(--crit-brand); }
+.shortcut-unassigned {
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  font-style: italic;
 }
 .shortcut-mode-badge {
   display: inline-block;


### PR DESCRIPTION
## Summary
- add customizable keyboard shortcuts with persistent user overrides
- support rebinding, disabling, conflict feedback, and resetting shortcuts
- apply custom bindings across code review, file, story, live, and preview modes
- keep shortcut rows stable while editing

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: deferred to the follow-up crit-web implementation

## Test plan
- unit tests for shortcut normalization, persistence, conflicts, and live dispatch
- browser coverage for git, file, mobile, and live/preview controllers
- golangci-lint and race-enabled Go test suite

Closes #758