### PR TITLE
fix: accept flags placed after the file/URL positional argument

### DIFF
--- a/internal/clicmd/clicmd.go
+++ b/internal/clicmd/clicmd.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // ExitError signals a CLI handler failure with a specific exit code.
@@ -72,4 +73,46 @@ func RequireFlagValue(args []string, i int, flag string) (string, error) {
 		return "", ExitError{Code: 1, Err: fmt.Errorf("%s requires a value", flag)}
 	}
 	return args[i+1], nil
+}
+
+// ReorderFlagsFirst rewrites args so all flags (and their values) precede
+// positional arguments, without changing the relative order within either
+// group. flag.Parse stops parsing at the first non-flag argument, so
+// `crit <file> --no-open` silently treats "--no-open" as a second file
+// argument instead of a flag. Passing the reordered slice through
+// flag.Parse lets users place flags anywhere on the command line.
+//
+// boolFlags must name every flag (without leading dashes) that takes no
+// value, so the argument that follows it isn't mistaken for its value.
+// "-h"/"--help"/"-help" are always treated as valueless, matching the
+// stdlib flag package's built-in handling. A "--" argument is dropped and
+// ends reordering — everything after it is treated as positional, matching
+// flag.Parse's own terminator semantics.
+func ReorderFlagsFirst(args []string, boolFlags map[string]bool) []string {
+	flags := make([]string, 0, len(args))
+	positional := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if a == "-" || len(a) == 0 || a[0] != '-' {
+			positional = append(positional, a)
+			continue
+		}
+		flags = append(flags, a)
+		if strings.Contains(a, "=") {
+			continue
+		}
+		name := strings.TrimLeft(a, "-")
+		if name == "h" || name == "help" || boolFlags[name] {
+			continue
+		}
+		if i+1 < len(args) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+	return append(flags, positional...)
 }

--- a/internal/clicmd/clicmd.go
+++ b/internal/clicmd/clicmd.go
@@ -85,15 +85,19 @@ func RequireFlagValue(args []string, i int, flag string) (string, error) {
 // boolFlags must name every flag (without leading dashes) that takes no
 // value, so the argument that follows it isn't mistaken for its value.
 // "-h"/"--help"/"-help" are always treated as valueless, matching the
-// stdlib flag package's built-in handling. A "--" argument is dropped and
-// ends reordering — everything after it is treated as positional, matching
-// flag.Parse's own terminator semantics.
+// stdlib flag package's built-in handling. A "--" argument ends
+// reordering: everything after it is treated as positional, and "--" is
+// re-emitted before the positional group so flag.Parse still treats
+// dash-looking positionals as non-flags (same terminator semantics).
+// Combined short flags like -pq are not expanded (same as stdlib flag).
 func ReorderFlagsFirst(args []string, boolFlags map[string]bool) []string {
 	flags := make([]string, 0, len(args))
 	positional := make([]string, 0, len(args))
+	sawTerminator := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		if a == "--" {
+			sawTerminator = true
 			positional = append(positional, args[i+1:]...)
 			break
 		}
@@ -113,6 +117,9 @@ func ReorderFlagsFirst(args []string, boolFlags map[string]bool) []string {
 			i++
 			flags = append(flags, args[i])
 		}
+	}
+	if sawTerminator {
+		return append(append(flags, "--"), positional...)
 	}
 	return append(flags, positional...)
 }

--- a/internal/clicmd/clicmd_test.go
+++ b/internal/clicmd/clicmd_test.go
@@ -2,6 +2,7 @@ package clicmd
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"reflect"
@@ -126,9 +127,19 @@ func TestReorderFlagsFirst(t *testing.T) {
 			want: []string{"--public-url=https://x.ts.net", "design.md"},
 		},
 		{
-			name: "double-dash terminates reordering",
+			name: "double-dash terminates reordering and is preserved",
 			args: []string{"design.md", "--", "-not-a-flag"},
-			want: []string{"design.md", "-not-a-flag"},
+			want: []string{"--", "design.md", "-not-a-flag"},
+		},
+		{
+			name: "flag before terminator keeps dash-looking positional",
+			args: []string{"--no-open", "--", "-weird.md"},
+			want: []string{"--no-open", "--", "-weird.md"},
+		},
+		{
+			name: "leading terminator keeps following flags positional",
+			args: []string{"--", "--no-open", "design.md"},
+			want: []string{"--", "--no-open", "design.md"},
 		},
 		{
 			name: "bare dash is positional, not a flag",
@@ -151,6 +162,50 @@ func TestReorderFlagsFirst(t *testing.T) {
 			got := ReorderFlagsFirst(tt.args, boolFlags)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ReorderFlagsFirst(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReorderFlagsFirst_RoundTripFlagParse(t *testing.T) {
+	boolFlags := map[string]bool{"no-open": true}
+	tests := []struct {
+		name       string
+		args       []string
+		wantNoOpen bool
+		wantArgs   []string
+	}{
+		{
+			name:       "flag after file",
+			args:       []string{"design.md", "--no-open"},
+			wantNoOpen: true,
+			wantArgs:   []string{"design.md"},
+		},
+		{
+			name:       "dash-looking file after terminator",
+			args:       []string{"--no-open", "--", "-weird.md"},
+			wantNoOpen: true,
+			wantArgs:   []string{"-weird.md"},
+		},
+		{
+			name:       "leading terminator keeps flag literal",
+			args:       []string{"--", "--no-open", "design.md"},
+			wantNoOpen: false,
+			wantArgs:   []string{"--no-open", "design.md"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			noOpen := fs.Bool("no-open", false, "")
+			if err := fs.Parse(ReorderFlagsFirst(tt.args, boolFlags)); err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if *noOpen != tt.wantNoOpen {
+				t.Errorf("no-open = %v, want %v", *noOpen, tt.wantNoOpen)
+			}
+			if !reflect.DeepEqual(fs.Args(), tt.wantArgs) {
+				t.Errorf("Args() = %v, want %v", fs.Args(), tt.wantArgs)
 			}
 		})
 	}

--- a/internal/clicmd/clicmd_test.go
+++ b/internal/clicmd/clicmd_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -85,4 +86,72 @@ func TestMustGetwd(t *testing.T) {
 func mustGetwdFallback() string {
 	wd, _ := os.Getwd()
 	return wd
+}
+
+func TestReorderFlagsFirst(t *testing.T) {
+	boolFlags := map[string]bool{
+		"no-open":                       true,
+		"allow-unauthenticated-network": true,
+		"quiet":                         true,
+		"q":                             true,
+	}
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "flag after file arg (crit#787 repro)",
+			args: []string{"design.md", "-p", "51573", "--public-url", "https://x.ts.net", "--no-open"},
+			want: []string{"-p", "51573", "--public-url", "https://x.ts.net", "--no-open", "design.md"},
+		},
+		{
+			name: "bool flag after file arg",
+			args: []string{"design.md", "--no-open"},
+			want: []string{"--no-open", "design.md"},
+		},
+		{
+			name: "already flags-first is unchanged in effect",
+			args: []string{"-p", "51573", "design.md"},
+			want: []string{"-p", "51573", "design.md"},
+		},
+		{
+			name: "multiple positional args stay in order",
+			args: []string{"a.md", "--no-open", "b.md", "-p", "51573"},
+			want: []string{"--no-open", "-p", "51573", "a.md", "b.md"},
+		},
+		{
+			name: "equals-form flag needs no lookahead",
+			args: []string{"design.md", "--public-url=https://x.ts.net"},
+			want: []string{"--public-url=https://x.ts.net", "design.md"},
+		},
+		{
+			name: "double-dash terminates reordering",
+			args: []string{"design.md", "--", "-not-a-flag"},
+			want: []string{"design.md", "-not-a-flag"},
+		},
+		{
+			name: "bare dash is positional, not a flag",
+			args: []string{"-", "--no-open"},
+			want: []string{"--no-open", "-"},
+		},
+		{
+			name: "help flag treated as valueless even though unregistered",
+			args: []string{"design.md", "-h"},
+			want: []string{"-h", "design.md"},
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReorderFlagsFirst(tt.args, boolFlags)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReorderFlagsFirst(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/tomasz-tomczyk/crit/internal/browser"
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/focus"
@@ -194,6 +195,13 @@ func parseLiveCLIFlags(args []string) liveCLIFlags {
 	fs.Var(&cookieFlags, "cookie", "Cookie header value for upstream requests (repeatable)")
 	cookieFile := fs.String("cookie-file", "", "File with upstream cookies (raw header or Netscape jar)")
 	cdpURL := fs.String("cdp-url", "", "Chrome DevTools URL (e.g. http://127.0.0.1:9222) to reuse browser cookies")
+	// Keep in sync with the fs.Bool/fs.BoolVar registrations above.
+	args = clicmd.ReorderFlagsFirst(args, map[string]bool{
+		config.AllowUnauthenticatedNetworkFlag: true,
+		"no-open":                              true,
+		"quiet":                                true,
+		"q":                                    true,
+	})
 	fs.Parse(args)
 
 	rawURL := ""

--- a/internal/live/serve_flags.go
+++ b/internal/live/serve_flags.go
@@ -1,6 +1,10 @@
 package live
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
+)
 
 type serverFlagSet struct {
 	port        int
@@ -50,6 +54,16 @@ func parseServerFlags(args []string) serverFlagSet {
 	liveOrigin := fs.String("live-origin", "", "")
 	liveCookie := fs.String("live-cookie", "", "")
 	previewFile := fs.String("preview-file", "", "")
+	// Keep in sync with the fs.Bool/fs.BoolVar registrations above.
+	args = clicmd.ReorderFlagsFirst(args, map[string]bool{
+		"no-open":   true,
+		"version":   true,
+		"v":         true,
+		"quiet":     true,
+		"q":         true,
+		"no-ignore": true,
+		"remote":    true,
+	})
 	fs.Parse(args)
 
 	return serverFlagSet{

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/tomasz-tomczyk/crit/internal/browser"
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
 )
@@ -65,6 +66,13 @@ func RunPreview(args []string) {
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
 	shareURL := fs.String("share-url", "", "Share service URL")
+	// Keep in sync with the fs.Bool/fs.BoolVar registrations above.
+	args = clicmd.ReorderFlagsFirst(args, map[string]bool{
+		"no-open":                              true,
+		config.AllowUnauthenticatedNetworkFlag: true,
+		"quiet":                                true,
+		"q":                                    true,
+	})
 	fs.Parse(args)
 
 	rawPath := ""

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/focus"
 	"github.com/tomasz-tomczyk/crit/internal/session"
@@ -116,6 +117,17 @@ func parseDaemonFlags(args []string) daemonFlagSet {
 			PrintHelpFn()
 		}
 	}
+	// Keep in sync with the fs.Bool/fs.BoolVar registrations above.
+	args = clicmd.ReorderFlagsFirst(args, map[string]bool{
+		config.AllowUnauthenticatedNetworkFlag: true,
+		"no-open":                              true,
+		"version":                              true,
+		"v":                                    true,
+		"quiet":                                true,
+		"q":                                    true,
+		"no-ignore":                            true,
+		"remote":                               true,
+	})
 	fs.Parse(args)
 
 	return daemonFlagSet{

--- a/internal/server/daemon_cli_config_test.go
+++ b/internal/server/daemon_cli_config_test.go
@@ -692,6 +692,16 @@ func TestParseDaemonFlags_Session(t *testing.T) {
 	}
 }
 
+func TestParseDaemonFlags_FlagsAfterFile(t *testing.T) {
+	sf := parseDaemonFlagsForTest([]string{"plan.md", "-p", "51573", "--no-open", "--quiet"})
+	if sf.port != 51573 || !sf.noOpen || !sf.quiet {
+		t.Fatalf("flags after file not applied: %+v", sf)
+	}
+	if len(sf.fileArgs) != 1 || sf.fileArgs[0] != "plan.md" {
+		t.Fatalf("fileArgs = %v, want [plan.md]", sf.fileArgs)
+	}
+}
+
 func TestResolveDaemonCLIConfig_SessionID(t *testing.T) {
 	defer resetBranchOverride(t)
 	vcs.SetDefaultBranchOverride("")

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -41,6 +41,13 @@ func resolvePlanConfig(args []string) planConfig {
 	quiet := fs.Bool("quiet", false, "Suppress status output")
 	fs.BoolVar(quiet, "q", false, "Suppress status (shorthand)")
 	shareURL := fs.String("share-url", "", "Share service URL")
+	// Keep in sync with the fs.Bool/fs.BoolVar registrations above.
+	args = clicmd.ReorderFlagsFirst(args, map[string]bool{
+		config.AllowUnauthenticatedNetworkFlag: true,
+		"no-open":                              true,
+		"quiet":                                true,
+		"q":                                    true,
+	})
 	fs.Parse(args)
 
 	pc := planConfig{


### PR DESCRIPTION
## Summary

- `crit <file> --no-open` (and the same shape for `crit`, `crit live`, `crit preview`, `crit plan`) silently misparsed: stdlib `flag.Parse` stops at the first non-flag argument, so any flags placed after the file/URL got swallowed as bogus extra file arguments instead of being recognized. The failure then surfaced downstream as a confusing daemon/connection error with no hint that argument order was the problem.
- Adds `clicmd.ReorderFlagsFirst`, a small shared helper that rewrites args so all flags (and their values) precede positional args before each `fs.Parse` call, preserving relative order within each group. Wired into all five flag-parsing sites that had the identical pattern (`internal/server/daemon_cli.go`, `internal/live/serve_flags.go`, `internal/live/live.go`, `internal/preview/preview.go`, `internal/session/plan_cli.go`).
- Verified against the two real invocations that hit this in practice — `crit test.md --no-open` and `crit test.md -p <port> --public-url <url> --allow-unauthenticated-network --no-open` — both now start correctly and apply every flag regardless of position.

Fixes #787

## Test plan

- `go test ./...` (one pre-existing unrelated failure in `internal/github` reproduces identically on `main`, unrelated to this change)
- `gofmt -l .` / `golangci-lint run ./...` clean
- New table-driven `TestReorderFlagsFirst` in `internal/clicmd/clicmd_test.go` covers: flag-after-file, bool-flag-after-file, already-flags-first, multiple positional args, `--flag=value` form, `--` terminator, bare `-`, and `-h`.
- Manually reproduced both historical failures against a built binary in a scratch git repo and confirmed both now start cleanly and bind the requested port/public-url.
