### PR TITLE
fix(e2e): settle theme transitions before axe contrast audit

### DIFF
--- a/test/e2e/tests/accessibility.spec.ts
+++ b/test/e2e/tests/accessibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { loadPage } from './helpers';
 
@@ -6,6 +6,29 @@ test.describe('Accessibility', () => {
   test.beforeEach(async ({ page }) => {
     await loadPage(page);
   });
+
+  // Switch to an explicit theme and wait until it has fully applied.
+  //
+  // `.toggle-btn` and other chrome elements transition colors over 150ms
+  // (`transition: all 0.15s` in style.css). Axe would otherwise measure the
+  // buttons mid-transition — light-theme tokens interpolating toward dark on
+  // dark surfaces — and report thousands of bogus color-contrast violations.
+  // Disable transitions so the audit sees the settled theme, exactly what a
+  // user sees after the theme switch completes.
+  async function setTheme(page: Page, theme: 'dark' | 'light', bgPage: string) {
+    await page.addStyleTag({ content: '* { transition: none !important; }' });
+    await page.evaluate(
+      (t) => document.documentElement.setAttribute('data-theme', t),
+      theme,
+    );
+    await page.waitForFunction(
+      (expected) =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--crit-bg-page')
+          .trim() === expected,
+      bgPage,
+    );
+  }
 
   test('should have no critical accessibility violations', async ({ page }) => {
     await page.waitForSelector('.file-section');
@@ -28,11 +51,7 @@ test.describe('Accessibility', () => {
 
   test('should have no color contrast violations in dark theme', async ({ page }) => {
     await page.waitForSelector('.file-section');
-    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
-    await page.waitForFunction(() => {
-      const bg = getComputedStyle(document.documentElement).getPropertyValue('--crit-bg-page').trim();
-      return bg === '#0e0f13';
-    });
+    await setTheme(page, 'dark', '#0e0f13');
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa'])
@@ -45,11 +64,7 @@ test.describe('Accessibility', () => {
 
   test('should have no color contrast violations in light theme', async ({ page }) => {
     await page.waitForSelector('.file-section');
-    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'light'));
-    await page.waitForFunction(() => {
-      const bg = getComputedStyle(document.documentElement).getPropertyValue('--crit-bg-page').trim();
-      return bg === '#ffffff';
-    });
+    await setTheme(page, 'light', '#ffffff');
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa'])


### PR DESCRIPTION
## Summary

Fixes a flaky `color-contrast` failure in `accessibility.spec.ts` that was reproducible locally but passing in CI.

The dark/light theme tests flip `data-theme` and immediately run the axe audit. Chrome elements (`.toggle-btn`, etc.) animate colors over 150ms (`transition: all 0.15s` in `style.css`). Axe therefore measures them **mid-transition** — light-theme tokens interpolating toward dark on dark surfaces — and reports ~1700 bogus contrast violations (e.g. brand `#2960bc` on `#262d4a`, ratio 2.24:1).

It's a pure timing race:

- Fast machines (local dev): axe reaches the contrast checks inside the 150ms window → fails
- Slow/loaded runners (GitHub Actions): transitions finish before axe evaluates → passes

## Fix

Disable CSS transitions before switching themes so the audit measures the **settled** theme — exactly what a user sees after the switch completes. No assertions weakened, no blind sleeps; uses an injected style tag and the existing `waitForFunction` theme check.

## Verification

- `bash run.sh tests/accessibility.spec.ts` → 3 passed (was: 1 failed, 1766 violations)
- `bash run.sh tests/theme.spec.ts` → 5 passed
- Pre-commit hook (gofmt, golangci-lint, tests, ESLint, Stylelint, CSS var checks) → passed

Note: this is the kind of flake that CI misses — main is only unit-tested on push (`coverage.yml`), and the e2e job only runs on PRs.