### PR TITLE
chore: Make plain wt switch -c tip at origin/main

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,7 +1,19 @@
-# Trust mise.toml before the worktree's shell auto-loads mise — otherwise
-# the shell entry triggers a mise parse error and aborts subsequent hooks.
 # Array-of-tables form ([[pre-start]]) — the deprecated [pre-start] table form
 # changes behavior in future worktrunk versions.
+
+# Local main is often stale (checked out in the primary worktree, rarely
+# pulled). When creating from the default base, tip the new branch at
+# origin/main so plain `wt switch -c` matches an explicit `-b origin/main`.
+# Skipped for stacked creates (`-b @`, `-b other-feature`).
+[[pre-start]]
+sync-origin = """
+{% if base and base == default_branch %}
+git fetch origin {{ default_branch }} && git reset --hard origin/{{ default_branch }}
+{% endif %}
+"""
+
+# Trust mise.toml before the worktree's shell auto-loads mise — otherwise
+# the shell entry triggers a mise parse error and aborts subsequent hooks.
 [[pre-start]]
 mise-trust = "mise trust ."
 


### PR DESCRIPTION
## Summary
- Add a Worktrunk `pre-start` hook that fetches and resets new default-base branches to `origin/main`
- Fixes stale local `main` so agents can use plain `wt switch -c` without `-b origin/main`
- Stacked creates (`-b @`, other bases) are unchanged

## Test plan
- [x] `wt switch -c <branch>` (no flags) → `HEAD == origin/main` while local `main` was behind
- [x] `wt switch -c -b @ <stacked>` keeps the stack tip (sync skipped)
- [ ] Reviewer: create a throwaway worktree with plain `wt switch -c` and confirm tip matches `origin/main`


Made with [Cursor](https://cursor.com)