### PR TITLE
fix: route browser share actions through the local Go server

### DIFF
--- a/.claude/rules/proxy-auth-transport.md
+++ b/.claude/rules/proxy-auth-transport.md
@@ -24,7 +24,18 @@ When `proxy_auth: true` (global config), crit-web sits behind an SSO reverse pro
 
 **Terminal subcommands** that HTTP-call crit-web directly (today: `crit share`, `crit fetch`, `crit unpublish`) must call `checkProxyAuthCLIAllowed("crit <cmd>")` at the top of their `Run*` entrypoint and exit with the shared error message. Do not attempt the network call.
 
-**Browser UI actions** (Share / Pull / Unpublish buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+**Browser UI actions** (Share / Pull / Unpublish / Re-share buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+
+Direct (non-proxy_auth) browser actions must go through the **local Go server**, never `fetch(shareURL + …)` cross-origin:
+
+| Action    | Local endpoint                          |
+|-----------|-----------------------------------------|
+| Share     | `POST /api/share`                       |
+| Pull      | `POST /api/share/pull`                  |
+| Re-share  | `POST /api/share/reshare`               |
+| Unpublish | `DELETE /api/share-url`                 |
+
+(The Go handlers attach the bearer token and talk to crit-web. Cross-origin browser fetches fail CORS on selfhosted+OAuth instances because preflight has no `Authorization`, and even with CORS fixed the browser never sends the token.)
 
 When adding a **new** crit-web interaction, decide which surface owns it:
 - **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.

--- a/.cursor/rules/proxy-auth-transport.mdc
+++ b/.cursor/rules/proxy-auth-transport.mdc
@@ -29,7 +29,18 @@ When `proxy_auth: true` (global config), crit-web sits behind an SSO reverse pro
 
 **Terminal subcommands** that HTTP-call crit-web directly (today: `crit share`, `crit fetch`, `crit unpublish`) must call `checkProxyAuthCLIAllowed("crit <cmd>")` at the top of their `Run*` entrypoint and exit with the shared error message. Do not attempt the network call.
 
-**Browser UI actions** (Share / Pull / Unpublish buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+**Browser UI actions** (Share / Pull / Unpublish / Re-share buttons in the review page) must still work: implement both transports per Rule 1 — direct when `proxy_auth` is false, popup relay when true (`web/crit-share.js` + crit-web `share_receiver/handlers.js`).
+
+Direct (non-proxy_auth) browser actions must go through the **local Go server**, never `fetch(shareURL + …)` cross-origin:
+
+| Action    | Local endpoint                          |
+|-----------|-----------------------------------------|
+| Share     | `POST /api/share`                       |
+| Pull      | `POST /api/share/pull`                  |
+| Re-share  | `POST /api/share/reshare`               |
+| Unpublish | `DELETE /api/share-url`                 |
+
+(The Go handlers attach the bearer token and talk to crit-web. Cross-origin browser fetches fail CORS on selfhosted+OAuth instances because preflight has no `Authorization`, and even with CORS fixed the browser never sends the token.)
 
 When adding a **new** crit-web interaction, decide which surface owns it:
 - **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -411,3 +411,174 @@ func TestHandleShareURL_LocalOnlySkipsRemoteDelete(t *testing.T) {
 		t.Errorf("hosted URL should be cleared")
 	}
 }
+
+func TestHandleSharePull_Unauthorized(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "authentication required"})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	s.authMu.Lock()
+	s.authToken = "bad"
+	s.authMu.Unlock()
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSharePull_NotFound(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Not found"})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/gone", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSharePull_NoNewComments(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]any{})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var result map[string]any
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["merged"].(float64) != 0 {
+		t.Errorf("merged = %v, want 0", result["merged"])
+	}
+}
+
+func TestHandleShareReshare_SoftFailsPullThenUpserts(t *testing.T) {
+	putHits := 0
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			// Non-auth transient failure — reshare should soft-fail pull and still PUT.
+			w.WriteHeader(http.StatusBadGateway)
+			json.NewEncoder(w).Encode(map[string]string{"error": "upstream down"})
+		case r.Method == http.MethodPut:
+			putHits++
+			json.NewEncoder(w).Encode(map[string]any{
+				"url": "https://crit.md/r/abc123", "review_round": 2, "changed": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if putHits != 1 {
+		t.Errorf("PUT hits = %d, want 1 after soft-failed pull", putHits)
+	}
+}
+
+func TestHandleShareReshare_FatalUnauthorizedPull(t *testing.T) {
+	putHits := 0
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			putHits++
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "authentication required"})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+	if putHits != 0 {
+		t.Errorf("PUT must not run after fatal pull auth error")
+	}
+}
+
+func TestHandleShareReshare_NoSharedReview(t *testing.T) {
+	s, _ := newShareTestServer(t, "https://example.com", true)
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	// softPull fatals with no shared review before upsert.
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleShareReshare_MethodNotAllowed(t *testing.T) {
+	s, _ := newShareTestServer(t, "https://example.com", true)
+	req := httptest.NewRequest(http.MethodGet, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleShareURL_DeleteUnpublishesRemotely(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotAuth = r.Method, r.URL.Path, r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	s.authMu.Lock()
+	s.authToken = "tok_del"
+	s.authMu.Unlock()
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/share-url", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204, body = %s", w.Code, w.Body.String())
+	}
+	if gotMethod != http.MethodDelete || gotPath != "/api/reviews" {
+		t.Errorf("remote = %s %s, want DELETE /api/reviews", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer tok_del" {
+		t.Errorf("Authorization = %q, want Bearer tok_del", gotAuth)
+	}
+	if sess.GetSharedURL() != "" {
+		t.Errorf("hosted URL should be cleared")
+	}
+}

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -582,3 +582,114 @@ func TestHandleShareURL_DeleteUnpublishesRemotely(t *testing.T) {
 		t.Errorf("hosted URL should be cleared")
 	}
 }
+
+func TestHandleShareReshare_UpsertUnauthorized(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "authentication required"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleShareReshare_NotFoundOnPull(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Not found"})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/gone", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleShareURL_DeleteRemoteFailure(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "boom"})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/share-url", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body = %s", w.Code, w.Body.String())
+	}
+	// Remote failed — local share state must remain so the user can retry.
+	if sess.GetSharedURL() == "" {
+		t.Errorf("hosted URL cleared despite remote unpublish failure")
+	}
+}
+
+func TestHandleSharePull_MissingReviewFile(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]any{})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+	// Remove the seeded review file so pullAndMergeRemoteComments hits the
+	// missing-file branch.
+	reviewPath := filepath.Join(sess.OutputDir, ".crit", "review.json")
+	if err := os.Remove(reviewPath); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleShareReshare_EmptyFiles(t *testing.T) {
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			json.NewEncoder(w).Encode([]any{})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+	// Clear session files so reshareUpsertInputs returns errNoFilesInSession.
+	sess.Files = nil
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
@@ -273,5 +274,140 @@ func TestHandleFileComments_RoundFiltersByReviewRound(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &got)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 comments, got %d", len(got))
+	}
+}
+
+func TestHandleSharePull_MergesRemoteComments(t *testing.T) {
+	var gotAuth string
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/comments") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id": "web-1", "body": "from web", "file_path": "plan.md",
+				"start_line": 1, "end_line": 1, "external_id": "web-ext-1",
+			},
+		})
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	s.authMu.Lock()
+	s.authToken = "tok_test_bearer"
+	s.authMu.Unlock()
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if gotAuth != "Bearer tok_test_bearer" {
+		t.Errorf("Authorization = %q, want Bearer tok_test_bearer", gotAuth)
+	}
+	var result map[string]any
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["merged"].(float64) != 1 {
+		t.Errorf("merged = %v, want 1", result["merged"])
+	}
+}
+
+func TestHandleSharePull_NoSharedReview(t *testing.T) {
+	s, _ := newShareTestServer(t, "https://example.com", true)
+	req := httptest.NewRequest(http.MethodPost, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleSharePull_MethodNotAllowed(t *testing.T) {
+	s, _ := newShareTestServer(t, "https://example.com", true)
+	req := httptest.NewRequest(http.MethodGet, "/api/share/pull", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleShareReshare_PullsAndUpserts(t *testing.T) {
+	var putAuth string
+	var putHits int
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/reviews/"):
+			putHits++
+			putAuth = r.Header.Get("Authorization")
+			json.NewEncoder(w).Encode(map[string]any{
+				"url":          "https://crit.md/r/abc123",
+				"review_round": 2,
+				"changed":      true,
+			})
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	s.authMu.Lock()
+	s.authToken = "tok_reshare"
+	s.authMu.Unlock()
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc123", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share/reshare", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if putHits != 1 {
+		t.Errorf("PUT hits = %d, want 1", putHits)
+	}
+	if putAuth != "Bearer tok_reshare" {
+		t.Errorf("Authorization = %q, want Bearer tok_reshare", putAuth)
+	}
+	var result map[string]any
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["changed"] != true {
+		t.Errorf("changed = %v, want true", result["changed"])
+	}
+}
+
+func TestHandleShareURL_LocalOnlySkipsRemoteDelete(t *testing.T) {
+	remoteHits := 0
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteHits++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer critWeb.Close()
+
+	s, sess := newShareTestServer(t, critWeb.URL, true)
+	sess.SetSharedURLAndToken(critWeb.URL+"/r/abc", "delete-tok")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/share-url?local_only=1", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if remoteHits != 0 {
+		t.Errorf("remote hits = %d, want 0 (local_only must skip UnpublishFromWeb)", remoteHits)
+	}
+	if sess.GetSharedURL() != "" {
+		t.Errorf("hosted URL should be cleared")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,6 +161,8 @@ func NewServer(session *Session, frontendFS embed.FS, shareURL string, proxyAuth
 	mux.HandleFunc("/api/share/payload", s.withReady(s.handleSharePayload))
 	mux.HandleFunc("/api/share/preview-payload", s.withReady(s.handlePreviewPayload))
 	mux.HandleFunc("/api/share/upsert-payload", s.withReady(s.handleUpsertPayload))
+	mux.HandleFunc("/api/share/pull", s.withReady(s.handleSharePull))
+	mux.HandleFunc("/api/share/reshare", s.withReady(s.handleShareReshare))
 	mux.HandleFunc("/api/share-policy", s.withReady(s.handleSharePolicy))
 	mux.HandleFunc("/api/share-url", s.withReady(s.handleShareURL))
 	mux.HandleFunc("/api/comments/merge", s.withReady(s.handleMergeComments))
@@ -820,8 +822,10 @@ func (s *Server) handleShareURL(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case http.MethodDelete:
-		// Unpublish from crit-web if we have a share URL and delete token.
-		if s.shareURL != "" {
+		// Unpublish from crit-web unless the caller already deleted remotely
+		// (proxy_auth popup path passes local_only=1 after the relay DELETE).
+		localOnly := r.URL.Query().Get("local_only") == "1"
+		if !localOnly && s.shareURL != "" {
 			if _, dt := s.session.Load().GetShareState(); dt != "" {
 				if err := share.UnpublishFromWeb(s.shareURL, dt, s.authTokenSnapshot()); err != nil {
 					w.Header().Set("Content-Type", "application/json")
@@ -1202,6 +1206,205 @@ func (s *Server) handleUpsertPayload(w http.ResponseWriter, r *http.Request) {
 	cliArgs := share.LoadCliArgsFromReviewFile(critPath)
 	deleteToken := sess.GetDeleteToken()
 	writeJSON(w, buildUpsertPayload(files, comments, deleteToken, reviewRound, cliArgs))
+}
+
+// handleSharePull fetches remote comments from crit-web (with the local bearer
+// token) and merges them into the review file. Used by the browser Share UI
+// when proxy_auth is off — the browser must not call crit-web cross-origin
+// (CORS + missing Authorization on selfhosted OAuth instances).
+//
+// POST /api/share/pull
+func (s *Server) handleSharePull(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	merged, repliesUpdated, err := s.pullAndMergeRemoteComments()
+	if err != nil {
+		s.writeShareTransportError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{"merged": merged, "replies_updated": repliesUpdated})
+}
+
+// handleShareReshare pulls remote comments, merges them locally, then upserts
+// the merged review to crit-web. Same direct-transport path the CLI uses for
+// re-share; the browser calls this instead of cross-origin PUT/GET.
+//
+// POST /api/share/reshare
+func (s *Server) handleShareReshare(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	merged, repliesUpdated := s.softPullForReshare(w)
+	if merged < 0 {
+		return // fatal pull error already written
+	}
+
+	sess := s.session.Load()
+	hostedURL, deleteToken := sess.GetShareState()
+	if hostedURL == "" || deleteToken == "" {
+		s.writeShareTransportError(w, errNoSharedReview)
+		return
+	}
+
+	files, comments, existingCfg, err := s.reshareUpsertInputs(sess, hostedURL, deleteToken)
+	if err != nil {
+		status := http.StatusBadRequest
+		if !errors.Is(err, errNoFilesInSession) {
+			status = http.StatusInternalServerError
+		}
+		s.writeJSONError(w, status, err.Error())
+		return
+	}
+
+	result, err := share.UpsertShareToWeb(existingCfg, files, comments, s.authTokenSnapshot())
+	if err != nil {
+		s.writeShareTransportError(w, err)
+		return
+	}
+	// Non-fatal if local hash/round persistence fails — remote upsert already succeeded.
+	_ = share.UpdateShareState(sess.CritJSONPath(), share.ComputeShareHash(files, comments), result.ReviewRound)
+	sess.SyncCommentsFromDisk()
+
+	writeJSON(w, map[string]any{
+		"url":             result.URL,
+		"changed":         result.Changed,
+		"review_round":    result.ReviewRound,
+		"merged":          merged,
+		"replies_updated": repliesUpdated,
+	})
+}
+
+// softPullForReshare runs pull+merge. Fatal auth/not-found errors are written
+// to w and return merged=-1. Other pull errors soft-fail (0, 0) like the CLI.
+func (s *Server) softPullForReshare(w http.ResponseWriter) (merged, repliesUpdated int) {
+	merged, repliesUpdated, err := s.pullAndMergeRemoteComments()
+	if err == nil {
+		return merged, repliesUpdated
+	}
+	if errors.Is(err, share.ErrShareUnauthorized) || errors.Is(err, share.ErrShareNotFound) {
+		s.writeShareTransportError(w, err)
+		return -1, 0
+	}
+	return 0, 0
+}
+
+// reshareUpsertInputs loads files + comments and builds the CritJSON used for
+// UpsertShareToWeb, preferring on-disk LastShareHash / ReviewRound / CliArgs.
+func (s *Server) reshareUpsertInputs(sess *Session, hostedURL, deleteToken string) ([]ShareFile, []shareComment, CritJSON, error) {
+	files, reviewType, err := s.shareFilesForSession()
+	if err != nil {
+		return nil, nil, CritJSON{}, err
+	}
+	if len(files) == 0 {
+		return nil, nil, CritJSON{}, errNoFilesInSession
+	}
+
+	critPath := sess.CritJSONPath()
+	var comments []shareComment
+	if reviewType == "preview" {
+		comments, _ = share.LoadPreviewShareComments(critPath, sess.FilePathsSnapshot(), s.author)
+	} else {
+		filePaths := make([]string, len(files))
+		for i, f := range files {
+			filePaths[i] = f.Path
+		}
+		comments, _ = share.LoadCommentsForShare(critPath, filePaths, s.author)
+	}
+
+	existingCfg := CritJSON{
+		ShareURL:    hostedURL,
+		DeleteToken: deleteToken,
+		ReviewRound: sess.ReviewRound,
+		CliArgs:     share.LoadCliArgsFromReviewFile(critPath),
+	}
+	if data, readErr := session.ReadFileShared(review.ReviewPathsFor(critPath).Review); readErr == nil {
+		var onDisk CritJSON
+		if json.Unmarshal(data, &onDisk) == nil {
+			existingCfg.LastShareHash = onDisk.LastShareHash
+			if onDisk.ReviewRound > 0 {
+				existingCfg.ReviewRound = onDisk.ReviewRound
+			}
+			if len(onDisk.CliArgs) > 0 {
+				existingCfg.CliArgs = onDisk.CliArgs
+			}
+		}
+	}
+	return files, comments, existingCfg, nil
+}
+
+func (s *Server) writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// pullAndMergeRemoteComments is the shared pull+merge used by /api/share/pull
+// and the first half of /api/share/reshare. Returns merged/replies_updated
+// counts. Caller must SyncCommentsFromDisk if they need a fresh in-memory view
+// after a successful merge (pull does; reshare does after upsert).
+func (s *Server) pullAndMergeRemoteComments() (merged, repliesUpdated int, err error) {
+	sess := s.session.Load()
+	hostedURL := sess.GetSharedURL()
+	if tokenFromHostedURL(hostedURL) == "" {
+		return 0, 0, errNoSharedReview
+	}
+	critPath := sess.CritJSONPath()
+	data, readErr := session.ReadFileShared(review.ReviewPathsFor(critPath).Review)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return 0, 0, fmt.Errorf("review file not found")
+		}
+		return 0, 0, readErr
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil {
+		return 0, 0, err
+	}
+
+	localIDs := share.BuildLocalIDSet(cj)
+	localFingerprints, localFingerprintIDs := share.BuildLocalFingerprintIndex(cj)
+	fetched, err := share.FetchWebComments(hostedURL, localIDs, localFingerprints, localFingerprintIDs, s.authTokenSnapshot())
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(fetched.NewComments) == 0 && len(fetched.ReplyUpdates) == 0 {
+		sess.SyncCommentsFromDisk()
+		return 0, 0, nil
+	}
+	if err := share.MergeWebComments(critPath, fetched.NewComments, fetched.ReplyUpdates); err != nil {
+		return 0, 0, err
+	}
+	sess.SyncCommentsFromDisk()
+	return len(fetched.NewComments), len(fetched.ReplyUpdates), nil
+}
+
+var (
+	errNoSharedReview   = errors.New("no shared review in this session")
+	errNoFilesInSession = errors.New("no files in session")
+)
+
+func (s *Server) writeShareTransportError(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case errors.Is(err, errNoSharedReview):
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+	case errors.Is(err, share.ErrShareUnauthorized):
+		auth.ClearAuthIdentity()
+		s.clearAuthState()
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+	case errors.Is(err, share.ErrShareNotFound):
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+	default:
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+	}
 }
 
 // handleMergeComments accepts comments fetched from crit-web (via the popup

--- a/web/crit-share.js
+++ b/web/crit-share.js
@@ -6,11 +6,13 @@
 // in-flight guard, the open modal element, the org cache) and wires the
 // #shareBtn click handler onto options.shareBtnEl.
 //
-// Transport, not protocol: every fetch() endpoint here is identical to the
-// pre-extraction app.js code. The proxy_auth relay (popup) hits the same
-// crit-web API endpoints with the same payload shapes as the direct path; the
-// only branch is which payload-builder endpoint is called for preview vs files
-// (see performShare).
+// Transport, not protocol: when proxy_auth is off, Share / Pull / Re-share /
+// Unpublish go through the local Go server (/api/share, /api/share/pull,
+// /api/share/reshare, /api/share-url), which attaches the bearer token. When
+// proxy_auth is on, the popup relay hits the same crit-web API endpoints with
+// the same payload shapes; the only branch is which payload-builder endpoint
+// is called for preview vs files (see performShare). The browser never calls
+// crit-web cross-origin in either mode.
 //
 // Dependencies (via window.crit.*):
 //   - none at module scope; all collaborators are injected through options.
@@ -871,9 +873,9 @@
       overlay.querySelector('#modalReshareBtn').addEventListener('click', handleReshare);
     }
 
-    // Pull remote comments through the popup relay (or directly when
-    // proxy_auth is unset), then merge into the local review file via
-    // /api/comments/merge, then refresh the UI in place.
+    // Pull remote comments. Direct transport goes through the local Go server
+    // (bearer token attached server-side) so the browser never hits crit-web
+    // cross-origin. Proxy-auth still uses the popup relay.
     async function handlePullComments() {
       const btn = document.getElementById('modalPullBtn');
       if (!btn) return;
@@ -897,23 +899,23 @@
       try {
         if (!hostedToken) throw new Error('no shared review token (try re-sharing)');
 
-        let comments;
         if (popupSession) {
-          comments = await popupSession.run('fetch', { token: hostedToken });
+          const comments = await popupSession.run('fetch', { token: hostedToken });
+          const mergeResp = await fetch('/api/comments/merge', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ comments: comments }),
+          });
+          if (!mergeResp.ok) {
+            const errBody = await mergeResp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'merge failed: ' + mergeResp.status);
+          }
         } else {
-          const r = await fetch(shareURL.replace(/\/$/, '') + '/api/reviews/' + encodeURIComponent(hostedToken) + '/comments');
-          if (!r.ok) throw new Error('Server error ' + r.status);
-          comments = await r.json();
-        }
-
-        const mergeResp = await fetch('/api/comments/merge', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ comments: comments }),
-        });
-        if (!mergeResp.ok) {
-          const errBody = await mergeResp.json().catch(function() { return {}; });
-          throw new Error(errBody.error || 'merge failed: ' + mergeResp.status);
+          const resp = await fetch('/api/share/pull', { method: 'POST' });
+          if (!resp.ok) {
+            const errBody = await resp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'Server error ' + resp.status);
+          }
         }
 
         await onCommentsRefreshed();
@@ -930,10 +932,9 @@
       }
     }
 
-    // Re-share chains pull -> merge -> upsert in a single popup session.
-    // If the upsert fails after the merge succeeds, the local review file is
-    // already updated with remote comments; the user must re-click Re-share
-    // (and possibly re-authenticate) to push the merged state back up.
+    // Re-share: pull -> merge -> upsert. Direct transport is entirely
+    // server-side (/api/share/reshare) so the browser never calls crit-web
+    // cross-origin. Proxy-auth keeps the popup relay for the same API calls.
     async function handleReshare() {
       const btn = document.getElementById('modalReshareBtn');
       if (!btn) return;
@@ -957,47 +958,39 @@
       try {
         if (!hostedToken) throw new Error('no shared review token (try re-sharing)');
 
-        // 1. Pull remote comments through the (still authenticated) popup.
-        let remoteComments;
         if (popupSession) {
-          remoteComments = await popupSession.run('fetch', { token: hostedToken });
-        } else {
-          const r = await fetch(shareURL.replace(/\/$/, '') + '/api/reviews/' + encodeURIComponent(hostedToken) + '/comments');
-          if (!r.ok) throw new Error('Server error ' + r.status);
-          remoteComments = await r.json();
-        }
+          // 1. Pull remote comments through the (still authenticated) popup.
+          const remoteComments = await popupSession.run('fetch', { token: hostedToken });
 
-        // 2. Merge locally. NOTE: this mutates the local review file even if
-        // the upsert in step 4 fails — the toast in the catch block documents
-        // the partial-failure recovery path.
-        const mergeResp = await fetch('/api/comments/merge', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ comments: remoteComments }),
-        });
-        if (!mergeResp.ok) {
-          const errBody = await mergeResp.json().catch(function() { return {}; });
-          throw new Error(errBody.error || 'merge failed: ' + mergeResp.status);
-        }
+          // 2. Merge locally. NOTE: this mutates the local review file even if
+          // the upsert in step 4 fails — the toast in the catch block documents
+          // the partial-failure recovery path.
+          const mergeResp = await fetch('/api/comments/merge', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ comments: remoteComments }),
+          });
+          if (!mergeResp.ok) {
+            const errBody = await mergeResp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'merge failed: ' + mergeResp.status);
+          }
 
-        // 3. Build upsert payload from the merged local state.
-        const payloadResp = await fetch('/api/share/upsert-payload');
-        if (!payloadResp.ok) {
-          const errBody = await payloadResp.json().catch(function() { return {}; });
-          throw new Error(errBody.error || 'failed to build upsert payload');
-        }
-        const payload = await payloadResp.json();
+          // 3. Build upsert payload from the merged local state.
+          const payloadResp = await fetch('/api/share/upsert-payload');
+          if (!payloadResp.ok) {
+            const errBody = await payloadResp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'failed to build upsert payload');
+          }
+          const payload = await payloadResp.json();
 
-        // 4. PUT through the same popup session (still authenticated).
-        if (popupSession) {
+          // 4. PUT through the same popup session (still authenticated).
           await popupSession.run('upsert', { token: hostedToken, payload: payload });
         } else {
-          const r = await fetch(shareURL.replace(/\/$/, '') + '/api/reviews/' + encodeURIComponent(hostedToken), {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-          if (!r.ok) throw new Error('Server error ' + r.status);
+          const resp = await fetch('/api/share/reshare', { method: 'POST' });
+          if (!resp.ok) {
+            const errBody = await resp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'Server error ' + resp.status);
+          }
         }
 
         await onCommentsRefreshed();
@@ -1010,8 +1003,9 @@
         // popup was closed.
         showToast('share', 'error',
           '<span>Re-share failed: ' + escapeHtml(err.message) +
-          '. Local comments may have been updated; click Re-share again to retry ' +
-          '(you may need to re-authenticate in the popup).</span>');
+          '. Local comments may have been updated; click Re-share again to retry' +
+          (proxyAuth ? ' (you may need to re-authenticate in the popup)' : '') +
+          '.</span>');
       } finally {
         if (popupSession) popupSession.close();
         const liveBtn = document.getElementById('modalReshareBtn');
@@ -1062,21 +1056,29 @@
         if (popupSession) {
           // Receiver normalises 404 (already deleted) to {already_deleted: true}.
           await popupSession.run('unpublish', { delete_token: deleteToken });
+          // Remote delete already happened via the popup; only clear local
+          // session state. A full DELETE /api/share-url would re-contact
+          // crit-web from Go and fail behind the SSO proxy.
+          const clearResp = await fetch('/api/share-url?local_only=1', { method: 'DELETE' });
+          if (!clearResp.ok && clearResp.status !== 204) {
+            console.warn('share: failed to clear local share-url state', clearResp.status);
+          }
         } else {
-          const resp = await fetch(shareURL + '/api/reviews', {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ delete_token: deleteToken }),
-          });
-          const alreadyDeleted = resp.status === 404;
-          if (!alreadyDeleted && !resp.ok) throw new Error('Server error ' + resp.status);
+          // Direct transport: DELETE /api/share-url unpublisheds remotely
+          // (bearer attached server-side) and clears local session state.
+          // Do NOT call crit-web cross-origin — that fails CORS on selfhosted
+          // OAuth instances and is redundant with this endpoint.
+          const resp = await fetch('/api/share-url', { method: 'DELETE' });
+          if (!resp.ok && resp.status !== 204) {
+            const errBody = await resp.json().catch(function() { return {}; });
+            throw new Error(errBody.error || 'Server error ' + resp.status);
+          }
         }
         hostedURL = '';
         deleteToken = '';
         hostedToken = '';
         sharedOrg = null;
         sharedVisibility = '';
-        fetch('/api/share-url', { method: 'DELETE' }).catch(function() { /* fire-and-forget */ });
         closeShareModal();
         setShareButtonState('default');
       } catch (err) {


### PR DESCRIPTION
## Summary
- Stop the browser UI from calling crit-web cross-origin for Pull / Re-share / Unpublish (CORS fails on selfhosted OAuth; bearer never sent).
- Add `POST /api/share/pull` and `POST /api/share/reshare`; Unpublish uses existing `DELETE /api/share-url` (bearer attached server-side).
- Proxy-auth path clears local state with `?local_only=1` after the popup remote delete so Go does not re-hit the SSO proxy.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (transport only; review-page UI unchanged)

## Test plan
- [x] Unit tests for pull / reshare / local_only
- [x] `make e2e-share` against companion crit-web worktree
- [x] golangci-lint + gofmt
- [ ] Manual: Unpublish / Pull / Re-share from crit UI with share_url pointing at a selfhosted OAuth instance

See also: tomasz-tomczyk/crit-web#331