### PR TITLE
fix: mount deferred bodies for nav and disable pending reply

### DIFF
--- a/web/__tests__/crit-settings-panes.test.js
+++ b/web/__tests__/crit-settings-panes.test.js
@@ -346,8 +346,19 @@ test('renderShortcutsPane: code-review mode shows code-review-only shortcuts', (
   assert.match(html, /<kbd>Esc<\/kbd>/);
   assert.match(html, /<kbd>\?<\/kbd>/);
   assert.match(html, /Ctrl<\/kbd>\+<kbd>Enter/);
+  // Capture a11y: idle binding buttons expose change label + aria-pressed
+  assert.match(html, /aria-pressed="false"/);
+  assert.match(html, /aria-label="Change shortcut for Next block"/);
+  assert.match(html, /data-shortcut-action="Next block"/);
   // Live-only binding absent
   assert.doesNotMatch(html, /Toggle pin mode/);
+});
+
+test('shortcut capture updates aria-label to Press new keys for …', () => {
+  const panesSrc = fs.readFileSync(path.join(__dirname, '..', 'crit-settings-panes.js'), 'utf8');
+  assert.match(panesSrc, /Press new keys for /);
+  assert.match(panesSrc, /aria-pressed',\s*'true'/);
+  assert.match(panesSrc, /function restoreBindingLabel\s*\(/);
 });
 
 test('renderShortcutsPane: live mode omits code-review-only shortcuts', () => {

--- a/web/__tests__/defer-file-body.test.js
+++ b/web/__tests__/defer-file-body.test.js
@@ -77,6 +77,90 @@ test('scrollToComment mounts deferred/lazy body before looking up the card', () 
   assert.match(body, /loadLazyFile/);
 });
 
+test('navigateToComment drives from the comment model and mounts before highlight', () => {
+  assert.match(appSrc, /function collectNavigableComments\s*\(/);
+  assert.match(appSrc, /function highlightNavComment\s*\(/);
+  const marker = 'function navigateToComment(';
+  const idx = appSrc.indexOf(marker);
+  assert.notEqual(idx, -1, 'navigateToComment must exist');
+  const nextFn = appSrc.indexOf('\n  function ', idx + marker.length);
+  const body = appSrc.slice(idx, nextFn === -1 ? undefined : nextFn);
+  assert.match(body, /collectNavigableComments\(\)/);
+  assert.match(body, /highlightNavComment\(/);
+  // Must not rely solely on mounted .comment-card query for the nav plan.
+  assert.doesNotMatch(body, /container\.querySelectorAll\('\.comment-card'\)/);
+
+  const highlightMarker = 'function highlightNavComment(';
+  const hIdx = appSrc.indexOf(highlightMarker);
+  const hNext = appSrc.indexOf('\n  function ', hIdx + highlightMarker.length);
+  const hBody = appSrc.slice(hIdx, hNext === -1 ? undefined : hNext);
+  assert.match(hBody, /ensureFileBodyMounted/);
+  assert.match(hBody, /loadLazyFile/);
+});
+
+test('j/k and change nav mount deferred file bodies at section boundaries', () => {
+  assert.match(appSrc, /function navigateBlock\s*\(/);
+  assert.match(appSrc, /function findDeferredFileForNav\s*\(/);
+  assert.match(appSrc, /function mountFileForNav\s*\(/);
+  assert.match(appSrc, /function fileSectionNeedsMount\s*\(/);
+
+  const blockMarker = 'function navigateBlock(';
+  const bIdx = appSrc.indexOf(blockMarker);
+  const bNext = appSrc.indexOf('\n  function ', bIdx + blockMarker.length);
+  const bBody = appSrc.slice(bIdx, bNext === -1 ? undefined : bNext);
+  assert.match(bBody, /findDeferredFileForNav/);
+  assert.match(bBody, /mountFileForNav/);
+
+  const changeMarker = 'function navigateToChange(';
+  const cIdx = appSrc.indexOf(changeMarker);
+  const cNext = appSrc.indexOf('\n  function ', cIdx + changeMarker.length);
+  const cBody = appSrc.slice(cIdx, cNext === -1 ? undefined : cNext);
+  assert.match(cBody, /findDeferredFileForNav/);
+  assert.match(cBody, /mountFileForNav/);
+  assert.match(cBody, /fileLikelyHasChanges/);
+  // Change-nav search must filter inside findDeferredFileForNav so a deferred
+  // no-hunk file cannot block a later lazy/deferred file with changes.
+  assert.match(cBody, /findDeferredFileForNav\([^)]*fileLikelyHasChanges\)/);
+});
+
+test('fileLikelyHasChanges treats lazy placeholders with additions/deletions as having changes', () => {
+  const marker = 'function fileLikelyHasChanges(';
+  const idx = appSrc.indexOf(marker);
+  assert.notEqual(idx, -1, 'fileLikelyHasChanges must exist');
+  const nextFn = appSrc.indexOf('\n  function ', idx + marker.length);
+  const body = appSrc.slice(idx, nextFn === -1 ? undefined : nextFn);
+  // Must not rely only on diffHunks — lazy placeholders keep diffHunks: [] until load.
+  assert.match(body, /file\.lazy/);
+  assert.match(body, /additions/);
+  assert.match(body, /deletions/);
+  assert.match(body, /diffHunks/);
+
+  // findDeferredFileForNav must accept a predicate and skip non-matching mounts.
+  const findMarker = 'function findDeferredFileForNav(';
+  const fIdx = appSrc.indexOf(findMarker);
+  const fNext = appSrc.indexOf('\n  function ', fIdx + findMarker.length);
+  const fBody = appSrc.slice(fIdx, fNext === -1 ? undefined : fNext);
+  assert.match(fBody, /predicate/);
+  assert.match(fBody, /if \(predicate && !predicate\(files\[i\]\)\) continue;/);
+});
+
+test('change-nav button titles use shortcut bindings, not hardcoded n/N', () => {
+  assert.match(appSrc, /getBinding\('previous_change'\)/);
+  assert.match(appSrc, /getBinding\('next_change'\)/);
+  assert.doesNotMatch(appSrc, /title="Previous change \(N\)"/);
+  assert.doesNotMatch(appSrc, /title="Next change \(n\)"/);
+});
+
+test('agent-pending reply form disables Cancel and Reply buttons', () => {
+  const marker = 'function createReplyInput(';
+  const idx = appSrc.indexOf(marker);
+  assert.notEqual(idx, -1);
+  const nextFn = appSrc.indexOf('\n  function ', idx + marker.length);
+  const body = appSrc.slice(idx, nextFn === -1 ? undefined : nextFn);
+  assert.match(body, /cancelBtn\.disabled\s*=\s*!!isPending/);
+  assert.match(body, /submitBtn\.disabled\s*=\s*!!isPending/);
+});
+
 test('renderFileByPath remounts the body for the replaced open section', () => {
   assert.match(appSrc, /function renderFileByPath\s*\(/);
   const idx = appSrc.indexOf('function renderFileByPath');

--- a/web/__tests__/defer-file-body.test.js
+++ b/web/__tests__/defer-file-body.test.js
@@ -144,6 +144,35 @@ test('fileLikelyHasChanges treats lazy placeholders with additions/deletions as 
   assert.match(fBody, /if \(predicate && !predicate\(files\[i\]\)\) continue;/);
 });
 
+test('n/N shortcuts call navigateToChange even when changeGroups is empty', () => {
+  // Keyboard n/N must reach navigateToChange's empty-groups mount path;
+  // header buttons already did. Guarding on changeGroups.length === 0 blocks that.
+  const nextCase = appSrc.indexOf("case 'next_change':");
+  const prevCase = appSrc.indexOf("case 'previous_change':");
+  assert.notEqual(nextCase, -1);
+  assert.notEqual(prevCase, -1);
+  const nextBody = appSrc.slice(nextCase, appSrc.indexOf('case ', nextCase + 10));
+  const prevBody = appSrc.slice(prevCase, appSrc.indexOf('case ', prevCase + 10));
+  assert.match(nextBody, /navigateToChange\(1\)/);
+  assert.match(prevBody, /navigateToChange\(-1\)/);
+  assert.doesNotMatch(nextBody, /changeGroups\.length\s*===\s*0/);
+  assert.doesNotMatch(prevBody, /changeGroups\.length\s*===\s*0/);
+});
+
+test('buildChangeGroups rebinds currentChangeIdx after rebuild instead of always clearing', () => {
+  assert.match(appSrc, /function changeNavAnchorFromIdx\s*\(/);
+  assert.match(appSrc, /function findChangeIdxForAnchor\s*\(/);
+  const marker = 'function buildChangeGroups(';
+  const idx = appSrc.indexOf(marker);
+  assert.notEqual(idx, -1);
+  const nextFn = appSrc.indexOf('\n  function ', idx + marker.length);
+  const body = appSrc.slice(idx, nextFn === -1 ? undefined : nextFn);
+  assert.match(body, /changeNavAnchorFromIdx\(currentChangeIdx\)/);
+  assert.match(body, /findChangeIdxForAnchor\(prevAnchor\)/);
+  // Must not unconditionally wipe the index when groups were rebuilt with content.
+  assert.doesNotMatch(body, /changeGroups\.push\(group\);[\s\S]*currentChangeIdx\s*=\s*-1;/);
+});
+
 test('change-nav button titles use shortcut bindings, not hardcoded n/N', () => {
   assert.match(appSrc, /getBinding\('previous_change'\)/);
   assert.match(appSrc, /getBinding\('next_change'\)/);

--- a/web/app.js
+++ b/web/app.js
@@ -1812,6 +1812,142 @@
     restoreKeyboardFocus();
   }
 
+  // Deferred / lazy file bodies are absent from .kb-nav and change-group
+  // queries. Keyboard nav (j/k, n/N) must mount the next file when it hits a
+  // section boundary so off-screen deferred content stays reachable.
+  function fileSectionNeedsMount(file) {
+    if (!file) return false;
+    const section = document.getElementById('file-section-' + file.path);
+    if (!section) return false;
+    if (file.lazy) return true;
+    const body = section.querySelector(':scope > .file-body');
+    return !!(body && body.getAttribute('data-body-deferred') === '1');
+  }
+
+  function fileLikelyHasChanges(file) {
+    if (!file) return false;
+    if (file.diffHunks && file.diffHunks.length > 0) return true;
+    // Lazy placeholders ship empty diffHunks until loadLazyFile; numstat
+    // additions/deletions are the only change signal available beforehand.
+    if (file.lazy && ((file.additions || 0) > 0 || (file.deletions || 0) > 0)) return true;
+    return false;
+  }
+
+  // Find the next deferred/lazy file between fromPath and towardPath.
+  // Optional predicate (e.g. fileLikelyHasChanges) skips mount candidates that
+  // would not qualify — so a deferred no-hunk file cannot block a later one.
+  function findDeferredFileForNav(fromPath, towardPath, direction, predicate) {
+    let fromIdx = -1;
+    let towardIdx = direction > 0 ? files.length : -1;
+    for (let i = 0; i < files.length; i++) {
+      if (files[i].path === fromPath) fromIdx = i;
+      if (towardPath && files[i].path === towardPath) towardIdx = i;
+    }
+    if (fromIdx < 0) return null;
+    if (direction > 0) {
+      for (let i = fromIdx + 1; i < towardIdx; i++) {
+        if (!fileSectionNeedsMount(files[i])) continue;
+        if (predicate && !predicate(files[i])) continue;
+        return files[i];
+      }
+    } else {
+      for (let i = fromIdx - 1; i > towardIdx; i--) {
+        if (!fileSectionNeedsMount(files[i])) continue;
+        if (predicate && !predicate(files[i])) continue;
+        return files[i];
+      }
+    }
+    return null;
+  }
+
+  function mountFileForNav(file, onReady) {
+    const section = document.getElementById('file-section-' + file.path);
+    if (!section) {
+      if (onReady) onReady(false);
+      return;
+    }
+    section.open = true;
+    if (file.lazy) {
+      loadLazyFile(section, file, function() { if (onReady) onReady(true); });
+      return;
+    }
+    ensureFileBodyMounted(section, file);
+    if (onReady) onReady(true);
+  }
+
+  function navElementFilePath(el) {
+    if (!el) return null;
+    return el.dataset.filePath || el.dataset.diffFilePath ||
+      (el.querySelector && (function() {
+        const side = el.querySelector('.diff-split-side[data-diff-file-path]');
+        return side ? side.dataset.diffFilePath : null;
+      })());
+  }
+
+  function navigateBlock(direction, _mountedPath) {
+    const allNav = navElements;
+    if (allNav.length === 0) {
+      const start = direction > 0 ? 0 : files.length - 1;
+      const step = direction > 0 ? 1 : -1;
+      for (let i = start; i >= 0 && i < files.length; i += step) {
+        const section = document.getElementById('file-section-' + files[i].path);
+        if (!section || !section.open) continue;
+        if (fileSectionNeedsMount(files[i]) && files[i].path !== _mountedPath) {
+          mountFileForNav(files[i], function() { navigateBlock(direction, files[i].path); });
+          return;
+        }
+      }
+      return;
+    }
+
+    let curIdx = focusedElement ? allNav.indexOf(focusedElement) : -1;
+    if (curIdx === -1) {
+      const match = findNavElementForFocusTarget(getKeyboardFocusTarget());
+      if (match) curIdx = allNav.indexOf(match);
+    }
+
+    let nextIdx;
+    if (curIdx === -1) {
+      nextIdx = direction > 0 ? 0 : allNav.length - 1;
+    } else {
+      nextIdx = curIdx + direction;
+      const curPath = focusedFilePath || navElementFilePath(focusedElement) || navElementFilePath(allNav[curIdx]);
+      if (nextIdx < 0 || nextIdx >= allNav.length) {
+        const deferred = curPath ? findDeferredFileForNav(curPath, null, direction) : null;
+        if (deferred && deferred.path !== _mountedPath) {
+          mountFileForNav(deferred, function() { navigateBlock(direction, deferred.path); });
+          return;
+        }
+        return;
+      }
+      const nextPath = navElementFilePath(allNav[nextIdx]);
+      if (curPath && nextPath && curPath !== nextPath) {
+        const deferred = findDeferredFileForNav(curPath, nextPath, direction);
+        if (deferred && deferred.path !== _mountedPath) {
+          mountFileForNav(deferred, function() { navigateBlock(direction, deferred.path); });
+          return;
+        }
+      }
+    }
+
+    document.querySelectorAll('.kb-nav.focused').forEach(function(el) { el.classList.remove('focused'); });
+    focusedElement = allNav[nextIdx];
+    focusedElement.classList.add('focused');
+    focusedElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    if (focusedElement.dataset.filePath) {
+      focusedFilePath = focusedElement.dataset.filePath;
+      focusedBlockIndex = parseInt(focusedElement.dataset.blockIndex);
+    } else {
+      const navTarget = navFocusTargetFromElement(focusedElement);
+      if (navTarget) {
+        focusedFilePath = navTarget.filePath;
+        focusedBlockIndex = null;
+      }
+    }
+    rememberKeyboardFocusFromNav(focusedElement);
+    if (visualMode) extendVisualSelection();
+  }
+
   function rememberKeyboardFocusTarget(target) {
     if (!target || !target.filePath) return;
     keyboardFocusTarget = target;
@@ -2033,8 +2169,36 @@
     return node === b;
   }
 
-  function navigateToChange(dir) {
-    if (changeGroups.length === 0) return;
+  function navigateToChange(dir, _mountedPath) {
+    // Empty groups: try mounting a deferred file that has diffs, then retry.
+    if (changeGroups.length === 0) {
+      const start = dir > 0 ? 0 : files.length - 1;
+      const step = dir > 0 ? 1 : -1;
+      for (let i = start; i >= 0 && i < files.length; i += step) {
+        if (!fileLikelyHasChanges(files[i])) continue;
+        if (fileSectionNeedsMount(files[i]) && files[i].path !== _mountedPath) {
+          mountFileForNav(files[i], function() { navigateToChange(dir, files[i].path); });
+          return;
+        }
+      }
+      return;
+    }
+
+    // At the last/first mounted change group — mount deferred neighbors first
+    // so n/N can reach off-screen file bodies.
+    if (currentChangeIdx >= 0 && currentChangeIdx < changeGroups.length) {
+      const atEnd = dir > 0 && currentChangeIdx === changeGroups.length - 1;
+      const atStart = dir < 0 && currentChangeIdx === 0;
+      if (atEnd || atStart) {
+        const curPath = changeGroups[currentChangeIdx].filePath;
+        const deferred = findDeferredFileForNav(curPath, null, dir, fileLikelyHasChanges);
+        if (deferred && deferred.path !== _mountedPath) {
+          mountFileForNav(deferred, function() { navigateToChange(dir, deferred.path); });
+          return;
+        }
+      }
+    }
+
     // Remove previous flash
     document.querySelectorAll('.change-flash').forEach(function(el) { el.classList.remove('change-flash'); });
 
@@ -2074,6 +2238,27 @@
           if (elCenter < viewCenter - threshold) { targetIdx = i; break; }
         }
         if (targetIdx === -1) targetIdx = changeGroups.length - 1;
+      }
+    }
+
+    // Crossing into another file: mount any deferred file between so its
+    // changes aren't skipped.
+    if (currentChangeIdx >= 0 && currentChangeIdx < changeGroups.length && targetIdx >= 0) {
+      const fromPath = changeGroups[currentChangeIdx].filePath;
+      const toPath = changeGroups[targetIdx].filePath;
+      const wrapping = (dir > 0 && targetIdx < currentChangeIdx) || (dir < 0 && targetIdx > currentChangeIdx);
+      if (wrapping) {
+        const deferred = findDeferredFileForNav(fromPath, null, dir, fileLikelyHasChanges);
+        if (deferred && deferred.path !== _mountedPath) {
+          mountFileForNav(deferred, function() { navigateToChange(dir, deferred.path); });
+          return;
+        }
+      } else if (fromPath && toPath && fromPath !== toPath) {
+        const deferred = findDeferredFileForNav(fromPath, toPath, dir, fileLikelyHasChanges);
+        if (deferred && deferred.path !== _mountedPath) {
+          mountFileForNav(deferred, function() { navigateToChange(dir, deferred.path); });
+          return;
+        }
       }
     }
 
@@ -2282,10 +2467,13 @@
       if (session.mode !== 'git') {
         const changeNav = document.createElement('div');
         changeNav.className = 'change-nav';
+        const sc = window.crit && window.crit.shortcuts;
+        const prevChangeKeys = (sc && sc.getBinding('previous_change')) || 'Shift+N';
+        const nextChangeKeys = (sc && sc.getBinding('next_change')) || 'n';
         changeNav.innerHTML =
-          '<button class="change-nav-btn" data-dir="-1" title="Previous change (N)">&#9650;</button>' +
+          '<button class="change-nav-btn" data-dir="-1" title="Previous change (' + escapeHtml(prevChangeKeys) + ')">&#9650;</button>' +
           '<span class="change-nav-label" data-file-path="' + escapeHtml(file.path) + '"></span>' +
-          '<button class="change-nav-btn" data-dir="1" title="Next change (n)">&#9660;</button>';
+          '<button class="change-nav-btn" data-dir="1" title="Next change (' + escapeHtml(nextChangeKeys) + ')">&#9660;</button>';
         changeNav.addEventListener('click', function(e) {
           const btn = e.target.closest('.change-nav-btn');
           if (!btn) return;
@@ -6378,10 +6566,12 @@
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'btn btn-sm';
     cancelBtn.textContent = 'Cancel';
+    cancelBtn.disabled = !!isPending;
 
     const submitBtn = document.createElement('button');
     submitBtn.className = 'btn btn-sm btn-primary';
     submitBtn.textContent = 'Reply';
+    submitBtn.disabled = !!isPending;
 
     buttons.appendChild(cancelBtn);
     buttons.appendChild(submitBtn);
@@ -8549,67 +8739,147 @@
   let navCommentId = null;
   let navHighlightTimer;
 
-  function navigateToComment(direction) {
+  function collectNavigableComments() {
+    // Document order matching render: file-scope cards above the body, then
+    // line comments by end_line / start_line. Used so [/] can reach comments
+    // whose .file-body is still deferred.
+    const list = [];
+    for (let fi = 0; fi < files.length; fi++) {
+      const file = files[fi];
+      const comments = file.comments || [];
+      if (comments.length === 0) continue;
+      if (file.orphaned) {
+        for (let ci = 0; ci < comments.length; ci++) {
+          list.push({ id: comments[ci].id, filePath: file.path, resolved: !!comments[ci].resolved });
+        }
+        continue;
+      }
+      const fileScope = [];
+      const lineScope = [];
+      for (let ci = 0; ci < comments.length; ci++) {
+        if (comments[ci].scope === 'file') fileScope.push(comments[ci]);
+        else lineScope.push(comments[ci]);
+      }
+      for (let ci = 0; ci < fileScope.length; ci++) {
+        list.push({ id: fileScope[ci].id, filePath: file.path, resolved: !!fileScope[ci].resolved });
+      }
+      lineScope.sort(function(a, b) {
+        const ae = a.end_line || 0, be = b.end_line || 0;
+        if (ae !== be) return ae - be;
+        const as = a.start_line || 0, bs = b.start_line || 0;
+        return as - bs;
+      });
+      for (let ci = 0; ci < lineScope.length; ci++) {
+        list.push({ id: lineScope[ci].id, filePath: file.path, resolved: !!lineScope[ci].resolved });
+      }
+    }
+    return list;
+  }
+
+  function highlightNavComment(commentId, filePath) {
     const panel = document.getElementById('commentsPanel');
-    const container = document.querySelector('.main-content');
-    const allCards = Array.from(container.querySelectorAll('.comment-card')).filter(function(card) {
-      return !panel || !panel.contains(card);
-    });
-    const isEligible = function(card) {
-      return !isHideResolved() || !card.classList.contains('resolved-card');
+    function applyHighlight(root) {
+      if (!root) return false;
+      const candidates = root.querySelectorAll
+        ? root.querySelectorAll('.comment-card[data-comment-id="' + CSS.escape(commentId) + '"]')
+        : [];
+      let target = null;
+      for (let i = 0; i < candidates.length; i++) {
+        if (panel && panel.contains(candidates[i])) continue;
+        target = candidates[i];
+        break;
+      }
+      if (!target) return false;
+
+      if (navHighlightTimer) {
+        clearTimeout(navHighlightTimer);
+        document.querySelectorAll('.comment-nav-highlight').forEach(function(el) {
+          el.classList.remove('comment-nav-highlight');
+        });
+      }
+
+      const header = document.querySelector('.header');
+      const headerHeight = header ? header.offsetHeight : 52;
+      const rect = target.getBoundingClientRect();
+      const fileSection = target.closest('.file-section');
+      const fileHeader = fileSection ? fileSection.querySelector('.file-header') : null;
+      const fileHeaderHeight = fileHeader ? fileHeader.offsetHeight : 0;
+      window.scrollTo({ top: rect.top + window.scrollY - headerHeight - fileHeaderHeight - 16, behavior: 'smooth' });
+      target.classList.add('comment-nav-highlight');
+      navHighlightTimer = setTimeout(function() {
+        target.classList.remove('comment-nav-highlight');
+        navHighlightTimer = null;
+      }, 1000);
+      return true;
+    }
+
+    const section = document.getElementById('file-section-' + filePath);
+    if (!section) return;
+    if (!section.open) section.open = true;
+
+    // File-scope cards sit outside .file-body and may already be mounted.
+    if (applyHighlight(section)) return;
+
+    const file = getFileByPath(filePath);
+    if (file && file.lazy) {
+      loadLazyFile(section, file, function onLoaded(newSection) {
+        applyHighlight(newSection || document.getElementById('file-section-' + filePath));
+      });
+      return;
+    }
+    if (file) ensureFileBodyMounted(section, file);
+    applyHighlight(section);
+  }
+
+  function navigateToComment(direction) {
+    const all = collectNavigableComments();
+    const isEligible = function(entry) {
+      return !isHideResolved() || !entry.resolved;
     };
-    const cards = allCards.filter(isEligible);
-    if (cards.length === 0) return;
+    const eligible = all.filter(isEligible);
+    if (eligible.length === 0) return;
 
     const header = document.querySelector('.header');
     const headerHeight = header ? header.offsetHeight : 52;
 
-    // Keep the current position in the full order even when that card becomes
-    // hidden, then scan in the requested direction for the next eligible card.
+    // Keep the current position in the full order even when that comment becomes
+    // hidden, then scan in the requested direction for the next eligible entry.
     let idx = -1;
     if (navCommentId) {
-      for (let i = 0; i < allCards.length; i++) {
-        if (allCards[i].dataset.commentId === navCommentId) { idx = i; break; }
+      for (let i = 0; i < all.length; i++) {
+        if (all[i].id === navCommentId) { idx = i; break; }
       }
     }
 
     let target;
     if (idx >= 0) {
-      for (let step = 1; step <= allCards.length; step++) {
-        const candidateIdx = (idx + direction * step + allCards.length) % allCards.length;
-        if (isEligible(allCards[candidateIdx])) {
-          target = allCards[candidateIdx];
+      for (let step = 1; step <= all.length; step++) {
+        const candidateIdx = (idx + direction * step + all.length) % all.length;
+        if (isEligible(all[candidateIdx])) {
+          target = all[candidateIdx];
           break;
         }
       }
     } else if (direction === 1) {
-      // First use: pick first card below the header area by viewport position
+      // First use: pick first mounted card below the header when available,
+      // otherwise the first eligible model entry (may need a mount).
       let targetIdx = -1;
-      for (let j = 0; j < cards.length; j++) {
-        if (cards[j].getBoundingClientRect().top > headerHeight + 8) { targetIdx = j; break; }
+      for (let j = 0; j < eligible.length; j++) {
+        const card = document.querySelector(
+          '.main-content .comment-card[data-comment-id="' + CSS.escape(eligible[j].id) + '"]'
+        );
+        if (!card) continue;
+        if (card.getBoundingClientRect().top > headerHeight + 8) { targetIdx = j; break; }
       }
       if (targetIdx < 0) targetIdx = 0;
-      target = cards[targetIdx];
+      target = eligible[targetIdx];
     } else {
-      target = cards[cards.length - 1];
+      target = eligible[eligible.length - 1];
     }
 
-    navCommentId = target.dataset.commentId;
-
-    if (navHighlightTimer) {
-      clearTimeout(navHighlightTimer);
-      document.querySelectorAll('.comment-nav-highlight').forEach(function(el) {
-        el.classList.remove('comment-nav-highlight');
-      });
-    }
-
-    const rect = target.getBoundingClientRect();
-    const fileSection = target.closest('.file-section');
-    const fileHeader = fileSection ? fileSection.querySelector('.file-header') : null;
-    const fileHeaderHeight = fileHeader ? fileHeader.offsetHeight : 0;
-    window.scrollTo({ top: rect.top + window.scrollY - headerHeight - fileHeaderHeight - 16, behavior: 'smooth' });
-    target.classList.add('comment-nav-highlight');
-    navHighlightTimer = setTimeout(function() { target.classList.remove('comment-nav-highlight'); navHighlightTimer = null; }, 1000);
+    if (!target) return;
+    navCommentId = target.id;
+    highlightNavComment(target.id, target.filePath);
   }
 
   document.getElementById('commentNavPrev').addEventListener('click', function() { navigateToComment(-1); });
@@ -9105,36 +9375,7 @@
     switch (shortcutAction || e.key) {
       case 'next_block': case 'previous_block': {
         e.preventDefault();
-        const allNav = navElements;
-        if (allNav.length === 0) return;
-        let curIdx = focusedElement ? allNav.indexOf(focusedElement) : -1;
-        if (curIdx === -1) {
-          const match = findNavElementForFocusTarget(getKeyboardFocusTarget());
-          if (match) curIdx = allNav.indexOf(match);
-        }
-        if (curIdx === -1) {
-          curIdx = shortcutAction === 'next_block' ? 0 : allNav.length - 1;
-        } else {
-          if (shortcutAction === 'next_block' && curIdx < allNav.length - 1) curIdx++;
-          if (shortcutAction === 'previous_block' && curIdx > 0) curIdx--;
-        }
-        document.querySelectorAll('.kb-nav.focused').forEach(function(el) { el.classList.remove('focused'); });
-        focusedElement = allNav[curIdx];
-        focusedElement.classList.add('focused');
-        focusedElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-        // Sync legacy state
-        if (focusedElement.dataset.filePath) {
-          focusedFilePath = focusedElement.dataset.filePath;
-          focusedBlockIndex = parseInt(focusedElement.dataset.blockIndex);
-        } else {
-          const navTarget = navFocusTargetFromElement(focusedElement);
-          if (navTarget) {
-            focusedFilePath = navTarget.filePath;
-            focusedBlockIndex = null;
-          }
-        }
-        rememberKeyboardFocusFromNav(focusedElement);
-        if (visualMode) extendVisualSelection();
+        navigateBlock(shortcutAction === 'next_block' ? 1 : -1);
         break;
       }
       case 'visual_mode': {

--- a/web/app.js
+++ b/web/app.js
@@ -2128,7 +2128,36 @@
     }
   }
 
+  function changeNavAnchorFromIdx(idx) {
+    if (idx < 0 || idx >= changeGroups.length) return null;
+    const g = changeGroups[idx];
+    let fileGroupIdx = 0;
+    for (let i = 0; i < idx; i++) {
+      if (changeGroups[i].filePath === g.filePath) fileGroupIdx++;
+    }
+    return { filePath: g.filePath, fileGroupIdx: fileGroupIdx };
+  }
+
+  function findChangeIdxForAnchor(anchor) {
+    if (!anchor) return -1;
+    let fileGroupIdx = 0;
+    for (let i = 0; i < changeGroups.length; i++) {
+      if (changeGroups[i].filePath !== anchor.filePath) continue;
+      if (fileGroupIdx === anchor.fileGroupIdx) return i;
+      fileGroupIdx++;
+    }
+    // File still present but group count shrank — land on its last group.
+    let last = -1;
+    for (let i = 0; i < changeGroups.length; i++) {
+      if (changeGroups[i].filePath === anchor.filePath) last = i;
+    }
+    return last;
+  }
+
   function buildChangeGroups() {
+    // Remounting a deferred/lazy body rebuilds groups and would otherwise wipe
+    // currentChangeIdx, breaking atEnd/atStart and wrap chaining on retry.
+    const prevAnchor = changeNavAnchorFromIdx(currentChangeIdx);
     changeGroups = [];
     // Document view: color-coded change blocks + deletion markers
     const docEls = document.querySelectorAll('.line-block-added, .line-block-modified, .deletion-marker');
@@ -2148,7 +2177,7 @@
         group.elements.push(el);
       }
     }
-    currentChangeIdx = -1;
+    currentChangeIdx = findChangeIdxForAnchor(prevAnchor);
     updateChangeCounters();
   }
 
@@ -9502,13 +9531,11 @@
         break;
       }
       case 'next_change': {
-        if (changeGroups.length === 0) break;
         e.preventDefault();
         navigateToChange(1);
         break;
       }
       case 'previous_change': {
-        if (changeGroups.length === 0) break;
         e.preventDefault();
         navigateToChange(-1);
         break;

--- a/web/crit-settings-panes.js
+++ b/web/crit-settings-panes.js
@@ -74,7 +74,8 @@
         if (s.id && !s.fixed) {
           var customized = shortcuts.isCustomized(s.id) ? ' is-customized' : '';
           key = '<button type="button" class="shortcut-binding' + customized + '" data-shortcut-id="' + escapeHTML(s.id)
-            + '" aria-label="Change shortcut for ' + escapeHTML(s.action) + '">' + key + '</button>';
+            + '" data-shortcut-action="' + escapeHTML(s.action)
+            + '" aria-pressed="false" aria-label="Change shortcut for ' + escapeHTML(s.action) + '">' + key + '</button>';
         }
         html += '<tr><td>' + key + '</td><td>' + escapeHTML(s.action) + modeTag + '</td></tr>';
       });
@@ -95,8 +96,17 @@
     });
 
     pane.querySelectorAll('.shortcut-binding').forEach(function (button) {
+      function restoreBindingLabel() {
+        button.classList.remove('is-capturing');
+        button.setAttribute('aria-pressed', 'false');
+        button.setAttribute('aria-label', 'Change shortcut for ' + (button.dataset.shortcutAction || 'shortcut'));
+        button.innerHTML = bindingHTML(shortcuts.getBinding(button.dataset.shortcutId));
+      }
+
       button.addEventListener('click', function () {
         button.classList.add('is-capturing');
+        button.setAttribute('aria-pressed', 'true');
+        button.setAttribute('aria-label', 'Press new keys for ' + (button.dataset.shortcutAction || 'shortcut'));
         // Keep the same <kbd> box while capturing so single-key rows do not
         // change height when plain button text replaces their binding.
         button.innerHTML = '<kbd>Press keys…</kbd>';
@@ -107,8 +117,7 @@
         var movesWithinShortcutControls = next && next.closest &&
           next.closest('.shortcut-binding, .shortcut-reset-all');
         if (movesWithinShortcutControls) {
-          button.classList.remove('is-capturing');
-          button.innerHTML = bindingHTML(shortcuts.getBinding(button.dataset.shortcutId));
+          restoreBindingLabel();
           return;
         }
         rerender();
@@ -125,8 +134,7 @@
         var id = button.dataset.shortcutId;
 
         function showError(message) {
-          button.classList.remove('is-capturing');
-          button.innerHTML = bindingHTML(shortcuts.getBinding(id));
+          restoreBindingLabel();
           var shared = window.crit && window.crit.shared;
           if (shared && shared.showToast) shared.showToast(message, { kind: 'error' });
         }


### PR DESCRIPTION
## Summary
- Comment/change navigation mounts deferred/lazy file bodies (including empty-groups and change-index rebind across remounts)
- Disable Reply/Cancel while an agent request is pending
- Change-nav tooltips from shortcut bindings; shortcut-capture a11y

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (CLI-only deferred/agent paths)

## Test plan
- [x] Frontend unit tests (49)
- [x] Pre-commit suite

See also: tomasz-tomczyk/crit-web#330, tomasz-tomczyk/crit#804