### PR TITLE
fix(web): don't load every lazy file on the create-time details toggle

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -40,7 +40,7 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	}
 
 	// Use a transport with DisableCompression=true so http.Transport does
-	// not silently re-add Accept-Encoding: gzip after our Director strips
+	// not silently re-add Accept-Encoding: gzip after our Rewrite strips
 	// it. Stripping matters because we need the upstream body uncompressed
 	// in order to inject scripts.
 	transport := &http.Transport{
@@ -53,21 +53,19 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	}
 
 	rp := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.Host = target.Host
-			req.Header.Del("Accept-Encoding")
-			req.Header.Del("If-None-Match")
-			req.Header.Del("If-Modified-Since")
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			pr.Out.Header.Del("Accept-Encoding")
+			pr.Out.Header.Del("If-None-Match")
+			pr.Out.Header.Del("If-Modified-Since")
 			if upstreamCookies != "" {
-				req.Header.Set("Cookie", upstreamCookies)
+				pr.Out.Header.Set("Cookie", upstreamCookies)
 			}
-			if req.Header.Get("Origin") != "" {
-				req.Header.Set("Origin", target.Scheme+"://"+target.Host)
+			if pr.Out.Header.Get("Origin") != "" {
+				pr.Out.Header.Set("Origin", target.Scheme+"://"+target.Host)
 			}
-			if req.Header.Get("Referer") != "" {
-				req.Header.Set("Referer", target.Scheme+"://"+target.Host+req.URL.Path)
+			if pr.Out.Header.Get("Referer") != "" {
+				pr.Out.Header.Set("Referer", target.Scheme+"://"+target.Host+pr.Out.URL.Path)
 			}
 		},
 		Transport:      transport,

--- a/web/__tests__/defer-file-body.test.js
+++ b/web/__tests__/defer-file-body.test.js
@@ -27,10 +27,14 @@ test('file body mount/unmount helpers are wired into details toggle without init
   assert.match(appSrc, /function deferFileBody\s*\(/);
   assert.match(appSrc, /function populateFileBody\s*\(/);
   assert.match(appSrc, /data-body-deferred/);
-  // Setting open before the listener means there is no synthetic first toggle
-  // to swallow — an initialToggle flag would drop the first real user toggle.
+  // Setting open before the listener does still deliver a synthetic toggle:
+  // it is queued, not fired. Gate the lazy fetch on the open state actually
+  // changing, not on an event count — an initialToggle flag would drop the
+  // first real user toggle, and ungated it loads every file in the review.
   assert.doesNotMatch(appSrc, /initialToggle/);
-  assert.match(appSrc, /if \(section\.open\) \{\s*if \(file\.lazy\) loadLazyFile\(section, file\);\s*else ensureFileBodyMounted\(section, file\);/s);
+  assert.match(appSrc, /if \(readerToggled\) loadLazyFile\(section, file\);/);
+  // Eager files must still mount, so a review under the threshold renders full.
+  assert.match(appSrc, /\} else \{\s*ensureFileBodyMounted\(section, file\);/s);
   assert.match(appSrc, /else if \(!fileHasOpenLineForms\(file\.path\)\) \{\s*deferFileBody\(section\);/s);
 });
 

--- a/web/app.js
+++ b/web/app.js
@@ -2645,14 +2645,23 @@
       }
       // Expanding: let native <details> handle it
     });
-    // open is set before this listener is attached, so the create-time open
-    // does not fire toggle here. Do not gate the first event — that would
-    // swallow the user's first collapse/expand.
+    // Setting .open above queues a toggle event rather than firing one, so it
+    // arrives here after this listener is attached. Loading a lazy file for
+    // that synthetic event pulls in the whole review at once. Track the last
+    // state, not the first event — a real toggle always flips it.
+    let lastOpen = section.open;
     section.addEventListener('toggle', function() {
+      const readerToggled = section.open !== lastOpen;
+      lastOpen = section.open;
       file.collapsed = !section.open;
       if (section.open) {
-        if (file.lazy) loadLazyFile(section, file);
-        else ensureFileBodyMounted(section, file);
+        // Eager files mount either way — under the threshold the whole
+        // review is meant to render.
+        if (file.lazy) {
+          if (readerToggled) loadLazyFile(section, file);
+        } else {
+          ensureFileBodyMounted(section, file);
+        }
       } else if (!fileHasOpenLineForms(file.path)) {
         deferFileBody(section);
       }


### PR DESCRIPTION
On a large review, crit renders every line of every changed file as soon as the page opens. The main thread is then blocked long enough that the UI stops responding — clicks queue, scrolling stalls, and collapsing a file takes over a second.

Severity tracks the total number of rendered diff lines, not the file count. A 400-file review with a one-line change each is fine today; a 300-file review with 9,000 changed lines is not.

## Root cause

`renderFileSection` sets `section.open` before attaching the toggle listener, and the comment there says the create-time open therefore doesn't reach the handler:

```js
// open is set before this listener is attached, so the create-time open
// does not fire toggle here.
```

It does reach it. Setting `open` **queues** a details toggle task rather than firing synchronously, so the event arrives *after* the listener is attached. Every section reports an "expand" the reader never performed, and the handler calls `loadLazyFile` for it — fetching and mounting the entire review at load, regardless of viewport.

The deferred-body + IntersectionObserver + `lazyFileThreshold` machinery already in `app.js` exists to prevent exactly this. It never ran. Instrumenting the mount call sites on a 300-file review showed the IntersectionObserver performing **0 mounts**, with all 275 lazy files loaded from the toggle handler — one of them for a section 543,948px below the viewport.

## Reproduce

Any repo with more than `lazyFileThreshold` (25) changed files shows the wrong mount count:

```bash
mkdir repro && cd repro && git init -q && mkdir pkg
for i in $(seq 1 300); do printf 'package pkg\n\nconst K%d = "a"\n' $i > pkg/f_$i.go; done
git add -A && git commit -qm base
for i in $(seq 1 300); do perl -pi -e 's/"a"/"b"/' pkg/f_$i.go; done
crit
```

In the browser console, without scrolling:

```js
document.querySelectorAll('.file-body:not([data-body-deferred])').length
// before: 300      after: 25   (lazyFileThreshold — the intended eager set)
```

To feel the slowness rather than just count it, give each file a real diff — 120 lines with every fourth line changed, ~9,000 changed lines total — and the numbers below follow.

## Fix

Gate on whether the open state actually changed, rather than on an event count. A real toggle always flips it, so the reader's first collapse/expand still lands:

```js
let lastOpen = section.open;
section.addEventListener('toggle', function() {
  const readerToggled = section.open !== lastOpen;
  lastOpen = section.open;
  file.collapsed = !section.open;
  if (section.open) {
    if (file.lazy) {
      if (readerToggled) loadLazyFile(section, file);
    } else {
      ensureFileBodyMounted(section, file);
    }
  } else if (...) {
```

Only the lazy fetch is gated. Eager files still mount on the synthetic event, so a review under the threshold renders in full and find-in-page behaves exactly as before.

## Impact

300 files, 9,000 changed lines, headless Chromium 1440x900.

**Responsiveness, measured immediately after the review opens:**

|  | before | after |
|---|---|---|
| `setTimeout(0)` scheduled right after load actually runs after | **18,653 ms** | **9 ms** |
| collapse a file (click → painted) | 332 ms | 92 ms |

That first row is the "everything is slow" symptom: for ~19 seconds nothing you click is serviced, because the main thread is busy mounting files you cannot see.

**Once the page has settled:**

|  | before | after |
|---|---|---|
| collapse a file (click → painted) | 1,549 ms | **125 ms** |
| open a comment form (click → painted) | 19 ms | 17 ms |
| DOM nodes | 999,608 | **92,658** |
| mounted file bodies | 300 | **25** |

Collapsing stays expensive on `main` because the operation touches a document with a million nodes in it. Opening a comment form is local enough not to care, at this size.

**Scrolling** — top-down in 40 viewport steps; blocking is the sum of main-thread task time over 50 ms:

|  | before | after |
|---|---|---|
| blocked main thread while scrolling | 32,626 ms | **0 ms** |
| worst single scroll step | 32,378 ms | **0 ms** |
| wall clock for the run | 100,718 ms | **8,992 ms** |

Three other approaches were tried first and dropped because measurement didn't support them: batching the post-mount rebuilds (real — 32,626 ms → 933 ms — but redundant once the root cause is fixed), releasing bodies that scroll out of range (measured *worse*, 8,411 ms, while barely reducing DOM), and reserving estimated height for deferred bodies (no measurable effect).

## Testing

- `test/e2e` git-mode suite passes across all three shards — 568 tests, zero failures.
- `web/__tests__/defer-file-body.test.js`: the assertion pinning the toggle handler now pins the guard. I also corrected the comment above it, which stated the belief that caused this bug and would invite someone to undo the fix.
- eslint clean.

**Known gap:** CONTRIBUTING asks for E2E tests on frontend changes and this PR has none. A behavioural test needs a fixture above `lazyFileThreshold` asserting that files far down the review aren't fetched at load — new fixture, setup script and Playwright project. Left out to keep the diff reviewable; happy to add it if you want it before merging. The benchmark harness behind the numbers above is also available to contribute if you'd like them reproducible in CI.

## CI

All green. The `lint` failure this PR originally showed was pre-existing — staticcheck now flags `ReverseProxy.Director` in `internal/live/proxy.go`, which fails identically on unmodified `main` (8a2cc26); `test.yml` only runs on `pull_request`, so main hadn't re-run since the rule shipped. @tomasz-tomczyk fixed it directly on this branch in fcab699, so that commit rides along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LruNB1zE2qBbGtymSM2eZA
