### PR TITLE
fix(live): migrate ReverseProxy off the deprecated Director hook

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -40,7 +40,7 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	}
 
 	// Use a transport with DisableCompression=true so http.Transport does
-	// not silently re-add Accept-Encoding: gzip after our Director strips
+	// not silently re-add Accept-Encoding: gzip after our Rewrite strips
 	// it. Stripping matters because we need the upstream body uncompressed
 	// in order to inject scripts.
 	transport := &http.Transport{
@@ -53,21 +53,25 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	}
 
 	rp := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.Host = target.Host
-			req.Header.Del("Accept-Encoding")
-			req.Header.Del("If-None-Match")
-			req.Header.Del("If-Modified-Since")
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			// SetURL leaves Out.Host empty so the Host header follows
+			// Out.URL.Host; set it explicitly to keep the previous behaviour
+			// of presenting the target's host upstream.
+			r.Out.Host = target.Host
+			// Director added X-Forwarded-For for us; Rewrite does not.
+			r.SetXForwarded()
+			r.Out.Header.Del("Accept-Encoding")
+			r.Out.Header.Del("If-None-Match")
+			r.Out.Header.Del("If-Modified-Since")
 			if upstreamCookies != "" {
-				req.Header.Set("Cookie", upstreamCookies)
+				r.Out.Header.Set("Cookie", upstreamCookies)
 			}
-			if req.Header.Get("Origin") != "" {
-				req.Header.Set("Origin", target.Scheme+"://"+target.Host)
+			if r.In.Header.Get("Origin") != "" {
+				r.Out.Header.Set("Origin", target.Scheme+"://"+target.Host)
 			}
-			if req.Header.Get("Referer") != "" {
-				req.Header.Set("Referer", target.Scheme+"://"+target.Host+req.URL.Path)
+			if r.In.Header.Get("Referer") != "" {
+				r.Out.Header.Set("Referer", target.Scheme+"://"+target.Host+r.Out.URL.Path)
 			}
 		},
 		Transport:      transport,


### PR DESCRIPTION
`golangci-lint` pins `version: latest`, and staticcheck now flags `ReverseProxy.Director` as deprecated since Go 1.26. The `lint` job fails on `main` as it stands — it just hasn't surfaced there, because `test.yml` only triggers on `pull_request` and main hasn't re-run since the rule shipped.

The practical effect is that **every PR opened against the repo right now starts with a red `lint` check**, regardless of what it changes.

```
internal/live/proxy.go:56:3: SA1019: (net/http/httputil.ReverseProxy).Director
has been deprecated since Go 1.26 and an alternative has been available since
Go 1.20: Use Rewrite instead. (staticcheck)
```

Verified against unmodified `main` (8a2cc26) in a clean worktree with golangci-lint v2.13.0 — same file, same line, so this is not specific to any branch.

## The migration

`Rewrite` is the documented replacement, but it doesn't carry over two things `Director` did implicitly. Both are restored explicitly rather than silently dropped:

- **Host header.** `SetURL` leaves `Out.Host` empty so the Host header follows `Out.URL.Host`. The old `Director` set `req.Host = target.Host`, so this sets it directly.
- **`X-Forwarded-For`.** With `Director`, `ReverseProxy` appended it automatically. With `Rewrite` it does not, so this calls `SetXForwarded()`. That also sends `X-Forwarded-Host` and `X-Forwarded-Proto`, which `Director` did not — harmless for a local dev proxy, and the alternative is hand-rolling the XFF append. Happy to do that instead if you'd rather keep the headers byte-identical.

`Origin` and `Referer` are now read from `r.In` and written to `r.Out`, which is what the old single-request `Director` was doing implicitly.

## Testing

- `golangci-lint run` — 0 issues.
- `go test ./internal/live/...` — pass.
- `go test -tags integration -run TestLiveCDPIntegration` — pass.
- `test/e2e` live-mode project — pass.

Split out of #846 so the proxy change can be judged on its own; that PR is a frontend fix and shouldn't be carrying this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LruNB1zE2qBbGtymSM2eZA
