### PR TITLE
test: add browser E2E smoke coverage for share transport

### DIFF
--- a/.claude/rules/proxy-auth-transport.md
+++ b/.claude/rules/proxy-auth-transport.md
@@ -37,6 +37,8 @@ Direct (non-proxy_auth) browser actions must go through the **local Go server**,
 
 (The Go handlers attach the bearer token and talk to crit-web. Cross-origin browser fetches fail CORS on selfhosted+OAuth instances because preflight has no `Authorization`, and even with CORS fixed the browser never sends the token.)
 
+The `share-transport` Playwright project (`test/e2e/tests/share-transport.sharetransport.spec.ts`) drives these three actions against a stub crit-web on a different origin and fails if the page issues any request to it, so a regression to cross-origin fetches is caught in CI. Extend that spec when you add a browser action that talks to crit-web.
+
 When adding a **new** crit-web interaction, decide which surface owns it:
 - **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.
 - **Terminal-only** (rare): document that it won't work behind SSO, or don't add it.

--- a/.cursor/rules/proxy-auth-transport.mdc
+++ b/.cursor/rules/proxy-auth-transport.mdc
@@ -42,6 +42,8 @@ Direct (non-proxy_auth) browser actions must go through the **local Go server**,
 
 (The Go handlers attach the bearer token and talk to crit-web. Cross-origin browser fetches fail CORS on selfhosted+OAuth instances because preflight has no `Authorization`, and even with CORS fixed the browser never sends the token.)
 
+The `share-transport` Playwright project (`test/e2e/tests/share-transport.sharetransport.spec.ts`) drives these three actions against a stub crit-web on a different origin and fails if the page issues any request to it, so a regression to cross-origin fetches is caught in CI. Extend that spec when you add a browser action that talks to crit-web.
+
 When adding a **new** crit-web interaction, decide which surface owns it:
 - **Browser-only** (like today's share/pull/unpublish behind SSO): block the terminal path with `checkProxyAuthCLIAllowed`; add relay handler + frontend branch.
 - **Terminal-only** (rare): document that it won't work behind SSO, or don't add it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ make e2e-report                                       # View HTML report with sc
 
 ### Projects
 
-Eight Playwright projects. Test naming convention determines which project runs which file:
+Nine Playwright projects. Test naming convention determines which project runs which file:
 
 | Project | Port | Fixture | Test glob |
 | --- | --- | --- | --- |
@@ -170,6 +170,7 @@ Eight Playwright projects. Test naming convention determines which project runs 
 | `multi-file-mode` | 3127 | `setup-fixtures-multifile.sh` (code + markdown files) | `*.multifile.spec.ts` |
 | `range-mode` | 3128 | `setup-fixtures-range-mode.sh` (`--range A..B` stacked git) | `*.rangemode.spec.ts` |
 | `live-mode` | 3129 | `setup-fixtures-livemode.sh` (Go upstream + crit live) | `*.livemode.spec.ts` |
+| `share-transport` | 3132 (stub crit-web on 3133) | `setup-fixtures-sharetransport.sh` (file mode + stub crit-web) | `*.sharetransport.spec.ts` |
 
 The `mobile` project shares the git-mode fixture port. In `run.sh` it runs strictly after `git-mode` finishes so the two don't race on shared comment state (both projects `DELETE /api/comments` in `beforeEach`).
 

--- a/test/e2e/fixtures/sharetransport-crit-web/go.mod
+++ b/test/e2e/fixtures/sharetransport-crit-web/go.mod
@@ -1,0 +1,3 @@
+module sharetransportcritweb
+
+go 1.21

--- a/test/e2e/fixtures/sharetransport-crit-web/main.go
+++ b/test/e2e/fixtures/sharetransport-crit-web/main.go
@@ -1,0 +1,254 @@
+// Package main is the share-transport E2E fixture: a minimal stand-in for a
+// crit-web instance, implementing only the four endpoints the local crit
+// server calls when sharing (POST/PUT/DELETE /api/reviews and
+// GET /api/reviews/:token/comments).
+//
+// Its purpose is to let the share-transport Playwright project drive the real
+// browser Share flow (share -> pull -> re-share -> unpublish) end to end
+// without a Postgres-backed crit-web. Every /api request is recorded together
+// with its Origin header, which is what makes the key regression assertion
+// possible: browser-issued cross-origin fetches carry an Origin, requests
+// proxied by the local Go server do not. See tests/share-transport.sharetransport.spec.ts.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+// recordedRequest is one /api call the fixture received. Origin is the raw
+// Origin header — empty for server-to-server calls, set for browser fetches.
+type recordedRequest struct {
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	Origin  string `json:"origin"`
+	HasAuth bool   `json:"has_auth"`
+}
+
+type review struct {
+	DeleteToken string            `json:"delete_token"`
+	ReviewRound int               `json:"review_round"`
+	Comments    []json.RawMessage `json:"comments"`
+}
+
+type fixture struct {
+	origin string
+
+	mu         sync.Mutex
+	reviews    map[string]*review
+	log        []recordedRequest
+	nextToken  int
+	failDelete bool
+}
+
+func main() {
+	port := flag.Int("port", 0, "TCP port to listen on (0 = pick a free port)")
+	flag.Parse()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+
+	f := &fixture{
+		origin:  "http://" + ln.Addr().String(),
+		reviews: map[string]*review{},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/reviews", f.handleReviewsCollection)
+	mux.HandleFunc("/api/reviews/", f.handleReviewByToken)
+	mux.HandleFunc("/api/share-policy", f.handleSharePolicy)
+	mux.HandleFunc("/__seed-comment", f.handleSeedComment)
+	mux.HandleFunc("/__config", f.handleConfig)
+	mux.HandleFunc("/__log", f.handleLog)
+	mux.HandleFunc("/__reset", f.handleReset)
+
+	// Stable stdout contract used by setup-fixtures-sharetransport.sh.
+	fmt.Printf("listening on %s\n", f.origin)
+	_ = os.Stdout.Sync()
+
+	srv := &http.Server{Handler: mux}
+	if err := srv.Serve(ln); err != nil && !strings.Contains(err.Error(), "Server closed") {
+		log.Fatal(err)
+	}
+}
+
+func (f *fixture) record(r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.log = append(f.log, recordedRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Origin:  r.Header.Get("Origin"),
+		HasAuth: r.Header.Get("Authorization") != "",
+	})
+}
+
+// POST /api/reviews creates a review; DELETE /api/reviews unpublishes one.
+func (f *fixture) handleReviewsCollection(w http.ResponseWriter, r *http.Request) {
+	f.record(r)
+	switch r.Method {
+	case http.MethodPost:
+		f.createReview(w)
+	case http.MethodDelete:
+		f.deleteReview(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fixture) createReview(w http.ResponseWriter) {
+	f.mu.Lock()
+	f.nextToken++
+	token := fmt.Sprintf("tok%d", f.nextToken)
+	f.reviews[token] = &review{DeleteToken: "del-" + token, ReviewRound: 1}
+	f.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"url":          f.origin + "/r/" + token,
+		"delete_token": "del-" + token,
+	})
+}
+
+func (f *fixture) deleteReview(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		DeleteToken string `json:"delete_token"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failDelete {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "unpublish rejected by fixture"})
+		return
+	}
+	for token, rev := range f.reviews {
+		if rev.DeleteToken == body.DeleteToken {
+			delete(f.reviews, token)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+	// Unknown token — crit treats 404 as "already gone", i.e. success.
+	w.WriteHeader(http.StatusNotFound)
+}
+
+// GET /api/reviews/:token/comments lists seeded comments; PUT /api/reviews/:token
+// upserts the review and bumps its round.
+func (f *fixture) handleReviewByToken(w http.ResponseWriter, r *http.Request) {
+	f.record(r)
+	rest := strings.TrimPrefix(r.URL.Path, "/api/reviews/")
+	token := strings.TrimSuffix(rest, "/comments")
+	isComments := strings.HasSuffix(rest, "/comments")
+
+	f.mu.Lock()
+	rev, ok := f.reviews[token]
+	f.mu.Unlock()
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+
+	switch {
+	case isComments && r.Method == http.MethodGet:
+		f.mu.Lock()
+		comments := append([]json.RawMessage{}, rev.Comments...)
+		f.mu.Unlock()
+		writeJSON(w, http.StatusOK, comments)
+	case !isComments && r.Method == http.MethodPut:
+		f.mu.Lock()
+		rev.ReviewRound++
+		round := rev.ReviewRound
+		f.mu.Unlock()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"url":          f.origin + "/r/" + token,
+			"review_round": round,
+			"changed":      true,
+		})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// GET /api/share-policy — the local server proxies this to populate the org
+// picker. An empty policy keeps the fixture in the anonymous/no-org path.
+func (f *fixture) handleSharePolicy(w http.ResponseWriter, r *http.Request) {
+	f.record(r)
+	writeJSON(w, http.StatusOK, map[string]any{"orgs": []any{}})
+}
+
+// POST /__seed-comment?token=<token> appends a comment to the review, standing
+// in for someone commenting in the browser on the hosted page.
+func (f *fixture) handleSeedComment(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	raw, err := readAllJSON(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rev, ok := f.reviews[token]
+	if !ok {
+		http.Error(w, "unknown token "+token, http.StatusNotFound)
+		return
+	}
+	rev.Comments = append(rev.Comments, raw)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// POST /__config toggles fault injection, e.g. {"fail_delete": true}.
+func (f *fixture) handleConfig(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		FailDelete bool `json:"fail_delete"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	f.failDelete = body.FailDelete
+	f.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *fixture) handleLog(w http.ResponseWriter, _ *http.Request) {
+	f.mu.Lock()
+	entries := append([]recordedRequest{}, f.log...)
+	f.mu.Unlock()
+	writeJSON(w, http.StatusOK, entries)
+}
+
+func (f *fixture) handleReset(w http.ResponseWriter, _ *http.Request) {
+	f.mu.Lock()
+	f.reviews = map[string]*review{}
+	f.log = nil
+	f.failDelete = false
+	f.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func readAllJSON(r *http.Request) (json.RawMessage, error) {
+	var raw json.RawMessage
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode body: %w", err)
+	}
+	return raw, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -9,6 +9,10 @@ const NOGIT_PORT = process.env.CRIT_TEST_NOGIT_PORT || '3126';
 const MULTI_PORT = process.env.CRIT_TEST_MULTI_PORT || '3127';
 const RANGE_PORT = process.env.CRIT_TEST_RANGE_PORT || '3128';
 const LIVE_PORT = process.env.CRIT_TEST_LIVE_PORT || '3129';
+const SHARE_PORT = process.env.CRIT_TEST_SHARE_PORT || '3132';
+// Stub crit-web backing the share-transport project. The spec talks to it
+// directly for seeding and assertions, so it needs the port too.
+const STUB_PORT = process.env.CRIT_TEST_STUB_PORT || '3133';
 // Mobile project re-uses the git-mode fixture — no separate server needed.
 const MOBILE_PORT = GIT_PORT;
 const debug = !!process.env.E2E_DEBUG;
@@ -42,7 +46,7 @@ export default defineConfig({
   projects: [
     {
       name: 'git-mode',
-      testMatch: /^(?!.*\.(filemode|singlefile|multifile|nogit|rangemode|mobile|livemode)\.).*\.spec\.ts$/,
+      testMatch: /^(?!.*\.(filemode|singlefile|multifile|nogit|rangemode|mobile|livemode|sharetransport)\.).*\.spec\.ts$/,
       use: {
         browserName: 'chromium',
         baseURL: `http://localhost:${GIT_PORT}`,
@@ -115,6 +119,18 @@ export default defineConfig({
         baseURL: `http://localhost:${LIVE_PORT}/live`,
       },
     },
+    {
+      // Drives the browser Share round trip against a stub crit-web. baseURL
+      // must be `localhost` while the stub binds `127.0.0.1` — the two are
+      // distinct origins to the browser, which is what lets the spec detect a
+      // regression back to cross-origin fetches.
+      name: 'share-transport',
+      testMatch: /\.sharetransport\.spec\.ts$/,
+      use: {
+        browserName: 'chromium',
+        baseURL: `http://localhost:${SHARE_PORT}`,
+      },
+    },
   ],
 
   webServer: [
@@ -163,6 +179,13 @@ export default defineConfig({
     {
       command: `bash setup-fixtures-livemode.sh ${LIVE_PORT}`,
       url: `http://127.0.0.1:${LIVE_PORT}/api/session`,
+      reuseExistingServer: true,
+      timeout: 60_000,
+      stdout: 'pipe',
+    },
+    {
+      command: `bash setup-fixtures-sharetransport.sh ${SHARE_PORT} ${STUB_PORT}`,
+      url: `http://localhost:${SHARE_PORT}/api/session`,
       reuseExistingServer: true,
       timeout: 60_000,
       stdout: 'pipe',

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -13,6 +13,8 @@ NOGIT_PORT="${CRIT_TEST_NOGIT_PORT:-3126}"
 MULTI_PORT="${CRIT_TEST_MULTI_PORT:-3127}"
 RANGE_PORT="${CRIT_TEST_RANGE_PORT:-3128}"
 LIVE_PORT="${CRIT_TEST_LIVE_PORT:-3129}"
+SHARE_PORT="${CRIT_TEST_SHARE_PORT:-3132}"
+STUB_PORT="${CRIT_TEST_STUB_PORT:-3133}"
 
 # Build crit once (skip if CRIT_BIN already points to an existing binary, e.g. CI coverage builds)
 if [ -n "${CRIT_BIN:-}" ] && [ -f "$CRIT_BIN" ]; then
@@ -33,7 +35,7 @@ fi
 (cd "$SCRIPT_DIR" && npx playwright install chromium)
 
 # Kill any stale processes on our test ports before starting fresh
-for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT"; do
+for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT" "$STUB_PORT"; do
   e2e_kill_port "$port"
 done
 
@@ -55,10 +57,12 @@ bash setup-fixtures-range-mode.sh "$RANGE_PORT" &
 RANGE_PID=$!
 bash setup-fixtures-livemode.sh "$LIVE_PORT" &
 LIVE_PID=$!
+bash setup-fixtures-sharetransport.sh "$SHARE_PORT" "$STUB_PORT" &
+SHARE_PID=$!
 
 cleanup() {
-  kill "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" 2>/dev/null || true
-  wait "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" 2>/dev/null || true
+  kill "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" 2>/dev/null || true
+  wait "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" 2>/dev/null || true
   # On Git Bash `kill <bash-pid>` doesn't reap the spawned crit.exe child;
   # taskkill /T flushes the whole tree.
   e2e_kill_stray_crit
@@ -67,7 +71,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Wait for servers to be ready
-for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT"; do
+for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT"; do
   while ! curl -sf "http://localhost:$port/api/session" >/dev/null 2>&1; do
     sleep 0.1
   done
@@ -95,6 +99,8 @@ if [ $# -eq 0 ]; then
   PW_RANGE=$!
   npx playwright test --project=live-mode > "$PWLOGS/live.log" 2>&1 &
   PW_LIVE=$!
+  npx playwright test --project=share-transport > "$PWLOGS/share.log" 2>&1 &
+  PW_SHARE=$!
 
   # Mobile shares the git-mode fixture (port 3123) and both projects call
   # DELETE /api/comments in beforeEach, so they must not overlap. Wait for
@@ -115,6 +121,7 @@ if [ $# -eq 0 ]; then
   wait $PW_MULTI  || FAILED=1
   wait $PW_RANGE  || FAILED=1
   wait $PW_LIVE   || FAILED=1
+  wait $PW_SHARE  || FAILED=1
   if [ -n "${PW_MOBILE:-}" ]; then
     wait $PW_MOBILE || FAILED=1
   fi

--- a/test/e2e/setup-fixtures-sharetransport.sh
+++ b/test/e2e/setup-fixtures-sharetransport.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Fixture for the share-transport Playwright project: a crit daemon in file mode
+# pointed at a stub crit-web (fixtures/sharetransport-crit-web) so the browser
+# Share flow — share, pull comments, re-share, unpublish — can be driven for
+# real without a Postgres-backed crit-web.
+set -euo pipefail
+
+PORT="${1:-3132}"
+STUB_PORT="${2:-3133}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CRIT_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+DIR=$(e2e_native_tempdir)
+BIN_DIR=$(e2e_native_tempdir)
+FAKE_HOME=$(e2e_native_tempdir)
+
+if [ "$E2E_IS_WINDOWS" -eq 1 ]; then
+  STUB_BIN="$BIN_DIR/stub-crit-web.exe"
+else
+  STUB_BIN="$BIN_DIR/stub-crit-web"
+fi
+STUB_LOG="$BIN_DIR/stub-crit-web.log"
+STUB_PID=""
+CRIT_PID=""
+
+cleanup() {
+  if [ -n "$CRIT_PID" ]; then kill "$CRIT_PID" 2>/dev/null || true; fi
+  if [ -n "$STUB_PID" ]; then kill "$STUB_PID" 2>/dev/null || true; fi
+  rm -rf "$DIR" "$BIN_DIR" "$FAKE_HOME"
+}
+trap cleanup EXIT INT TERM
+
+cd "$DIR"
+
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+cat > plan.md << 'MDFILE'
+# Share Transport Plan
+
+## Overview
+
+Exercise the browser share round trip against a stub crit-web.
+
+## Steps
+
+1. Share
+2. Pull comments
+3. Re-share
+4. Unpublish
+MDFILE
+
+cat > main.go << 'GOFILE'
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("share transport fixture")
+}
+
+func helper(n int) int {
+	return n * 2
+}
+GOFILE
+
+git add -A && git commit -q -m "initial commit"
+
+# 1. Build the stub crit-web and launch it on a fixed port.
+(cd "$SCRIPT_DIR/fixtures/sharetransport-crit-web" && go build -o "$STUB_BIN" .)
+"$STUB_BIN" --port "$STUB_PORT" >"$STUB_LOG" 2>&1 &
+STUB_PID=$!
+
+STUB_ORIGIN=""
+for _ in $(seq 1 50); do
+  if grep -q '^listening on ' "$STUB_LOG"; then
+    STUB_ORIGIN=$(awk '/^listening on / {print $3; exit}' "$STUB_LOG")
+    break
+  fi
+  sleep 0.1
+done
+if [ -z "$STUB_ORIGIN" ]; then
+  echo "stub crit-web failed to start" >&2
+  cat "$STUB_LOG" >&2
+  exit 1
+fi
+echo "stub crit-web listening at $STUB_ORIGIN" >&2
+
+# 2. Build (or reuse) crit.
+if [ -n "${CRIT_BIN:-}" ] && [ -f "$CRIT_BIN" ]; then
+  echo "Using pre-built binary: $CRIT_BIN"
+else
+  CRIT_BIN="$BIN_DIR/$(e2e_bin_name)"
+  (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" ./cmd/crit)
+fi
+
+# 3. Isolate from the user's ~/.crit.config.json. A non-default --share-url also
+#    means no share-consent prompt, so the Share button works unattended.
+e2e_export_fake_home "$FAKE_HOME"
+
+"$CRIT_BIN" _serve --no-open --port "$PORT" --share-url "$STUB_ORIGIN" plan.md main.go &
+CRIT_PID=$!
+
+for _ in $(seq 1 100); do
+  if curl -sf "http://localhost:$PORT/api/session" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+
+# Foreground wait — Playwright treats this as the long-running webServer.
+wait "$CRIT_PID"

--- a/test/e2e/tests/share-transport.sharetransport.spec.ts
+++ b/test/e2e/tests/share-transport.sharetransport.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { addComment, clearAllComments, loadPage } from './helpers';
+
+// ============================================================
+// Share Transport — browser round trip against a stub crit-web
+//
+// Smoke coverage for the Share modal actions that talk to crit-web: Pull
+// comments, Re-share, and Unpublish. With proxy_auth off these all go through
+// the local Go server (/api/share/pull, /api/share/reshare,
+// DELETE /api/share-url) so the browser never issues a cross-origin request.
+// A regression to direct fetches would break every self-hosted instance with
+// authentication enabled, since browsers omit Authorization on CORS preflight.
+//
+// The fixture (setup-fixtures-sharetransport.sh) points crit at a stub crit-web
+// on a different origin and records the Origin header of every request it
+// receives — empty for server-to-server calls, populated for browser fetches.
+// ============================================================
+
+const STUB_ORIGIN = `http://127.0.0.1:${process.env.CRIT_TEST_STUB_PORT || '3133'}`;
+
+type StubRequest = { method: string; path: string; origin: string; has_auth: boolean };
+
+async function resetStub(request: APIRequestContext) {
+  const res = await request.post(`${STUB_ORIGIN}/__reset`);
+  expect(res.ok()).toBeTruthy();
+}
+
+async function configureStub(request: APIRequestContext, config: { fail_delete: boolean }) {
+  const res = await request.post(`${STUB_ORIGIN}/__config`, { data: config });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function stubRequests(request: APIRequestContext): Promise<StubRequest[]> {
+  const res = await request.get(`${STUB_ORIGIN}/__log`);
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
+
+/** Stand in for a viewer commenting on the hosted review page. */
+async function seedRemoteComment(request: APIRequestContext, token: string, body: string, line: number) {
+  const res = await request.post(`${STUB_ORIGIN}/__seed-comment?token=${token}`, {
+    data: {
+      body,
+      file_path: 'main.go',
+      start_line: line,
+      end_line: line,
+      review_round: 1,
+      external_id: `web-${line}`,
+      author_display_name: 'Web Reviewer',
+      replies: [],
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function hostedToken(request: APIRequestContext): Promise<string> {
+  const config = await request.get('/api/config').then(r => r.json());
+  expect(config.hosted_token).toBeTruthy();
+  return config.hosted_token as string;
+}
+
+async function fileCommentBodies(request: APIRequestContext): Promise<string[]> {
+  const comments = await request.get('/api/file/comments?path=main.go').then(r => r.json());
+  return comments.map((c: { body: string }) => c.body);
+}
+
+/**
+ * Newest share toast. showToast replaces a toast by appending the new node and
+ * letting the superseded one play its exit animation, so two #toast-share
+ * elements briefly coexist and a bare id locator is not strict-mode safe.
+ */
+function shareToast(page: Page) {
+  return page.locator('#toast-share').last();
+}
+
+test.describe('Share Transport', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+    // Drop any share recorded by a previous test without re-contacting the
+    // stub (which has just been reset and no longer knows the review).
+    await request.delete('/api/share-url?local_only=1');
+    await clearAllComments(request);
+  });
+
+  test('share, pull, re-share and unpublish all stay on the local origin', async ({ page, request }) => {
+    const browserCallsToCritWeb: string[] = [];
+    page.on('request', req => {
+      if (req.url().startsWith(STUB_ORIGIN)) {
+        browserCallsToCritWeb.push(`${req.method()} ${req.url()}`);
+      }
+    });
+
+    await addComment(request, 'main.go', 3, 'Local comment before sharing');
+    await loadPage(page);
+
+    await page.locator('#shareBtn').click();
+    await expect(page.locator('.share-dialog')).toBeVisible();
+    await expect(page.locator('.share-dialog-url')).toContainText(`${STUB_ORIGIN}/r/`);
+
+    // Pull: a viewer's comment on the hosted page lands in the local review.
+    await seedRemoteComment(request, await hostedToken(request), 'Remote reviewer comment', 7);
+    await page.locator('#modalPullBtn').click();
+    await expect(shareToast(page)).toContainText('Comments pulled');
+    expect(await fileCommentBodies(request)).toContain('Remote reviewer comment');
+
+    // Re-share: the local edit changes the content hash, so a PUT is required
+    // (an unchanged review is a no-op upsert and would send nothing).
+    await addComment(request, 'main.go', 5, 'Local comment before re-sharing');
+    await page.locator('#modalReshareBtn').click();
+    await expect(shareToast(page)).toContainText('Re-shared');
+    expect(await stubRequests(request)).toContainEqual(
+      expect.objectContaining({ method: 'PUT', path: expect.stringMatching(/^\/api\/reviews\/\w+$/) }),
+    );
+
+    // Unpublish: the review goes away remotely and the button resets locally.
+    await page.locator('#modalUnpublishBtn').click();
+    await page.locator('#confirmUnpublishBtn').click();
+    await expect(page.locator('.share-dialog')).toBeHidden();
+    await expect(page.locator('#shareBtn')).toHaveText('Share');
+    expect(await stubRequests(request)).toContainEqual(
+      expect.objectContaining({ method: 'DELETE', path: '/api/reviews' }),
+    );
+    const config = await request.get('/api/config').then(r => r.json());
+    expect(config.hosted_url).toBe('');
+
+    // The regression guard: crit-web was reached only by the local Go server.
+    expect(browserCallsToCritWeb).toEqual([]);
+    const withOrigin = (await stubRequests(request)).filter(r => r.origin !== '');
+    expect(withOrigin).toEqual([]);
+  });
+
+  test('a rejected unpublish keeps the review shared and offers a retry', async ({ page, request }) => {
+    await addComment(request, 'main.go', 3, 'Local comment before sharing');
+    await loadPage(page);
+
+    await page.locator('#shareBtn').click();
+    await expect(page.locator('.share-dialog')).toBeVisible();
+
+    await configureStub(request, { fail_delete: true });
+    await page.locator('#modalUnpublishBtn').click();
+    await page.locator('#confirmUnpublishBtn').click();
+
+    await expect(shareToast(page)).toContainText('Unpublish failed');
+    await expect(page.locator('#shareUnpublishRetryBtn')).toBeVisible();
+
+    // Local state must survive a failed remote delete, otherwise the user is
+    // left with a live review they can no longer unpublish from the UI.
+    const config = await request.get('/api/config').then(r => r.json());
+    expect(config.hosted_url).toContain(`${STUB_ORIGIN}/r/`);
+  });
+
+  test('pulling with nothing shared returns a readable error rather than a CORS failure', async ({ request }) => {
+    const res = await request.post('/api/share/pull');
+    expect(res.status()).toBe(400);
+    expect((await res.json()).error).toContain('no shared review');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #809. The Share modal's Pull / Re-share / Unpublish buttons had no browser-level test, so the regression that made them fetch crit-web cross-origin — which breaks every self-hosted instance with authentication, because browsers omit `Authorization` on CORS preflight — could only be caught by hand.

- New `share-transport` Playwright project (crit on 3132, stub crit-web on 3133) driving the real Share modal end to end: share, seed a viewer comment, pull, re-share, unpublish.
- New stub crit-web fixture (`test/e2e/fixtures/sharetransport-crit-web`) implementing only the four `/api/reviews` endpoints crit calls, plus control endpoints for seeding comments and injecting a failing unpublish. It records the `Origin` header of every request, which is what makes the regression assertion possible: server-to-server calls have no `Origin`, browser fetches do.
- The spec asserts crit-web was reached only by the local Go server, from both sides — the page issued zero requests to the stub origin, and the stub saw zero requests carrying an `Origin`.
- Also covers the two error paths behind the original report: a rejected unpublish keeps the review shared and offers a retry, and pulling with nothing shared returns a readable 400 instead of an opaque CORS failure.

## Test plan

- [x] `bash run.sh --project=share-transport --repeat-each=3` — 9/9 pass
- [x] Mutation check: reverting `handleUnpublish` to a cross-origin `DELETE` makes the round-trip test fail with the exact symptom users reported (button stays "Shared")
- [x] Full `make e2e` — all projects pass except a pre-existing flake in `select-to-comment.spec.ts` ("quote highlight … issue #133"), which fails on this branch with no production code touched
- [x] `gofmt`/`go vet` clean on the new fixture module; pre-commit hooks pass

Made with [Cursor](https://cursor.com)