### PR TITLE
fix: honor plan review opt-out in Claude Code

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -68,6 +68,10 @@ deterministically, set `plan_approve_mode` in your global Crit config:
 }
 ```
 
+Disable automatic plan review per shell or globally with
+`export CRIT_PLAN_REVIEW=off`. This only disables the plan-exit hook; manually
+running `crit plan` still opens a review.
+
 Supported values are `default`, `manual`, `acceptEdits`, `plan`, `auto`,
 `dontAsk`, and `bypassPermissions`. The `manual` alias requires Claude Code
 2.1.200 or newer. On approval, Crit returns Claude Code's documented
@@ -125,7 +129,8 @@ Plugin source files live in `integrations/codex/plugin/crit/`. See [`integration
 
 Both approaches give you `$crit` and the `crit-cli` skill. Only `codex-plugin` adds the proposed-plan hook — without it, typing `$crit` on an in-chat plan (e.g. after choosing "No and stay in Plan Mode") does nothing useful because there is no file path for `crit` to open.
 
-Disable the plan hook per-shell or globally: `export CRIT_PLAN_REVIEW=off`
+Disable automatic plan review per shell or globally with
+`export CRIT_PLAN_REVIEW=off`. Manual `crit plan` invocations are unaffected.
 
 ## Invocation policy
 

--- a/internal/session/codex_plan_test.go
+++ b/internal/session/codex_plan_test.go
@@ -135,6 +135,22 @@ func TestRunCodexPlanHookReviewsTaggedPlanWhenStopHookActive(t *testing.T) {
 	}
 }
 
+func TestRunCodexPlanHookDisabledByEnvironment(t *testing.T) {
+	t.Setenv("CRIT_PLAN_REVIEW", "off")
+
+	prevHook := runCodexPlanReviewHook
+	t.Cleanup(func() { runCodexPlanReviewHook = prevHook })
+	runCodexPlanReviewHook = func(string, []byte) {
+		t.Fatal("did not expect disabled plan hook to start a review")
+	}
+
+	visible := "<proposed_plan>\n- should not open\n</proposed_plan>"
+	runCodexPlanHookWithInput(t, codexStopHookEvent{
+		SessionID:            "codex-session-disabled",
+		LastAssistantMessage: &visible,
+	})
+}
+
 func TestRunCodexPlanHookSkipsStopHookActiveWithoutTaggedPlan(t *testing.T) {
 	prevHook := runCodexPlanReviewHook
 	t.Cleanup(func() { runCodexPlanReviewHook = prevHook })

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -111,13 +111,13 @@ func resolvePlanSlug(name string, content []byte) string {
 }
 
 func RunPlan(args []string) error {
-	go backgroundCleanup()
-
 	pc := resolvePlanConfig(args)
 	content, err := readPlanContent(pc)
 	if err != nil {
 		return err
 	}
+
+	go backgroundCleanup()
 
 	slug := resolvePlanSlug(pc.name, content)
 	storageDir, err := PlanStorageDir(slug)

--- a/internal/session/plan_cli.go
+++ b/internal/session/plan_cli.go
@@ -317,8 +317,16 @@ func runPlanReviewHook(logPrefix, sessionID string, content []byte, emitDecision
 	emitDecision(approved, prompt)
 }
 
+func automaticPlanReviewDisabled() bool {
+	return os.Getenv("CRIT_PLAN_REVIEW") == "off"
+}
+
 // RunPlanHook is the PermissionRequest hook handler for ExitPlanMode.
 func RunPlanHook() error {
+	if automaticPlanReviewDisabled() {
+		return nil
+	}
+
 	go backgroundCleanup()
 
 	var event planHookEvent
@@ -359,6 +367,10 @@ func RunPlanHook() error {
 
 // RunCodexPlanHook is the Stop hook handler for Codex proposed-plan review.
 func RunCodexPlanHook() error {
+	if automaticPlanReviewDisabled() {
+		return nil
+	}
+
 	var event codexStopHookEvent
 	if err := json.NewDecoder(os.Stdin).Decode(&event); err != nil {
 		fmt.Fprintf(os.Stderr, "crit plan-hook --mode codex: could not parse stdin: %v\n", err)

--- a/internal/session/plan_cli_main_test.go
+++ b/internal/session/plan_cli_main_test.go
@@ -163,6 +163,16 @@ func TestRunPlanHook_DisabledByEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunPlan_EnvironmentOptOutDoesNotDisableManualReview(t *testing.T) {
+	t.Setenv("CRIT_PLAN_REVIEW", "off")
+	testutil.SetHome(t, t.TempDir())
+
+	missingPlan := filepath.Join(t.TempDir(), "missing-plan.md")
+	if err := RunPlan([]string{missingPlan}); err == nil {
+		t.Fatal("manual RunPlan() unexpectedly skipped missing-file validation")
+	}
+}
+
 func TestRunPlanHook_ApprovalSetsConfiguredMode(t *testing.T) {
 	homeDir := t.TempDir()
 	testutil.SetHome(t, homeDir)

--- a/internal/session/plan_cli_main_test.go
+++ b/internal/session/plan_cli_main_test.go
@@ -138,6 +138,31 @@ func TestRunPlanHook_ApprovalEchoesCompleteToolInput(t *testing.T) {
 	}
 }
 
+func TestRunPlanHook_DisabledByEnvironment(t *testing.T) {
+	t.Setenv("CRIT_PLAN_REVIEW", "off")
+	setPlanHookStdin(t, []byte(`{
+		"session_id": "session-disabled",
+		"tool_input": {"plan": "# Should not open"}
+	}`))
+
+	previousReviewHook := runClaudePlanReviewHook
+	runClaudePlanReviewHook = func(string, []byte, func(bool, string)) {
+		t.Fatal("did not expect disabled plan hook to start a review")
+	}
+	t.Cleanup(func() {
+		runClaudePlanReviewHook = previousReviewHook
+	})
+
+	output := captureHookDecision(t, func() {
+		if err := RunPlanHook(); err != nil {
+			t.Fatalf("RunPlanHook() error = %v", err)
+		}
+	})
+	if len(output) != 0 {
+		t.Fatalf("disabled hook output = %q, want empty output", output)
+	}
+}
+
 func TestRunPlanHook_ApprovalSetsConfiguredMode(t *testing.T) {
 	homeDir := t.TempDir()
 	testutil.SetHome(t, homeDir)


### PR DESCRIPTION
## Summary
- honor `CRIT_PLAN_REVIEW=off` before Claude Code plan-hook parsing or side effects
- keep Codex hook behavior in parity and leave manual `crit plan` reviews enabled
- delay manual-plan cleanup until input validation so invalid invocations have no asynchronous cleanup side effects
- document the automatic-only opt-out and add focused regressions

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A (no review-page changes)
- [x] Security scan: passed

## Test plan
- `mise exec -- go test -race -count=1 ./...`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- go generate ./...`
- focused Claude, Codex, and manual-plan opt-out regressions

Closes #824
