### PR TITLE
test: stabilize lazy session threshold fixture

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -49,6 +49,10 @@ func newTestSession(t *testing.T) *Session {
 			},
 		},
 	}
+	// AddComment arms a 200ms debounced disk write. Quiesce before t.TempDir's
+	// cleanup so a delayed WriteFiles doesn't race with RemoveAll — on Windows
+	// that manifests as "directory is not empty".
+	t.Cleanup(func() { quiesceSession(t, s) })
 	return s
 }
 
@@ -3057,7 +3061,8 @@ func TestEnsureLoadedNotLazy(t *testing.T) {
 
 func TestNewSessionFromGitLazyThreshold(t *testing.T) {
 	dir := initTestRepo(t)
-	vcs.SetDefaultBranchOverride("")
+	// Keep the fixture independent of cached or ambient default-branch detection.
+	vcs.SetDefaultBranchOverride("main")
 	defer func() { vcs.SetDefaultBranchOverride("") }()
 
 	gitT(t, dir, "checkout", "-b", "feature-many-files")


### PR DESCRIPTION
## Summary

- Fixes the flaky `TestNewSessionFromGitLazyThreshold` test by pinning its fixture's default branch to `main`.
- Prevents cached or ambient default-branch detection from treating the initial `README.md` as part of the feature diff, which caused the test to see 121 files instead of 120.

## Evidence

- Original failed run: https://github.com/tomasz-tomczyk/crit/actions/runs/31212752869
  - `unit` failed with `expected 120 files, got 121`.
- Rerun without code changes passed (attempt 2), confirming nondeterministic test behavior.

## Tests

- `mise exec -- go test ./internal/session -run '^TestNewSessionFromGitLazyThreshold$' -count=10`
- `mise exec -- go test ./internal/session`
- `mise exec -- gofmt -l .`
