### PR TITLE
test: isolate default branch cache in lazy threshold test

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3056,9 +3056,17 @@ func TestEnsureLoadedNotLazy(t *testing.T) {
 }
 
 func TestNewSessionFromGitLazyThreshold(t *testing.T) {
+	// DefaultBranch is cached process-wide, while this test creates a fresh
+	// repository whose branch is renamed to main after its initial commit.
+	// Reset the cache so an earlier test cannot make the merge-base lookup use
+	// a stale branch name and accidentally include README.md in the change set.
+	vcs.ResetDefaultBranchOnceForTest()
 	dir := initTestRepo(t)
 	vcs.SetDefaultBranchOverride("")
-	defer func() { vcs.SetDefaultBranchOverride("") }()
+	defer func() {
+		vcs.SetDefaultBranchOverride("")
+		vcs.ResetDefaultBranchOnceForTest()
+	}()
 
 	gitT(t, dir, "checkout", "-b", "feature-many-files")
 	for i := 0; i < 120; i++ {


### PR DESCRIPTION
## Flaky failure

The `Coverage` run [32020360466](https://github.com/tomasz-tomczyk/crit/actions/runs/32020360466) failed in `TestNewSessionFromGitLazyThreshold` with `expected 120 files, got 121`. The identical failed run passed when rerun without code changes (attempt 2), confirming nondeterministic test-process state rather than a product assertion failure.

## Root cause

The test creates a fresh temporary repository, but `vcs.DefaultBranch()` caches the detected default branch process-wide. An earlier test could leave that cache pointing at a stale branch name, causing the merge-base lookup to fall back to the working-tree change set and include the initial `README.md`.

## Fix

Reset the default-branch cache before and after the test so the temporary repository is isolated from prior tests. This preserves the lazy-loading assertions and does not weaken coverage or production behavior.

## Tests

- `mise exec -- go test ./internal/session -run '^TestNewSessionFromGitLazyThreshold$' -count=100`
- `mise exec -- go test ./internal/session -count=2`
- `mise exec -- go test ./...`
- Pre-commit checks (gofmt, golangci-lint, tests, ESLint, Stylelint) passed locally.
