### PR TITLE
test: clean up wait-for-event flake

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1960,9 +1960,12 @@ func TestWaitForEventIgnoresOtherEvents(t *testing.T) {
 	srv, session := newTestServer(t)
 	session.AddComment(session.Files[0].Path, 1, 1, "", "test", "", "", "")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	done := make(chan struct{})
 	go func() {
-		req := httptest.NewRequest(http.MethodGet, "/api/wait-for-event", nil)
+		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/wait-for-event", nil)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
 		close(done)
@@ -1977,6 +1980,14 @@ func TestWaitForEventIgnoresOtherEvents(t *testing.T) {
 		t.Fatal("long-poll should not return on comments-changed event")
 	case <-time.After(200 * time.Millisecond):
 		// Good — still blocking
+	}
+
+	// Stop the long-poll before the test's temporary directory is cleaned up.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("long-poll did not stop after request cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- cancel the long-poll request in `TestWaitForEventIgnoresOtherEvents`
- wait for its handler goroutine to exit before temporary-directory cleanup

## Flaky failure and evidence
The unit job in [workflow run 31901537019](https://github.com/tomasz-tomczyk/crit/actions/runs/31901537019) failed in `TestWaitForEventIgnoresOtherEvents` with:

```
TempDir RemoveAll cleanup: unlinkat ...: directory not empty
```

The test launched `/api/wait-for-event` with a background context and returned while that handler could still be processing session work in the temporary directory. The rerun of the same workflow run passed without code changes ([rerun job](https://github.com/tomasz-tomczyk/crit/actions/runs/31901537019)), confirming nondeterministic cleanup timing rather than an ordinary assertion failure.

## Root cause and fix
The test's goroutine was not canceled or joined before `t.TempDir` cleanup. The request now uses a cancelable context, and the test cancels and joins the handler after confirming that `comments-changed` does not end the long poll. This preserves the behavior assertion and prevents leaked work from racing cleanup.

## Tests
- `mise exec -- go test ./internal/server -run '^TestWaitForEvent(IgnoresOtherEvents|ReturnsOnFinish|RespectsCancel)$' -count=1` (5 runs)
- `mise exec -- go test ./internal/server`
- `mise exec -- go test ./...`
