### PR TITLE
fix: render Markdown YAML frontmatter as a highlighted block

### DIFF
--- a/test/e2e/setup-fixtures.sh
+++ b/test/e2e/setup-fixtures.sh
@@ -575,6 +575,23 @@ Feature: User login
 GHERKIN
 git add login.feature
 
+# Stage a Markdown file with YAML frontmatter for document-view coverage.
+cat > skill.md << 'MDFILE'
+---
+name: demo-skill
+description: A skill for agents
+# this would become an h1 if parsed as markdown
+paths:
+  - "src/**/*.go"
+  - "internal/*.go"
+---
+
+# Skill Body
+
+Body paragraph for commenting.
+MDFILE
+git add skill.md
+
 # === Unstaged changes (working tree only) ===
 # Create an untracked file
 cat > config.yaml << 'EOF'

--- a/test/e2e/setup-fixtures.sh
+++ b/test/e2e/setup-fixtures.sh
@@ -461,6 +461,23 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 - Top gamma
 MDFILE
 
+# Markdown file with YAML frontmatter (document-view coverage for #821).
+# Committed with the branch so staged-scope counts stay stable.
+cat > skill.md << 'MDFILE'
+---
+name: demo-skill
+description: A skill for agents
+# this would become an h1 if parsed as markdown
+paths:
+  - "src/**/*.go"
+  - "internal/*.go"
+---
+
+# Skill Body
+
+Body paragraph for commenting.
+MDFILE
+
 # Modify routes.go: change beginning and end, leave large middle gap (>20 unchanged lines)
 cat > routes.go << 'GOFILE'
 package main
@@ -574,23 +591,6 @@ Feature: User login
     Then I should see an error message
 GHERKIN
 git add login.feature
-
-# Stage a Markdown file with YAML frontmatter for document-view coverage.
-cat > skill.md << 'MDFILE'
----
-name: demo-skill
-description: A skill for agents
-# this would become an h1 if parsed as markdown
-paths:
-  - "src/**/*.go"
-  - "internal/*.go"
----
-
-# Skill Body
-
-Body paragraph for commenting.
-MDFILE
-git add skill.md
 
 # === Unstaged changes (working tree only) ===
 # Create an untracked file

--- a/test/e2e/tests/commit-selection.spec.ts
+++ b/test/e2e/tests/commit-selection.spec.ts
@@ -63,7 +63,8 @@ test.describe('Commit Selection', () => {
     const fileSections = page.locator('.file-section');
     await expect(async () => {
       const count = await fileSections.count();
-      expect(count).toBeLessThanOrEqual(5);
+      // Auth commit touches several files; skill.md is included (branch fixture).
+      expect(count).toBeLessThanOrEqual(6);
       expect(count).toBeGreaterThan(0);
     }).toPass();
   });

--- a/test/e2e/tests/file-tree.spec.ts
+++ b/test/e2e/tests/file-tree.spec.ts
@@ -15,10 +15,10 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file tree lists all files from the session', async ({ page }) => {
-    // Git fixture has: plan.md, server.go, handler.js, deleted.txt, routes.go, legacy.go (committed)
-    // + utils.go, login.feature (staged), config.yaml (untracked) = 9 total
+    // Git fixture has: plan.md, skill.md, server.go, handler.js, deleted.txt, routes.go, legacy.go (committed)
+    // + utils.go, login.feature (staged), config.yaml (untracked) = 10 total
     const treeFiles = page.locator('.tree-file');
-    await expect(treeFiles).toHaveCount(9);
+    await expect(treeFiles).toHaveCount(10);
   });
 
   test('file tree shows correct file names', async ({ page }) => {
@@ -36,7 +36,7 @@ test.describe('File Tree — Git Mode', () => {
   test('file tree header shows file count', async ({ page }) => {
     const stats = page.locator('#fileTreeStats');
     await expect(stats).toBeVisible();
-    await expect(stats).toContainText('9');
+    await expect(stats).toContainText('10');
   });
 
   test('file tree header shows addition stats', async ({ page }) => {
@@ -110,9 +110,9 @@ test.describe('File Tree — Git Mode', () => {
   });
 
   test('file status icons have correct classes', async ({ page }) => {
-    // plan.md, handler.js, login.feature, and config.yaml (untracked) are added
+    // plan.md, skill.md, handler.js, login.feature, and config.yaml (untracked) are added
     const addedIcons = page.locator('.tree-file-status-icon.added');
-    await expect(addedIcons).toHaveCount(4);
+    await expect(addedIcons).toHaveCount(5);
 
     // server.go, routes.go, legacy.go, and utils.go (staged modification) are modified
     const modifiedIcons = page.locator('.tree-file-status-icon.modified');

--- a/test/e2e/tests/markdown-frontmatter.spec.ts
+++ b/test/e2e/tests/markdown-frontmatter.spec.ts
@@ -24,9 +24,12 @@ test.describe('Markdown frontmatter — skill.md', () => {
 
     await expect(section.locator('h1', { hasText: 'this would become an h1' })).toHaveCount(0);
     await expect(section.locator('.line-block[data-start-line="1"] .fence-marker', { hasText: '---' })).toBeVisible();
-    await expect(section.locator('.line-block[data-start-line="7"] .fence-marker', { hasText: '---' })).toBeVisible();
-    await expect(section.locator('.line-block[data-start-line="2"] .code-line, .line-block[data-start-line="2"] code.hljs')).toContainText('name: demo-skill');
+    await expect(section.locator('.line-block[data-start-line="8"] .fence-marker', { hasText: '---' })).toBeVisible();
+    await expect(section.locator('.line-block[data-start-line="2"] code.hljs')).toContainText('name: demo-skill');
     await expect(section.locator('.line-block[data-start-line="2"] [class^="hljs-"]').first()).toBeVisible();
+    // Line 4 is a YAML `# comment` — must not become a heading.
+    await expect(section.locator('.line-block[data-start-line="4"]')).toContainText('this would become an h1');
+    await expect(section.locator('.line-block[data-start-line="4"] h1, .line-block[data-start-line="4"] h2')).toHaveCount(0);
 
     for (let line = 1; line <= 10; line++) {
       await expect(section.locator(`.line-block[data-start-line="${line}"]`)).toHaveCount(1);
@@ -41,8 +44,11 @@ test.describe('Markdown frontmatter — skill.md', () => {
     const bodyCard = reloadedSection.locator(`.comment-card[data-comment-id="${bodyComment.id}"]`);
     await expect(frontmatterCard).toBeVisible();
     await expect(bodyCard).toBeVisible();
-    await expect(reloadedSection.locator('.line-block[data-start-line="2"] + .comment-block').filter({ has: frontmatterCard })).toHaveCount(1);
-    await expect(reloadedSection.locator('.line-block[data-start-line="10"] + .comment-block').filter({ has: bodyCard })).toHaveCount(1);
+    await expect(frontmatterCard).toContainText('Frontmatter comment');
+    await expect(bodyCard).toContainText('Body comment');
+    // Anchored to the frontmatter / body lines (has-comment on the line-block).
+    await expect(reloadedSection.locator('.line-block[data-start-line="2"].has-comment')).toBeVisible();
+    await expect(reloadedSection.locator('.line-block[data-start-line="10"].has-comment')).toBeVisible();
     await expect(reloadedSection.locator('.line-block[data-start-line="2"]')).toContainText('name: demo-skill');
     await expect(reloadedSection.locator('.line-block[data-start-line="10"]')).toContainText('Skill Body');
 

--- a/test/e2e/tests/markdown-frontmatter.spec.ts
+++ b/test/e2e/tests/markdown-frontmatter.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { addComment, clearAllComments, loadPage } from './helpers';
+
+function skillSection(page: Parameters<typeof loadPage>[0]) {
+  return page.locator('.file-section').filter({ hasText: 'skill.md' });
+}
+
+async function switchSkillToDocumentView(page: Parameters<typeof loadPage>[0]) {
+  const section = skillSection(page);
+  await expect(section).toBeVisible();
+  await section.locator('.file-header-toggle .toggle-btn[data-mode="document"]').click();
+  await expect(section.locator('.document-wrapper')).toBeVisible();
+  return section;
+}
+
+test.describe('Markdown frontmatter — skill.md', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('renders YAML frontmatter as commentable highlighted code', async ({ page, request }) => {
+    await loadPage(page);
+    const section = await switchSkillToDocumentView(page);
+
+    await expect(section.locator('h1', { hasText: 'this would become an h1' })).toHaveCount(0);
+    await expect(section.locator('.line-block[data-start-line="1"] .fence-marker', { hasText: '---' })).toBeVisible();
+    await expect(section.locator('.line-block[data-start-line="7"] .fence-marker', { hasText: '---' })).toBeVisible();
+    await expect(section.locator('.line-block[data-start-line="2"] .code-line, .line-block[data-start-line="2"] code.hljs')).toContainText('name: demo-skill');
+    await expect(section.locator('.line-block[data-start-line="2"] [class^="hljs-"]').first()).toBeVisible();
+
+    for (let line = 1; line <= 10; line++) {
+      await expect(section.locator(`.line-block[data-start-line="${line}"]`)).toHaveCount(1);
+    }
+
+    const frontmatterComment = await addComment(request, 'skill.md', 2, 'Frontmatter comment');
+    const bodyComment = await addComment(request, 'skill.md', 10, 'Body comment');
+
+    await loadPage(page);
+    const reloadedSection = await switchSkillToDocumentView(page);
+    const frontmatterCard = reloadedSection.locator(`.comment-card[data-comment-id="${frontmatterComment.id}"]`);
+    const bodyCard = reloadedSection.locator(`.comment-card[data-comment-id="${bodyComment.id}"]`);
+    await expect(frontmatterCard).toBeVisible();
+    await expect(bodyCard).toBeVisible();
+    await expect(reloadedSection.locator('.line-block[data-start-line="2"] + .comment-block').filter({ has: frontmatterCard })).toHaveCount(1);
+    await expect(reloadedSection.locator('.line-block[data-start-line="10"] + .comment-block').filter({ has: bodyCard })).toHaveCount(1);
+    await expect(reloadedSection.locator('.line-block[data-start-line="2"]')).toContainText('name: demo-skill');
+    await expect(reloadedSection.locator('.line-block[data-start-line="10"]')).toContainText('Skill Body');
+
+    await reloadedSection.screenshot({ path: 'test-results/markdown-frontmatter-skill.png' });
+  });
+});

--- a/test/e2e/tests/scope-toggle.spec.ts
+++ b/test/e2e/tests/scope-toggle.spec.ts
@@ -43,8 +43,8 @@ test.describe('Scope Toggle', () => {
   test('switching to branch scope shows only committed files', async ({ page }) => {
     await loadPage(page);
     await switchScope(page, 'branch');
-    // Branch: server.go, deleted.txt, plan.md, handler.js, routes.go, legacy.go (6 committed)
-    await expect(page.locator('.file-section')).toHaveCount(6);
+    // Branch: server.go, deleted.txt, plan.md, skill.md, handler.js, routes.go, legacy.go (7 committed)
+    await expect(page.locator('.file-section')).toHaveCount(7);
     await expect(page.locator('.file-section', { hasText: 'server.go' })).toBeVisible();
     await expect(page.locator('.file-section', { hasText: 'plan.md' })).toBeVisible();
   });

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -16,14 +16,80 @@ const sandbox = {
       }
     },
     hljs: {
-      getLanguage: function() { return null; },
-      highlight: function() { return { value: '' }; }
+      getLanguage: function(language) { return language === 'yaml'; },
+      highlight: function(content) {
+        return { value: content.replace(/^(\w+):/gm, '<span class="hljs-attr">$1</span>:') };
+      }
     }
   },
   document: {}
 };
 fn(sandbox.window, sandbox.document);
 const lineBlocks = sandbox.window.crit.lineBlocks;
+
+// --- rewriteFrontmatterAsYamlFence ---
+
+test('rewriteFrontmatterAsYamlFence converts only valid opening and closing delimiters', () => {
+  const content = '---\nname: demo\n...\n\n# Body';
+  assert.equal(
+    lineBlocks.rewriteFrontmatterAsYamlFence(content),
+    '```yaml\nname: demo\n```\n\n# Body'
+  );
+});
+
+test('rewriteFrontmatterAsYamlFence preserves content without a closing delimiter', () => {
+  const content = '---\nname: demo\n# Not a closing delimiter';
+  assert.equal(lineBlocks.rewriteFrontmatterAsYamlFence(content), content);
+});
+
+test('rewriteFrontmatterAsYamlFence ignores delimiters that are not on the first line', () => {
+  const content = 'Intro\n---\nname: demo\n---';
+  assert.equal(lineBlocks.rewriteFrontmatterAsYamlFence(content), content);
+});
+
+test('rewriteFrontmatterAsYamlFence preserves line count and document maps', () => {
+  const content = [
+    '\uFEFF---',
+    'name: demo',
+    '# not a heading',
+    'paths:',
+    '  - "src/**/*.go"',
+    '---',
+    '',
+    '# Skill Body'
+  ].join('\n');
+  const rewritten = lineBlocks.rewriteFrontmatterAsYamlFence(content);
+  const tokens = [
+    { type: 'fence', map: [0, 6], info: 'yaml', content: 'name: demo\n# not a heading\npaths:\n  - "src/**/*.go"\n' },
+    { type: 'heading_open', map: [7, 8], nesting: 1, tag: 'h1' },
+    { type: 'inline', map: [7, 8], nesting: 0, content: 'Skill Body' },
+    { type: 'heading_close', map: null, nesting: -1, tag: 'h1' }
+  ];
+  const md = {
+    options: {},
+    renderer: {
+      render: function(renderedTokens) {
+        return renderedTokens.some(token => token.type === 'heading_open')
+          ? '<h1>Skill Body</h1>'
+          : '';
+      }
+    }
+  };
+  const blocks = lineBlocks.buildLineBlocks(tokens, md, content);
+
+  assert.equal(rewritten.split('\n').length, content.split('\n').length);
+  assert.equal(tokens[0].info, 'yaml');
+  assert.equal(tokens.some(token => token.type === 'heading_open' && token.map[0] === 2), false);
+
+  for (let line = 1; line <= 8; line++) {
+    assert.ok(blocks.some(block => block.startLine === line), `line ${line} is commentable`);
+  }
+  assert.equal(blocks[0].html, '<span class="fence-marker">﻿---</span>');
+  assert.match(blocks[1].html, /code class="hljs"/);
+  assert.match(blocks[1].html, /hljs-attr/);
+  assert.equal(blocks[5].html, '<span class="fence-marker">---</span>');
+  assert.ok(blocks.some(block => block.startLine === 8 && /<h1/.test(block.html)));
+});
 
 // --- splitHighlightedCode ---
 

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -37,6 +37,14 @@ test('rewriteFrontmatterAsYamlFence converts only valid opening and closing deli
   );
 });
 
+test('rewriteFrontmatterAsYamlFence allows trailing spaces on delimiters', () => {
+  const content = '---  \nname: demo\n---\t\n\n# Body';
+  assert.equal(
+    lineBlocks.rewriteFrontmatterAsYamlFence(content),
+    '```yaml\nname: demo\n```\n\n# Body'
+  );
+});
+
 test('rewriteFrontmatterAsYamlFence preserves content without a closing delimiter', () => {
   const content = '---\nname: demo\n# Not a closing delimiter';
   assert.equal(lineBlocks.rewriteFrontmatterAsYamlFence(content), content);

--- a/web/app.js
+++ b/web/app.js
@@ -1202,7 +1202,8 @@
   // ===== Markdown Parsing =====
   function parseMarkdown(content) {
     headingSlugCounter.clear();
-    const tokens = documentMd.parse(content, {});
+    const rewrittenContent = rewriteFrontmatterAsYamlFence(content);
+    const tokens = documentMd.parse(rewrittenContent, {});
     const blocks = buildLineBlocks(tokens, documentMd, content);
     const tocItems = extractTocItems(tokens);
     return { blocks, tocItems };
@@ -1226,6 +1227,7 @@
   const splitHighlightedCode = window.crit.lineBlocks.splitHighlightedCode;
   const buildCodeLineBlocks = window.crit.lineBlocks.buildCodeLineBlocks;
   const buildLineBlocks = window.crit.lineBlocks.buildLineBlocks;
+  const rewriteFrontmatterAsYamlFence = window.crit.lineBlocks.rewriteFrontmatterAsYamlFence;
 
   // ===== Utility Functions =====
   function processTaskLists(html) {

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -21,10 +21,10 @@
   // Callers retain the original content for source line display.
   function rewriteFrontmatterAsYamlFence(content) {
     var lines = content.split('\n');
-    if (!/^\uFEFF?---\r?$/.test(lines[0])) return content;
+    if (!/^\uFEFF?---[ \t]*\r?$/.test(lines[0])) return content;
 
     for (var i = 1; i < lines.length; i++) {
-      if (/^(?:---|\.\.\.)\r?$/.test(lines[i])) {
+      if (/^(?:---|\.\.\.)[ \t]*\r?$/.test(lines[i])) {
         lines[0] = '```yaml' + (lines[0].endsWith('\r') ? '\r' : '');
         lines[i] = '```' + (lines[i].endsWith('\r') ? '\r' : '');
         return lines.join('\n');

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -17,6 +17,23 @@
       .replace(/^-+|-+$/g, '');
   }
 
+  // Turn valid document frontmatter into a YAML fence without shifting maps.
+  // Callers retain the original content for source line display.
+  function rewriteFrontmatterAsYamlFence(content) {
+    var lines = content.split('\n');
+    if (!/^\uFEFF?---\r?$/.test(lines[0])) return content;
+
+    for (var i = 1; i < lines.length; i++) {
+      if (/^(?:---|\.\.\.)\r?$/.test(lines[i])) {
+        lines[0] = '```yaml' + (lines[0].endsWith('\r') ? '\r' : '');
+        lines[i] = '```' + (lines[i].endsWith('\r') ? '\r' : '');
+        return lines.join('\n');
+      }
+    }
+
+    return content;
+  }
+
   // Split highlighted HTML into per-line strings, preserving open spans across lines.
   function splitHighlightedCode(html) {
     var result = [];
@@ -487,6 +504,7 @@
 
   var api = {
     splitHighlightedCode: splitHighlightedCode,
+    rewriteFrontmatterAsYamlFence: rewriteFrontmatterAsYamlFence,
     buildCodeLineBlocks: buildCodeLineBlocks,
     buildLineBlocks: buildLineBlocks,
     findCloseToken: findCloseToken,


### PR DESCRIPTION
## Summary
- Document Markdown view now treats leading YAML frontmatter (`---` … `---` / `...`) as a YAML fence instead of parsing it as Markdown (HRs, headings, lists).
- Line-count-preserving rewrite keeps `token.map` aligned so every frontmatter and body line stays commentable; fence markers still show the original `---`.
- Adds unit coverage and a Playwright regression on `skill.md`.

Closes #821

Companion: crit-web (same branch name) — parity port of the document renderer.

## Test plan
- [x] `node --test web/__tests__/crit-line-blocks.test.js`
- [x] Playwright `markdown-frontmatter.spec.ts` (git-mode)
- [ ] CI green


Made with [Cursor](https://cursor.com)