### PR TITLE
fix: harden custom keyboard shortcuts

### DIFF
--- a/web/__tests__/crit-shortcuts.test.js
+++ b/web/__tests__/crit-shortcuts.test.js
@@ -62,3 +62,28 @@ test('eventToBinding supports modifier chords and readable special keys', () => 
   assert.equal(shortcuts.eventToBinding({ key: ' ', code: 'Space' }), 'Space');
   assert.equal(shortcuts.eventToBinding({ key: 'Shift', code: 'ShiftLeft', shiftKey: true }), '');
 });
+
+test('malformed and unknown persisted overrides are ignored', () => {
+  const { shortcuts } = loadShortcuts({ shortcuts: { next_block: 7, unknown: 'x' } });
+  assert.equal(shortcuts.getBinding('next_block'), 'j');
+});
+
+test('reserved and conflicting persisted overrides are ignored', () => {
+  const { shortcuts } = loadShortcuts({ shortcuts: { next_block: 'Ctrl+Enter', previous_block: 'j' } });
+  assert.equal(shortcuts.getBinding('next_block'), 'j');
+  assert.equal(shortcuts.getBinding('previous_block'), 'k');
+});
+
+test('setBinding rejects reserved and conflicting bindings', () => {
+  const { shortcuts, settings } = loadShortcuts();
+  assert.equal(shortcuts.setBinding('next_block', 'Ctrl+Enter'), false);
+  assert.equal(shortcuts.setBinding('next_block', 'k'), false);
+  assert.deepEqual(settings, {});
+});
+
+test('all modified question-mark chords are reserved', () => {
+  const { shortcuts } = loadShortcuts();
+  assert.equal(shortcuts.isReservedBinding('Shift+/'), true);
+  assert.equal(shortcuts.isReservedBinding('Ctrl+Shift+/'), true);
+  assert.equal(shortcuts.isReservedBinding('Meta+Alt+Shift+/'), true);
+});

--- a/web/__tests__/live-mode.shortcut.test.js
+++ b/web/__tests__/live-mode.shortcut.test.js
@@ -148,3 +148,36 @@ test('resolved actions are suppressed while settings are open', () => {
   handleShortcut({ key: 'x' }, ctx);
   assert.equal(mode, 'navigate');
 });
+
+test('printable shortcuts remain available after a button retains focus', () => {
+  let mode = 'navigate';
+  const button = { closest: () => button };
+  handleShortcut({ key: 'x', target: button, preventDefault: () => {} }, shortcutCtx({
+    actionForEvent: () => 'toggle_pin_mode',
+    getMode: () => mode,
+    setMode: (next) => { mode = next; },
+  }));
+  assert.equal(mode, 'pin');
+});
+
+test('native button keys are not hijacked by shortcuts', () => {
+  let mode = 'navigate';
+  const button = { closest: () => button };
+  handleShortcut({ key: ' ', target: button }, shortcutCtx({
+    actionForEvent: () => 'toggle_pin_mode',
+    getMode: () => mode,
+    setMode: (next) => { mode = next; },
+  }));
+  assert.equal(mode, 'navigate');
+});
+
+test('native select keys are not hijacked by shortcuts', () => {
+  let mode = 'navigate';
+  const select = { tagName: 'SELECT', closest: () => select, isContentEditable: false };
+  handleShortcut({ key: 'ArrowDown', target: select }, shortcutCtx({
+    actionForEvent: () => 'toggle_pin_mode',
+    getMode: () => mode,
+    setMode: (next) => { mode = next; },
+  }));
+  assert.equal(mode, 'navigate');
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8877,6 +8877,10 @@
     const shortcutRegistry = window.crit && window.crit.shortcuts;
     const shortcutAction = shortcutRegistry ? shortcutRegistry.actionForEvent(e, 'code-review') : '';
     if (!shortcutAction && (e.metaKey || e.ctrlKey || e.altKey)) return;
+    const interactive = e.target && e.target.closest && e.target.closest(
+      'button, a[href], summary, [role="button"], [role="link"], [role="radio"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"], [role="option"], [role="slider"]'
+    );
+    if (interactive && [' ', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
 
     // Story navigation actions (chapter nav / overview / jump / help). Scoped
     // to the active story view. Returns early if consumed.

--- a/web/crit-settings-panes.js
+++ b/web/crit-settings-panes.js
@@ -44,11 +44,8 @@
   }
 
   function isReservedBinding(binding) {
-    var reserved = ['Esc', 'Shift+/', 'Tab', 'Enter', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-    if (reserved.indexOf(binding) !== -1) return true;
-    var parts = binding.split('+');
-    return parts[parts.length - 1] === 'Enter' &&
-      (parts.indexOf('Ctrl') !== -1 || parts.indexOf('Meta') !== -1);
+    var shortcuts = window.crit && window.crit.shortcuts;
+    return shortcuts && shortcuts.isReservedBinding ? shortcuts.isReservedBinding(binding) : false;
   }
 
   function renderShortcutsPane(pane, opts) {
@@ -104,8 +101,17 @@
         // change height when plain button text replaces their binding.
         button.innerHTML = '<kbd>Press keys…</kbd>';
       });
-      button.addEventListener('blur', function () {
-        if (button.classList.contains('is-capturing')) rerender();
+      button.addEventListener('blur', function (e) {
+        if (!button.classList.contains('is-capturing')) return;
+        var next = e && e.relatedTarget;
+        var movesWithinShortcutControls = next && next.closest &&
+          next.closest('.shortcut-binding, .shortcut-reset-all');
+        if (movesWithinShortcutControls) {
+          button.classList.remove('is-capturing');
+          button.innerHTML = bindingHTML(shortcuts.getBinding(button.dataset.shortcutId));
+          return;
+        }
+        rerender();
       });
       button.addEventListener('keydown', function (e) {
         if (!button.classList.contains('is-capturing')) return;

--- a/web/crit-shortcuts.js
+++ b/web/crit-shortcuts.js
@@ -72,10 +72,36 @@
     return root.crit && root.crit.shared;
   }
 
+  function isReservedBinding(binding) {
+    if (['Esc', 'Tab', 'Enter', '1', '2', '3', '4', '5', '6', '7', '8', '9'].indexOf(binding) !== -1) return true;
+    var parts = binding ? binding.split('+') : [];
+    return parts[parts.length - 1] === '/' && parts.indexOf('Shift') !== -1 ||
+      parts[parts.length - 1] === 'Enter' && (parts.indexOf('Ctrl') !== -1 || parts.indexOf('Meta') !== -1);
+  }
+
   function overrides() {
     var helpers = shared();
     var value = helpers && helpers.getSetting ? helpers.getSetting('shortcuts', {}) : {};
-    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+    var candidates = {};
+    var valid = {};
+    Object.keys(value).forEach(function (id) {
+      if (byID[id] && typeof value[id] === 'string' && !isReservedBinding(value[id])) candidates[id] = value[id];
+    });
+    Object.keys(candidates).forEach(function (id) {
+      var binding = candidates[id];
+      var conflict = false;
+      groups.some(function (group) {
+        return group.shortcuts.some(function (other) {
+          if (!other.id || other.id === id || other.modes.every(function (mode) { return byID[id].modes.indexOf(mode) === -1; })) return false;
+          var otherBinding = Object.prototype.hasOwnProperty.call(candidates, other.id) ? candidates[other.id] : other.binding;
+          if (otherBinding === binding) { conflict = true; return true; }
+          return false;
+        });
+      });
+      if (!conflict) valid[id] = binding;
+    });
+    return valid;
   }
 
   function getBinding(id) {
@@ -87,6 +113,8 @@
 
   function setBinding(id, binding) {
     if (!byID[id]) return false;
+    if (binding && isReservedBinding(binding)) return false;
+    if (binding && findConflict(id, binding)) return false;
     var saved = overrides();
     if (binding === byID[id].binding) delete saved[id];
     else saved[id] = binding;
@@ -194,5 +222,6 @@
     eventToBinding: eventToBinding,
     actionForEvent: actionForEvent,
     findConflict: findConflict,
+    isReservedBinding: isReservedBinding,
   };
 });

--- a/web/live-mode.js
+++ b/web/live-mode.js
@@ -2211,7 +2211,7 @@
   // ---- keyboard shortcut (p/Esc) gated on focus-state ----
   document.addEventListener('keydown', function (ev) {
     var t = ev.target;
-    var localFocus = t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || (t.isContentEditable));
+    var localFocus = t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || (t.isContentEditable));
     if (localFocus) return;
     var sc = window.crit && window.crit.live && window.crit.live.shortcut;
     if (!sc) return;

--- a/web/live-mode.shortcut.js
+++ b/web/live-mode.shortcut.js
@@ -17,6 +17,13 @@
       return;
     }
     if (ctx.settingsOpen) return;
+    var target = ev.target;
+    var tag = target && target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (target && target.isContentEditable)) return;
+    var interactive = target && target.closest && target.closest(
+      'button, a[href], select, summary, [role="button"], [role="link"], [role="radio"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"], [role="option"], [role="slider"], [role="combobox"], [role="textbox"], [role="spinbutton"]'
+    );
+    if (interactive && [' ', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].indexOf(ev.key) !== -1) return;
     var action = typeof ctx.actionForEvent === 'function' ? ctx.actionForEvent(ev) : '';
     // Shift+F triggers Finish Review for parity with code-review mode.
     // Match against `key` (case-sensitive 'F' arrives when shift is held)


### PR DESCRIPTION
## Summary
- reject reserved and conflicting persisted shortcut bindings
- preserve native button and select keyboard behavior
- stabilize shortcut capture focus transitions
- add regression coverage for these edge cases

Closes #758

Crit Web counterpart: https://github.com/tomasz-tomczyk/crit-web/pull/329

## Tests
- node --test web/__tests__/crit-shortcuts.test.js web/__tests__/live-mode.shortcut.test.js
- npm run test:frontend
- mise exec -- golangci-lint run ./...
- mise exec -- go test -race -count=1 ./...