### PR TITLE
test: isolate default branch cache in lazy threshold test

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3056,9 +3056,17 @@ func TestEnsureLoadedNotLazy(t *testing.T) {
 }
 
 func TestNewSessionFromGitLazyThreshold(t *testing.T) {
+	// DefaultBranch is cached process-wide, while this test creates a fresh
+	// repository whose branch is renamed to main after its initial commit.
+	// Reset the cache so an earlier test cannot make the merge-base lookup use
+	// a stale branch name and accidentally include README.md in the change set.
+	vcs.ResetDefaultBranchOnceForTest()
 	dir := initTestRepo(t)
 	vcs.SetDefaultBranchOverride("")
-	defer func() { vcs.SetDefaultBranchOverride("") }()
+	defer func() {
+		vcs.SetDefaultBranchOverride("")
+		vcs.ResetDefaultBranchOnceForTest()
+	}()
 
 	gitT(t, dir, "checkout", "-b", "feature-many-files")
 	for i := 0; i < 120; i++ {


### PR DESCRIPTION
## Summary
- Fixes the flaky `TestNewSessionFromGitLazyThreshold` test.
- Resets the process-wide default-branch cache before and after the test so prior tests cannot leak a stale branch name into the fresh repository fixture.
- Preserves the test's 120-file assertion and coverage.

## Evidence
- Failed workflow: https://github.com/tomasz-tomczyk/crit/actions/runs/32013289232 (`TestNewSessionFromGitLazyThreshold`: expected 120 files, got 121).
- Rerun of the unchanged failing SHA passed: https://github.com/tomasz-tomczyk/crit/actions/runs/32013289232.
- The extra file was `README.md`, consistent with the cached default-branch lookup using stale fixture state.

## Root cause and fix
`DefaultBranch` is cached process-wide. This test creates a temporary repository whose initial branch is renamed to `main`; if an earlier test initializes the cache differently, the merge-base lookup can include the fixture's README and produce 121 files. The test now explicitly resets the cache around its isolated repository setup and cleanup.

## Tests
- `mise exec -- go test ./internal/session -run 'TestNewSessionFromGitLazyThreshold' -count=20`
- `mise exec -- go test ./internal/session`
- `mise exec -- go test ./...`
- `mise exec -- gofmt -l .` (clean)
