### PR TITLE
fix: disable markdown-it replacements to preserve (c)/(r)/(tm) (#820)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "update-deps": "bun run copy-deps.js",
-    "test:frontend": "node web/__tests__/markdown-patch.test.mjs && node web/__tests__/crit-diff-renderer.test.js && node web/test-diff-render.mjs"
+    "test:frontend": "node web/__tests__/markdown-patch.test.mjs && node web/__tests__/crit-diff-renderer.test.js && node web/__tests__/markdown-replacements.test.js && node web/test-diff-render.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.28.2",

--- a/web/__tests__/markdown-replacements.test.js
+++ b/web/__tests__/markdown-replacements.test.js
@@ -1,0 +1,77 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const markdownit = require('markdown-it');
+
+// Regression test for #820: markdown-it's typographer rule turns literal
+// (c)/(r)/(tm) into ©/®/™, which mangles enumerated options in review docs.
+// We disable only the replacements rule so smart quotes still work.
+
+function makeDocumentMd() {
+  const md = markdownit({
+    html: true,
+    typographer: true,
+    linkify: true,
+    highlight() { return ''; }
+  });
+  md.disable('replacements');
+  return md;
+}
+
+function makeCommentMd() {
+  const md = markdownit({
+    html: false,
+    linkify: true,
+    typographer: true,
+    highlight() { return ''; }
+  });
+  md.disable('replacements');
+  return md;
+}
+
+describe('markdown-it replacements disabled (#820)', () => {
+  it('preserves literal (c), (r), (tm) in document renderer', () => {
+    const md = makeDocumentMd();
+    const html = md.render('Three ways: (a) keep, (b) drop, (c) split. (r) (tm)');
+    assert.match(html, /\(c\)/);
+    assert.match(html, /\(r\)/);
+    assert.match(html, /\(tm\)/);
+    assert.doesNotMatch(html, /©/);
+    assert.doesNotMatch(html, /®/);
+    assert.doesNotMatch(html, /™/);
+  });
+
+  it('preserves literal (c), (r), (tm) in comment renderer', () => {
+    const md = makeCommentMd();
+    const html = md.render('Option (c) is best. (r) (tm)');
+    assert.match(html, /\(c\)/);
+    assert.match(html, /\(r\)/);
+    assert.match(html, /\(tm\)/);
+    assert.doesNotMatch(html, /©/);
+    assert.doesNotMatch(html, /®/);
+    assert.doesNotMatch(html, /™/);
+  });
+
+  it('still converts straight quotes to smart quotes', () => {
+    const md = makeDocumentMd();
+    const html = md.render('"hello"');
+    assert.match(html, /“hello”/);
+  });
+
+  it('has .disable("replacements") applied in web/app.js for both renderers', () => {
+    const appJsPath = path.join(__dirname, '..', 'app.js');
+    const appJs = fs.readFileSync(appJsPath, 'utf8');
+
+    // Each markdown-it instance in app.js should be followed by the disable call.
+    const documentMdBlock = appJs.indexOf('const documentMd = window.markdownit({');
+    const commentMdBlock = appJs.indexOf('const commentMd = window.markdownit({');
+    assert.notEqual(documentMdBlock, -1, 'documentMd instance not found');
+    assert.notEqual(commentMdBlock, -1, 'commentMd instance not found');
+
+    const documentDisable = appJs.indexOf("documentMd.disable('replacements')", documentMdBlock);
+    const commentDisable = appJs.indexOf("commentMd.disable('replacements')", commentMdBlock);
+    assert.notEqual(documentDisable, -1, 'documentMd.disable("replacements") not found');
+    assert.notEqual(commentDisable, -1, 'commentMd.disable("replacements") not found');
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,9 @@
       return '';
     }
   });
+  // Disable (c)/(r)/(tm) → ©/®/™ replacements so enumerated options render
+  // literally. Keep typographer (smart quotes) and disable only replacements.
+  commentMd.disable('replacements');
 
   // ===== File Reference Inline Rule =====
   commentMd.inline.ruler.push('file_ref', function(state, silent) {
@@ -255,6 +258,9 @@
       return '';
     }
   });
+  // Disable (c)/(r)/(tm) → ©/®/™ replacements so enumerated options render
+  // literally. Keep typographer (smart quotes) and disable only replacements.
+  documentMd.disable('replacements');
 
   // Add id attributes and anchor links to headings
   const HEADING_LINK_SVG = '<svg class="heading-anchor-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a2.002 2.002 0 0 0 0 2.83Z"></path></svg>';


### PR DESCRIPTION
Closes #820

Disable markdown-it's `replacements` rule on the document and comment renderers so literal `(c)`, `(r)`, and `(tm)` are preserved. Keeps `typographer: true` so smart quotes still work.

Changes:
- `web/app.js`: `.disable('replacements')` for `commentMd` and `documentMd`
- `web/__tests__/markdown-replacements.test.js`: regression tests verifying literal `(c)`/`(r)`/`(tm)` and smart-quote behavior
- `package.json`: include the new test in `test:frontend`

Parity: tomasz-tomczyk/crit-web#352