### PR TITLE
fix: show comment form for unified cross-side selections

### DIFF
--- a/web/__tests__/crit-diff-renderer.test.js
+++ b/web/__tests__/crit-diff-renderer.test.js
@@ -286,3 +286,66 @@ test('buildSplitChangeRows handles dels-only and adds-only', function() {
   assert.equal(addOnly.length, 1);
   assert.equal(addOnly[0].add.NewNum, 3);
 });
+
+// --- resolveUnifiedDragFormRange ---
+// Unified drag may cross old/new number spaces. The form must resolve to a
+// single side (the release line's) with start/end from that side only, so
+// appendDiffForm can attach it under the selected change.
+
+test('resolveUnifiedDragFormRange uses release side across del→add selection', function() {
+  // Visual selection: old 33-36 then new 34-37 (user's screenshot case).
+  // Released on the last added line.
+  var selected = [
+    { visualIdx: 10, lineNum: 33, side: 'old' },
+    { visualIdx: 11, lineNum: 34, side: 'old' },
+    { visualIdx: 12, lineNum: 35, side: 'old' },
+    { visualIdx: 13, lineNum: 36, side: 'old' },
+    { visualIdx: 14, lineNum: 34, side: '' },
+    { visualIdx: 15, lineNum: 35, side: '' },
+    { visualIdx: 16, lineNum: 36, side: '' },
+    { visualIdx: 17, lineNum: 37, side: '' },
+  ];
+  var fallback = { startLine: 33, endLine: 37, side: 'old' }; // buggy mixed-space range
+  var resolved = diffRenderer.resolveUnifiedDragFormRange(selected, 17, fallback);
+  assert.deepEqual(resolved, { startLine: 34, endLine: 37, side: '' });
+});
+
+test('resolveUnifiedDragFormRange uses release side across add→del selection', function() {
+  var selected = [
+    { visualIdx: 10, lineNum: 33, side: 'old' },
+    { visualIdx: 11, lineNum: 34, side: 'old' },
+    { visualIdx: 12, lineNum: 35, side: 'old' },
+    { visualIdx: 13, lineNum: 36, side: 'old' },
+    { visualIdx: 14, lineNum: 34, side: '' },
+    { visualIdx: 15, lineNum: 35, side: '' },
+    { visualIdx: 16, lineNum: 36, side: '' },
+    { visualIdx: 17, lineNum: 37, side: '' },
+  ];
+  var fallback = { startLine: 33, endLine: 37, side: '' };
+  // Released on the first deleted line (dragged upward).
+  var resolved = diffRenderer.resolveUnifiedDragFormRange(selected, 10, fallback);
+  assert.deepEqual(resolved, { startLine: 33, endLine: 36, side: 'old' });
+});
+
+test('resolveUnifiedDragFormRange keeps same-side ranges intact', function() {
+  var selected = [
+    { visualIdx: 5, lineNum: 33, side: 'old' },
+    { visualIdx: 6, lineNum: 34, side: 'old' },
+    { visualIdx: 7, lineNum: 36, side: 'old' },
+  ];
+  var fallback = { startLine: 33, endLine: 36, side: 'old' };
+  var resolved = diffRenderer.resolveUnifiedDragFormRange(selected, 7, fallback);
+  assert.deepEqual(resolved, { startLine: 33, endLine: 36, side: 'old' });
+});
+
+test('resolveUnifiedDragFormRange returns fallback when selection is empty', function() {
+  var fallback = { startLine: 10, endLine: 12, side: 'old' };
+  assert.deepEqual(
+    diffRenderer.resolveUnifiedDragFormRange([], 0, fallback),
+    fallback
+  );
+  assert.deepEqual(
+    diffRenderer.resolveUnifiedDragFormRange(null, 0, fallback),
+    fallback
+  );
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3736,8 +3736,8 @@
     // single-side range from the visual selection so the form attaches under
     // the selected change (see resolveUnifiedDragFormRange).
     if (diffMode !== 'split' &&
-        diffDragState.anchorVisualIdx != null && !isNaN(diffDragState.anchorVisualIdx) &&
-        diffDragState.currentVisualIdx != null && !isNaN(diffDragState.currentVisualIdx)) {
+        typeof diffDragState.anchorVisualIdx === 'number' && !isNaN(diffDragState.anchorVisualIdx) &&
+        typeof diffDragState.currentVisualIdx === 'number' && !isNaN(diffDragState.currentVisualIdx)) {
       const vLo = Math.min(diffDragState.anchorVisualIdx, diffDragState.currentVisualIdx);
       const vHi = Math.max(diffDragState.anchorVisualIdx, diffDragState.currentVisualIdx);
       const releaseVisualIdx = diffDragState.currentVisualIdx;

--- a/web/app.js
+++ b/web/app.js
@@ -3550,6 +3550,7 @@
   const applyWordDiffPair = window.crit.diffRenderer.applyWordDiffPair;
   const buildHunkWordDiffs = window.crit.diffRenderer.buildHunkWordDiffs;
   const buildSplitChangeRows = window.crit.diffRenderer.buildSplitChangeRows;
+  const resolveUnifiedDragFormRange = window.crit.diffRenderer.resolveUnifiedDragFormRange;
 
 
   // ===== Diff Gutter Drag (multi-line comment selection) =====
@@ -3725,11 +3726,47 @@
     document.body.classList.remove('dragging');
 
     if (!diffDragState) return;
-    const rangeStart = Math.min(diffDragState.anchorLine, diffDragState.currentLine);
-    const rangeEnd = Math.max(diffDragState.anchorLine, diffDragState.currentLine);
 
+    let rangeStart = Math.min(diffDragState.anchorLine, diffDragState.currentLine);
+    let rangeEnd = Math.max(diffDragState.anchorLine, diffDragState.currentLine);
+    let side = diffDragState.side;
     const fp = diffDragState.filePath;
-    const side = diffDragState.side;
+
+    // Unified mode may drag across old/new number spaces. Resolve to a
+    // single-side range from the visual selection so the form attaches under
+    // the selected change (see resolveUnifiedDragFormRange).
+    if (diffMode !== 'split' &&
+        diffDragState.anchorVisualIdx != null && !isNaN(diffDragState.anchorVisualIdx) &&
+        diffDragState.currentVisualIdx != null && !isNaN(diffDragState.currentVisualIdx)) {
+      const vLo = Math.min(diffDragState.anchorVisualIdx, diffDragState.currentVisualIdx);
+      const vHi = Math.max(diffDragState.anchorVisualIdx, diffDragState.currentVisualIdx);
+      const releaseVisualIdx = diffDragState.currentVisualIdx;
+      const selected = [];
+      const section = document.getElementById('file-section-' + fp);
+      if (section) {
+        const els = section.querySelectorAll('.diff-container.unified .diff-line[data-diff-visual-idx]');
+        for (let i = 0; i < els.length; i++) {
+          const vi = parseInt(els[i].dataset.diffVisualIdx, 10);
+          if (isNaN(vi) || vi < vLo || vi > vHi) continue;
+          const ln = parseInt(els[i].dataset.diffLineNum, 10);
+          if (!ln) continue;
+          selected.push({
+            visualIdx: vi,
+            lineNum: ln,
+            side: els[i].dataset.diffSide || '',
+          });
+        }
+      }
+      const resolved = resolveUnifiedDragFormRange(selected, releaseVisualIdx, {
+        startLine: rangeStart,
+        endLine: rangeEnd,
+        side: side,
+      });
+      rangeStart = resolved.startLine;
+      rangeEnd = resolved.endLine;
+      side = resolved.side;
+    }
+
     diffDragState = null;
     unifiedVisualStart = null;
     unifiedVisualEnd = null;

--- a/web/app.js
+++ b/web/app.js
@@ -3742,7 +3742,7 @@
       const vHi = Math.max(diffDragState.anchorVisualIdx, diffDragState.currentVisualIdx);
       const releaseVisualIdx = diffDragState.currentVisualIdx;
       const selected = [];
-      const section = document.getElementById('file-section-' + fp);
+      const section = currentRenderedFileSection(fp);
       if (section) {
         const els = section.querySelectorAll('.diff-container.unified .diff-line[data-diff-visual-idx]');
         for (let i = 0; i < els.length; i++) {

--- a/web/crit-diff-renderer.js
+++ b/web/crit-diff-renderer.js
@@ -276,6 +276,39 @@
     return rows;
   }
 
+  // Resolve a unified-diff drag into a single-side form range.
+  // Unified drag may cross old/new number spaces (del OldNum vs add NewNum).
+  // Mixing those with Math.min/max while keeping the anchor side produces a
+  // form that appendDiffForm cannot attach (invisible until split re-render).
+  // selectedLines: [{ visualIdx, lineNum, side }, ...] in visual order.
+  // releaseVisualIdx: the line where the pointer was released.
+  // fallback: { startLine, endLine, side } used when selection is empty.
+  function resolveUnifiedDragFormRange(selectedLines, releaseVisualIdx, fallback) {
+    if (!selectedLines || selectedLines.length === 0) return fallback;
+    var release = null;
+    for (var i = 0; i < selectedLines.length; i++) {
+      if (selectedLines[i].visualIdx === releaseVisualIdx) {
+        release = selectedLines[i];
+        break;
+      }
+    }
+    if (!release) release = selectedLines[selectedLines.length - 1];
+    var side = release.side || '';
+    var nums = [];
+    for (var j = 0; j < selectedLines.length; j++) {
+      var line = selectedLines[j];
+      if ((line.side || '') === side && line.lineNum > 0) {
+        nums.push(line.lineNum);
+      }
+    }
+    if (nums.length === 0) return fallback;
+    return {
+      startLine: Math.min.apply(null, nums),
+      endLine: Math.max.apply(null, nums),
+      side: side,
+    };
+  }
+
   var api = {
     lineSimilarity: lineSimilarity,
     bestWordDiffPairing: bestWordDiffPairing,
@@ -285,6 +318,7 @@
     applyWordDiffPair: applyWordDiffPair,
     buildHunkWordDiffs: buildHunkWordDiffs,
     buildSplitChangeRows: buildSplitChangeRows,
+    resolveUnifiedDragFormRange: resolveUnifiedDragFormRange,
   };
   if (typeof window !== 'undefined') {
     window.crit = window.crit || {};


### PR DESCRIPTION
## Summary
- Unified drag across deleted + added lines mixed OldNum/NewNum while keeping the anchor side, so the comment form never attached in unified view (visible after switching to split).
- Resolve the form to the release line's side and that side's line range; gather lines from `currentRenderedFileSection` so story mode uses the visible hunk clone.

## Review
- [x] Code review: passed (story-section blocker fixed)
- [x] Parity audit: N/A (CLI unified git-diff drag only)

## Test plan
- [x] `node --test web/__tests__/crit-diff-renderer.test.js` (29 pass)
- [x] Pre-commit (gofmt, golangci-lint, eslint, go tests)
- [ ] Manual: unified view, drag 4 deleted + 4 added lines → form appears under selection
- [ ] Manual: same selection in story mode

Made with [Cursor](https://cursor.com)