### PR TITLE
deps: bump typesetting past the CFF2 INDEX allocation bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require golang.org/x/net v0.55.0
 require github.com/gorilla/websocket v1.5.3
 
 require golang.org/x/image v0.44.0
+
+replace github.com/go-text/typesetting => github.com/felix-dumit/typesetting v0.3.5-0.20260820032151-e2bdb1c6edd8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=
-github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
+github.com/felix-dumit/typesetting v0.3.5-0.20260820032151-e2bdb1c6edd8 h1:ugmKpi7vRbr5MGZPK1usNMnn+/HS3xoFAu1ss4cYOSo=
+github.com/felix-dumit/typesetting v0.3.5-0.20260820032151-e2bdb1c6edd8/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=


### PR DESCRIPTION
## Why

`/api/code-fonts` parses every font on the system. On macOS one of them,
`/System/Library/Fonts/SFIndia.ttc`, makes typesetting `v0.3.4` allocate tens of
GB before panicking — its CFF2 INDEX parser sizes a slice from an unvalidated
`uint32` count.

`safelyInspectCodeFont` recovers the panic, so discovery returns normally and
nothing is logged. The allocation still happened, and Go does not hand it back
on Darwin. A `_serve` process after one Settings open went 7.6 GB → 2.5 GB and
stayed at 2.5 GB for the rest of its life.

Full system font scan (`TestDiscoverCodeFontFamiliesScansTheCurrentSystem`):

| | peak RSS |
|---|---|
| `v0.3.4` | ~14.9 GB |
| this PR | **469 MB** |

## What

Bumps typesetting to a pseudo-version off upstream `main`, which carries the fix
(go-text/typesetting `9e0086e` and `4b2141b`). No tagged release has it yet —
`v0.3.4` predates both. Worth swapping for a normal version tag once upstream
cuts one.

## Testing

`go build ./...` and `go test ./internal/server/` both clean.
