### PR TITLE
fix: append preview agent scripts when HTML has no </body>

### DIFF
--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -215,6 +215,37 @@ func TestHandlePreviewContent_InjectsAgent(t *testing.T) {
 	}
 }
 
+// Fragment HTML (no </body>) must still get the agent bundle appended, otherwise
+// Pin stays stuck on "Loading…" forever — matching crit-web's raw_controller.
+func TestHandlePreviewContent_AppendsAgentWhenNoBodyTag(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "index.html"), []byte("<div>fragment with no body tag</div>"), 0644)
+	s, _ := newPreviewTestServer(t, dir)
+
+	req := httptest.NewRequest("GET", "/preview-content/", nil)
+	w := httptest.NewRecorder()
+	s.HandlePreviewContentForTest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "fragment with no body tag") {
+		t.Error("response missing original content")
+	}
+	if !strings.Contains(body, "crit-agent.js") {
+		t.Error("agent script not appended when </body> is absent")
+	}
+	if !strings.Contains(body, "agent-protocol.js") {
+		t.Error("agent-protocol.js not appended when </body> is absent")
+	}
+	fragIdx := strings.Index(body, "fragment with no body tag")
+	agentIdx := strings.Index(body, "crit-agent.js")
+	if fragIdx < 0 || agentIdx < 0 || agentIdx < fragIdx {
+		t.Error("expected agent scripts appended after fragment content")
+	}
+}
+
 func TestHandlePreviewContent_InjectsAgentOnSiblingHTML(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html><body>home</body></html>"), 0644)

--- a/internal/server/preview_handlers.go
+++ b/internal/server/preview_handlers.go
@@ -76,6 +76,8 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 	}
 	agentScripts := sb.String()
 
+	// Insert before the last </body>, or append when the file is a fragment
+	// with no closing body tag (matches crit-web raw_controller).
 	idx := bytes.LastIndex(bytes.ToLower(body), []byte("</body>"))
 	if idx >= 0 {
 		var out []byte
@@ -83,6 +85,8 @@ func (s *Server) servePreviewHTML(w http.ResponseWriter, filePath string) {
 		out = append(out, []byte(agentScripts)...)
 		out = append(out, body[idx:]...)
 		body = out
+	} else {
+		body = append(body, []byte(agentScripts)...)
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/server/preview_handlers_test.go
+++ b/internal/server/preview_handlers_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newPreviewContentTestServer(t *testing.T, htmlFile string) *Server {
+	t.Helper()
+	sess := &Session{
+		Mode:        "files",
+		RepoRoot:    filepath.Dir(htmlFile),
+		ReviewRound: 1,
+		ReviewType:  "preview",
+		Origin:      htmlFile,
+		Files: []*FileEntry{
+			{
+				Path:     filepath.Base(htmlFile),
+				Status:   "added",
+				FileType: "code",
+				Content:  "<html><body>test</body></html>",
+			},
+		},
+	}
+	sess.InitTestChannels()
+	s, err := NewServer(sess, frontendFS, "", false, "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestServePreviewHTML_AppendsAgentWhenNoBodyTag(t *testing.T) {
+	dir := t.TempDir()
+	htmlFile := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(htmlFile, []byte("<div>fragment with no body tag</div>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	s := newPreviewContentTestServer(t, htmlFile)
+
+	req := httptest.NewRequest("GET", "/preview-content/", nil)
+	w := httptest.NewRecorder()
+	s.handlePreviewContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "fragment with no body tag") {
+		t.Error("response missing original content")
+	}
+	if !strings.Contains(body, "crit-agent.js") {
+		t.Error("agent script not appended when </body> is absent")
+	}
+	fragIdx := strings.Index(body, "fragment with no body tag")
+	agentIdx := strings.Index(body, "crit-agent.js")
+	if fragIdx < 0 || agentIdx < 0 || agentIdx < fragIdx {
+		t.Error("expected agent scripts appended after fragment content")
+	}
+}


### PR DESCRIPTION
## Summary
- Preview Pin stayed stuck on "Loading…" for fragment HTML with no `</body>`, because `servePreviewHTML` skipped agent injection entirely.
- Append the agent script bundle when `</body>` is absent, matching crit-web's `raw_controller` fallback.
- Add a regression test for fragment HTML injection.

## Test plan
- [x] `go test ./internal/preview/ -run AppendsAgentWhenNoBodyTag`
- [x] `go test ./...`
- [ ] Manual: `crit preview` a fragment HTML file, open `/preview`, confirm Pin enables after load

Closes #806

Made with [Cursor](https://cursor.com)