### PR TITLE
fix: render markdown tables with native layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,9 @@ Hunk headers (`@@ -27,6 +31,23 @@`), dual gutters, colored backgrounds for addit
 
 - `markdown-it` token.map quirks: last list item often claims a trailing blank line — code trims trailing blank lines from item ranges.
 - Table separators (`|---|---|`): not in tokens, appear as gap lines. Detected via regex and hidden with CSS.
-- Per-row tables: each row in its own `<table>` with `table-layout: fixed` + `<colgroup>` for column alignment.
+- Table rows remain separate source blocks for comments. Document view groups
+  them into one native auto-layout `<table>`; rendered diff paths retain
+  standalone row HTML as a compatibility fallback.
 - `splitHighlightedCode()` tracks open `<span>` tags across lines to properly close/reopen them.
 </important>
 

--- a/test/e2e/tests/change-nav.filemode.spec.ts
+++ b/test/e2e/tests/change-nav.filemode.spec.ts
@@ -198,6 +198,31 @@ test.describe('Change Navigation — File Mode', () => {
     expect(await fallbackTables.first().evaluate(element => getComputedStyle(element).marginTop)).toBe('0px');
   });
 
+  test('navigating to a deleted table row flashes its deletion marker', async ({ page, request }) => {
+    await loadPage(page);
+    const current = fs.readFileSync(path.join(fixtureDir, 'plan.md'), 'utf-8');
+    const deletedRow = '| Key storage | Env var, database | Database | Supports rotation |\n';
+    expect(current).toContain(deletedRow);
+    await doRoundWithEdit(page, request, fixtureDir, 'plan.md', current.replace(deletedRow, ''));
+
+    const section = mdSection(page);
+    const annotation = section.locator('.native-table-annotation', {
+      has: page.locator('.deletion-marker'),
+    });
+    await expect(annotation).toBeVisible();
+    const label = section.locator('.change-nav-label');
+    const totalGroups = Number((await label.textContent())?.match(/\/ (\d+) changes?/)?.[1]);
+    expect(totalGroups).toBeGreaterThan(0);
+    for (let index = 0; index < totalGroups; index++) {
+      await page.keyboard.press('n');
+      if (await annotation.evaluate(element => element.classList.contains('change-flash'))) break;
+    }
+
+    await expect(annotation).toHaveClass(/change-flash/);
+    const marker = annotation.locator('.deletion-marker');
+    expect(await marker.evaluate(element => getComputedStyle(element).animationName)).toContain('change-flash');
+  });
+
   test('n key navigates to next change', async ({ page, request }) => {
     await loadPage(page);
 

--- a/test/e2e/tests/change-nav.filemode.spec.ts
+++ b/test/e2e/tests/change-nav.filemode.spec.ts
@@ -150,6 +150,54 @@ test.describe('Change Navigation — File Mode', () => {
     expect(text).toMatch(/\d+\s*change/);
   });
 
+  test('a changed table stays one navigation group and keeps aligned round-diff columns', async ({ page, request }) => {
+    await loadPage(page);
+    const current = fs.readFileSync(path.join(fixtureDir, 'plan.md'), 'utf-8');
+    const marker = Date.now();
+    const modified = current +
+      `\n\n| Choice ${marker} | Result |\n` +
+      '| --- | --- |\n' +
+      '| short | available |\n' +
+      '| a much longer visible choice | waiting for review |\n';
+    await doRoundWithEdit(page, request, fixtureDir, 'plan.md', modified);
+
+    const section = mdSection(page);
+    const table = section.locator('table.native-table').last();
+    await expect(table).toBeVisible();
+    await expect(table.locator('.line-block-added')).toHaveCount(4);
+    const label = section.locator('.change-nav-label');
+    const totalGroups = Number((await label.textContent())?.match(/\/ (\d+) changes?/)?.[1]);
+    expect(totalGroups).toBeGreaterThan(0);
+    for (let index = 0; index < totalGroups; index++) {
+      await page.keyboard.press('n');
+      if (await table.locator('.line-block.change-flash').count()) break;
+    }
+    await expect(table.locator('.line-block.change-flash')).toHaveCount(4);
+    const flashedCell = table.locator('.line-block.change-flash > .line-content').first();
+    await expect(flashedCell).toBeVisible();
+    expect(await flashedCell.evaluate(cell => getComputedStyle(cell).animationName)).toContain('change-flash');
+
+    await page.locator('#diffToggle').click();
+    const diff = section.locator('.diff-view');
+    await expect(diff).toBeVisible();
+    const fallbackTables = diff.locator('table.split-table');
+    await expect(fallbackTables.first()).toBeVisible();
+    await expect(fallbackTables.locator('colgroup').first()).toBeAttached();
+    const changedTableId = await fallbackTables.filter({ hasText: `Choice ${marker}` }).first().getAttribute('data-table-id');
+    expect(changedTableId).toBeTruthy();
+    const sideWidthSets = await diff.evaluate((element, tableId) => {
+      const cells = Array.from(element.querySelectorAll(':scope > .diff-view-cell'));
+      return [0, 1].map(side => Array.from(new Set(cells
+        .filter((_, index) => index % 2 === side)
+        .map(cell => Array.from(cell.querySelectorAll(`table.split-table[data-table-id="${tableId}"] col`))
+          .map(col => (col as HTMLElement).style.width).join(','))
+        .filter(Boolean))));
+    }, changedTableId);
+    expect(sideWidthSets[0].length).toBeLessThanOrEqual(1);
+    expect(sideWidthSets[1]).toHaveLength(1);
+    expect(await fallbackTables.first().evaluate(element => getComputedStyle(element).marginTop)).toBe('0px');
+  });
+
   test('n key navigates to next change', async ({ page, request }) => {
     await loadPage(page);
 

--- a/test/e2e/tests/rendered-tables.spec.ts
+++ b/test/e2e/tests/rendered-tables.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import {
+  clearAllComments,
+  focusKbNavElement,
+  loadPage,
+  mdSection,
+  switchToDocumentView,
+} from './helpers';
+
+function decisionRow(page: Page, label: string): Locator {
+  return mdSection(page).getByRole('cell', { name: label, exact: true }).locator('..');
+}
+
+async function selectPhrase(cell: Locator, phrase: string) {
+  await cell.evaluate((element, selectedPhrase) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      const start = node.textContent?.indexOf(selectedPhrase) ?? -1;
+      if (start === -1) continue;
+      const range = document.createRange();
+      range.setStart(node, start);
+      range.setEnd(node, start + selectedPhrase.length);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      return;
+    }
+    throw new Error(`Phrase not found: ${selectedPhrase}`);
+  }, phrase);
+}
+
+test.describe('Native rendered tables', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToDocumentView(page);
+  });
+
+  test('uses one auto-layout table without generated column widths or outer border', async ({ page }) => {
+    const table = mdSection(page).locator('table.native-table').first();
+    await expect(table).toBeVisible();
+    await expect(table.locator('thead tr.table-row')).toHaveCount(1);
+    await expect(table.locator('tbody tr.table-row')).toHaveCount(3);
+    await expect(table.locator('colgroup')).toHaveCount(0);
+
+    const layout = await table.evaluate(element => getComputedStyle(element).tableLayout);
+    expect(layout).toBe('auto');
+
+    const wrapper = table.locator('..');
+    const borderWidth = await wrapper.evaluate(element => getComputedStyle(element).borderTopWidth);
+    expect(borderWidth).toBe('0px');
+
+    const widths = await table.locator('thead th.line-content').evaluateAll(cells =>
+      cells.map(cell => cell.getBoundingClientRect().width),
+    );
+    expect(new Set(widths.map(width => Math.round(width))).size).toBeGreaterThan(1);
+  });
+
+  test('table-row comment forms cancel with both button and Escape', async ({ page }) => {
+    let row = decisionRow(page, 'Auth method');
+    await row.hover();
+    await row.locator('.line-comment-gutter').click();
+    await expect(page.locator('.comment-form')).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+
+    row = decisionRow(page, 'Auth method');
+    await row.hover();
+    await row.locator('.line-comment-gutter').click();
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeFocused();
+    await textarea.press('Escape');
+    await expect(page.locator('.comment-form')).toHaveCount(0);
+  });
+
+  test('selected phrases in any table cell are highlighted when commenting', async ({ page }) => {
+    const optionsCell = mdSection(page).getByRole('cell', { name: 'OAuth, API keys, JWT', exact: true });
+    await selectPhrase(optionsCell, 'API keys');
+    await page.keyboard.press('c');
+
+    await expect(page.locator('.comment-form textarea')).toBeFocused();
+    await expect(mdSection(page).locator('mark.quote-highlight')).toHaveText('API keys');
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+    const row = decisionRow(page, 'Auth method');
+    await row.evaluate(element => {
+      const cells = element.querySelectorAll('.line-content');
+      const first = cells[0].firstChild;
+      const second = cells[1].firstChild;
+      if (!first || !second) throw new Error('Expected text in adjacent table cells');
+      const range = document.createRange();
+      range.setStart(first, 0);
+      range.setEnd(second, 5);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    await page.keyboard.press('c');
+    await expect(mdSection(page).locator('mark.quote-highlight')).toHaveCount(2);
+    await expect(mdSection(page).locator('mark.quote-highlight').nth(0)).toHaveText('Auth method');
+    await expect(mdSection(page).locator('mark.quote-highlight').nth(1)).toHaveText('OAuth');
+  });
+
+  test('row stripes and interaction backgrounds do not shift around annotations', async ({ page }) => {
+    const evenRow = decisionRow(page, 'Key storage');
+    const oddRow = decisionRow(page, 'Header format');
+    await expect(evenRow).toHaveClass(/table-even/);
+    await expect(oddRow).not.toHaveClass(/table-even/);
+    const before = await Promise.all([
+      evenRow.locator('td.line-content').first().evaluate(cell => getComputedStyle(cell).backgroundColor),
+      oddRow.locator('td.line-content').first().evaluate(cell => getComputedStyle(cell).backgroundColor),
+    ]);
+    expect(before[0]).not.toBe(before[1]);
+
+    const firstRow = decisionRow(page, 'Auth method');
+    await firstRow.locator('.line-comment-gutter').click();
+    const after = await Promise.all([
+      decisionRow(page, 'Key storage').locator('td.line-content').first().evaluate(cell => getComputedStyle(cell).backgroundColor),
+      decisionRow(page, 'Header format').locator('td.line-content').first().evaluate(cell => getComputedStyle(cell).backgroundColor),
+    ]);
+    expect(after).toEqual(before);
+    await expect(decisionRow(page, 'Auth method')).toHaveClass(/selected|form-selected/);
+  });
+
+  test('drag connector fills every selected table row without gaps', async ({ page }) => {
+    const first = decisionRow(page, 'Auth method').locator('.line-comment-gutter');
+    const last = decisionRow(page, 'Header format').locator('.line-comment-gutter');
+    await first.scrollIntoViewIfNeeded();
+    const firstBox = await first.boundingBox();
+    const lastBox = await last.boundingBox();
+    expect(firstBox).toBeTruthy();
+    expect(lastBox).toBeTruthy();
+    if (!firstBox || !lastBox) return;
+
+    await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + 10);
+    await page.mouse.down();
+    await page.mouse.move(lastBox.x + lastBox.width / 2, lastBox.y + 10, { steps: 5 });
+
+    const segments = await mdSection(page).locator('.native-table .line-comment-gutter.drag-range')
+      .evaluateAll(gutters => gutters.map(gutter => {
+        const rect = gutter.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom, height: rect.height };
+      }));
+    expect(segments).toHaveLength(3);
+    for (let index = 0; index < segments.length - 1; index++) {
+      expect(Math.abs(segments[index].bottom - segments[index + 1].top)).toBeLessThanOrEqual(0.5);
+      expect(segments[index].height).toBeGreaterThan(20);
+    }
+
+    await page.mouse.up();
+    await expect(page.locator('.comment-form')).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+  });
+
+  test('keyboard commenting and submitted comments stay anchored to a table row', async ({ page }) => {
+    let row = decisionRow(page, 'Key storage');
+    await focusKbNavElement(page, row);
+    await page.keyboard.press('c');
+    const textarea = page.locator('.comment-form textarea');
+    await expect(textarea).toBeFocused();
+    await textarea.fill('Table row comment');
+    await textarea.press('Control+Enter');
+
+    row = decisionRow(page, 'Key storage');
+    const annotation = row.locator('xpath=following-sibling::tr[1]');
+    await expect(annotation).toHaveClass(/native-table-annotation/);
+    await expect(annotation.locator('.comment-card')).toContainText('Table row comment');
+  });
+});

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const fs = require('node:fs');
+const markdownit = require('markdown-it');
 
 // Load crit-line-blocks.js in a fake-browser shim.
 const src = fs.readFileSync(path.join(__dirname, '..', 'crit-line-blocks.js'), 'utf8');
@@ -243,6 +244,24 @@ test('buildTableColgroup sizes columns from content while preserving alignment',
   assert.match(colgroup, /<col style="width:8\.00%">/);
   assert.match(colgroup, /<col style="text-align:center;width:82\.00%">/);
   assert.match(colgroup, /<col style="width:10\.00%">/);
+});
+
+test('buildTableColgroup measures rendered link labels instead of hidden URLs', () => {
+  const md = markdownit();
+  const tokens = md.parse(
+    '| Link | Status |\n' +
+    '| --- | --- |\n' +
+    '| [x](https://example.com/a/very/very/very/long/hidden/path) | available |',
+    {}
+  );
+  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
+  const tableClose = tokens.findIndex(token => token.type === 'table_close');
+
+  const colgroup = lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose);
+  assert.equal(
+    colgroup,
+    '<colgroup><col style="width:30.77%"><col style="width:69.23%"></colgroup>'
+  );
 });
 
 // --- buildLineBlocks ---

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -264,6 +264,46 @@ test('buildTableColgroup measures rendered link labels instead of hidden URLs', 
   );
 });
 
+test('buildTableColgroup ignores inline HTML tags with quoted angle brackets', () => {
+  const md = markdownit({ html: true });
+  const tokens = md.parse(
+    '| Markup | Status |\n' +
+    '| --- | --- |\n' +
+    '| <span title="1 > 0">x</span> | ok |',
+    {}
+  );
+  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
+  const tableClose = tokens.findIndex(token => token.type === 'table_close');
+
+  assert.equal(
+    lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose),
+    '<colgroup><col style="width:50.00%"><col style="width:50.00%"></colgroup>'
+  );
+});
+
+test('visibleTextLength counts normalized grapheme clusters', () => {
+  assert.equal(lineBlocks.visibleTextLength('é'), 1);
+  assert.equal(lineBlocks.visibleTextLength('e\u0301'), 1);
+  assert.equal(lineBlocks.visibleTextLength('👨‍👩‍👧‍👦'), 1);
+});
+
+test('buildTableColgroup percentages sum to exactly 100', () => {
+  const md = markdownit();
+  const tokens = md.parse(
+    '| A | B | C | D | E | F |\n' +
+    '| --- | --- | --- | --- | --- | --- |\n' +
+    '| 1 | 2 | 3 | 4 | 5 | 6 |',
+    {}
+  );
+  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
+  const tableClose = tokens.findIndex(token => token.type === 'table_close');
+  const colgroup = lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose);
+  const widths = Array.from(colgroup.matchAll(/width:([\d.]+)%/g), match => Number(match[1]));
+
+  assert.equal(widths.reduce((total, width) => total + width, 0), 100);
+  assert.deepEqual(widths, [16.67, 16.67, 16.67, 16.67, 16.67, 16.65]);
+});
+
 // --- buildLineBlocks ---
 
 test('buildLineBlocks with simple paragraph tokens produces correct blocks', () => {

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -216,92 +216,23 @@ test('addGapLineBlocks marks empty lines as isEmpty', () => {
   assert.equal(blocks[3].isEmpty, false);
 });
 
-// --- buildTableColgroup ---
+// --- rendered tables ---
 
-test('buildTableColgroup sizes columns from content while preserving alignment', () => {
-  const cell = (type, content, style = '') => [
-    { type: type + '_open', attrGet: name => name === 'style' ? style : null },
-    { type: 'inline', content },
-    { type: type + '_close' }
-  ];
-  const tokens = [
-    { type: 'table_open' },
-    { type: 'tr_open' },
-    ...cell('th', '#'),
-    ...cell('th', 'Description', 'text-align:center'),
-    ...cell('th', 'State'),
-    { type: 'tr_close' },
-    { type: 'tr_open' },
-    ...cell('td', '1'),
-    ...cell('td', 'A much longer description that needs room'),
-    ...cell('td', 'Yes'),
-    { type: 'tr_close' },
-    { type: 'table_close' }
-  ];
-
-  const colgroup = lineBlocks.buildTableColgroup(tokens, 0, tokens.length - 1);
-  assert.match(colgroup, /^<colgroup>/);
-  assert.match(colgroup, /<col style="width:8\.00%">/);
-  assert.match(colgroup, /<col style="text-align:center;width:82\.00%">/);
-  assert.match(colgroup, /<col style="width:10\.00%">/);
-});
-
-test('buildTableColgroup measures rendered link labels instead of hidden URLs', () => {
+test('buildLineBlocks groups table rows for native table rendering', () => {
   const md = markdownit();
-  const tokens = md.parse(
-    '| Link | Status |\n' +
+  const source = '| Label | Status |\n' +
     '| --- | --- |\n' +
-    '| [x](https://example.com/a/very/very/very/long/hidden/path) | available |',
-    {}
-  );
-  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
-  const tableClose = tokens.findIndex(token => token.type === 'table_close');
+    '| [x](https://example.com/a/very/long/hidden/path) | available |';
+  const blocks = lineBlocks.buildLineBlocks(md.parse(source, {}), md, source);
 
-  const colgroup = lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose);
-  assert.equal(
-    colgroup,
-    '<colgroup><col style="width:30.77%"><col style="width:69.23%"></colgroup>'
-  );
-});
-
-test('buildTableColgroup ignores inline HTML tags with quoted angle brackets', () => {
-  const md = markdownit({ html: true });
-  const tokens = md.parse(
-    '| Markup | Status |\n' +
-    '| --- | --- |\n' +
-    '| <span title="1 > 0">x</span> | ok |',
-    {}
-  );
-  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
-  const tableClose = tokens.findIndex(token => token.type === 'table_close');
-
-  assert.equal(
-    lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose),
-    '<colgroup><col style="width:50.00%"><col style="width:50.00%"></colgroup>'
-  );
-});
-
-test('visibleTextLength counts normalized grapheme clusters', () => {
-  assert.equal(lineBlocks.visibleTextLength('é'), 1);
-  assert.equal(lineBlocks.visibleTextLength('e\u0301'), 1);
-  assert.equal(lineBlocks.visibleTextLength('👨‍👩‍👧‍👦'), 1);
-});
-
-test('buildTableColgroup percentages sum to exactly 100', () => {
-  const md = markdownit();
-  const tokens = md.parse(
-    '| A | B | C | D | E | F |\n' +
-    '| --- | --- | --- | --- | --- | --- |\n' +
-    '| 1 | 2 | 3 | 4 | 5 | 6 |',
-    {}
-  );
-  const tableOpen = tokens.findIndex(token => token.type === 'table_open');
-  const tableClose = tokens.findIndex(token => token.type === 'table_close');
-  const colgroup = lineBlocks.buildTableColgroup(tokens, tableOpen, tableClose);
-  const widths = Array.from(colgroup.matchAll(/width:([\d.]+)%/g), match => Number(match[1]));
-
-  assert.equal(widths.reduce((total, width) => total + width, 0), 100);
-  assert.deepEqual(widths, [16.67, 16.67, 16.67, 16.67, 16.67, 16.65]);
+  assert.equal(blocks.length, 3);
+  assert.equal(blocks[0].tableId, blocks[1].tableId);
+  assert.equal(blocks[1].tableId, blocks[2].tableId);
+  assert.equal(blocks[0].tableSection, 'thead');
+  assert.equal(blocks[1].cssClass, 'table-separator');
+  assert.equal(blocks[2].tableSection, 'tbody');
+  assert.match(blocks[0].html, /^<tr>/);
+  assert.doesNotMatch(blocks[0].html, /<table|<colgroup/);
 });
 
 // --- buildLineBlocks ---

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -215,6 +215,36 @@ test('addGapLineBlocks marks empty lines as isEmpty', () => {
   assert.equal(blocks[3].isEmpty, false);
 });
 
+// --- buildTableColgroup ---
+
+test('buildTableColgroup sizes columns from content while preserving alignment', () => {
+  const cell = (type, content, style = '') => [
+    { type: type + '_open', attrGet: name => name === 'style' ? style : null },
+    { type: 'inline', content },
+    { type: type + '_close' }
+  ];
+  const tokens = [
+    { type: 'table_open' },
+    { type: 'tr_open' },
+    ...cell('th', '#'),
+    ...cell('th', 'Description', 'text-align:center'),
+    ...cell('th', 'State'),
+    { type: 'tr_close' },
+    { type: 'tr_open' },
+    ...cell('td', '1'),
+    ...cell('td', 'A much longer description that needs room'),
+    ...cell('td', 'Yes'),
+    { type: 'tr_close' },
+    { type: 'table_close' }
+  ];
+
+  const colgroup = lineBlocks.buildTableColgroup(tokens, 0, tokens.length - 1);
+  assert.match(colgroup, /^<colgroup>/);
+  assert.match(colgroup, /<col style="width:8\.00%">/);
+  assert.match(colgroup, /<col style="text-align:center;width:82\.00%">/);
+  assert.match(colgroup, /<col style="width:10\.00%">/);
+});
+
 // --- buildLineBlocks ---
 
 test('buildLineBlocks with simple paragraph tokens produces correct blocks', () => {

--- a/web/__tests__/crit-line-blocks.test.js
+++ b/web/__tests__/crit-line-blocks.test.js
@@ -231,8 +231,11 @@ test('buildLineBlocks groups table rows for native table rendering', () => {
   assert.equal(blocks[0].tableSection, 'thead');
   assert.equal(blocks[1].cssClass, 'table-separator');
   assert.equal(blocks[2].tableSection, 'tbody');
-  assert.match(blocks[0].html, /^<tr>/);
-  assert.doesNotMatch(blocks[0].html, /<table|<colgroup/);
+  assert.match(blocks[0].nativeRowHtml, /^<tr>/);
+  assert.doesNotMatch(blocks[0].nativeRowHtml, /<table|<colgroup/);
+  assert.match(blocks[0].html, /^<table class="split-table" data-table-id="table-0">/);
+  assert.match(blocks[0].html, /<col style="width:35\.71%"><col style="width:64\.29%">/);
+  assert.match(blocks[2].html, /<col style="width:35\.71%"><col style="width:64\.29%">/);
 });
 
 // --- buildLineBlocks ---

--- a/web/app.js
+++ b/web/app.js
@@ -3316,10 +3316,46 @@
       }
     }
 
+    let activeTableId = null;
+    let activeTableHead = null;
+    let activeTableBody = null;
+
+    function appendTableAnnotation(section, element) {
+      const row = document.createElement('tr');
+      row.className = 'native-table-annotation';
+      const cell = document.createElement('td');
+      cell.colSpan = 100;
+      cell.appendChild(element);
+      row.appendChild(cell);
+      section.appendChild(row);
+    }
+
     for (let bi = 0; bi < file.lineBlocks.length; bi++) {
       const block = file.lineBlocks[bi];
+      const isTableBlock = !!block.tableId;
 
-      const lineBlockEl = document.createElement('div');
+      if (isTableBlock && block.tableId !== activeTableId) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'native-table-wrapper';
+        const table = document.createElement('table');
+        table.className = 'native-table';
+        activeTableHead = document.createElement('thead');
+        activeTableBody = document.createElement('tbody');
+        table.appendChild(activeTableHead);
+        table.appendChild(activeTableBody);
+        wrapper.appendChild(table);
+        container.appendChild(wrapper);
+        activeTableId = block.tableId;
+      } else if (!isTableBlock) {
+        activeTableId = null;
+        activeTableHead = null;
+        activeTableBody = null;
+      }
+      const tableSection = isTableBlock && block.tableSection === 'thead'
+        ? activeTableHead
+        : activeTableBody;
+
+      const lineBlockEl = document.createElement(isTableBlock ? 'tr' : 'div');
       lineBlockEl.className = 'line-block kb-nav';
       lineBlockEl.dataset.blockIndex = bi;
       lineBlockEl.dataset.startLine = block.startLine;
@@ -3381,17 +3417,42 @@
       commentGutter.appendChild(lineAdd);
       commentGutter.addEventListener('mousedown', handleGutterMouseDown);
 
-      // Content
-      const content = document.createElement('div');
-      content.className = buildContentClasses(block);
-      let html = block.html;
-      html = processTaskLists(html);
-      html = rewriteImageSrcs(html, file.path);
-      content.innerHTML = html;
-
       gutter.appendChild(commentGutter);
-      lineBlockEl.appendChild(gutter);
-      lineBlockEl.appendChild(content);
+      if (isTableBlock) {
+        const gutterCell = document.createElement('td');
+        gutterCell.className = 'native-table-gutter';
+        gutterCell.appendChild(gutter);
+        lineBlockEl.appendChild(gutterCell);
+
+        if (block.cssClass && block.cssClass.indexOf('table-separator') !== -1) {
+          lineBlockEl.classList.add('native-table-separator');
+          const separatorCell = document.createElement('td');
+          separatorCell.colSpan = 100;
+          lineBlockEl.appendChild(separatorCell);
+        } else {
+          let html = processTaskLists(block.html);
+          html = rewriteImageSrcs(html, file.path);
+          const scratch = document.createElement('table');
+          scratch.innerHTML = '<tbody>' + html + '</tbody>';
+          const renderedRow = scratch.querySelector('tr');
+          if (renderedRow) {
+            while (renderedRow.firstChild) {
+              const cell = renderedRow.firstChild;
+              cell.className = buildContentClasses(block) + (cell.className ? ' ' + cell.className : '');
+              lineBlockEl.appendChild(cell);
+            }
+          }
+        }
+      } else {
+        const content = document.createElement('div');
+        content.className = buildContentClasses(block);
+        let html = block.html;
+        html = processTaskLists(html);
+        html = rewriteImageSrcs(html, file.path);
+        content.innerHTML = html;
+        lineBlockEl.appendChild(gutter);
+        lineBlockEl.appendChild(content);
+      }
 
       // Insert deletion marker before this block if deletions occurred before it
       if (changeInfo && bi === 0 && deletionMarkerMap[0]) {
@@ -3399,10 +3460,12 @@
         marker0.className = 'deletion-marker';
         marker0.dataset.filePath = file.path;
         marker0.textContent = '\u2212' + deletionMarkerMap[0].count + ' line' + (deletionMarkerMap[0].count !== 1 ? 's' : '');
-        container.appendChild(marker0);
+        if (isTableBlock) appendTableAnnotation(tableSection, marker0);
+        else container.appendChild(marker0);
       }
 
-      container.appendChild(lineBlockEl);
+      if (isTableBlock) tableSection.appendChild(lineBlockEl);
+      else container.appendChild(lineBlockEl);
 
       // Insert deletion marker after this block if deletions occurred after it
       if (changeInfo && deletionMarkerMap[block.endLine]) {
@@ -3410,15 +3473,20 @@
         marker.className = 'deletion-marker';
         marker.dataset.filePath = file.path;
         marker.textContent = '\u2212' + deletionMarkerMap[block.endLine].count + ' line' + (deletionMarkerMap[block.endLine].count !== 1 ? 's' : '');
-        container.appendChild(marker);
+        if (isTableBlock) appendTableAnnotation(tableSection, marker);
+        else container.appendChild(marker);
       }
 
       // Comments after block
       for (const comment of blockComments) {
         if (comment.resolved) {
-          container.appendChild(createResolvedElement(comment, file.path));
+          const commentEl = createResolvedElement(comment, file.path);
+          if (isTableBlock) appendTableAnnotation(tableSection, commentEl);
+          else container.appendChild(commentEl);
         } else {
-          container.appendChild(createCommentElement(comment, file.path));
+          const commentEl = createCommentElement(comment, file.path);
+          if (isTableBlock) appendTableAnnotation(tableSection, commentEl);
+          else container.appendChild(commentEl);
         }
       }
 
@@ -3426,7 +3494,9 @@
       const fileForms = getFormsForFile(file.path);
       for (let fi = 0; fi < fileForms.length; fi++) {
         if (!fileForms[fi].editingId && fileForms[fi].afterBlockIndex === bi) {
-          container.appendChild(createCommentForm(fileForms[fi]));
+          const formEl = createCommentForm(fileForms[fi]);
+          if (isTableBlock) appendTableAnnotation(tableSection, formEl);
+          else container.appendChild(formEl);
         }
       }
     }
@@ -6067,9 +6137,11 @@
           const s = parseInt(el.dataset.startLine);
           const e = parseInt(el.dataset.endLine);
           if (s <= ln && e >= ln) {
-            // Get the content div (skip gutter)
-            const content = el.querySelector('.line-content');
-            if (content && contentEls.indexOf(content) === -1) contentEls.push(content);
+            // Native table rows have one content element per cell. Other
+            // blocks have one content div.
+            el.querySelectorAll('.line-content').forEach(function(content) {
+              if (contentEls.indexOf(content) === -1) contentEls.push(content);
+            });
           }
         });
         // Diff view: diff lines with data-diff-line-num
@@ -9881,11 +9953,12 @@
             if (el.dataset.filePath !== range.filePath) return;
             const s = parseInt(el.dataset.startLine), endLn = parseInt(el.dataset.endLine);
             if (s <= ln && endLn >= ln) {
-              const content = el.querySelector('.line-content');
-              if (content && contentEls.indexOf(content) === -1) {
-                fullText += (fullText ? '\n' : '') + content.textContent.trim();
-                contentEls.push(content);
-              }
+              el.querySelectorAll('.line-content').forEach(function(content) {
+                if (contentEls.indexOf(content) === -1) {
+                  fullText += (fullText ? '\n' : '') + content.textContent.trim();
+                  contentEls.push(content);
+                }
+              });
             }
           });
           const selSide = range.side || '';

--- a/web/app.js
+++ b/web/app.js
@@ -2382,7 +2382,9 @@
     const prevAnchor = changeNavAnchorFromIdx(currentChangeIdx);
     changeGroups = [];
     // Document view: color-coded change blocks + deletion markers
-    const docEls = document.querySelectorAll('.line-block-added, .line-block-modified, .deletion-marker');
+    const docEls = Array.from(document.querySelectorAll('.line-block-added, .line-block-modified, .deletion-marker'))
+      .map(function(el) { return el.closest('.native-table-annotation') || el; })
+      .filter(function(el, index, elements) { return elements.indexOf(el) === index; });
     // Diff view: diff-added and diff-removed blocks in rendered diff (file mode)
     const diffEls = document.querySelectorAll('.diff-view .line-block.diff-added, .diff-view .line-block.diff-removed, .diff-view-unified .line-block.diff-added, .diff-view-unified .line-block.diff-removed');
     const all = docEls.length > 0 ? docEls : diffEls;
@@ -2405,7 +2407,7 @@
 
   function isConsecutiveSibling(a, b) {
     // Check if b immediately follows a, skipping comment elements between them
-    let node = a.nextElementSibling;
+    let node = nextLogicalTableSibling(a);
     while (node && node !== b) {
       // A non-changed line-block in between breaks the group
       if (node.classList.contains('line-block') &&
@@ -2414,10 +2416,18 @@
           !node.classList.contains('diff-added') &&
           !node.classList.contains('diff-removed')) return false;
       // Deletion markers don't break the group
-      if (node.classList.contains('deletion-marker')) { node = node.nextElementSibling; continue; }
-      node = node.nextElementSibling;
+      if (node.classList.contains('deletion-marker')) { node = nextLogicalTableSibling(node); continue; }
+      node = nextLogicalTableSibling(node);
     }
     return node === b;
+  }
+
+  function nextLogicalTableSibling(node) {
+    if (node.nextElementSibling) return node.nextElementSibling;
+    const section = node.parentElement;
+    if (!section || section.tagName !== 'THEAD') return null;
+    const table = section.closest('table.native-table');
+    return table && table.tBodies.length ? table.tBodies[0].firstElementChild : null;
   }
 
   function navigateToChange(dir, _mountedPath) {
@@ -3323,6 +3333,7 @@
     function appendTableAnnotation(section, element) {
       const row = document.createElement('tr');
       row.className = 'native-table-annotation';
+      if (element.dataset.filePath) row.dataset.filePath = element.dataset.filePath;
       const cell = document.createElement('td');
       cell.colSpan = 100;
       cell.appendChild(element);
@@ -3357,6 +3368,11 @@
 
       const lineBlockEl = document.createElement(isTableBlock ? 'tr' : 'div');
       lineBlockEl.className = 'line-block kb-nav';
+      if (isTableBlock && block.cssClass) {
+        block.cssClass.split(/\s+/).forEach(function(className) {
+          if (className) lineBlockEl.classList.add(className);
+        });
+      }
       lineBlockEl.dataset.blockIndex = bi;
       lineBlockEl.dataset.startLine = block.startLine;
       lineBlockEl.dataset.endLine = block.endLine;
@@ -3430,7 +3446,7 @@
           separatorCell.colSpan = 100;
           lineBlockEl.appendChild(separatorCell);
         } else {
-          let html = processTaskLists(block.html);
+          let html = processTaskLists(block.nativeRowHtml || block.html);
           html = rewriteImageSrcs(html, file.path);
           const scratch = document.createElement('table');
           scratch.innerHTML = '<tbody>' + html + '</tbody>';
@@ -6157,21 +6173,26 @@
 
       if (contentEls.length === 0) return;
 
-      // Collect all text nodes across the content elements
-      const textNodes = [];
-      contentEls.forEach(function(el) {
+      // Preserve a whitespace boundary between cells/line blocks while retaining
+      // each real text node's offsets for DOM highlighting.
+      const nodeRanges = [];
+      let fullText = '';
+      contentEls.forEach(function(el, contentIndex) {
+        if (contentIndex > 0) fullText += ' ';
         const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null);
         let node;
         while ((node = walker.nextNode())) {
-          if (node.textContent.length > 0) textNodes.push(node);
+          if (node.textContent.length === 0) continue;
+          const start = fullText.length;
+          fullText += node.textContent;
+          nodeRanges.push({ node: node, start: start, end: fullText.length });
         }
       });
 
-      if (textNodes.length === 0) return;
+      if (nodeRanges.length === 0) return;
 
       // Build concatenated text and find the quote within it.
       // Normalize the quote: collapse whitespace/newlines so cross-line selections match.
-      const fullText = textNodes.map(function(n) { return n.textContent; }).join('');
       const normalizedQuote = comment.quote.replace(/\s+/g, ' ');
       const normalizedFull = fullText.replace(/\s+/g, ' ');
       let quoteIdx = -1;
@@ -6218,20 +6239,19 @@
 
       // Walk text nodes to find which ones overlap with the quote range
       const quoteEnd = quoteIdx + matchLen;
-      let pos = 0;
-      for (let i = 0; i < textNodes.length; i++) {
-        const node = textNodes[i];
-        const nodeEnd = pos + node.textContent.length;
-        if (nodeEnd <= quoteIdx) { pos = nodeEnd; continue; }
-        if (pos >= quoteEnd) break;
+      for (let i = 0; i < nodeRanges.length; i++) {
+        const nodeRange = nodeRanges[i];
+        const node = nodeRange.node;
+        if (nodeRange.end <= quoteIdx) continue;
+        if (nodeRange.start >= quoteEnd) break;
 
         // This node overlaps with the quote range
-        const startInNode = Math.max(0, quoteIdx - pos);
-        const endInNode = Math.min(node.textContent.length, quoteEnd - pos);
+        const startInNode = Math.max(0, quoteIdx - nodeRange.start);
+        const endInNode = Math.min(node.textContent.length, quoteEnd - nodeRange.start);
 
         // Skip wrapping whitespace-only matches (e.g. newlines between blocks)
         const matchText = node.textContent.slice(startInNode, endInNode);
-        if (!matchText.trim()) { pos = nodeEnd; continue; }
+        if (!matchText.trim()) continue;
 
         if (startInNode === 0 && endInNode === node.textContent.length) {
           // Wrap entire text node
@@ -6255,7 +6275,6 @@
           if (after) frag.appendChild(document.createTextNode(after));
           node.parentNode.replaceChild(frag, node);
         }
-        pos = nodeEnd;
       }
     });
   }
@@ -9987,6 +10006,7 @@
             let charsBefore = 0;
             let foundEl = false;
             for (let ci = 0; ci < contentEls.length; ci++) {
+              if (ci > 0) charsBefore++;
               if (contentEls[ci].contains(startContainer)) {
                 const walker = document.createTreeWalker(contentEls[ci], NodeFilter.SHOW_TEXT, null);
                 let tn;
@@ -10004,13 +10024,8 @@
             }
 
             if (foundEl) {
-              let rawAll = '';
-              const rawUpTo = charsBefore;
-              for (let ri = 0; ri < contentEls.length; ri++) {
-                rawAll += contentEls[ri].textContent;
-                if (contentEls[ri].contains(startContainer)) break;
-              }
-              const textBefore = rawAll.slice(0, rawUpTo);
+              const rawAll = contentEls.map(function(el) { return el.textContent; }).join(' ');
+              const textBefore = rawAll.slice(0, charsBefore);
               quoteOffset = textBefore.replace(/\s+/g, ' ').trimStart().length;
             }
           } catch { /* offset is a nice-to-have */ }

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -309,12 +309,65 @@
     return result;
   }
 
+  function escapeAttr(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  }
+
+  function inlineVisibleLength(token) {
+    if (!token.children || token.children.length === 0) {
+      return Array.from(token.content || '').length;
+    }
+
+    return token.children.reduce(function(length, child) {
+      if (child.nesting !== 0) return length;
+      var content = child.content || '';
+      if (child.type === 'html_inline') content = content.replace(/<[^>]*>/g, '');
+      return length + Array.from(content).length;
+    }, 0);
+  }
+
+  // Rendered diffs still place each source row in an independent line block.
+  // Give those fallback tables one shared colgroup so their columns align.
+  function buildTableColgroup(tokens, startIdx, endIdx) {
+    var preferredWidths = [];
+    var alignments = [];
+    var columnIndex = 0;
+
+    for (var j = startIdx + 1; j < endIdx; j++) {
+      var token = tokens[j];
+      if (token.type === 'tr_open') {
+        columnIndex = 0;
+      } else if (token.type === 'th_open' || token.type === 'td_open') {
+        var contentLength = 0;
+        for (var k = j + 1; k < endIdx &&
+             tokens[k].type !== 'th_close' && tokens[k].type !== 'td_close'; k++) {
+          if (tokens[k].type === 'inline') contentLength += inlineVisibleLength(tokens[k]);
+        }
+        preferredWidths[columnIndex] = Math.max(preferredWidths[columnIndex] || 0, contentLength);
+        if (token.type === 'th_open') alignments[columnIndex] = token.attrGet('style') || '';
+        columnIndex++;
+      }
+    }
+
+    if (!preferredWidths.length) return '';
+    var weights = preferredWidths.map(function(length) { return Math.max(4, Math.min(48, length)); });
+    var totalWeight = weights.reduce(function(total, weight) { return total + weight; }, 0);
+
+    return '<colgroup>' + weights.map(function(weight, index) {
+      var alignment = alignments[index] || '';
+      if (alignment && alignment.slice(-1) !== ';') alignment += ';';
+      return '<col style="' + escapeAttr(alignment) + 'width:' +
+        (weight / totalWeight * 100).toFixed(2) + '%">';
+    }).join('') + '</colgroup>';
+  }
+
   // Keep source rows as independently commentable blocks, but mark them as one
   // table so the DOM renderer can place every row in the same native table.
   function handleTableToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockEnd) {
     var tableCloseIdx = findCloseToken(tokens, i);
     var tableMap = tokens[i].map;
     var tableId = 'table-' + (tableMap ? tableMap[0] : i);
+    var fallbackColgroup = buildTableColgroup(tokens, i, tableCloseIdx);
 
     var j = i + 1;
     var inThead = false;
@@ -342,14 +395,18 @@
 
           var trTokens = tokens.slice(j, trCloseIdx + 1);
           var section = inThead ? 'thead' : 'tbody';
-          var rowHtml = md.renderer.render(trTokens, md.options, {});
+          var nativeRowHtml = md.renderer.render(trTokens, md.options, {});
+          var rowHtml = '<table class="split-table" data-table-id="' + escapeAttr(tableId) + '">' +
+            fallbackColgroup + '<' + section + '>' +
+            nativeRowHtml + '</' + section + '></table>';
 
           var cls = 'table-row';
           if (rowIndex === 0) cls += ' table-first';
           if (!inThead && bodyRowIndex % 2 === 1) cls += ' table-even';
           blocks.push({
             startLine: trMap[0] + 1, endLine: trMap[1],
-            html: rowHtml, isEmpty: false, cssClass: cls,
+            html: rowHtml, nativeRowHtml: nativeRowHtml,
+            isEmpty: false, cssClass: cls,
             tableId: tableId, tableSection: section
           });
           coveredUpTo = trMap[1];

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -309,89 +309,12 @@
     return result;
   }
 
-  function escapeAttr(s) {
-    return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-  }
-
-  var graphemeSegmenter = typeof Intl !== 'undefined' && Intl.Segmenter
-    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
-    : null;
-
-  function visibleTextLength(content) {
-    var normalized = String(content || '').normalize('NFC');
-    if (graphemeSegmenter) return Array.from(graphemeSegmenter.segment(normalized)).length;
-    return Array.from(normalized).length;
-  }
-
-  function inlineVisibleLength(token) {
-    if (!token.children || token.children.length === 0) {
-      return visibleTextLength(token.content);
-    }
-
-    return token.children.reduce(function(length, child) {
-      if (child.nesting !== 0) return length;
-      // markdown-it emits inline HTML tags separately from their visible text.
-      if (child.type === 'html_inline') return length;
-      return length + visibleTextLength(child.content);
-    }, 0);
-  }
-
-  // Split tables are rendered as one table per source row so every row can be
-  // commented on independently. Give each of those tables the same
-  // content-aware colgroup; otherwise fixed table layout makes every column
-  // equally wide, while auto layout lets each row choose different widths.
-  function buildTableColgroup(tokens, startIdx, endIdx) {
-    var preferredWidths = [];
-    var alignments = [];
-    var columnIndex = 0;
-
-    for (var j = startIdx + 1; j < endIdx; j++) {
-      var token = tokens[j];
-      if (token.type === 'tr_open') {
-        columnIndex = 0;
-      } else if (token.type === 'th_open' || token.type === 'td_open') {
-        var contentLength = 0;
-        for (var k = j + 1; k < endIdx &&
-             tokens[k].type !== 'th_close' && tokens[k].type !== 'td_close'; k++) {
-          if (tokens[k].type === 'inline') {
-            contentLength += inlineVisibleLength(tokens[k]);
-          }
-        }
-        preferredWidths[columnIndex] = Math.max(preferredWidths[columnIndex] || 0, contentLength);
-        if (token.type === 'th_open') {
-          alignments[columnIndex] = token.attrGet('style') || '';
-        }
-        columnIndex++;
-      }
-    }
-
-    if (!preferredWidths.length) return '';
-
-    // Four characters leaves compact columns enough room for cell padding;
-    // the upper bound keeps a single long prose/code cell from dominating.
-    var weights = preferredWidths.map(function(length) {
-      return Math.max(4, Math.min(48, length));
-    });
-    var totalWeight = weights.reduce(function(total, weight) { return total + weight; }, 0);
-
-    var remainingPercent = 100;
-    return '<colgroup>' + weights.map(function(weight, index) {
-      var alignment = alignments[index] || '';
-      if (alignment && alignment.slice(-1) !== ';') alignment += ';';
-      var percent = index === weights.length - 1
-        ? remainingPercent
-        : Number((weight / totalWeight * 100).toFixed(2));
-      remainingPercent -= percent;
-      return '<col style="' + escapeAttr(alignment) + 'width:' +
-        percent.toFixed(2) + '%">';
-    }).join('') + '</colgroup>';
-  }
-
-  // Handle a table token — split into per-row blocks.
+  // Keep source rows as independently commentable blocks, but mark them as one
+  // table so the DOM renderer can place every row in the same native table.
   function handleTableToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockEnd) {
     var tableCloseIdx = findCloseToken(tokens, i);
-
-    var colgroup = buildTableColgroup(tokens, i, tableCloseIdx);
+    var tableMap = tokens[i].map;
+    var tableId = 'table-' + (tableMap ? tableMap[0] : i);
 
     var j = i + 1;
     var inThead = false;
@@ -411,7 +334,7 @@
           for (var ln = coveredUpTo; ln < trMap[0]; ln++) {
             var lineText = sourceLines[ln].trim();
             if (/^\|[\s\-:|]+\|$/.test(lineText) || /^[-:|][\s\-:|]*$/.test(lineText)) {
-              blocks.push({ startLine: ln + 1, endLine: ln + 1, html: '', isEmpty: false, cssClass: 'table-separator' });
+              blocks.push({ startLine: ln + 1, endLine: ln + 1, html: '', isEmpty: false, cssClass: 'table-separator', tableId: tableId, tableSection: 'tbody' });
             } else {
               blocks.push({ startLine: ln + 1, endLine: ln + 1, html: lineText === '' ? '' : escapeHtml(lineText), isEmpty: lineText === '' });
             }
@@ -419,17 +342,15 @@
 
           var trTokens = tokens.slice(j, trCloseIdx + 1);
           var section = inThead ? 'thead' : 'tbody';
-          var rowHtml = '<table class="split-table">' + colgroup +
-            '<' + section + '>' +
-            md.renderer.render(trTokens, md.options, {}) +
-            '</' + section + '></table>';
+          var rowHtml = md.renderer.render(trTokens, md.options, {});
 
           var cls = 'table-row';
           if (rowIndex === 0) cls += ' table-first';
           if (!inThead && bodyRowIndex % 2 === 1) cls += ' table-even';
           blocks.push({
             startLine: trMap[0] + 1, endLine: trMap[1],
-            html: rowHtml, isEmpty: false, cssClass: cls
+            html: rowHtml, isEmpty: false, cssClass: cls,
+            tableId: tableId, tableSection: section
           });
           coveredUpTo = trMap[1];
           rowIndex++;
@@ -573,9 +494,6 @@
     addGapLineBlocks: addGapLineBlocks,
     handleFenceToken: handleFenceToken,
     handleListToken: handleListToken,
-    visibleTextLength: visibleTextLength,
-    inlineVisibleLength: inlineVisibleLength,
-    buildTableColgroup: buildTableColgroup,
     handleTableToken: handleTableToken,
     handleBlockquoteToken: handleBlockquoteToken,
     slugifyHeading: slugifyHeading

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -313,16 +313,26 @@
     return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   }
 
+  var graphemeSegmenter = typeof Intl !== 'undefined' && Intl.Segmenter
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+  function visibleTextLength(content) {
+    var normalized = String(content || '').normalize('NFC');
+    if (graphemeSegmenter) return Array.from(graphemeSegmenter.segment(normalized)).length;
+    return Array.from(normalized).length;
+  }
+
   function inlineVisibleLength(token) {
     if (!token.children || token.children.length === 0) {
-      return Array.from(token.content || '').length;
+      return visibleTextLength(token.content);
     }
 
     return token.children.reduce(function(length, child) {
       if (child.nesting !== 0) return length;
-      var content = child.content || '';
-      if (child.type === 'html_inline') content = content.replace(/<[^>]*>/g, '');
-      return length + Array.from(content).length;
+      // markdown-it emits inline HTML tags separately from their visible text.
+      if (child.type === 'html_inline') return length;
+      return length + visibleTextLength(child.content);
     }, 0);
   }
 
@@ -364,11 +374,16 @@
     });
     var totalWeight = weights.reduce(function(total, weight) { return total + weight; }, 0);
 
+    var remainingPercent = 100;
     return '<colgroup>' + weights.map(function(weight, index) {
       var alignment = alignments[index] || '';
       if (alignment && alignment.slice(-1) !== ';') alignment += ';';
+      var percent = index === weights.length - 1
+        ? remainingPercent
+        : Number((weight / totalWeight * 100).toFixed(2));
+      remainingPercent -= percent;
       return '<col style="' + escapeAttr(alignment) + 'width:' +
-        (weight / totalWeight * 100).toFixed(2) + '%">';
+        percent.toFixed(2) + '%">';
     }).join('') + '</colgroup>';
   }
 
@@ -558,6 +573,7 @@
     addGapLineBlocks: addGapLineBlocks,
     handleFenceToken: handleFenceToken,
     handleListToken: handleListToken,
+    visibleTextLength: visibleTextLength,
     inlineVisibleLength: inlineVisibleLength,
     buildTableColgroup: buildTableColgroup,
     handleTableToken: handleTableToken,

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -313,25 +313,59 @@
     return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   }
 
+  // Split tables are rendered as one table per source row so every row can be
+  // commented on independently. Give each of those tables the same
+  // content-aware colgroup; otherwise fixed table layout makes every column
+  // equally wide, while auto layout lets each row choose different widths.
+  function buildTableColgroup(tokens, startIdx, endIdx) {
+    var preferredWidths = [];
+    var alignments = [];
+    var columnIndex = 0;
+
+    for (var j = startIdx + 1; j < endIdx; j++) {
+      var token = tokens[j];
+      if (token.type === 'tr_open') {
+        columnIndex = 0;
+      } else if (token.type === 'th_open' || token.type === 'td_open') {
+        var contentLength = 0;
+        for (var k = j + 1; k < endIdx &&
+             tokens[k].type !== 'th_close' && tokens[k].type !== 'td_close'; k++) {
+          if (tokens[k].type === 'inline') {
+            contentLength += Array.from(tokens[k].content || '').length;
+          }
+        }
+        preferredWidths[columnIndex] = Math.max(preferredWidths[columnIndex] || 0, contentLength);
+        if (token.type === 'th_open') {
+          alignments[columnIndex] = token.attrGet('style') || '';
+        }
+        columnIndex++;
+      }
+    }
+
+    if (!preferredWidths.length) return '';
+
+    // Four characters leaves compact columns enough room for cell padding;
+    // the upper bound keeps a single long prose/code cell from dominating.
+    var weights = preferredWidths.map(function(length) {
+      return Math.max(4, Math.min(48, length));
+    });
+    var totalWeight = weights.reduce(function(total, weight) { return total + weight; }, 0);
+
+    return '<colgroup>' + weights.map(function(weight, index) {
+      var alignment = alignments[index] || '';
+      if (alignment && alignment.slice(-1) !== ';') alignment += ';';
+      return '<col style="' + escapeAttr(alignment) + 'width:' +
+        (weight / totalWeight * 100).toFixed(2) + '%">';
+    }).join('') + '</colgroup>';
+  }
+
   // Handle a table token — split into per-row blocks.
   function handleTableToken(tokens, i, md, blocks, sourceLines, coveredUpTo, blockEnd) {
     var tableCloseIdx = findCloseToken(tokens, i);
 
-    // Build colgroup from header cell alignments
-    var colgroup = '';
-    var aligns = [];
-    for (var j = i + 1; j < tableCloseIdx; j++) {
-      if (tokens[j].type === 'th_open') {
-        aligns.push(tokens[j].attrGet('style') || '');
-      }
-    }
-    if (aligns.length) {
-      colgroup = '<colgroup>' +
-        aligns.map(function(s) { return '<col' + (s ? ' style="' + s + '"' : '') + '>'; }).join('') +
-        '</colgroup>';
-    }
+    var colgroup = buildTableColgroup(tokens, i, tableCloseIdx);
 
-    j = i + 1;
+    var j = i + 1;
     var inThead = false;
     var rowIndex = 0;
     var bodyRowIndex = 0;
@@ -511,6 +545,7 @@
     addGapLineBlocks: addGapLineBlocks,
     handleFenceToken: handleFenceToken,
     handleListToken: handleListToken,
+    buildTableColgroup: buildTableColgroup,
     handleTableToken: handleTableToken,
     handleBlockquoteToken: handleBlockquoteToken,
     slugifyHeading: slugifyHeading

--- a/web/crit-line-blocks.js
+++ b/web/crit-line-blocks.js
@@ -313,6 +313,19 @@
     return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   }
 
+  function inlineVisibleLength(token) {
+    if (!token.children || token.children.length === 0) {
+      return Array.from(token.content || '').length;
+    }
+
+    return token.children.reduce(function(length, child) {
+      if (child.nesting !== 0) return length;
+      var content = child.content || '';
+      if (child.type === 'html_inline') content = content.replace(/<[^>]*>/g, '');
+      return length + Array.from(content).length;
+    }, 0);
+  }
+
   // Split tables are rendered as one table per source row so every row can be
   // commented on independently. Give each of those tables the same
   // content-aware colgroup; otherwise fixed table layout makes every column
@@ -331,7 +344,7 @@
         for (var k = j + 1; k < endIdx &&
              tokens[k].type !== 'th_close' && tokens[k].type !== 'td_close'; k++) {
           if (tokens[k].type === 'inline') {
-            contentLength += Array.from(tokens[k].content || '').length;
+            contentLength += inlineVisibleLength(tokens[k]);
           }
         }
         preferredWidths[columnIndex] = Math.max(preferredWidths[columnIndex] || 0, contentLength);
@@ -545,6 +558,7 @@
     addGapLineBlocks: addGapLineBlocks,
     handleFenceToken: handleFenceToken,
     handleListToken: handleListToken,
+    inlineVisibleLength: inlineVisibleLength,
     buildTableColgroup: buildTableColgroup,
     handleTableToken: handleTableToken,
     handleBlockquoteToken: handleBlockquoteToken,

--- a/web/style.css
+++ b/web/style.css
@@ -1311,7 +1311,8 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 .native-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   table-layout: auto;
   font-size: 0.925rem;
   margin: 0;
@@ -1343,8 +1344,22 @@ body.dragging { user-select: none; cursor: grabbing; }
   padding: 8px 14px;
   border-bottom: 1px solid var(--crit-border);
 }
-.native-table tbody tr:nth-child(even) td.line-content {
+.native-table tbody tr.table-even td.line-content {
   background: var(--crit-table-stripe);
+}
+.native-table .line-block.has-comment > .line-content {
+  background: var(--crit-comment-range-bg);
+}
+.native-table .line-block:hover > .line-content,
+.native-table .line-block.selected > .line-content,
+.native-table .line-block.form-selected > .line-content {
+  background: var(--crit-brand-subtle);
+}
+.native-table .line-block.focused > .line-content {
+  background: var(--crit-line-focus-bg);
+}
+.native-table .line-block.change-flash > .line-content {
+  animation: change-flash 1s ease-out;
 }
 .native-table .table-last td {
   border-bottom: none;
@@ -1355,6 +1370,20 @@ body.dragging { user-select: none; cursor: grabbing; }
 .native-table-annotation > td {
   padding: 0 24px 0 56px;
 }
+
+/* Rendered round diffs cannot group rows across the two diff sides, so their
+   per-row fallback tables share renderer-generated column widths. */
+.line-content.table-row table.split-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 0.925rem;
+  margin: 0;
+}
+.line-content.table-even td { background: var(--crit-table-stripe); }
+.line-content.table-last td { border-bottom: none; }
+.line-content.table-separator { height: 0; padding: 0; overflow: hidden; }
+.line-block:has(.table-separator) { height: 0; overflow: hidden; min-height: 0; }
 
 .line-content blockquote {
   margin: 6px 0;

--- a/web/style.css
+++ b/web/style.css
@@ -1307,6 +1307,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 .line-content.table-row table.split-table {
   width: 100%;
   border-collapse: collapse;
+  /* Widths come from a shared, content-aware colgroup for every split row. */
   table-layout: fixed;
   font-size: 0.925rem;
   margin: 0;

--- a/web/style.css
+++ b/web/style.css
@@ -1303,52 +1303,57 @@ body.dragging { user-select: none; cursor: grabbing; }
   margin: 4px 0;
 }
 
-/* === Per-row table blocks === */
-.line-content.table-row table.split-table {
+/* === Native rendered tables === */
+.native-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+.native-table {
   width: 100%;
   border-collapse: collapse;
-  /* Widths come from a shared, content-aware colgroup for every split row. */
-  table-layout: fixed;
+  table-layout: auto;
   font-size: 0.925rem;
   margin: 0;
 }
-.line-content.table-row th {
+.native-table .line-block {
+  display: table-row;
+}
+.native-table-gutter {
+  position: relative;
+  width: 44px;
+  min-width: 44px;
+  padding: 0;
+  vertical-align: top;
+}
+.native-table-gutter > .line-gutter {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  width: 44px;
+}
+.native-table th.line-content {
   text-align: left;
   font-weight: 600;
   padding: 10px 14px;
   color: var(--crit-editor-fg-secondary);
   border-bottom: 2px solid var(--crit-border);
 }
-.line-content.table-row td {
+.native-table td.line-content {
   padding: 8px 14px;
   border-bottom: 1px solid var(--crit-border);
 }
-.line-content.table-even td {
+.native-table tbody tr:nth-child(even) td.line-content {
   background: var(--crit-table-stripe);
 }
-.line-content.table-first {
-  border-top: 1px solid var(--crit-border);
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  overflow: hidden;
-}
-.line-content.table-last {
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  overflow: hidden;
-}
-.line-content.table-last td {
+.native-table .table-last td {
   border-bottom: none;
 }
-.line-content.table-separator {
-  height: 0;
-  padding: 0;
-  overflow: hidden;
+.native-table-separator {
+  display: none !important;
 }
-.line-block:has(.table-separator) {
-  height: 0;
-  overflow: hidden;
-  min-height: 0;
+.native-table-annotation > td {
+  padding: 0 24px 0 56px;
 }
 
 .line-content blockquote {

--- a/web/style.css
+++ b/web/style.css
@@ -994,6 +994,9 @@ body.visual-mode .diff-split-row.focused .diff-split-side {
 .deletion-marker.change-flash {
   animation: change-flash 1s ease-out;
 }
+.native-table-annotation.change-flash .deletion-marker {
+  animation: change-flash 1s ease-out;
+}
 
 /* ===== Gutter ===== */
 .line-gutter {


### PR DESCRIPTION
## Summary
- render Markdown tables with native browser column sizing while preserving per-row comments and gutters
- keep table columns aligned in rendered round diffs
- preserve selection, comment forms, change navigation, and deletion-row feedback
- add focused unit and browser coverage for table interactions and layout

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- Go formatting, lint, race-enabled tests, and frontend checks
- full local browser suite
- rendered-table unit and browser coverage

See also: https://github.com/tomasz-tomczyk/crit-web/pull/356