### PR TITLE
perf: defer off-screen file bodies for large PR reviews

### DIFF
--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -221,5 +223,112 @@ func TestSetFocus_RangeToWorkingTree_StashesLastRangeFocus(t *testing.T) {
 	}
 	if s.LastRangeFocus.PRNumber != 42 || s.LastRangeFocus.HeadSHA != head {
 		t.Errorf("LastRangeFocus = %+v; want PR=42 head=%s", s.LastRangeFocus, head)
+	}
+}
+
+// Range focus with many files must apply lazyFileThreshold and populate
+// sidebar +/- stats (same contract as working-tree rebuild).
+func TestSetFocus_Range_AppliesLazyThreshold(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+
+	total := lazyFileThreshold + 5
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("doc%03d.md", i)
+		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("# doc %d\n\nbody line\n", i))
+	}
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add many docs")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		RepoRoot:  dir,
+		OutputDir: dir,
+		VCS:       &vcs.GitVCS{},
+	}
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Files) != total {
+		t.Fatalf("files = %d, want %d", len(s.Files), total)
+	}
+
+	eager, lazy := 0, 0
+	for _, f := range s.Files {
+		if f.Lazy {
+			lazy++
+			if f.Content != "" {
+				t.Errorf("lazy file %s should not have content", f.Path)
+			}
+			if f.LazyAdditions == 0 && f.Status != "deleted" {
+				t.Errorf("lazy file %s should have LazyAdditions from between-SHA numstat", f.Path)
+			}
+		} else {
+			eager++
+		}
+	}
+	if eager != lazyFileThreshold {
+		t.Errorf("eager = %d, want %d", eager, lazyFileThreshold)
+	}
+	if lazy != total-lazyFileThreshold {
+		t.Errorf("lazy = %d, want %d", lazy, total-lazyFileThreshold)
+	}
+}
+
+// Lazy range files must load HeadSHA content, not a dirty working tree.
+func TestGetFileSnapshot_RangeLazy_UsesHeadSHANotWorkingTree(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+
+	total := lazyFileThreshold + 1
+	var lazyPath string
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("doc%03d.md", i)
+		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("# committed %d\n", i))
+		if i == lazyFileThreshold {
+			lazyPath = name
+		}
+	}
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add docs")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	// Dirty the lazy file in the working tree — SHA-aware load must ignore this.
+	dirty := "# dirty working tree\nshould-not-appear\n"
+	if err := os.WriteFile(filepath.Join(dir, lazyPath), []byte(dirty), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Session{
+		RepoRoot:  dir,
+		OutputDir: dir,
+		VCS:       &vcs.GitVCS{},
+	}
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
+		t.Fatal(err)
+	}
+
+	var lazyFile *FileEntry
+	for _, f := range s.Files {
+		if f.Path == lazyPath {
+			lazyFile = f
+			break
+		}
+	}
+	if lazyFile == nil || !lazyFile.Lazy {
+		t.Fatalf("expected %s to be lazy, got %+v", lazyPath, lazyFile)
+	}
+
+	snap, ok := s.GetFileSnapshot(lazyPath)
+	if !ok {
+		t.Fatal("GetFileSnapshot failed")
+	}
+	content, _ := snap["content"].(string)
+	want := fmt.Sprintf("# committed %d\n", lazyFileThreshold)
+	if content != want {
+		t.Fatalf("content = %q, want HeadSHA content %q (not dirty WT)", content, want)
+	}
+	if lazyFile.Lazy {
+		t.Fatal("file should no longer be lazy after GetFileSnapshot")
 	}
 }

--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -1,10 +1,12 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
@@ -475,4 +477,169 @@ func TestGetFileSnapshot_RangeLazy_Deleted(t *testing.T) {
 	if lazyFile.Lazy {
 		t.Fatal("deleted lazy file should be loaded after GetFileSnapshot")
 	}
+}
+
+func TestEnsureFileLoaded_NilAndNonLazy(t *testing.T) {
+	s := &Session{Focus: Focus{Kind: FocusWorkingTree}}
+	if err := s.ensureFileLoaded(nil); err != nil {
+		t.Fatalf("nil file: %v", err)
+	}
+	fe := &FileEntry{Path: "x.md", Lazy: false, Content: "already"}
+	if err := s.ensureFileLoaded(fe); err != nil {
+		t.Fatalf("non-lazy: %v", err)
+	}
+	if fe.Content != "already" {
+		t.Fatalf("non-lazy content mutated: %q", fe.Content)
+	}
+}
+
+func TestEnsureFileLoaded_WorkingTreeLazy(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	path := filepath.Join(dir, "lazy.md")
+	writeFile(t, path, "# from disk\n")
+	gitT(t, dir, "add", "lazy.md")
+	gitT(t, dir, "commit", "-m", "add lazy")
+
+	s := &Session{
+		Focus:    Focus{Kind: FocusWorkingTree, BaseRef: base},
+		RepoRoot: dir,
+		BaseRef:  base,
+		VCS:      &vcs.GitVCS{},
+	}
+	fe := &FileEntry{
+		Path:    "lazy.md",
+		AbsPath: path,
+		Status:  "added",
+		Lazy:    true,
+	}
+	if err := s.ensureFileLoaded(fe); err != nil {
+		t.Fatal(err)
+	}
+	if fe.Lazy {
+		t.Fatal("expected Lazy=false after working-tree load")
+	}
+	if fe.Content != "# from disk\n" {
+		t.Fatalf("content = %q", fe.Content)
+	}
+	if len(fe.DiffHunks) == 0 {
+		t.Fatal("expected unified new-file hunks for added lazy file")
+	}
+}
+
+func TestEnsureLoadedAtRange_RemoteErrorAndNilContent(t *testing.T) {
+	wantErr := errors.New("remote boom")
+	var calls int32
+	stubFetchFn(t, nil, wantErr, &calls)
+
+	s := &Session{
+		RemoteFiles: true,
+		Focus: Focus{
+			Kind:    FocusRange,
+			BaseSHA: "base",
+			HeadSHA: "head",
+			PRURL:   "https://github.com/foo/bar/pull/1",
+		},
+		VCS: &vcs.GitVCS{},
+	}
+	fe := &FileEntry{Path: "x.md", Status: "added", Lazy: true}
+	err := s.ensureFileLoaded(fe)
+	if err == nil || !strings.Contains(err.Error(), "remote boom") {
+		t.Fatalf("got %v, want remote boom", err)
+	}
+	if !fe.Lazy {
+		t.Fatal("failed load must leave Lazy=true")
+	}
+
+	// nil body, no error → "not found"
+	var calls2 int32
+	stubFetchFn(t, nil, nil, &calls2)
+	fe2 := &FileEntry{Path: "y.md", Status: "added", Lazy: true}
+	err = s.ensureFileLoaded(fe2)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got %v, want not found", err)
+	}
+}
+
+func TestEnsureLoadedAtRange_ModifiedRequiresVCS(t *testing.T) {
+	dir := initTestRepo(t)
+	writeFile(t, filepath.Join(dir, "m.md"), "# base\n")
+	gitT(t, dir, "add", "m.md")
+	gitT(t, dir, "commit", "-m", "base")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	writeFile(t, filepath.Join(dir, "m.md"), "# head\n")
+	gitT(t, dir, "add", "m.md")
+	gitT(t, dir, "commit", "-m", "head")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	// Session has VCS for content reads; pass nil v to hit the require-VCS branch.
+	s := &Session{
+		RepoRoot: dir,
+		VCS:      &vcs.GitVCS{},
+		Focus:    Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head},
+	}
+	fe := &FileEntry{Path: "m.md", Status: "modified", Lazy: true, AbsPath: filepath.Join(dir, "m.md")}
+	err := fe.ensureLoadedAtRange(s, s.Focus, dir, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires VCS") {
+		t.Fatalf("got %v, want requires VCS", err)
+	}
+}
+
+func TestEnsureLoadedAtRange_AlreadyLoadedNoop(t *testing.T) {
+	s := &Session{Focus: Focus{Kind: FocusRange, BaseSHA: "a", HeadSHA: "b"}}
+	fe := &FileEntry{Path: "x.md", Status: "added", Lazy: false, Content: "kept"}
+	if err := fe.ensureLoadedAtRange(s, s.Focus, "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if fe.Content != "kept" {
+		t.Fatalf("content changed: %q", fe.Content)
+	}
+}
+
+func TestPopulateLazyFile_DiskFallbackFlag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.md")
+	writeFile(t, path, "one\ntwo\nthree\n")
+	fe := &FileEntry{Path: "a.md", AbsPath: path, Status: "added"}
+	fc := vcs.FileChange{Path: "a.md", Status: "added"}
+
+	populateLazyFile(fe, fc, nil, false)
+	if !fe.Lazy || fe.LazyAdditions != 0 {
+		t.Fatalf("diskFallback=false: lazy=%v adds=%d", fe.Lazy, fe.LazyAdditions)
+	}
+
+	fe2 := &FileEntry{Path: "a.md", AbsPath: path, Status: "added"}
+	populateLazyFile(fe2, fc, nil, true)
+	if fe2.LazyAdditions != 3 {
+		t.Fatalf("diskFallback=true: adds=%d, want 3", fe2.LazyAdditions)
+	}
+
+	fe3 := &FileEntry{Path: "a.md", AbsPath: path, Status: "added"}
+	populateLazyFile(fe3, fc, map[string]vcs.NumstatEntry{"a.md": {Additions: 9, Deletions: 1}}, false)
+	if fe3.LazyAdditions != 9 || fe3.LazyDeletions != 1 {
+		t.Fatalf("numstat map: +%d/-%d", fe3.LazyAdditions, fe3.LazyDeletions)
+	}
+}
+
+func TestGetFileSnapshot_RangeLazy_RemoteErrorReturnsFalse(t *testing.T) {
+	wantErr := errors.New("fetch failed")
+	var calls int32
+	stubFetchFn(t, nil, wantErr, &calls)
+
+	fe := &FileEntry{Path: "x.md", Status: "added", Lazy: true}
+	s := &Session{
+		RemoteFiles: true,
+		Focus: Focus{
+			Kind:    FocusRange,
+			BaseSHA: "base",
+			HeadSHA: "head",
+			PRURL:   "https://github.com/foo/bar/pull/2",
+		},
+		VCS:   &vcs.GitVCS{},
+		Files: []*FileEntry{fe},
+	}
+	if _, ok := s.GetFileSnapshot("x.md"); ok {
+		t.Fatal("expected GetFileSnapshot false when remote lazy load fails")
+	}
+	_ = atomic.LoadInt32(&calls) // ensure stub was wired
 }

--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/vcs"
@@ -330,5 +331,148 @@ func TestGetFileSnapshot_RangeLazy_UsesHeadSHANotWorkingTree(t *testing.T) {
 	}
 	if lazyFile.Lazy {
 		t.Fatal("file should no longer be lazy after GetFileSnapshot")
+	}
+}
+
+// Lazy range modified files must load between-SHA diffs, not working-tree diffs.
+func TestGetFileDiffSnapshot_RangeLazy_UsesBetweenSHADiff(t *testing.T) {
+	dir := initTestRepo(t)
+
+	total := lazyFileThreshold + 1
+	var lazyPath string
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("doc%03d.md", i)
+		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("# base %d\nline two\n", i))
+		if i == lazyFileThreshold {
+			lazyPath = name
+		}
+	}
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "base docs")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("doc%03d.md", i)
+		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("# head %d\nline two\n", i))
+	}
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "head docs")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	// Dirty WT content that would produce a different diff if read from disk.
+	if err := os.WriteFile(filepath.Join(dir, lazyPath), []byte("# dirty\nentirely different\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Session{
+		Mode:      "git",
+		RepoRoot:  dir,
+		OutputDir: dir,
+		VCS:       &vcs.GitVCS{},
+	}
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
+		t.Fatal(err)
+	}
+
+	var lazyFile *FileEntry
+	for _, f := range s.Files {
+		if f.Path == lazyPath {
+			lazyFile = f
+			break
+		}
+	}
+	if lazyFile == nil || !lazyFile.Lazy {
+		t.Fatalf("expected %s lazy, got %+v", lazyPath, lazyFile)
+	}
+	if lazyFile.LazyAdditions == 0 {
+		t.Fatalf("expected LazyAdditions from between-SHA numstat for %s", lazyPath)
+	}
+
+	result, ok := s.GetFileDiffSnapshot(lazyPath, false)
+	if !ok {
+		t.Fatal("GetFileDiffSnapshot failed")
+	}
+	hunks, _ := result["hunks"].([]vcs.DiffHunk)
+	if len(hunks) == 0 {
+		t.Fatal("expected between-SHA hunks for modified lazy file")
+	}
+	joined := ""
+	for _, h := range hunks {
+		for _, l := range h.Lines {
+			joined += l.Content + "\n"
+		}
+	}
+	if !strings.Contains(joined, "head "+fmt.Sprint(lazyFileThreshold)) {
+		t.Fatalf("hunks missing HeadSHA content; got %q", joined)
+	}
+	if strings.Contains(joined, "dirty") || strings.Contains(joined, "entirely different") {
+		t.Fatalf("hunks used dirty working tree; got %q", joined)
+	}
+	if lazyFile.Lazy {
+		t.Fatal("file should no longer be lazy after GetFileDiffSnapshot")
+	}
+}
+
+// Deleted lazy range files load without reading HeadSHA content.
+func TestGetFileSnapshot_RangeLazy_Deleted(t *testing.T) {
+	dir := initTestRepo(t)
+
+	total := lazyFileThreshold + 1
+	var lazyPath string
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("doc%03d.md", i)
+		writeFile(t, filepath.Join(dir, name), fmt.Sprintf("# doc %d\n", i))
+		if i == lazyFileThreshold {
+			lazyPath = name
+		}
+	}
+	gitT(t, dir, "add", ".")
+	gitT(t, dir, "commit", "-m", "add docs")
+	base := gitT(t, dir, "rev-parse", "HEAD")
+
+	if err := os.Remove(filepath.Join(dir, lazyPath)); err != nil {
+		t.Fatal(err)
+	}
+	gitT(t, dir, "add", "-A")
+	gitT(t, dir, "commit", "-m", "delete lazy doc")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		RepoRoot:  dir,
+		OutputDir: dir,
+		VCS:       &vcs.GitVCS{},
+	}
+	if err := s.SetFocus(Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: head, DiffScope: DiffScopeLayer}); err != nil {
+		t.Fatal(err)
+	}
+
+	var lazyFile *FileEntry
+	for _, f := range s.Files {
+		if f.Path == lazyPath {
+			lazyFile = f
+			break
+		}
+	}
+	if lazyFile == nil {
+		t.Fatalf("%s missing from file list", lazyPath)
+	}
+	if lazyFile.Status != "deleted" {
+		t.Fatalf("status = %q, want deleted", lazyFile.Status)
+	}
+	if !lazyFile.Lazy {
+		// Ordering is by ChangedFilesBetweenSHAs; if the deleted file landed
+		// in the eager prefix, skip — the load path still matters when lazy.
+		t.Skip("deleted file was eagerly loaded; threshold ordering put it under the cut")
+	}
+
+	snap, ok := s.GetFileSnapshot(lazyPath)
+	if !ok {
+		t.Fatal("GetFileSnapshot failed for deleted lazy file")
+	}
+	if content, _ := snap["content"].(string); content != "" {
+		t.Fatalf("deleted file content = %q, want empty", content)
+	}
+	if lazyFile.Lazy {
+		t.Fatal("deleted lazy file should be loaded after GetFileSnapshot")
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -606,13 +606,16 @@ type CritJSONFile struct {
 }
 
 // populateLazyFile fills stats for a file that will be loaded on demand.
-func populateLazyFile(fe *FileEntry, fc vcs.FileChange, numstats map[string]vcs.NumstatEntry) {
+// When diskFallback is true (working-tree focus), missing numstat for
+// added/untracked files is estimated from the on-disk file. Range/--pr
+// focus must pass false so dirty trees / --remote don't contaminate stats.
+func populateLazyFile(fe *FileEntry, fc vcs.FileChange, numstats map[string]vcs.NumstatEntry, diskFallback bool) {
 	fe.Lazy = true
 	fe.Comments = []Comment{}
 	if ns, ok := numstats[fc.Path]; ok {
 		fe.LazyAdditions = ns.Additions
 		fe.LazyDeletions = ns.Deletions
-	} else if fc.Status == "untracked" || fc.Status == "added" {
+	} else if diskFallback && (fc.Status == "untracked" || fc.Status == "added") {
 		if data, err := os.ReadFile(fe.AbsPath); err == nil {
 			fe.LazyAdditions = strings.Count(string(data), "\n")
 			if len(data) > 0 && data[len(data)-1] != '\n' {
@@ -816,7 +819,7 @@ func newGitSession(v vcs.VCS, ignorePatterns []string, requireChanges bool) (*Se
 		}
 
 		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
-			populateLazyFile(fe, fc, numstats)
+			populateLazyFile(fe, fc, numstats, true)
 		} else if !populateEagerFile(fe, fc, baseRef, root, v) {
 			continue
 		}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -28,8 +28,10 @@ var ErrNoChangedFiles = errors.New("no changed files detected (after applying ig
 
 // lazyFileThreshold is the maximum number of files to eagerly load
 // content and diffs for. Files beyond this threshold are loaded on demand
-// when the user expands them in the UI. Only applies when >threshold files.
-const lazyFileThreshold = 100
+// when the user expands them in the UI. Kept modest so large doc PRs don't
+// pay full parse/network cost up front; the frontend also defers collapsed
+// file bodies in the DOM.
+const lazyFileThreshold = 25
 
 // computeFileHash returns the hex-encoded SHA256 hash of data.
 func computeFileHash(data []byte) string {
@@ -214,7 +216,7 @@ type FileEntry struct {
 	PreviousComments []Comment `json:"-"`
 
 	// Lazy loading: when true, Content and DiffHunks are not yet populated.
-	// Call ensureLoaded() before accessing them. Only used when >100 files.
+	// Call ensureLoaded() before accessing them. Only used when >lazyFileThreshold files.
 	Lazy     bool      `json:"-"`
 	loadOnce sync.Once // guards one-time loading of content + diffs
 	loadErr  error     // error from loading, if any
@@ -241,8 +243,28 @@ type ShareFile struct {
 	Encoding  string `json:"encoding,omitempty"`
 }
 
-// ensureLoaded loads content and diff hunks for a lazy file on first access.
-// For non-lazy files, this is an immediate no-op.
+// ensureFileLoaded loads a lazy file using the session's current focus.
+// Range/--pr focus reads content and diffs at HeadSHA/BaseSHA (including
+// --remote via readFileAtSHA). Working-tree focus reads the disk path.
+func (s *Session) ensureFileLoaded(f *FileEntry) error {
+	if f == nil || !f.Lazy {
+		return nil
+	}
+	s.mu.RLock()
+	focus := s.Focus
+	repoRoot := s.RepoRoot
+	baseRef := s.BaseRef
+	vc := s.VCS
+	s.mu.RUnlock()
+
+	if focus.Kind == FocusRange {
+		return f.ensureLoadedAtRange(s, focus, repoRoot, vc)
+	}
+	return f.ensureLoaded(repoRoot, baseRef, vc)
+}
+
+// ensureLoaded loads content and diff hunks for a lazy file on first access
+// from the working tree. For non-lazy files, this is an immediate no-op.
 // The vcs parameter is used for computing diffs; pass nil to fall back to
 // the git package-level functions (backward compat for tests).
 func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string, v vcs.VCS) error {
@@ -267,6 +289,46 @@ func (fe *FileEntry) ensureLoaded(repoRoot, baseRef string, v vcs.VCS) error {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
 				fe.loadDiff(ctx, repoRoot, baseRef, v)
+			}
+		}
+
+		fe.Lazy = false
+	})
+	return fe.loadErr
+}
+
+// ensureLoadedAtRange loads a lazy file from a fixed (BaseSHA, HeadSHA) range.
+func (fe *FileEntry) ensureLoadedAtRange(s *Session, focus Focus, repoRoot string, v vcs.VCS) error {
+	if !fe.Lazy {
+		return nil
+	}
+	fe.loadOnce.Do(func() {
+		if fe.Status != "deleted" {
+			data, err := s.readFileAtSHA(focus.HeadSHA, fe.Path)
+			if err != nil {
+				fe.loadErr = fmt.Errorf("reading %s at %s: %w", fe.Path, focus.HeadSHA, err)
+				return
+			}
+			if data == nil {
+				fe.loadErr = fmt.Errorf("reading %s at %s: not found", fe.Path, focus.HeadSHA)
+				return
+			}
+			fe.Content = string(data)
+			fe.FileHash = fileHash(data)
+		}
+
+		switch {
+		case fe.Status == "added" || fe.Status == "untracked":
+			fe.DiffHunks = vcs.FileDiffUnifiedNewFile(fe.Content)
+		case v == nil:
+			fe.loadErr = fmt.Errorf("range lazy load requires VCS for %s", fe.Path)
+			return
+		default:
+			hunks, err := v.FileDiffBetweenSHAs(fe.Path, fe.OldPath, focus.DiffBaseSHA(), focus.HeadSHA, repoRoot, false)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: range diff failed for %s: %v\n", fe.Path, err)
+			} else {
+				fe.DiffHunks = hunks
 			}
 		}
 
@@ -2594,13 +2656,10 @@ func (s *Session) GetFileSnapshot(path string) (map[string]any, bool) {
 		s.mu.RUnlock()
 		return nil, false
 	}
-	repoRoot := s.RepoRoot
-	baseRef := s.BaseRef
-	vc := s.VCS
 	s.mu.RUnlock()
 
-	// Load content on demand for lazy files
-	if err := f.ensureLoaded(repoRoot, baseRef, vc); err != nil {
+	// Load content on demand for lazy files (SHA-aware in range/--pr focus).
+	if err := s.ensureFileLoaded(f); err != nil {
 		return nil, false
 	}
 
@@ -2698,8 +2757,8 @@ func (s *Session) GetFileDiffSnapshot(path string, ignoreWhitespace bool) (map[s
 	vc := s.VCS
 	s.mu.RUnlock()
 
-	// Load content + diffs on demand for lazy files
-	if err := f.ensureLoaded(repoRoot, baseRef, vc); err != nil {
+	// Load content + diffs on demand for lazy files (SHA-aware in range/--pr focus).
+	if err := s.ensureFileLoaded(f); err != nil {
 		return nil, false
 	}
 

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -417,13 +417,9 @@ func (s *Session) buildFilesForFocus(f Focus, v vcs.VCS, repoRoot string) ([]*Fi
 	}
 	var numstats map[string]vcs.NumstatEntry
 	if len(changes) > lazyFileThreshold {
-		// Prefer between-SHA numstat so sidebar +/- match the PR range even
-		// when the working tree is dirty or --remote (no local checkout).
-		if ns, nsErr := vcs.DiffNumstatBetweenSHAs(f.DiffBaseSHA(), f.HeadSHA, repoRoot); nsErr == nil {
-			numstats = ns
-		} else {
-			numstats, _ = v.DiffNumstat(f.DiffBaseSHA(), repoRoot)
-		}
+		// Between-SHA only — never fall back to working-tree numstat, which
+		// contaminates sidebar +/- when the tree is dirty or --remote.
+		numstats, _ = vcs.DiffNumstatBetweenSHAs(f.DiffBaseSHA(), f.HeadSHA, repoRoot)
 	}
 	out := make([]*FileEntry, 0, len(changes))
 	for i, fc := range changes {
@@ -438,7 +434,7 @@ func (s *Session) buildFilesForFocus(f Focus, v vcs.VCS, repoRoot string) ([]*Fi
 		// Same eager/lazy split as NewGitSession: range focus is how --pr
 		// rebuilds the file list, so large doc PRs must not load every file.
 		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
-			populateLazyFile(fe, fc, numstats)
+			populateLazyFile(fe, fc, numstats, false)
 			out = append(out, fe)
 			continue
 		}
@@ -501,7 +497,7 @@ func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileE
 			Comments: []Comment{},
 		}
 		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
-			populateLazyFile(fe, fc, numstats)
+			populateLazyFile(fe, fc, numstats, true)
 			out = append(out, fe)
 			continue
 		}

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -415,8 +415,18 @@ func (s *Session) buildFilesForFocus(f Focus, v vcs.VCS, repoRoot string) ([]*Fi
 	if err != nil {
 		return nil, "", err
 	}
+	var numstats map[string]vcs.NumstatEntry
+	if len(changes) > lazyFileThreshold {
+		// Prefer between-SHA numstat so sidebar +/- match the PR range even
+		// when the working tree is dirty or --remote (no local checkout).
+		if ns, nsErr := vcs.DiffNumstatBetweenSHAs(f.DiffBaseSHA(), f.HeadSHA, repoRoot); nsErr == nil {
+			numstats = ns
+		} else {
+			numstats, _ = v.DiffNumstat(f.DiffBaseSHA(), repoRoot)
+		}
+	}
 	out := make([]*FileEntry, 0, len(changes))
-	for _, fc := range changes {
+	for i, fc := range changes {
 		fe := &FileEntry{
 			Path:     fc.Path,
 			OldPath:  fc.OldPath,
@@ -424,6 +434,13 @@ func (s *Session) buildFilesForFocus(f Focus, v vcs.VCS, repoRoot string) ([]*Fi
 			Status:   fc.Status,
 			FileType: detectFileType(fc.Path),
 			Comments: []Comment{},
+		}
+		// Same eager/lazy split as NewGitSession: range focus is how --pr
+		// rebuilds the file list, so large doc PRs must not load every file.
+		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
+			populateLazyFile(fe, fc, numstats)
+			out = append(out, fe)
+			continue
 		}
 		if fc.Status != "deleted" {
 			data, readErr := s.readFileAtSHA(f.HeadSHA, fc.Path)
@@ -469,8 +486,12 @@ func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileE
 	}
 	changes = config.FilterIgnored(changes, ignorePatterns)
 	changes = filterBinary(changes)
+	var numstats map[string]vcs.NumstatEntry
+	if len(changes) > lazyFileThreshold && baseRef != "" {
+		numstats, _ = v.DiffNumstat(baseRef, repoRoot)
+	}
 	out := make([]*FileEntry, 0, len(changes))
-	for _, fc := range changes {
+	for i, fc := range changes {
 		fe := &FileEntry{
 			Path:     fc.Path,
 			OldPath:  fc.OldPath,
@@ -478,6 +499,11 @@ func (s *Session) buildFilesForWorkingTree(v vcs.VCS, repoRoot string) ([]*FileE
 			Status:   fc.Status,
 			FileType: detectFileType(fc.Path),
 			Comments: []Comment{},
+		}
+		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
+			populateLazyFile(fe, fc, numstats)
+			out = append(out, fe)
+			continue
 		}
 		if !populateEagerFile(fe, fc, baseRef, repoRoot, v) {
 			continue
@@ -852,7 +878,7 @@ func (s *Session) loadScopedFileState(path, scope, commit string) (status, conte
 	s.mu.RUnlock()
 
 	if f != nil {
-		if err := f.ensureLoaded(repoRoot, baseRef, vc); err == nil {
+		if err := s.ensureFileLoaded(f); err == nil {
 			s.mu.RLock()
 			content = f.Content
 			s.mu.RUnlock()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3096,11 +3096,11 @@ func TestNewSessionFromGitLazyThreshold(t *testing.T) {
 		}
 	}
 
-	if eagerCount != 100 {
-		t.Errorf("expected 100 eager files, got %d", eagerCount)
+	if eagerCount != lazyFileThreshold {
+		t.Errorf("expected %d eager files, got %d", lazyFileThreshold, eagerCount)
 	}
-	if lazyCount != 20 {
-		t.Errorf("expected 20 lazy files, got %d", lazyCount)
+	if lazyCount != 120-lazyFileThreshold {
+		t.Errorf("expected %d lazy files, got %d", 120-lazyFileThreshold, lazyCount)
 	}
 }
 

--- a/internal/session/story_scope.go
+++ b/internal/session/story_scope.go
@@ -101,7 +101,7 @@ func (s *Session) StoryScope(ignorePatterns []string) StoryScope {
 	}
 
 	for _, fe := range s.Files {
-		_ = fe.ensureLoaded(s.RepoRoot, s.BaseRef, s.VCS)
+		_ = s.ensureFileLoaded(fe)
 		scope.Files = append(scope.Files, StoryScopeFile{
 			Path:   fe.Path,
 			Status: fe.Status,

--- a/internal/session/watch_refresh_test.go
+++ b/internal/session/watch_refresh_test.go
@@ -183,7 +183,7 @@ func TestRefreshFileList_LazyThresholdMarksOverflow(t *testing.T) {
 		defaultBranch: "main",
 		numstats:      map[string]vcs.NumstatEntry{},
 	}
-	// Build > lazyFileThreshold (100) changes.
+	// Build > lazyFileThreshold changes.
 	total := lazyFileThreshold + 5
 	for i := 0; i < total; i++ {
 		path := fmt.Sprintf("dir/f%d.go", i)

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -1201,7 +1201,21 @@ type NumstatEntry struct {
 // DiffNumstatDir runs git diff --numstat against the given base ref and returns per-file stats.
 // If dir is non-empty, git runs in that directory.
 func DiffNumstatDir(baseRef, dir string) (map[string]NumstatEntry, error) {
-	cmd := exec.Command("git", "-c", "diff.external=", "diff", "--no-ext-diff", "--numstat", baseRef)
+	return runDiffNumstat(dir, baseRef)
+}
+
+// DiffNumstatBetweenSHAs runs git diff --numstat baseSHA headSHA and returns
+// per-file stats for that fixed range (not vs the working tree).
+func DiffNumstatBetweenSHAs(baseSHA, headSHA, dir string) (map[string]NumstatEntry, error) {
+	if baseSHA == "" || headSHA == "" {
+		return nil, fmt.Errorf("diff numstat between SHAs requires both base and head")
+	}
+	return runDiffNumstat(dir, baseSHA, headSHA)
+}
+
+func runDiffNumstat(dir string, refs ...string) (map[string]NumstatEntry, error) {
+	args := append([]string{"-c", "diff.external=", "diff", "--no-ext-diff", "--numstat"}, refs...)
+	cmd := exec.Command("git", args...)
 	cmd.Env = stripExternalDiffEnv()
 	if dir != "" {
 		cmd.Dir = dir
@@ -1215,7 +1229,10 @@ func DiffNumstatDir(baseRef, dir string) (map[string]NumstatEntry, error) {
 			return nil, fmt.Errorf("git diff --numstat failed: %w", err)
 		}
 	}
+	return parseNumstatOutput(out), nil
+}
 
+func parseNumstatOutput(out []byte) map[string]NumstatEntry {
 	stats := make(map[string]NumstatEntry)
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
@@ -1238,7 +1255,7 @@ func DiffNumstatDir(baseRef, dir string) (map[string]NumstatEntry, error) {
 			stats[path[i+4:]] = entry
 		}
 	}
-	return stats, nil
+	return stats
 }
 
 var hunkHeaderRe = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$`)

--- a/internal/vcs/git_test.go
+++ b/internal/vcs/git_test.go
@@ -1573,6 +1573,44 @@ func TestDiffNumstat(t *testing.T) {
 	}
 }
 
+func TestDiffNumstatBetweenSHAs(t *testing.T) {
+	dir := testutil.InitTestRepo(t)
+
+	testutil.WriteFile(t, filepath.Join(dir, "stats.go"), "package main\n\nfunc hello() {}\n")
+	testutil.Git(t, dir, "add", "stats.go")
+	testutil.Git(t, dir, "commit", "-m", "add stats.go")
+	base := strings.TrimSpace(testutil.Git(t, dir, "rev-parse", "HEAD"))
+
+	testutil.Git(t, dir, "checkout", "-b", "feature-numstat-between")
+	testutil.WriteFile(t, filepath.Join(dir, "stats.go"), "package main\n\nfunc hello() {\n\tfmt.Println(\"hi\")\n}\n\nfunc world() {}\n")
+	testutil.WriteFile(t, filepath.Join(dir, "newfile.txt"), "line1\nline2\nline3\n")
+	testutil.Git(t, dir, "add", "stats.go", "newfile.txt")
+	testutil.Git(t, dir, "commit", "-m", "modify stats and add newfile")
+	head := strings.TrimSpace(testutil.Git(t, dir, "rev-parse", "HEAD"))
+
+	// Dirty WT must not affect between-SHA numstat.
+	testutil.WriteFile(t, filepath.Join(dir, "stats.go"), "package main\n\nfunc dirty() {}\n")
+
+	stats, err := DiffNumstatBetweenSHAs(base, head, dir)
+	if err != nil {
+		t.Fatalf("DiffNumstatBetweenSHAs failed: %v", err)
+	}
+	if s, ok := stats["stats.go"]; !ok {
+		t.Fatal("missing stats.go in between-SHA numstat")
+	} else if s.Additions != 5 || s.Deletions != 1 {
+		t.Errorf("stats.go: got +%d/-%d, want +5/-1 (HeadSHA, not dirty WT)", s.Additions, s.Deletions)
+	}
+	if s, ok := stats["newfile.txt"]; !ok {
+		t.Fatal("missing newfile.txt")
+	} else if s.Additions != 3 || s.Deletions != 0 {
+		t.Errorf("newfile.txt: got +%d/-%d, want +3/-0", s.Additions, s.Deletions)
+	}
+
+	if _, err := DiffNumstatBetweenSHAs("", head, dir); err == nil {
+		t.Fatal("expected error for empty base SHA")
+	}
+}
+
 func TestDiffNumstatBinary(t *testing.T) {
 	dir := testutil.InitTestRepo(t)
 

--- a/test/e2e/tests/lazy-loading.spec.ts
+++ b/test/e2e/tests/lazy-loading.spec.ts
@@ -10,9 +10,9 @@ test.describe('Lazy loading', () => {
     const res = await request.get('/api/session');
     const session = await res.json();
 
-    // Git-mode fixture has <100 files — none should be lazy
+    // Git-mode fixture has <25 files — none should be lazy
     expect(session.files.length).toBeGreaterThan(0);
-    expect(session.files.length).toBeLessThan(100);
+    expect(session.files.length).toBeLessThan(25);
 
     for (const file of session.files) {
       expect(file.lazy).toBeFalsy();

--- a/web/__tests__/defer-file-body.test.js
+++ b/web/__tests__/defer-file-body.test.js
@@ -45,8 +45,16 @@ test('loadLazyFile mounts body after re-render so observer suppress cannot leave
   // After replaceWith(renderFileSection(...)), body must be mounted when open.
   assert.match(
     appSrc,
-    /section\.replaceWith\(newSection\);[\s\S]{0,250}ensureFileBodyMounted\(newSection,\s*file\)/s,
+    /replaceWith\(newSection\);[\s\S]{0,250}ensureFileBodyMounted\(newSection,\s*file\)/s,
   );
+  // Concurrent callers must queue onLoaded, not drop it while _lazyLoading.
+  assert.match(appSrc, /_lazyLoadCallbacks/);
+});
+
+test('viewport mounters skip collapsed sections so collapse keeps bodies deferred', () => {
+  assert.match(appSrc, /function setupBodyMountObserver\s*\(/);
+  assert.match(appSrc, /function mountVisibleDeferredBodies\s*\(/);
+  assert.match(appSrc, /if \(!section\.open\) continue;/);
 });
 
 test('body-mount observer suppress schedules a remount when the window expires', () => {
@@ -90,7 +98,7 @@ test('range/PR focus applies lazyFileThreshold via populateLazyFile', () => {
   // Range path must populate lazy stats the same way as working-tree.
   assert.match(
     focusSrc,
-    /if len\(changes\) > lazyFileThreshold && i >= lazyFileThreshold \{\s*populateLazyFile\(fe, fc, numstats\)/s,
+    /if len\(changes\) > lazyFileThreshold && i >= lazyFileThreshold \{\s*populateLazyFile\(fe, fc, numstats, false\)/s,
   );
 });
 

--- a/web/__tests__/defer-file-body.test.js
+++ b/web/__tests__/defer-file-body.test.js
@@ -1,0 +1,102 @@
+'use strict';
+// Source-contract tests for deferred file-body mounting (crit-web#318 /
+// multi-file markdown PR perf). app.js is a monolithic IIFE, so we assert
+// the critical helpers and call sites stay wired rather than spinning a DOM.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appSrc = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+const sessionSrc = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'internal', 'session', 'session.go'),
+  'utf8',
+);
+
+test('files stay open by default and bodies mount via viewport observer', () => {
+  assert.match(appSrc, /function setupBodyMountObserver\s*\(/);
+  assert.match(appSrc, /function mountDeferredBody\s*\(/);
+  assert.match(appSrc, /function mountVisibleDeferredBodies\s*\(/);
+  assert.doesNotMatch(appSrc, /applyDefaultFileCollapse\s*\(/);
+  assert.doesNotMatch(appSrc, /DEFAULT_COLLAPSE_FILE_THRESHOLD/);
+});
+
+test('file body mount/unmount helpers are wired into details toggle without initialToggle gate', () => {
+  assert.match(appSrc, /function ensureFileBodyMounted\s*\(/);
+  assert.match(appSrc, /function deferFileBody\s*\(/);
+  assert.match(appSrc, /function populateFileBody\s*\(/);
+  assert.match(appSrc, /data-body-deferred/);
+  // Setting open before the listener means there is no synthetic first toggle
+  // to swallow — an initialToggle flag would drop the first real user toggle.
+  assert.doesNotMatch(appSrc, /initialToggle/);
+  assert.match(appSrc, /if \(section\.open\) \{\s*if \(file\.lazy\) loadLazyFile\(section, file\);\s*else ensureFileBodyMounted\(section, file\);/s);
+  assert.match(appSrc, /else if \(!fileHasOpenLineForms\(file\.path\)\) \{\s*deferFileBody\(section\);/s);
+});
+
+test('scrollToFile mounts deferred body or loads lazy file before scrolling', () => {
+  assert.match(appSrc, /function scrollToFile\s*\(/);
+  assert.match(appSrc, /if \(file\.lazy\)[\s\S]{0,400}loadLazyFile\(sectionEl, file, function onLoaded\(newSection\)/s);
+  assert.match(appSrc, /ensureFileBodyMounted\(sectionEl, file\)/);
+});
+
+test('loadLazyFile mounts body after re-render so observer suppress cannot leave empty section', () => {
+  assert.match(appSrc, /function loadLazyFile\s*\(/);
+  // After replaceWith(renderFileSection(...)), body must be mounted when open.
+  assert.match(
+    appSrc,
+    /section\.replaceWith\(newSection\);[\s\S]{0,250}ensureFileBodyMounted\(newSection,\s*file\)/s,
+  );
+});
+
+test('body-mount observer suppress schedules a remount when the window expires', () => {
+  assert.match(appSrc, /ignoreBodyMountObserverUntil\s*=/);
+  assert.match(appSrc, /mountVisibleDeferredBodies\(\)/);
+  // Suppress helper must re-run viewport mount after the quiet period.
+  assert.match(
+    appSrc,
+    /function suppressBodyMountObserver\s*\(\s*ms\s*\)[\s\S]{0,400}setTimeout\([\s\S]{0,200}mountVisibleDeferredBodies/s,
+  );
+});
+
+test('scrollToComment mounts deferred/lazy body before looking up the card', () => {
+  const marker = 'function scrollToComment(';
+  const scrollToCommentIdx = appSrc.indexOf(marker);
+  assert.notEqual(scrollToCommentIdx, -1, 'scrollToComment must exist');
+  const nextFn = appSrc.indexOf('\n  function ', scrollToCommentIdx + marker.length);
+  const body = appSrc.slice(scrollToCommentIdx, nextFn === -1 ? undefined : nextFn);
+  assert.match(body, /ensureFileBodyMounted/);
+  assert.match(body, /loadLazyFile/);
+});
+
+test('renderFileByPath remounts the body for the replaced open section', () => {
+  assert.match(appSrc, /function renderFileByPath\s*\(/);
+  const idx = appSrc.indexOf('function renderFileByPath');
+  const nextFn = appSrc.indexOf('\n  function ', idx + 1);
+  const body = appSrc.slice(idx, nextFn === -1 ? undefined : nextFn);
+  assert.match(body, /ensureFileBodyMounted|mountVisibleDeferredBodies/);
+});
+
+test('backend eager-load threshold is 25', () => {
+  assert.match(sessionSrc, /const lazyFileThreshold = 25/);
+});
+
+test('range/PR focus applies lazyFileThreshold via populateLazyFile', () => {
+  const focusSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'internal', 'session', 'session_focus.go'),
+    'utf8',
+  );
+  assert.match(focusSrc, /len\(changes\) > lazyFileThreshold && i >= lazyFileThreshold/);
+  // Range path must populate lazy stats the same way as working-tree.
+  assert.match(
+    focusSrc,
+    /if len\(changes\) > lazyFileThreshold && i >= lazyFileThreshold \{\s*populateLazyFile\(fe, fc, numstats\)/s,
+  );
+});
+
+test('session loads lazy range files via SHA-aware path', () => {
+  assert.match(sessionSrc, /func \(s \*Session\) ensureFileLoaded\(/);
+  assert.match(sessionSrc, /ensureLoadedAtRange|readFileAtSHA/);
+  // GetFileSnapshot / GetFileDiffSnapshot must use session-aware loader.
+  assert.match(sessionSrc, /ensureFileLoaded\(f\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -94,7 +94,7 @@
         }
         if (!found) continue;
         const section = document.getElementById('file-section-' + f.path);
-        if (!section) break;
+        if (!section) continue;
         section.open = true;
         if (f.lazy) {
           loadLazyFile(section, f, function() { scrollToCommentRef(id); });
@@ -1699,6 +1699,7 @@
       for (let i = 0; i < entries.length; i++) {
         if (!entries[i].isIntersecting) continue;
         const section = entries[i].target;
+        if (!section.open) continue;
         const path = section.id.replace('file-section-', '');
         const file = getFileByPath(path);
         if (!file) continue;
@@ -1728,6 +1729,7 @@
     let mountedAny = false;
     for (let i = 0; i < sections.length; i++) {
       const section = sections[i];
+      if (!section.open) continue;
       const rect = section.getBoundingClientRect();
       if (rect.bottom < -windowHeight || rect.top > windowHeight * 2) continue;
       const path = section.id.replace('file-section-', '');
@@ -2376,10 +2378,14 @@
   }
 
   function loadLazyFile(section, file, onLoaded) {
-    if (!section.open || !file.lazy || file._lazyLoading) {
-      if (onLoaded && !file.lazy) onLoaded();
+    if (!section.open) return;
+    if (!file.lazy) {
+      if (onLoaded) onLoaded(section);
       return;
     }
+    if (!file._lazyLoadCallbacks) file._lazyLoadCallbacks = [];
+    if (onLoaded) file._lazyLoadCallbacks.push(onLoaded);
+    if (file._lazyLoading) return;
     file._lazyLoading = true;
     section.classList.add('file-section-loading');
 
@@ -2408,11 +2414,22 @@
       if (loaded.highlightCache) file.highlightCache = loaded.highlightCache;
       if (loaded.lang) file.lang = loaded.lang;
 
-      // Re-render this file section in place
-      section.classList.remove('file-section-loading');
+      const callbacks = file._lazyLoadCallbacks || [];
+      file._lazyLoadCallbacks = [];
+
+      // Re-render this file section in place (prefer live node if caller raced).
+      let liveSection = section;
+      if (!section.isConnected) {
+        liveSection = document.getElementById('file-section-' + file.path);
+        if (!liveSection) {
+          for (let i = 0; i < callbacks.length; i++) callbacks[i](null);
+          return;
+        }
+      }
+      liveSection.classList.remove('file-section-loading');
       const newSection = renderFileSection(file);
-      newSection.open = section.open;
-      section.replaceWith(newSection);
+      newSection.open = liveSection.open;
+      liveSection.replaceWith(newSection);
       // Always mount when open: observer may be suppressed (scrollToFile) and
       // will not re-fire for an already-intersecting replacement section.
       if (newSection.open) ensureFileBodyMounted(newSection, file);
@@ -2422,12 +2439,14 @@
       updateCommentCount();
       setupBodyMountObserver();
       rebuildNavList();
-      if (onLoaded) onLoaded(newSection);
+      for (let i = 0; i < callbacks.length; i++) callbacks[i](newSection);
     }).catch(function() {
       file._lazyLoading = false;
+      const callbacks = file._lazyLoadCallbacks || [];
+      file._lazyLoadCallbacks = [];
       // Guard against stale DOM node: only re-attach if still in the document
-      if (!section.isConnected) return;
-      section.classList.remove('file-section-loading');
+      if (section.isConnected) section.classList.remove('file-section-loading');
+      for (let i = 0; i < callbacks.length; i++) callbacks[i](null);
     });
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -82,7 +82,29 @@
   // Scroll/expand/flash a comment card located anywhere in the document, given just its id.
   // Distinct from scrollToComment(commentId, filePath) below — that one needs filePath context.
   function scrollToCommentRef(id) {
-    const card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
+    let card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
+    if (!card) {
+      // Line cards live in deferred .file-body — mount the owning file and retry.
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i];
+        const comments = f.comments || [];
+        let found = false;
+        for (let j = 0; j < comments.length; j++) {
+          if (comments[j].id === id) { found = true; break; }
+        }
+        if (!found) continue;
+        const section = document.getElementById('file-section-' + f.path);
+        if (!section) break;
+        section.open = true;
+        if (f.lazy) {
+          loadLazyFile(section, f, function() { scrollToCommentRef(id); });
+          return;
+        }
+        ensureFileBodyMounted(section, f);
+        card = document.querySelector('.comment-card[data-comment-id="' + CSS.escape(id) + '"]');
+        break;
+      }
+    }
     if (!card) return;
     // Make sure any containing <details> file section is open
     const section = card.closest('details');
@@ -553,7 +575,7 @@
         lineBlocks: null,
         previousLineBlocks: null,
         tocItems: [],
-        collapsed: true,
+        collapsed: false,
         viewMode: (session.mode === 'git') ? 'diff' : 'document',
         additions: fi.additions || 0,
         deletions: fi.deletions || 0,
@@ -1252,8 +1274,25 @@
   // ===== File Tree Sidebar =====
   let activeTreePath = null;
   let treeObserver = null;
+  let bodyMountObserver = null;
   let ignoreTreeObserverUntil = 0;
+  let ignoreBodyMountObserverUntil = 0;
+  let bodyMountSuppressTimer = null;
   const treeFolderState = {}; // { 'src': true, 'src/components': false } — true = collapsed
+
+  // Suppress observer-driven mounts briefly (e.g. during scrollToFile) so
+  // adjacent bodies don't push the target out of view. When the window
+  // expires, remount anything still visible — IntersectionObserver will not
+  // re-fire for elements that stayed intersecting while we ignored callbacks.
+  function suppressBodyMountObserver(ms) {
+    ignoreBodyMountObserverUntil = Date.now() + ms;
+    if (bodyMountSuppressTimer) clearTimeout(bodyMountSuppressTimer);
+    bodyMountSuppressTimer = setTimeout(function() {
+      bodyMountSuppressTimer = null;
+      if (Date.now() < ignoreBodyMountObserverUntil) return;
+      mountVisibleDeferredBodies();
+    }, ms + 10);
+  }
 
   function buildFileTree(fileList) {
     // Build a nested tree from flat paths
@@ -1320,7 +1359,9 @@
     if (files.length > 1) {
       const collapseBtn = document.createElement('button');
       collapseBtn.className = 'file-tree-collapse-btn';
-      collapseBtn.title = 'Collapse all files';
+      const initiallyExpanded = files.some(function(f) { return !f.collapsed; });
+      collapseBtn.title = initiallyExpanded ? 'Collapse all files' : 'Expand all files';
+      collapseBtn.classList.toggle('all-collapsed', !initiallyExpanded);
       // Stacked chevron SVG
       collapseBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.22 3.22a.75.75 0 0 1 1.06 0L8 5.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 4.28a.75.75 0 0 1 0-1.06zm0 5a.75.75 0 0 1 1.06 0L8 10.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 9.28a.75.75 0 0 1 0-1.06z"/></svg>';
       collapseBtn.addEventListener('click', function() {
@@ -1331,6 +1372,10 @@
         const sections = document.querySelectorAll('.file-section');
         for (let i = 0; i < sections.length; i++) {
           sections[i].open = !anyExpanded;
+        }
+        if (!anyExpanded) {
+          // Re-attach observer so it fires for newly visible sections and mounts their bodies.
+          setupBodyMountObserver();
         }
         collapseBtn.title = anyExpanded ? 'Expand all files' : 'Collapse all files';
         collapseBtn.classList.toggle('all-collapsed', anyExpanded);
@@ -1641,6 +1686,67 @@
     }
   }
 
+  function setupBodyMountObserver() {
+    if (bodyMountObserver) bodyMountObserver.disconnect();
+    const sections = document.querySelectorAll('.file-section[id]');
+    if (sections.length === 0) return;
+
+    bodyMountObserver = new IntersectionObserver(function(entries) {
+      // Skip observer-driven mounts briefly after a manual scrollToFile so the
+      // requested file doesn't get pushed out of view by adjacent bodies mounting.
+      if (Date.now() < ignoreBodyMountObserverUntil) return;
+      let mountedAny = false;
+      for (let i = 0; i < entries.length; i++) {
+        if (!entries[i].isIntersecting) continue;
+        const section = entries[i].target;
+        const path = section.id.replace('file-section-', '');
+        const file = getFileByPath(path);
+        if (!file) continue;
+        if (file.lazy) {
+          loadLazyFile(section, file);
+        } else {
+          mountDeferredBody(section, file);
+          mountedAny = true;
+        }
+      }
+      if (mountedAny) {
+        renderMermaidBlocks();
+        rebuildNavList();
+        applyHideResolved();
+      }
+    }, { rootMargin: '100% 0px 100% 0px' });
+
+    for (let i = 0; i < sections.length; i++) {
+      bodyMountObserver.observe(sections[i]);
+    }
+  }
+
+  function mountVisibleDeferredBodies() {
+    const sections = document.querySelectorAll('.file-section[id]');
+    if (sections.length === 0) return;
+    const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+    let mountedAny = false;
+    for (let i = 0; i < sections.length; i++) {
+      const section = sections[i];
+      const rect = section.getBoundingClientRect();
+      if (rect.bottom < -windowHeight || rect.top > windowHeight * 2) continue;
+      const path = section.id.replace('file-section-', '');
+      const file = getFileByPath(path);
+      if (!file) continue;
+      if (file.lazy) {
+        loadLazyFile(section, file);
+      } else {
+        mountDeferredBody(section, file);
+        mountedAny = true;
+      }
+    }
+    if (mountedAny) {
+      renderMermaidBlocks();
+      rebuildNavList();
+      applyHideResolved();
+    }
+  }
+
   function scrollToFile(filePath) {
     const sectionEl = document.getElementById('file-section-' + filePath);
     if (!sectionEl) return;
@@ -1648,9 +1754,27 @@
     const file = getFileByPath(filePath);
     if (file) file.collapsed = false;
     sectionEl.open = true;
-    // Suppress IntersectionObserver for 200ms so it doesn't override our manual active state
+    // toggle handler mounts deferred bodies; call explicitly so layout exists before scroll
+    if (file) {
+      if (file.lazy) {
+        // Scroll to header immediately while loading; re-scroll to the loaded section once
+        // the body mounts so the user lands reliably on the requested file.
+        sectionEl.scrollIntoView({ block: 'start', behavior: 'instant' });
+        loadLazyFile(sectionEl, file, function onLoaded(newSection) {
+          const el = newSection || document.getElementById('file-section-' + filePath);
+          if (el) el.scrollIntoView({ block: 'start', behavior: 'instant' });
+        });
+      } else {
+        ensureFileBodyMounted(sectionEl, file);
+      }
+    }
+    // Suppress observers briefly so adjacent bodies mounting don't push the
+    // requested file out of view after we scroll to it.
     ignoreTreeObserverUntil = Date.now() + 200;
-    sectionEl.scrollIntoView({ block: 'start', behavior: 'instant' });
+    suppressBodyMountObserver(500);
+    if (!file || !file.lazy) {
+      sectionEl.scrollIntoView({ block: 'start', behavior: 'instant' });
+    }
     updateTreeActive(filePath);
   }
 
@@ -1669,8 +1793,13 @@
     // Render the inline Review Conversation section above filesContainer
     renderReviewConversation();
 
-    // Re-attach intersection observer for file tree active tracking
+    // Re-attach intersection observers for file tree active tracking and
+    // deferred body mounting (keeps large reviews fast while leaving files open).
     setupTreeObserver();
+    setupBodyMountObserver();
+    // Mount bodies that are already visible so first paint doesn't show empty
+    // open sections while the observer fires.
+    mountVisibleDeferredBodies();
     rebuildNavList();
     applyHideResolved();
   }
@@ -2007,8 +2136,15 @@
     }
     const oldSection = document.getElementById('file-section-' + file.path);
     if (!oldSection) { renderAllFiles(); return; }
-    oldSection.replaceWith(renderFileSection(file));
+    const newSection = renderFileSection(file);
+    oldSection.replaceWith(newSection);
+    if (newSection.open) {
+      if (file.lazy) loadLazyFile(newSection, file);
+      else ensureFileBodyMounted(newSection, file);
+    }
     renderMermaidBlocks();
+    setupBodyMountObserver();
+    mountVisibleDeferredBodies();
     rebuildNavList();
     applyHideResolved();
   }
@@ -2054,63 +2190,18 @@
       }
       // Expanding: let native <details> handle it
     });
+    // open is set before this listener is attached, so the create-time open
+    // does not fire toggle here. Do not gate the first event — that would
+    // swallow the user's first collapse/expand.
     section.addEventListener('toggle', function() {
       file.collapsed = !section.open;
+      if (section.open) {
+        if (file.lazy) loadLazyFile(section, file);
+        else ensureFileBodyMounted(section, file);
+      } else if (!fileHasOpenLineForms(file.path)) {
+        deferFileBody(section);
+      }
     });
-
-    // Lazy file: load content on first expand
-    if (file.lazy) {
-      section.addEventListener('toggle', function onLazyExpand() {
-        if (!section.open || !file.lazy) return;
-        if (file._lazyLoading) return;
-        file._lazyLoading = true;
-        section.removeEventListener('toggle', onLazyExpand);
-        section.classList.add('file-section-loading');
-
-        loadSingleFile({
-          path: file.path,
-          old_path: file.oldPath,
-          status: file.status,
-          file_type: file.fileType,
-          additions: file.additions,
-          deletions: file.deletions,
-        }, effectiveDiffScope()).then(function(loaded) {
-          // Copy loaded data into the existing file object
-          file.oldPath = loaded.oldPath;
-          file.content = loaded.content;
-          file.previousContent = loaded.previousContent;
-          file.comments = loaded.comments;
-          file.diffHunks = loaded.diffHunks;
-          file._autoExpandDone = false;
-          file.lineBlocks = loaded.lineBlocks;
-          file.previousLineBlocks = loaded.previousLineBlocks;
-          file.tocItems = loaded.tocItems;
-          file.diffTooLarge = loaded.diffTooLarge;
-          file.diffLoaded = loaded.diffLoaded;
-          file.lazy = false;
-          file._lazyLoading = false;
-          if (loaded.highlightCache) file.highlightCache = loaded.highlightCache;
-          if (loaded.lang) file.lang = loaded.lang;
-
-          // Re-render this file section in place
-          section.classList.remove('file-section-loading');
-          const newSection = renderFileSection(file);
-          newSection.open = section.open;
-          section.replaceWith(newSection);
-
-          // Update UI state
-          renderFileTree();
-          updateCommentCount();
-          rebuildNavList();
-        }).catch(function() {
-          file._lazyLoading = false;
-          // Guard against stale DOM node: only re-attach if still in the document
-          if (!section.isConnected) return;
-          section.classList.remove('file-section-loading');
-          section.addEventListener('toggle', onLazyExpand);
-        });
-      });
-    }
 
     const dirParts = file.path.split('/');
     const fileName = dirParts.pop();
@@ -2268,9 +2359,107 @@
       section.appendChild(fileCommentsContainer);
     }
 
-    // File body
+    // File body — mount heavy diff/document DOM only while expanded. Keeping
+    // <details> open by default (GitHub-style) but deferring the body until it
+    // scrolls near the viewport keeps first paint cheap on large PRs.
     const body = document.createElement('div');
     body.className = 'file-body';
+    section.appendChild(body);
+
+    body.setAttribute('data-body-deferred', '1');
+
+    return section;
+  }
+
+  function fileHasOpenLineForms(filePath) {
+    return getFormsForFile(filePath).some(function(f) { return f.scope !== 'file'; });
+  }
+
+  function loadLazyFile(section, file, onLoaded) {
+    if (!section.open || !file.lazy || file._lazyLoading) {
+      if (onLoaded && !file.lazy) onLoaded();
+      return;
+    }
+    file._lazyLoading = true;
+    section.classList.add('file-section-loading');
+
+    loadSingleFile({
+      path: file.path,
+      old_path: file.oldPath,
+      status: file.status,
+      file_type: file.fileType,
+      additions: file.additions,
+      deletions: file.deletions,
+    }, effectiveDiffScope()).then(function(loaded) {
+      // Copy loaded data into the existing file object
+      file.oldPath = loaded.oldPath;
+      file.content = loaded.content;
+      file.previousContent = loaded.previousContent;
+      file.comments = loaded.comments;
+      file.diffHunks = loaded.diffHunks;
+      file._autoExpandDone = false;
+      file.lineBlocks = loaded.lineBlocks;
+      file.previousLineBlocks = loaded.previousLineBlocks;
+      file.tocItems = loaded.tocItems;
+      file.diffTooLarge = loaded.diffTooLarge;
+      file.diffLoaded = loaded.diffLoaded;
+      file.lazy = false;
+      file._lazyLoading = false;
+      if (loaded.highlightCache) file.highlightCache = loaded.highlightCache;
+      if (loaded.lang) file.lang = loaded.lang;
+
+      // Re-render this file section in place
+      section.classList.remove('file-section-loading');
+      const newSection = renderFileSection(file);
+      newSection.open = section.open;
+      section.replaceWith(newSection);
+      // Always mount when open: observer may be suppressed (scrollToFile) and
+      // will not re-fire for an already-intersecting replacement section.
+      if (newSection.open) ensureFileBodyMounted(newSection, file);
+
+      // Update UI state
+      renderFileTree();
+      updateCommentCount();
+      setupBodyMountObserver();
+      rebuildNavList();
+      if (onLoaded) onLoaded(newSection);
+    }).catch(function() {
+      file._lazyLoading = false;
+      // Guard against stale DOM node: only re-attach if still in the document
+      if (!section.isConnected) return;
+      section.classList.remove('file-section-loading');
+    });
+  }
+
+  function deferFileBody(section) {
+    const body = section.querySelector(':scope > .file-body');
+    if (!body || body.getAttribute('data-body-deferred') === '1') return;
+    body.innerHTML = '';
+    body.setAttribute('data-body-deferred', '1');
+    rebuildNavList();
+  }
+
+  function mountDeferredBody(section, file) {
+    const body = section.querySelector(':scope > .file-body');
+    if (!body || body.getAttribute('data-body-deferred') !== '1') return;
+    populateFileBody(body, file);
+    highlightQuotesInSection(section, file);
+  }
+
+  function ensureFileBodyMounted(section, file) {
+    if (!section || !file || file.lazy) return;
+    const body = section.querySelector(':scope > .file-body');
+    if (!body) return;
+    if (body.getAttribute('data-body-deferred') !== '1' && body.childElementCount > 0) return;
+    mountDeferredBody(section, file);
+    renderMermaidBlocks();
+    rebuildNavList();
+    applyHideResolved();
+  }
+
+  function populateFileBody(body, file) {
+    body.innerHTML = '';
+    body.removeAttribute('data-body-deferred');
 
     const showDiff = file.viewMode === 'diff' || (file.fileType === 'code' && session.mode === 'git');
 
@@ -2314,10 +2503,6 @@
     } else {
       body.appendChild(renderDocumentView(file));
     }
-
-    section.appendChild(body);
-    highlightQuotesInSection(section, file);
-    return section;
   }
 
   // ===== Rendered Diff View (Markdown, file mode) =====
@@ -6688,9 +6873,21 @@
     const section = document.getElementById('file-section-' + filePath);
     if (!section) return;
     if (!section.open) section.open = true;
-    const commentCard = section.querySelector('.comment-card[data-comment-id="' + CSS.escape(commentId) + '"]');
-    if (!commentCard) return;
-    flashCommentCard(commentCard);
+    const file = getFileByPath(filePath);
+    const flashCardIn = function(el) {
+      if (!el) return;
+      const commentCard = el.querySelector('.comment-card[data-comment-id="' + CSS.escape(commentId) + '"]');
+      if (commentCard) flashCommentCard(commentCard);
+    };
+    // Line comment cards live inside .file-body — mount (or lazy-load) first.
+    if (file && file.lazy) {
+      loadLazyFile(section, file, function onLoaded(newSection) {
+        flashCardIn(newSection || document.getElementById('file-section-' + filePath));
+      });
+      return;
+    }
+    if (file) ensureFileBodyMounted(section, file);
+    flashCardIn(section);
   }
 
   // ===== PR Overview Panel =====


### PR DESCRIPTION
## Summary
- Keep file sections expanded (GitHub-style) but mount heavy `.file-body` DOM only near the viewport, cutting first-paint DOM on large multi-file PRs (~152k → ~5k nodes on a 40-file sandbox).
- Apply `lazyFileThreshold` (25) on `--pr`/range focus rebuilds; load overflow files SHA-aware (`readFileAtSHA` / between-SHA diffs) so `--remote` and dirty working trees stay correct.
- Harden collapse/unmount, sidebar scroll, comment navigation, and lazy-load callback races found in review.

Reported upstream (wrong repo): https://github.com/tomasz-tomczyk/crit-web/issues/318

## Review
- [x] Code review: passed (frontend blockers fixed; Go range numstat/disk fallback hardened)
- [x] Parity audit: N/A (CLI `--pr`/session lazy path; crit-web has no equivalent multi-file lazy loader)

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `node --test web/__tests__/defer-file-body.test.js`
- [x] Playwright `lazy-loading.spec.ts` (git-mode)
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)