### PR TITLE
chore: run CI on PRs only, upload coverage on main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,53 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Install jj
+        run: |
+          JJ_VERSION=0.40.0
+          mkdir -p /tmp/jj-install
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz -C /tmp/jj-install
+          sudo install /tmp/jj-install/jj /usr/local/bin/jj
+          jj --version
+
+      - name: Install sapling
+        run: |
+          SL_VERSION="0.2.20260317-201835+0234c21f"
+          SL_VERSION_ENC="${SL_VERSION//+/%2B}"
+          sudo mkdir -p /opt/sapling
+          curl -fsSL "https://github.com/facebook/sapling/releases/download/${SL_VERSION_ENC}/sapling-${SL_VERSION}-linux-x64.tar.xz" \
+            | sudo tar xJ -C /opt/sapling
+          sudo ln -sf /opt/sapling/sl /usr/local/bin/sl
+          sl --version
+
+      - name: Cache Go build cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: go-build-${{ runner.os }}-
+
+      - name: Run tests with coverage
+        run: |
+          PKGS=$(go list ./... | grep -v /node_modules/)
+          go test -coverprofile=coverage.out -covermode=atomic $PKGS
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: coverage.out
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Eight Playwright projects. Test naming convention determines which project runs 
 
 The `mobile` project shares the git-mode fixture port. In `run.sh` it runs strictly after `git-mode` finishes so the two don't race on shared comment state (both projects `DELETE /api/comments` in `beforeEach`).
 
-CI runs E2E on push to `main` and PRs via `.github/workflows/test.yml`. Failed test artifacts are uploaded.
+CI runs E2E on PRs via `.github/workflows/test.yml`; a separate `coverage.yml` uploads unit coverage on push to `main`. Failed test artifacts are uploaded.
 
 ### Best practices
 


### PR DESCRIPTION
## Summary

CI was running the full test suite on every push to `main` in addition to PRs, but just about every change already goes through a PR. This PR makes CI PR-only and keeps a minimal coverage upload on main so Codecov base coverage stays fresh.

- `test.yml` now triggers on `pull_request` only (drops the 9-job run on push to `main`).
- New `coverage.yml` runs the unit tests with coverage and uploads to Codecov on push to `main`, keeping PR base coverage and the badge accurate.
- Updated the stale AGENTS.md CI reference.

## Review

- [x] Code review: passed
- [x] Parity audit: N/A (CI-only)

## Test plan

- [x] `actionlint` passes on all workflows
- [x] Local pre-commit (gofmt, golangci-lint, tests, frontend lint) passed

See also: tomasz-tomczyk/crit-web#327 — same change for crit-web.