### PR TITLE
fix: preserve preview CLI args on re-share and detect GitHub PR URLs

### DIFF
--- a/internal/forge/cli.go
+++ b/internal/forge/cli.go
@@ -19,8 +19,12 @@ func RunPull(args []string) error {
 	if err != nil {
 		return err
 	}
-	if kind == Auto && argsContainMRURL(cleanArgs) {
-		kind = GitLab
+	if kind == Auto {
+		if argsContainMRURL(cleanArgs) {
+			kind = GitLab
+		} else if argsContainPRURL(cleanArgs) {
+			kind = GitHub
+		}
 	}
 	request, err := parsePullRequest(cleanArgs)
 	if err != nil {
@@ -40,8 +44,12 @@ func RunPush(args []string) error {
 	if err != nil {
 		return err
 	}
-	if kind == Auto && argsContainMRURL(cleanArgs) {
-		kind = GitLab
+	if kind == Auto {
+		if argsContainMRURL(cleanArgs) {
+			kind = GitLab
+		} else if argsContainPRURL(cleanArgs) {
+			kind = GitHub
+		}
 	}
 	request, err := parsePushRequest(cleanArgs)
 	if err != nil {
@@ -114,6 +122,15 @@ func extractKindFlag(args []string) (Kind, []string, error) {
 func argsContainMRURL(args []string) bool {
 	for _, arg := range args {
 		if strings.Contains(arg, "/-/merge_requests/") {
+			return true
+		}
+	}
+	return false
+}
+
+func argsContainPRURL(args []string) bool {
+	for _, arg := range args {
+		if strings.Contains(arg, "/pull/") {
 			return true
 		}
 	}

--- a/internal/forge/cli_test.go
+++ b/internal/forge/cli_test.go
@@ -97,6 +97,15 @@ func TestArgsContainMRURL(t *testing.T) {
 	}
 }
 
+func TestArgsContainPRURL(t *testing.T) {
+	if !argsContainPRURL([]string{"https://github.com/a/b/pull/4"}) {
+		t.Fatal("PR URL not detected")
+	}
+	if argsContainPRURL([]string{"https://gitlab.example.com/a/b/-/merge_requests/4"}) {
+		t.Fatal("GitLab URL detected as PR")
+	}
+}
+
 func TestRunPullSelectsGitLabFromURLAndDispatches(t *testing.T) {
 	provider := &cliTestProvider{kind: GitLab}
 	selected := withCLIProvider(t, provider)
@@ -109,6 +118,35 @@ func TestRunPullSelectsGitLabFromURLAndDispatches(t *testing.T) {
 	}
 	if provider.pullRequest.OutputDir != "reviews" || provider.pullRequest.ChangeSpec != url {
 		t.Fatalf("pull request = %+v", provider.pullRequest)
+	}
+}
+
+func TestRunPullSelectsGitHubFromPRURLBeforeRemoteDetection(t *testing.T) {
+	gitHubProvider := &cliTestProvider{kind: GitHub}
+	gitLabProvider := &cliTestProvider{kind: GitLab}
+	oldSelect := SelectProviderFn
+	var selected Kind
+	SelectProviderFn = func(kind Kind) (Provider, error) {
+		selected = kind
+		if kind == Auto {
+			return gitLabProvider, nil
+		}
+		return gitHubProvider, nil
+	}
+	t.Cleanup(func() { SelectProviderFn = oldSelect })
+
+	url := "https://github.com/acme/widget/pull/9"
+	if err := RunPull([]string{"--output", "reviews", url}); err != nil {
+		t.Fatal(err)
+	}
+	if selected != GitHub {
+		t.Fatalf("selected provider = %q, want github", selected)
+	}
+	if gitHubProvider.pullRequest.ChangeSpec != url {
+		t.Fatalf("GitHub pull request = %+v, want URL %q", gitHubProvider.pullRequest, url)
+	}
+	if gitLabProvider.pullRequest.ChangeSpec != "" {
+		t.Fatalf("GitLab provider received request despite GitHub PR URL: %+v", gitLabProvider.pullRequest)
 	}
 }
 

--- a/internal/server/handle_share_round_test.go
+++ b/internal/server/handle_share_round_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -206,6 +207,77 @@ func TestShareCLIArgsForSession_NormalizesPersistedPreviewArgs(t *testing.T) {
 
 	if got := (&Server{}).shareCLIArgsForSession(sess); len(got) != 2 || got[0] != "preview" || got[1] != "persisted.html" {
 		t.Fatalf("persisted cli args = %v, want [preview persisted.html]", got)
+	}
+}
+
+func newPreviewReshareTestServer(t *testing.T) (*Server, *Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	origin := filepath.Join(dir, "original-preview.html")
+	if err := os.WriteFile(origin, []byte("<!doctype html><h1>Preview</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sess := &Session{
+		Mode:        "files",
+		ReviewType:  "preview",
+		RepoRoot:    dir,
+		OutputDir:   dir,
+		Origin:      origin,
+		CLIArgs:     []string{"preview", origin},
+		ReviewRound: 1,
+		Files: []*FileEntry{{
+			Path: "original-preview.html", AbsPath: origin, Content: "<!doctype html><h1>Preview</h1>",
+		}},
+	}
+	sess.InitTestChannels()
+	stale, err := json.Marshal(CritJSON{
+		CliArgs: []string{"files", "stale.md"},
+		Files:   map[string]CritJSONFile{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewPath := session.ReviewPathsFor(sess.CritJSONPath()).Review
+	if err := os.MkdirAll(filepath.Dir(reviewPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewServer(sess, frontendFS, "", false, "", "", "test", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, sess, origin
+}
+
+func TestHandleUpsertPayload_PreviewPreservesOriginalCLIPath(t *testing.T) {
+	s, _, origin := newPreviewReshareTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/share/upsert-payload", nil)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var payload struct {
+		CLIArgs []string `json:"cli_args"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(payload.CLIArgs, []string{"preview", origin}) {
+		t.Fatalf("cli_args = %v, want [preview %s]", payload.CLIArgs, origin)
+	}
+}
+
+func TestReshareUpsertInputs_PreviewPreservesOriginalCLIPath(t *testing.T) {
+	s, sess, origin := newPreviewReshareTestServer(t)
+	_, _, cfg, err := s.reshareUpsertInputs(sess, "https://crit.md/r/preview", "delete-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cfg.CliArgs, []string{"preview", origin}) {
+		t.Fatalf("cli args = %v, want [preview %s]", cfg.CliArgs, origin)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1267,7 +1267,7 @@ func (s *Server) handleUpsertPayload(w http.ResponseWriter, r *http.Request) {
 		}
 		comments, reviewRound = share.LoadCommentsForShare(critPath, filePaths, s.author)
 	}
-	cliArgs := share.LoadCliArgsFromReviewFile(critPath)
+	cliArgs := s.shareCLIArgsForSession(sess)
 	deleteToken := sess.GetDeleteToken()
 	writeJSON(w, buildUpsertPayload(files, comments, deleteToken, reviewRound, cliArgs))
 }
@@ -1383,7 +1383,7 @@ func (s *Server) reshareUpsertInputs(sess *Session, hostedURL, deleteToken strin
 		ShareURL:    hostedURL,
 		DeleteToken: deleteToken,
 		ReviewRound: sess.ReviewRound,
-		CliArgs:     share.LoadCliArgsFromReviewFile(critPath),
+		CliArgs:     s.shareCLIArgsForSession(sess),
 	}
 	if data, readErr := session.ReadFileShared(review.ReviewPathsFor(critPath).Review); readErr == nil {
 		var onDisk CritJSON
@@ -1391,9 +1391,6 @@ func (s *Server) reshareUpsertInputs(sess *Session, hostedURL, deleteToken strin
 			existingCfg.LastShareHash = onDisk.LastShareHash
 			if onDisk.ReviewRound > 0 {
 				existingCfg.ReviewRound = onDisk.ReviewRound
-			}
-			if len(onDisk.CliArgs) > 0 {
-				existingCfg.CliArgs = onDisk.CliArgs
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Wire upsert/reshare share paths through `shareCLIArgsForSession` so preview re-shares keep the original preview path (completes #835 coverage).
- In Auto forge mode, force GitHub when args look like a PR URL (MR URLs already force GitLab).

## Test plan
- [x] `go test ./internal/server -run 'Test(HandleUpsertPayload|ReshareUpsertInputs)_PreviewPreservesOriginalCLIPath'`
- [x] `go test ./internal/forge -run 'TestArgsContain(MR|PR)URL|TestRunPullSelects(GitHub|GitLab)From'`
- [x] Pre-commit full suite


Made with [Cursor](https://cursor.com)