### PR TITLE
fix: send original paths for shared HTML previews

### DIFF
--- a/internal/preview/preview_share_test.go
+++ b/internal/preview/preview_share_test.go
@@ -134,6 +134,14 @@ func TestHandlePreviewPayload_IncludesRemappedComments(t *testing.T) {
 	if got := comments[0].(map[string]any)["file"]; got != previewMainHTMLKey {
 		t.Errorf("comment file = %v, want %q", got, previewMainHTMLKey)
 	}
+	cliArgs, _ := payload["cli_args"].([]any)
+	if len(cliArgs) != 2 || cliArgs[0] != "preview" || cliArgs[1] != sessPath {
+		t.Errorf("cli_args = %v, want [preview %s]", cliArgs, sessPath)
+	}
+	files, _ := payload["files"].([]any)
+	if len(files) == 0 || files[0].(map[string]any)["path"] != previewMainHTMLKey {
+		t.Errorf("files = %v, want entry HTML at %q", files, previewMainHTMLKey)
+	}
 }
 
 // previewSessionWithPin builds a preview Session with two FileEntries: the
@@ -146,6 +154,7 @@ func previewSessionWithPin(dir, origin, review, sessPath string) *Session {
 		ReviewType:     "preview",
 		RepoRoot:       dir,
 		Origin:         origin,
+		CLIArgs:        []string{"preview", sessPath, "ignored-extra"},
 		ReviewFilePath: review,
 		ReviewRound:    1,
 		Files: []*FileEntry{

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
 
@@ -86,6 +87,125 @@ func TestHandleShare_Success(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&result)
 	if result["url"] != "https://crit.md/r/test123" {
 		t.Errorf("url = %v", result["url"])
+	}
+}
+
+func TestHandleShare_FreshPreviewPreservesMetadataWithoutReviewFile(t *testing.T) {
+	testutil.SetHome(t, t.TempDir())
+	dir := t.TempDir()
+	originalPath := filepath.Join("artifacts", "reports", "checkout.html")
+	origin := filepath.Join(dir, originalPath)
+	if err := os.MkdirAll(filepath.Dir(origin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(origin, []byte("<!doctype html><h1>Checkout</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured map[string]any
+	critWeb := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"url":          "https://crit.md/r/preview123",
+			"delete_token": "tok_preview",
+		})
+	}))
+	defer critWeb.Close()
+
+	sess := &Session{
+		Mode:        "files",
+		ReviewType:  "preview",
+		RepoRoot:    dir,
+		OutputDir:   dir,
+		Origin:      origin,
+		ReviewRound: 1,
+		Files: []*FileEntry{{
+			Path: originalPath, AbsPath: origin, FileType: "code", Content: "<!doctype html><h1>Checkout</h1>",
+		}},
+	}
+	sess.InitTestChannels()
+	s, err := NewServer(sess, frontendFS, critWeb.URL, false, "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.authMu.Lock()
+	s.cfg.ShareConsented = true
+	s.authMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/share", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	cliArgs, _ := captured["cli_args"].([]any)
+	if len(cliArgs) != 2 || cliArgs[0] != "preview" || cliArgs[1] != origin {
+		t.Errorf("cli_args = %v, want [preview %s]", cliArgs, origin)
+	}
+	files, _ := captured["files"].([]any)
+	if len(files) != 1 || files[0].(map[string]any)["path"] != session.PreviewMainHTMLKey {
+		t.Errorf("files = %v, want entry HTML at %q", files, session.PreviewMainHTMLKey)
+	}
+
+	// A stale review file must not override the live preview's canonical path.
+	stale, err := json.Marshal(CritJSON{CliArgs: []string{"files", "stale.html"}, Files: map[string]CritJSONFile{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewPath := session.ReviewPathsFor(sess.CritJSONPath()).Review
+	if err := os.MkdirAll(filepath.Dir(reviewPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.shareCLIArgsForSession(sess); len(got) != 2 || got[0] != "preview" || got[1] != origin {
+		t.Errorf("cli args with stale persisted metadata = %v, want [preview %s]", got, origin)
+	}
+}
+
+func TestShareCLIArgsForSession_PreviewFallbacks(t *testing.T) {
+	s := &Server{}
+
+	if got := s.shareCLIArgsForSession(nil); got != nil {
+		t.Fatalf("nil session cli args = %v, want nil", got)
+	}
+
+	live := &Session{ReviewType: "preview", CLIArgs: []string{"preview", "live.html", "ignored"}}
+	if got := s.shareCLIArgsForSession(live); len(got) != 2 || got[0] != "preview" || got[1] != "live.html" {
+		t.Fatalf("live session cli args = %v, want [preview live.html]", got)
+	}
+
+	empty := &Session{ReviewType: "preview"}
+	if got := s.shareCLIArgsForSession(empty); got != nil {
+		t.Fatalf("empty preview cli args = %v, want nil", got)
+	}
+}
+
+func TestShareCLIArgsForSession_NormalizesPersistedPreviewArgs(t *testing.T) {
+	dir := t.TempDir()
+	sess := &Session{ReviewType: "preview", OutputDir: dir, RepoRoot: dir}
+	persisted, err := json.Marshal(CritJSON{
+		CliArgs: []string{"preview", "persisted.html", "ignored"},
+		Files:   map[string]CritJSONFile{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewPath := session.ReviewPathsFor(sess.CritJSONPath()).Review
+	if err := os.MkdirAll(filepath.Dir(reviewPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, persisted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := (&Server{}).shareCLIArgsForSession(sess); len(got) != 2 || got[0] != "preview" || got[1] != "persisted.html" {
+		t.Fatalf("persisted cli args = %v, want [preview persisted.html]", got)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -900,6 +900,30 @@ func (s *Server) shareFilesForSession() (files []ShareFile, reviewType string, e
 	return sess.LoadShareFilesFromDisk(), "", nil
 }
 
+// shareCLIArgsForSession prefers persisted metadata. Preview metadata is
+// normalized to the canonical ["preview", path] shape and falls back to the
+// live session when the persisted value is stale or malformed. File-review
+// sessions retain their existing review.json-only behavior.
+func (s *Server) shareCLIArgsForSession(sess *Session) []string {
+	if sess == nil {
+		return nil
+	}
+	cliArgs := share.LoadCliArgsFromReviewFile(sess.CritJSONPath())
+	if sess.ReviewType != "preview" {
+		return cliArgs
+	}
+	if len(cliArgs) >= 2 && cliArgs[0] == "preview" && cliArgs[1] != "" {
+		return []string{"preview", cliArgs[1]}
+	}
+	if len(sess.CLIArgs) >= 2 && sess.CLIArgs[0] == "preview" && sess.CLIArgs[1] != "" {
+		return []string{"preview", sess.CLIArgs[1]}
+	}
+	if sess.Origin != "" {
+		return []string{"preview", sess.Origin}
+	}
+	return nil
+}
+
 func (s *Server) writeExistingShareIfPresent(w http.ResponseWriter) (bool, error) {
 	// Uses GetShareState() to read both fields under a single lock (avoids TOCTOU race
 	// where a concurrent DELETE /api/share-url could clear the token between two calls).
@@ -1000,7 +1024,8 @@ func (s *Server) handleShare(w http.ResponseWriter, r *http.Request) {
 		commentPaths = scopePaths
 	}
 
-	res, err := share.ShareReviewFiles(critPath, files, commentPaths, s.shareURL, s.authTokenSnapshot(), s.author, shareReq.Org, shareReq.Visibility, reviewType)
+	cliArgs := s.shareCLIArgsForSession(s.session.Load())
+	res, err := share.ShareReviewFilesWithCLIArgs(critPath, files, commentPaths, s.shareURL, s.authTokenSnapshot(), s.author, cliArgs, shareReq.Org, shareReq.Visibility, reviewType)
 	if err != nil {
 		if errors.Is(err, share.ErrShareUnauthorized) {
 			auth.ClearAuthIdentity()
@@ -1200,7 +1225,7 @@ func (s *Server) handlePreviewPayload(w http.ResponseWriter, r *http.Request) {
 	if reviewRound == 0 {
 		reviewRound = 1
 	}
-	writeJSON(w, share.BuildSharePayload(files, comments, reviewRound, nil, "", "", "preview"))
+	writeJSON(w, share.BuildSharePayload(files, comments, reviewRound, s.shareCLIArgsForSession(sess), "", "", "preview"))
 }
 
 // handleUpsertPayload returns the JSON payload that would be PUT to

--- a/internal/share/cli.go
+++ b/internal/share/cli.go
@@ -48,7 +48,7 @@ func postPreviewShare(htmlPath, svcURL, authToken string) (string, error) {
 		return "", fmt.Errorf("crawling preview assets: %w", err)
 	}
 
-	payload := BuildSharePayload(files, nil, 1, nil, "", "", "preview")
+	payload := BuildSharePayload(files, nil, 1, []string{"preview", htmlPath}, "", "", "preview")
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return "", fmt.Errorf("marshaling preview payload: %w", err)

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -244,6 +244,16 @@ func remapPreviewCommentFiles(comments []ShareComment) {
 // and POSTs the files to crit-web. Used by both the CLI (`crit share`) and the
 // server's POST /api/share endpoint so payload wiring stays in one place.
 func ShareReviewFiles(critPath string, files []ShareFile, filePaths []string, svcURL, authToken, fallbackAuthor, org, visibility, reviewType string) (ShareReviewFilesResult, error) {
+	return ShareReviewFilesWithCLIArgs(
+		critPath, files, filePaths, svcURL, authToken, fallbackAuthor,
+		LoadCliArgsFromReviewFile(critPath), org, visibility, reviewType,
+	)
+}
+
+// ShareReviewFilesWithCLIArgs is ShareReviewFiles with caller-supplied CLI
+// metadata. Server-backed sessions use it so a first share can preserve the
+// live session arguments before review.json has been written.
+func ShareReviewFilesWithCLIArgs(critPath string, files []ShareFile, filePaths []string, svcURL, authToken, fallbackAuthor string, cliArgs []string, org, visibility, reviewType string) (ShareReviewFilesResult, error) {
 	comments, reviewRound := LoadCommentsForShare(critPath, filePaths, fallbackAuthor)
 	if reviewType == "preview" {
 		// Preview comments are stored under the session's on-disk path (passed
@@ -251,7 +261,6 @@ func ShareReviewFiles(critPath string, files []ShareFile, filePaths []string, sv
 		// previewMainHTMLKey — re-key so crit-web attaches them to that entry.
 		remapPreviewCommentFiles(comments)
 	}
-	cliArgs := LoadCliArgsFromReviewFile(critPath)
 
 	url, deleteToken, err := shareFilesToWeb(files, comments, svcURL, reviewRound, authToken, cliArgs, org, visibility, reviewType)
 	if err != nil {

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -16,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
 func critWebURL(t *testing.T) string {
@@ -457,6 +460,58 @@ func documentFromAPI(t *testing.T, baseURL, token string) []map[string]any {
 }
 
 // --- New test cases ---
+
+// TestShareSyncPreviewPreservesOriginalPath verifies the standalone preview
+// share keeps the source path as display metadata without renaming the crawled
+// entry HTML artifact.
+func TestShareSyncPreviewPreservesOriginalPath(t *testing.T) {
+	baseURL := critWebURL(t)
+	binary := critBinary(t)
+	dir := t.TempDir()
+	originalPath := filepath.Join("artifacts", "reports", "checkout.html")
+
+	if err := os.MkdirAll(filepath.Join(dir, "artifacts", "reports"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, originalPath), []byte("<!doctype html><title>Checkout</title><h1>Checkout</h1>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runCritCmd(t, binary, dir,
+		"share", "--share-url", baseURL, "--preview", originalPath)
+	if err != nil {
+		t.Fatalf("crit share --preview failed: %s\n%s", err, output)
+	}
+	logReview(t, output)
+	token := extractToken(t, output)
+
+	files := documentFromAPI(t, baseURL, token)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 crawled file, got %d", len(files))
+	}
+	if files[0]["path"] != session.PreviewMainHTMLKey {
+		t.Errorf("preview artifact path = %v, want %q", files[0]["path"], session.PreviewMainHTMLKey)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("%s/r/%s", baseURL, token))
+	if err != nil {
+		t.Fatalf("review page request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("review page returned %d", resp.StatusCode)
+	}
+	page, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading review page: %v", err)
+	}
+	pageHTML := string(page)
+	titleStart := strings.Index(pageHTML, "<title")
+	titleEnd := strings.Index(pageHTML, "</title>")
+	if titleStart == -1 || titleEnd <= titleStart || !strings.Contains(pageHTML[titleStart:titleEnd], originalPath) {
+		t.Errorf("review page title does not contain original preview path %q", originalPath)
+	}
+}
 
 // TestShareSyncNoComments verifies sharing a file with no comments.
 func TestShareSyncNoComments(t *testing.T) {

--- a/internal/share/share_preview_test.go
+++ b/internal/share/share_preview_test.go
@@ -25,9 +25,10 @@ func TestParseShareFlagsPreview(t *testing.T) {
 }
 
 // TestPostPreviewShareDispatch verifies the --preview path crawls the local
-// HTML file (plus its assets) and POSTs a payload with review_type=preview and
-// a base64-encoded binary entry. A stub server stands in for crit-web so the
-// test exercises the full dispatch seam without the network.
+// HTML file (plus its assets) and POSTs a payload with review_type=preview,
+// original path metadata, and a base64-encoded binary entry. A stub server
+// stands in for crit-web so the test exercises the full dispatch seam without
+// the network.
 func TestPostPreviewShareDispatch(t *testing.T) {
 	dir := t.TempDir()
 	writeSharePreviewFixture(t, dir)
@@ -56,6 +57,11 @@ func TestPostPreviewShareDispatch(t *testing.T) {
 
 	if got["review_type"] != "preview" {
 		t.Errorf("review_type = %v, want preview", got["review_type"])
+	}
+	wantPath := filepath.Join(dir, "index.html")
+	cliArgs, ok := got["cli_args"].([]any)
+	if !ok || len(cliArgs) != 2 || cliArgs[0] != "preview" || cliArgs[1] != wantPath {
+		t.Errorf("cli_args = %v, want [preview %s]", got["cli_args"], wantPath)
 	}
 
 	files, ok := got["files"].([]any)


### PR DESCRIPTION
## Summary

- send canonical `["preview", original_path]` metadata for standalone, direct browser, and proxy-auth preview shares
- keep the crawled HTML artifact path as `index.html`
- normalize stale or malformed persisted preview metadata from the live session
- add a real crit → crit-web E2E asserting both the stored artifact key and rendered page title

## Tests

- pre-commit checks
- race tests for server/share/preview packages
- `scripts/e2e-share.sh -run TestShareSyncPreviewPreservesOriginalPath` against the companion crit-web branch

Companion web change: tomasz-tomczyk/crit-web#357

Closes #833