### PR TITLE
fix: wrap overflowing markdown table cells

### DIFF
--- a/test/e2e/tests/rendered-tables.spec.ts
+++ b/test/e2e/tests/rendered-tables.spec.ts
@@ -46,6 +46,9 @@ test.describe('Native rendered tables', () => {
 
     const layout = await table.evaluate(element => getComputedStyle(element).tableLayout);
     expect(layout).toBe('auto');
+    const wrap = await table.locator('thead th.line-content').first()
+      .evaluate(element => getComputedStyle(element).overflowWrap);
+    expect(wrap).toBe('break-word');
 
     const wrapper = table.locator('..');
     const borderWidth = await wrapper.evaluate(element => getComputedStyle(element).borderTopWidth);

--- a/web/app.js
+++ b/web/app.js
@@ -3330,12 +3330,18 @@
     let activeTableHead = null;
     let activeTableBody = null;
 
+    function nativeTableColCount(section) {
+      const table = section.closest('table');
+      const sample = table && table.querySelector('tr.line-block:not(.native-table-separator)');
+      return (sample && sample.cells.length) || 1;
+    }
+
     function appendTableAnnotation(section, element) {
       const row = document.createElement('tr');
       row.className = 'native-table-annotation';
       if (element.dataset.filePath) row.dataset.filePath = element.dataset.filePath;
       const cell = document.createElement('td');
-      cell.colSpan = 100;
+      cell.colSpan = nativeTableColCount(section);
       cell.appendChild(element);
       row.appendChild(cell);
       section.appendChild(row);

--- a/web/style.css
+++ b/web/style.css
@@ -1314,6 +1314,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 .native-table {
   width: 100%;
+  max-width: 100%;
   border-collapse: separate;
   border-spacing: 0;
   table-layout: auto;
@@ -1336,6 +1337,10 @@ body.dragging { user-select: none; cursor: grabbing; }
   box-sizing: border-box;
   width: 44px;
 }
+.native-table th.line-content,
+.native-table td.line-content {
+  overflow-wrap: break-word;
+}
 .native-table th.line-content {
   text-align: left;
   font-weight: 600;
@@ -1346,6 +1351,10 @@ body.dragging { user-select: none; cursor: grabbing; }
 .native-table td.line-content {
   padding: 8px 14px;
   border-bottom: 1px solid var(--crit-border);
+}
+.native-table .line-content code {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 .native-table tbody tr.table-even td.line-content {
   background: var(--crit-table-stripe);


### PR DESCRIPTION
## Summary
- Wrap overflowing native markdown table cells with `overflow-wrap: break-word` while keeping `table-layout: auto`, so short columns stay content-sized instead of splitting equally or forcing a horizontal scrollbar.
- Span comment annotation rows by the table's real column count instead of `colspan=100`, so commenting across rows cannot collapse cells.
- Assert wrap mode in the native-table e2e spec.

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- `npx playwright test tests/rendered-tables.spec.ts` (6 passed)
- Pre-commit: gofmt, golangci-lint, `go test`, ESLint, Stylelint

See also: tomasz-tomczyk/crit-web#362