### PR TITLE
fix: explain Host and Sec-Fetch-Site 403s instead of bare Forbidden

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -256,7 +256,7 @@ func requestHost(hostport string) string {
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !s.checkHost(r) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		http.Error(w, s.hostForbiddenMessage(r), http.StatusForbidden)
 		return
 	}
 	// CSRF defense for browser clients: modern browsers always send
@@ -265,10 +265,34 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// header = non-browser client (CLI, curl, agent) — allow. same-origin =
 	// Crit UI on this port — allow. DNS-rebinding is handled by checkHost.
 	if !checkSecFetchSite(r) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		http.Error(w, secFetchSiteForbiddenMessage(r), http.StatusForbidden)
 		return
 	}
 	s.mux.ServeHTTP(w, r)
+}
+
+// hostForbiddenMessage explains a checkHost rejection so a reverse-proxy /
+// --public-url misconfig is diagnosable from the 403 body (see #788).
+func (s *Server) hostForbiddenMessage(r *http.Request) string {
+	host := requestHost(r.Host)
+	if s.publicURLHost == "" {
+		return fmt.Sprintf(
+			"Forbidden: request Host %q does not match loopback (set --public-url if reaching Crit via a reverse proxy)",
+			host,
+		)
+	}
+	return fmt.Sprintf(
+		"Forbidden: request Host %q does not match loopback or --public-url %q",
+		host, s.publicURLHost,
+	)
+}
+
+// secFetchSiteForbiddenMessage explains a checkSecFetchSite rejection.
+func secFetchSiteForbiddenMessage(r *http.Request) string {
+	return fmt.Sprintf(
+		"Forbidden: cross-origin browser request rejected (Sec-Fetch-Site: %q)",
+		r.Header.Get("Sec-Fetch-Site"),
+	)
 }
 
 // checkSecFetchSite reports whether a request is allowed under the CSRF policy.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -131,6 +131,77 @@ func TestHostCheck(t *testing.T) {
 	}
 }
 
+// TestHostCheckForbiddenMessage pins #788: a Host-header mismatch must name
+// the offending Host and point at --public-url (or say it isn't set), so a
+// reverse-proxy misconfig doesn't look like a silent networking failure.
+func TestHostCheckForbiddenMessage(t *testing.T) {
+	t.Run("no public-url configured", func(t *testing.T) {
+		s, _ := newTestServer(t)
+		s.SetListenHost("127.0.0.1")
+		req := httptest.NewRequest("GET", "/api/session", nil)
+		req.Host = "machine.ts.net"
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, `Host "machine.ts.net"`) {
+			t.Errorf("body missing Host quote: %q", body)
+		}
+		if !strings.Contains(body, "--public-url") {
+			t.Errorf("body missing --public-url hint: %q", body)
+		}
+		if strings.TrimSpace(body) == "Forbidden" {
+			t.Errorf("body is bare Forbidden with no reason: %q", body)
+		}
+	})
+	t.Run("public-url set but Host mismatches", func(t *testing.T) {
+		s, _ := newTestServer(t)
+		s.SetListenHost("127.0.0.1")
+		s.SetPublicURL("https://correct.ts.net")
+		req := httptest.NewRequest("GET", "/api/session", nil)
+		req.Host = "wrong.ts.net"
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, `Host "wrong.ts.net"`) {
+			t.Errorf("body missing Host quote: %q", body)
+		}
+		if !strings.Contains(body, "correct.ts.net") {
+			t.Errorf("body missing configured --public-url host: %q", body)
+		}
+	})
+}
+
+// TestSecFetchSiteForbiddenMessage pins #788 for the CSRF gate: rejected
+// cross-site POSTs must name Sec-Fetch-Site rather than a bare "Forbidden".
+func TestSecFetchSiteForbiddenMessage(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.SetListenHost("127.0.0.1")
+	req := httptest.NewRequest(http.MethodPost, "/api/file/comments?path=test.md", strings.NewReader(`{}`))
+	req.Host = "127.0.0.1:9"
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Sec-Fetch-Site") {
+		t.Errorf("body missing Sec-Fetch-Site: %q", body)
+	}
+	if !strings.Contains(body, "cross-site") {
+		t.Errorf("body missing cross-site value: %q", body)
+	}
+	if strings.TrimSpace(body) == "Forbidden" {
+		t.Errorf("body is bare Forbidden with no reason: %q", body)
+	}
+}
+
 func TestIsLoopbackHost(t *testing.T) {
 	tests := []struct {
 		host string


### PR DESCRIPTION
## Summary
- Host-header and Sec-Fetch-Site 403s now name the offending value (and hint at `--public-url` when unset) instead of a bare `Forbidden`, so reverse-proxy misconfigs are diagnosable from the response body.
- Adds regression tests for both rejection paths (#788).

## Review
- [x] Code review: passed (inline; subagents rate-limited)
- [x] Parity audit: N/A (daemon Host/CSRF gate is crit-only)
- [x] Intent audit: clean — only `server.go` message helpers + tests

## Test plan
- [x] `go test ./internal/server/ -run 'TestHostCheck|TestSecFetchSite|TestSetPublicURL'`
- [x] Full `go test ./...`
- [ ] Curl Crit via a mismatched Host and confirm the 403 body names Host / `--public-url`

Closes #788


Made with [Cursor](https://cursor.com)