### PR TITLE
fix: canonicalize range focus SHAs so stack nav keeps comments visible

### DIFF
--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -278,6 +278,17 @@ func resolveFocusFromRange(rangeSpec string, remoteFiles bool, v vcs.VCS, repoRo
 		if !vcs.HasObject(head, repoRoot) {
 			return nil, fmt.Errorf("head SHA %s not present locally", head)
 		}
+		// Resolve branch names / abbreviated SHAs to full OIDs so Focus and
+		// comment focus_keys stay stable when the UI later re-enters with OIDs.
+		baseOID, err := vcs.ResolveCommitOID(v, base, repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolving base %q: %w", base, err)
+		}
+		headOID, err := vcs.ResolveCommitOID(v, head, repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolving head %q: %w", head, err)
+		}
+		base, head = baseOID, headOID
 	}
 	return &Focus{
 		Kind:      FocusRange,

--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -272,10 +272,10 @@ func resolveFocusFromRange(rangeSpec string, remoteFiles bool, v vcs.VCS, repoRo
 	// In --remote mode, content reads come from the GitHub API; we can't
 	// prove the SHAs exist locally because we don't intend to use them.
 	if !remoteFiles && v != nil {
-		if !vcs.HasObject(base, repoRoot) {
+		if !v.HasObject(base, repoRoot) {
 			return nil, fmt.Errorf("base SHA %s not present locally", base)
 		}
-		if !vcs.HasObject(head, repoRoot) {
+		if !v.HasObject(head, repoRoot) {
 			return nil, fmt.Errorf("head SHA %s not present locally", head)
 		}
 		// Resolve branch names / abbreviated SHAs to full OIDs so Focus and

--- a/internal/focus/focus_cli_test.go
+++ b/internal/focus/focus_cli_test.go
@@ -3,6 +3,8 @@ package focus
 import (
 	"strings"
 	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 func TestParsePRSpec(t *testing.T) {
@@ -168,5 +170,23 @@ func TestResolveFocus_InvalidScopeRejected(t *testing.T) {
 	_, err := ResolveFocus(ChangeSpec{}, "a..b", "bogus", false, nil, "")
 	if err == nil {
 		t.Fatal("expected error from invalid scope")
+	}
+}
+
+func TestResolveFocus_RangeResolvesBranchNamesToOIDs(t *testing.T) {
+	vcs.ClearGitEnvForTest(t) // HasObject/rev-parse must not inherit hook GIT_DIR
+	dir := vcs.InitTestRepo(t)
+	base := vcs.GitRun(t, dir, "rev-parse", "HEAD")
+	vcs.GitRun(t, dir, "branch", "parent")
+	vcs.GitRun(t, dir, "checkout", "-b", "feature")
+	vcs.CommitAtForTest(t, dir, "f.txt", "hi\n", "add f")
+	head := vcs.GitRun(t, dir, "rev-parse", "HEAD")
+
+	f, err := ResolveFocus(ChangeSpec{}, "parent..feature", "", false, &vcs.GitVCS{}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.BaseSHA != base || f.HeadSHA != head {
+		t.Fatalf("got %s..%s, want %s..%s", f.BaseSHA, f.HeadSHA, base, head)
 	}
 }

--- a/internal/focus/focus_cli_test.go
+++ b/internal/focus/focus_cli_test.go
@@ -173,6 +173,15 @@ func TestResolveFocus_InvalidScopeRejected(t *testing.T) {
 	}
 }
 
+func TestResolveFocus_RangeResolveOIDError(t *testing.T) {
+	// HasObject succeeds via the fake, but ResolveCommitOID rejects unknown VCS names.
+	v := &fakeStackVCS{name: "hg", hasSeq: []bool{true, true}}
+	_, err := ResolveFocus(ChangeSpec{}, "base..head", "", false, v, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "resolving") {
+		t.Fatalf("got %v, want resolving error", err)
+	}
+}
+
 func TestResolveFocus_RangeResolvesBranchNamesToOIDs(t *testing.T) {
 	vcs.ClearGitEnvForTest(t) // HasObject/rev-parse must not inherit hook GIT_DIR
 	dir := vcs.InitTestRepo(t)

--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -751,3 +751,104 @@ func TestBuildFilesForWorkingTree_NumstatWarn(t *testing.T) {
 		t.Fatalf("stderr = %q, want numstat warning", stderr)
 	}
 }
+
+// TestSetFocus_CanonicalizesBranchRefsToFullSHAs locks the going-forward fix for
+// stacked-PR comment visibility: range focus used to keep branch names in
+// BaseSHA/HeadSHA (from --range parent..feature or early stack payloads), so
+// focusKeyFor stamped comments as range:branch..branch. A later SetFocus with
+// resolved OIDs produced a different focus_key and hid those comments with no
+// hidden_unresolved signal. SetFocus must rewrite refs to full commit OIDs
+// before storing Focus so stamps stay stable across stack navigation.
+func TestSetFocus_CanonicalizesBranchRefsToFullSHAs(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "branch", "parent")
+	gitT(t, dir, "checkout", "-b", "feature")
+	commitAt(t, dir, "added.txt", "hello\n", "add file")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{
+		RepoRoot:  dir,
+		OutputDir: dir,
+		VCS:       &vcs.GitVCS{},
+		Branch:    "feature",
+	}
+	t.Cleanup(func() { quiesceSession(t, s) })
+
+	if err := s.SetFocus(Focus{
+		Kind:      FocusRange,
+		BaseSHA:   "parent",
+		HeadSHA:   "feature",
+		DiffScope: DiffScopeLayer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if s.Focus.BaseSHA != base {
+		t.Fatalf("BaseSHA = %q, want full OID %q", s.Focus.BaseSHA, base)
+	}
+	if s.Focus.HeadSHA != head {
+		t.Fatalf("HeadSHA = %q, want full OID %q", s.Focus.HeadSHA, head)
+	}
+
+	c, ok := s.AddComment("added.txt", 1, 1, "RIGHT", "keep me visible", "", "reviewer", "u1")
+	if !ok {
+		t.Fatal("AddComment failed")
+	}
+	wantKey := fmt.Sprintf("range:%s..%s", base, head)
+	if c.FocusKey != wantKey {
+		t.Fatalf("FocusKey = %q, want %q", c.FocusKey, wantKey)
+	}
+
+	// Simulate stack-popover re-entry with OID form of the same tips.
+	if err := s.SetFocus(Focus{
+		Kind:      FocusRange,
+		BaseSHA:   base,
+		HeadSHA:   head,
+		DiffScope: DiffScopeLayer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var got *FileEntry
+	for _, f := range s.Files {
+		if f.Path == "added.txt" {
+			got = f
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("added.txt missing after OID SetFocus")
+	}
+	visible := 0
+	for _, comment := range got.Comments {
+		if visibleInFocus(comment, s.Focus) {
+			visible++
+		}
+	}
+	if visible != 1 {
+		t.Fatalf("visible comments after OID re-focus = %d (comments=%+v); want 1", visible, got.Comments)
+	}
+}
+
+// TestSetFocus_ExpandsShortSHAsToFullOIDs ensures abbreviated SHAs also
+// canonicalize so focus keys never mix short and full forms.
+func TestSetFocus_ExpandsShortSHAsToFullOIDs(t *testing.T) {
+	dir := initTestRepo(t)
+	base := gitT(t, dir, "rev-parse", "HEAD")
+	commitAt(t, dir, "added.txt", "y\n", "add y")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+
+	s := &Session{RepoRoot: dir, OutputDir: dir, VCS: &vcs.GitVCS{}}
+	t.Cleanup(func() { quiesceSession(t, s) })
+
+	if err := s.SetFocus(Focus{
+		Kind:      FocusRange,
+		BaseSHA:   base[:7],
+		HeadSHA:   head[:7],
+		DiffScope: DiffScopeLayer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if s.Focus.BaseSHA != base || s.Focus.HeadSHA != head {
+		t.Fatalf("Focus SHAs = %s..%s, want %s..%s", s.Focus.BaseSHA, s.Focus.HeadSHA, base, head)
+	}
+}

--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -852,3 +852,77 @@ func TestSetFocus_ExpandsShortSHAsToFullOIDs(t *testing.T) {
 		t.Fatalf("Focus SHAs = %s..%s, want %s..%s", s.Focus.BaseSHA, s.Focus.HeadSHA, base, head)
 	}
 }
+
+func TestCanonicalizeFocusSHAs_RemoteAndNilNoops(t *testing.T) {
+	f := Focus{Kind: FocusRange, BaseSHA: "parent", HeadSHA: "feature", DiffScope: DiffScopeLayer}
+	if err := canonicalizeFocusSHAs(&f, &vcs.GitVCS{}, t.TempDir(), true); err != nil {
+		t.Fatal(err)
+	}
+	if f.BaseSHA != "parent" || f.HeadSHA != "feature" {
+		t.Fatalf("remoteFiles should leave symbolic refs alone: %+v", f)
+	}
+	if err := canonicalizeFocusSHAs(nil, &vcs.GitVCS{}, t.TempDir(), false); err != nil {
+		t.Fatal(err)
+	}
+	wt := Focus{Kind: FocusWorkingTree}
+	if err := canonicalizeFocusSHAs(&wt, &vcs.GitVCS{}, t.TempDir(), false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCanonicalizeFocusSHAs_DefaultSHAAndErrors(t *testing.T) {
+	dir := initTestRepo(t)
+	main := gitT(t, dir, "rev-parse", "HEAD")
+	gitT(t, dir, "checkout", "-b", "feature")
+	commitAt(t, dir, "f.txt", "x\n", "add")
+	head := gitT(t, dir, "rev-parse", "HEAD")
+	base := main
+
+	f := Focus{
+		Kind: FocusRange, BaseSHA: base, HeadSHA: head,
+		DefaultSHA: "main", DiffScope: DiffScopeFullStack,
+	}
+	if err := canonicalizeFocusSHAs(&f, &vcs.GitVCS{}, dir, false); err != nil {
+		t.Fatal(err)
+	}
+	if f.DefaultSHA != main {
+		t.Fatalf("DefaultSHA = %q, want %q", f.DefaultSHA, main)
+	}
+
+	bad := Focus{Kind: FocusRange, BaseSHA: "missing-base", HeadSHA: head, DiffScope: DiffScopeLayer}
+	if err := canonicalizeFocusSHAs(&bad, &vcs.GitVCS{}, dir, false); err == nil {
+		t.Fatal("expected base resolve error")
+	}
+	badHead := Focus{Kind: FocusRange, BaseSHA: base, HeadSHA: "missing-head", DiffScope: DiffScopeLayer}
+	if err := canonicalizeFocusSHAs(&badHead, &vcs.GitVCS{}, dir, false); err == nil {
+		t.Fatal("expected head resolve error")
+	}
+	badDef := Focus{
+		Kind: FocusRange, BaseSHA: base, HeadSHA: head,
+		DefaultSHA: "missing-default", DiffScope: DiffScopeFullStack,
+	}
+	if err := canonicalizeFocusSHAs(&badDef, &vcs.GitVCS{}, dir, false); err == nil {
+		t.Fatal("expected default resolve error")
+	}
+}
+
+func TestSetFocus_CanonicalizeErrorSurfaces(t *testing.T) {
+	dir := initTestRepo(t)
+	// HasObject says yes; ResolveCommitOID rejects Name "hg".
+	v := &canonicalizeFailVCS{}
+	s := &Session{RepoRoot: dir, OutputDir: dir, VCS: v}
+	t.Cleanup(func() { quiesceSession(t, s) })
+	err := s.SetFocus(Focus{
+		Kind: FocusRange, BaseSHA: "a", HeadSHA: "b", DiffScope: DiffScopeLayer,
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonicalizing") {
+		t.Fatalf("got %v, want canonicalizing error", err)
+	}
+}
+
+// canonicalizeFailVCS pretends objects exist so validateFocusSHAs passes, but
+// ResolveCommitOID rejects its Name ("hg").
+type canonicalizeFailVCS struct{ vcs.GitVCS }
+
+func (c *canonicalizeFailVCS) Name() string               { return "hg" }
+func (c *canonicalizeFailVCS) HasObject(_, _ string) bool { return true }

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -133,8 +133,12 @@ func (f Focus) PickerVisible() bool {
 // focusKeyFor returns the per-view key used to scope comment visibility.
 //
 //	pr:<num>                       — range focus with PR number
-//	range:<baseSHA>..<headSHA>     — range focus without PR number (full 40-char SHAs)
+//	range:<baseSHA>..<headSHA>     — range focus without PR number
 //	""                             — working-tree (and unknown)
+//
+// Callers must pass Focus whose BaseSHA/HeadSHA are full OIDs (SetFocus
+// canonicalizeFocusSHAs enforces this). Symbolic refs in those fields would
+// stamp unstable keys and hide comments after stack navigation.
 func focusKeyFor(f Focus) string {
 	if f.Kind != FocusRange {
 		return ""
@@ -208,7 +212,8 @@ func countVisibleComments(comments []Comment, f Focus) int {
 // so it's all-or-nothing — no torn ActiveDiffScope on disk).
 //
 // Caller is responsible for validating the request shape upstream;
-// SetFocus owns SHA validation (via ensureSHAFetched) and persistence.
+// SetFocus owns SHA validation (via ensureSHAFetched), OID canonicalization
+// of BaseSHA/HeadSHA/DefaultSHA, and persistence.
 func (s *Session) SetFocus(f Focus) error {
 	if f.Kind == FocusRange &&
 		f.DiffScope == DiffScopeFullStack &&
@@ -223,6 +228,9 @@ func (s *Session) SetFocus(f Focus) error {
 	s.mu.RUnlock()
 
 	if err := validateFocusSHAs(f, vc, repoRoot, remoteFiles); err != nil {
+		return err
+	}
+	if err := canonicalizeFocusSHAs(&f, vc, repoRoot, remoteFiles); err != nil {
 		return err
 	}
 
@@ -348,6 +356,35 @@ func validateFocusSHAs(f Focus, v vcs.VCS, repoRoot string, remoteFiles bool) er
 		if err := vcs.EnsureSHAFetched(v, f.DefaultSHA, repoRoot, ""); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// canonicalizeFocusSHAs rewrites BaseSHA/HeadSHA/DefaultSHA to full commit
+// OIDs. Branch names and abbreviated SHAs are accepted by validateFocusSHAs
+// (HasObject resolves them), but leaving them in Focus makes focusKeyFor
+// unstable across stack navigation that re-enters with resolved OIDs.
+// No-op for working-tree focus, remote mode, or missing VCS/repo.
+func canonicalizeFocusSHAs(f *Focus, v vcs.VCS, repoRoot string, remoteFiles bool) error {
+	if f == nil || f.Kind != FocusRange || remoteFiles || v == nil || repoRoot == "" {
+		return nil
+	}
+	base, err := vcs.ResolveCommitOID(v, f.BaseSHA, repoRoot)
+	if err != nil {
+		return fmt.Errorf("canonicalizing base %q: %w", f.BaseSHA, err)
+	}
+	head, err := vcs.ResolveCommitOID(v, f.HeadSHA, repoRoot)
+	if err != nil {
+		return fmt.Errorf("canonicalizing head %q: %w", f.HeadSHA, err)
+	}
+	f.BaseSHA = base
+	f.HeadSHA = head
+	if f.DefaultSHA != "" {
+		def, err := vcs.ResolveCommitOID(v, f.DefaultSHA, repoRoot)
+		if err != nil {
+			return fmt.Errorf("canonicalizing default %q: %w", f.DefaultSHA, err)
+		}
+		f.DefaultSHA = def
 	}
 	return nil
 }

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -633,6 +633,50 @@ func ResolveDefaultBranchSHA(vcs VCS, repoRoot, defaultBranch string) (string, e
 	}
 }
 
+// ResolveCommitOID resolves ref (branch name, tag, abbreviated SHA, or full
+// OID) to a full commit object id. Used to canonicalize Focus.BaseSHA/HeadSHA
+// so comment focus_keys stay stable when stack navigation switches between
+// symbolic refs and resolved OIDs.
+func ResolveCommitOID(v VCS, ref, dir string) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf("nil VCS")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("empty ref")
+	}
+	switch v.Name() {
+	case "git":
+		out, err := RunGitInDir(dir, "rev-parse", "--verify", ref+"^{commit}")
+		if err != nil {
+			return "", fmt.Errorf("resolve %q: %w", ref, err)
+		}
+		return strings.TrimSpace(out), nil
+	case "jj":
+		sha, err := ResolveJJRevisionToCommitID(dir, ref)
+		if err != nil {
+			return "", fmt.Errorf("resolve %q: %w", ref, err)
+		}
+		sha = strings.TrimSpace(sha)
+		if sha == "" {
+			return "", fmt.Errorf("resolve %q: empty commit id", ref)
+		}
+		return sha, nil
+	case "sl":
+		out, err := SLCommandInDir(dir, "log", "-r", ref, "-T", "{node}", "-l", "1")
+		if err != nil {
+			return "", fmt.Errorf("resolve %q: %w", ref, err)
+		}
+		out = strings.TrimSpace(out)
+		if out == "" {
+			return "", fmt.Errorf("resolve %q: empty node", ref)
+		}
+		return out, nil
+	default:
+		return "", fmt.Errorf("resolve not supported for vcs=%q", v.Name())
+	}
+}
+
 // walkAncestors enumerates HEAD-first the recent ancestor SHAs that are
 // candidates for stack stops. Capped at maxDepth.
 func WalkAncestors(vcs VCS, repoRoot string, maxDepth int) ([]string, error) {

--- a/internal/vcs/git_vcs_methods_test.go
+++ b/internal/vcs/git_vcs_methods_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -290,5 +291,29 @@ func TestResolveCommitOID_BranchAndShortSHA(t *testing.T) {
 	}
 	if got != full {
 		t.Fatalf("short SHA resolve = %q, want %q", got, full)
+	}
+}
+
+func TestResolveCommitOID_ErrorPaths(t *testing.T) {
+	if _, err := ResolveCommitOID(nil, "HEAD", ""); err == nil {
+		t.Fatal("expected nil VCS error")
+	}
+	dir := InitTestRepo(t)
+	if _, err := ResolveCommitOID(&GitVCS{}, "   ", dir); err == nil {
+		t.Fatal("expected empty ref error")
+	}
+	if _, err := ResolveCommitOID(&GitVCS{}, "definitely-missing-ref-xyz", dir); err == nil {
+		t.Fatal("expected missing git ref error")
+	}
+	unknown := &fakeFetchVCS{name: "hg"}
+	if _, err := ResolveCommitOID(unknown, "tip", dir); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("got %v, want not supported", err)
+	}
+	// jj/sl error branches (no real bookmark / rev in empty-ish dir).
+	if _, err := ResolveCommitOID(&fakeFetchVCS{name: "jj"}, "no-such-bookmark", dir); err == nil {
+		t.Fatal("expected jj resolve error")
+	}
+	if _, err := ResolveCommitOID(&fakeFetchVCS{name: "sl"}, "no-such-rev", dir); err == nil {
+		t.Fatal("expected sl resolve error")
 	}
 }

--- a/internal/vcs/git_vcs_methods_test.go
+++ b/internal/vcs/git_vcs_methods_test.go
@@ -271,3 +271,24 @@ func TestGitVCS_WorkingTreeFingerprint(t *testing.T) {
 		t.Error("WorkingTreeFingerprint empty for dirty tree")
 	}
 }
+
+func TestResolveCommitOID_BranchAndShortSHA(t *testing.T) {
+	dir := InitTestRepo(t)
+	full := GitRun(t, dir, "rev-parse", "HEAD")
+	v := &GitVCS{}
+
+	got, err := ResolveCommitOID(v, "main", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != full {
+		t.Fatalf("branch resolve = %q, want %q", got, full)
+	}
+	got, err = ResolveCommitOID(v, full[:7], dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != full {
+		t.Fatalf("short SHA resolve = %q, want %q", got, full)
+	}
+}


### PR DESCRIPTION
## Summary
- Range focus kept branch names / short SHAs in `BaseSHA`/`HeadSHA`, so comment `focus_key`s diverged after stack navigation re-entered with full OIDs and comments vanished with no `hidden_unresolved` signal.
- `SetFocus` and `--range` construction now resolve those fields to full commit OIDs going forward (git/jj/sl).

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- [x] Unit tests for branch-name and short-SHA canonicalize + comment visibility after OID re-focus
- [x] `ResolveFocus` branch→OID test (with hook `GIT_DIR` cleared)
- [x] Pre-commit + `golangci-lint` + package tests


Made with [Cursor](https://cursor.com)