### PR TITLE
fix: resolve mixed-side text selections to the start side

### DIFF
--- a/web/__tests__/crit-diff-renderer.test.js
+++ b/web/__tests__/crit-diff-renderer.test.js
@@ -42,9 +42,10 @@ const sandbox = {
     DiffMatchPatch: mockDMP,
   },
   document: {},
+  NodeFilter: { SHOW_TEXT: 4 },
 };
-const fn = new Function('window', 'document', src + '\nreturn window;');
-fn(sandbox.window, sandbox.document);
+const fn = new Function('window', 'document', 'NodeFilter', src + '\nreturn window;');
+fn(sandbox.window, sandbox.document, sandbox.NodeFilter);
 const diffRenderer = sandbox.window.crit.diffRenderer;
 
 // --- lineSimilarity ---
@@ -484,8 +485,13 @@ test('app.js wires text selection through resolveTextSelectionLineRange', functi
   var appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
   assert.match(
     appJs,
-    /preferredSideFromNode\(range\.startContainer\)/,
-    'getLineRangeFromSelection must derive preferred side from selection start'
+    /preferredSideFromNode\(selection\.anchorNode\)/,
+    'getLineRangeFromSelection must prefer selection.anchorNode for side'
+  );
+  assert.match(
+    appJs,
+    /selectedTextWithinElements\(selection,\s*contentEls\)/,
+    'quote capture must clip to side-filtered contentEls'
   );
   assert.match(
     appJs,
@@ -498,3 +504,52 @@ test('app.js wires text selection through resolveTextSelectionLineRange', functi
     'old bail-out comment for mixed sides must be gone'
   );
 });
+
+test('selectedTextWithinElements joins only intersecting contentEls', function() {
+  // Minimal Selection/Range stubs — no jsdom.
+  var t1 = { textContent: 'old line', nodeType: 3 };
+  var t2 = { textContent: 'new line', nodeType: 3 };
+  var el1 = {
+    _nodes: [t1],
+    contains: function(n) { return n === t1 || n === this; },
+  };
+  var el2 = {
+    _nodes: [t2],
+    contains: function(n) { return n === t2 || n === this; },
+  };
+  // TreeWalker stub via document.createTreeWalker — inject via global in helper.
+  // Instead exercise by monkeypatching: call with selection that only hits el2.
+  var selRange = {
+    startContainer: t2,
+    startOffset: 0,
+    endContainer: t2,
+    endOffset: 8,
+    intersectsNode: function(el) { return el === el2; },
+  };
+  var selection = {
+    rangeCount: 1,
+    getRangeAt: function() { return selRange; },
+    containsNode: function(n, _partial) { return n === t2; },
+  };
+  // Mutate the sandbox document the module closed over (no jsdom).
+  var prevTW = sandbox.document.createTreeWalker;
+  sandbox.document.createTreeWalker = function(root, _what, _filter) {
+    var nodes = root._nodes || [];
+    var i = -1;
+    return {
+      nextNode: function() {
+        i++;
+        return i < nodes.length ? nodes[i] : null;
+      },
+    };
+  };
+  try {
+    assert.equal(
+      diffRenderer.selectedTextWithinElements(selection, [el1, el2]),
+      'new line'
+    );
+  } finally {
+    sandbox.document.createTreeWalker = prevTW;
+  }
+});
+

--- a/web/__tests__/crit-diff-renderer.test.js
+++ b/web/__tests__/crit-diff-renderer.test.js
@@ -349,3 +349,152 @@ test('resolveUnifiedDragFormRange returns fallback when selection is empty', fun
     fallback
   );
 });
+
+// --- resolveTextSelectionLineRange ---
+// Text selection (select-to-comment via `c`) can intersect both diff sides:
+// - split: multi-line right selection includes left nodes via DOM order
+// - unified: selection spanning del+add mixes old/new sides
+// Resolve to the preferred side (selection start) and that side's line range.
+
+test('resolveTextSelectionLineRange keeps same-side split selection', function() {
+  var candidates = [
+    { filePath: 'a.ex', startLine: 7, endLine: 7, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: '' },
+  ];
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, ''),
+    { filePath: 'a.ex', startLine: 7, endLine: 8, afterBlockIndex: null, side: '' }
+  );
+});
+
+test('resolveTextSelectionLineRange filters split bleed to preferred new side', function() {
+  // Multi-line right selection also intersects left lines between rows.
+  var candidates = [
+    { filePath: 'a.ex', startLine: 7, endLine: 7, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: 'old' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 9, endLine: 9, blockIndex: null, side: 'old' },
+  ];
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, ''),
+    { filePath: 'a.ex', startLine: 7, endLine: 8, afterBlockIndex: null, side: '' }
+  );
+});
+
+test('resolveTextSelectionLineRange filters split bleed to preferred old side', function() {
+  var candidates = [
+    { filePath: 'a.ex', startLine: 7, endLine: 7, blockIndex: null, side: 'old' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: 'old' },
+  ];
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, 'old'),
+    { filePath: 'a.ex', startLine: 7, endLine: 8, afterBlockIndex: null, side: 'old' }
+  );
+});
+
+test('resolveTextSelectionLineRange filters unified del+add to start side', function() {
+  var candidates = [
+    { filePath: 'a.ex', startLine: 33, endLine: 33, blockIndex: null, side: 'old' },
+    { filePath: 'a.ex', startLine: 34, endLine: 34, blockIndex: null, side: 'old' },
+    { filePath: 'a.ex', startLine: 34, endLine: 34, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 35, endLine: 35, blockIndex: null, side: '' },
+  ];
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, 'old'),
+    { filePath: 'a.ex', startLine: 33, endLine: 34, afterBlockIndex: null, side: 'old' }
+  );
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, ''),
+    { filePath: 'a.ex', startLine: 34, endLine: 35, afterBlockIndex: null, side: '' }
+  );
+});
+
+test('resolveTextSelectionLineRange returns null for multi-file selection', function() {
+  var candidates = [
+    { filePath: 'a.ex', startLine: 1, endLine: 1, blockIndex: null, side: '' },
+    { filePath: 'b.ex', startLine: 2, endLine: 2, blockIndex: null, side: '' },
+  ];
+  assert.equal(diffRenderer.resolveTextSelectionLineRange(candidates, ''), null);
+});
+
+test('resolveTextSelectionLineRange returns null for empty candidates', function() {
+  assert.equal(diffRenderer.resolveTextSelectionLineRange([], ''), null);
+  assert.equal(diffRenderer.resolveTextSelectionLineRange(null, ''), null);
+});
+
+test('resolveTextSelectionLineRange preserves markdown afterBlockIndex', function() {
+  var candidates = [
+    { filePath: 'doc.md', startLine: 10, endLine: 12, blockIndex: 3, side: undefined },
+    { filePath: 'doc.md', startLine: 13, endLine: 14, blockIndex: 4, side: undefined },
+  ];
+  assert.deepEqual(
+    diffRenderer.resolveTextSelectionLineRange(candidates, undefined),
+    { filePath: 'doc.md', startLine: 10, endLine: 14, afterBlockIndex: 4, side: undefined }
+  );
+});
+
+test('preferredSideFromNode walks to nearest diff line side', function() {
+  // Minimal element chain: text parent → content → side el with dataset
+  var sideEl = {
+    dataset: { diffLineNum: '8', diffSide: '' },
+    closest: function(sel) {
+      if (sel === '[data-diff-line-num]') return this;
+      return null;
+    },
+  };
+  var textParent = {
+    closest: function(sel) { return sideEl.closest(sel); },
+  };
+  assert.equal(diffRenderer.preferredSideFromNode(textParent), '');
+
+  var oldSideEl = {
+    dataset: { diffLineNum: '8', diffSide: 'old' },
+    closest: function(sel) {
+      if (sel === '[data-diff-line-num]') return this;
+      return null;
+    },
+  };
+  assert.equal(diffRenderer.preferredSideFromNode(oldSideEl), 'old');
+});
+
+test('preferredSideFromNode returns undefined for markdown line blocks', function() {
+  var block = {
+    closest: function(sel) {
+      if (sel === '[data-diff-line-num]') return null;
+      if (sel === '.line-block[data-file-path]') return this;
+      return null;
+    },
+  };
+  assert.equal(diffRenderer.preferredSideFromNode(block), undefined);
+});
+
+test('resolveTextSelectionLineRange returns null when mixed sides lack preferredSide', function() {
+  var candidates = [
+    { filePath: 'a.ex', startLine: 7, endLine: 7, blockIndex: null, side: '' },
+    { filePath: 'a.ex', startLine: 8, endLine: 8, blockIndex: null, side: 'old' },
+  ];
+  assert.equal(diffRenderer.resolveTextSelectionLineRange(candidates, undefined), null);
+  assert.equal(diffRenderer.resolveTextSelectionLineRange(candidates, null), null);
+});
+
+// Wiring: app.js must resolve mixed-side text selections via the helpers above
+// (not bail on side mismatch).
+test('app.js wires text selection through resolveTextSelectionLineRange', function() {
+  var appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+  assert.match(
+    appJs,
+    /preferredSideFromNode\(range\.startContainer\)/,
+    'getLineRangeFromSelection must derive preferred side from selection start'
+  );
+  assert.match(
+    appJs,
+    /resolveTextSelectionLineRange\(candidates,\s*preferredSide\)/,
+    'getLineRangeFromSelection must resolve via resolveTextSelectionLineRange'
+  );
+  assert.doesNotMatch(
+    appJs,
+    /If the selection straddles\s+multiple files or diff sides, bail out/,
+    'old bail-out comment for mixed sides must be gone'
+  );
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3553,6 +3553,7 @@
   const resolveUnifiedDragFormRange = window.crit.diffRenderer.resolveUnifiedDragFormRange;
   const resolveTextSelectionLineRange = window.crit.diffRenderer.resolveTextSelectionLineRange;
   const preferredSideFromNode = window.crit.diffRenderer.preferredSideFromNode;
+  const selectedTextWithinElements = window.crit.diffRenderer.selectedTextWithinElements;
 
 
   // ===== Diff Gutter Drag (multi-line comment selection) =====
@@ -5060,9 +5061,13 @@
 
     if (candidates.length === 0) return null;
 
-    // Prefer the side where the selection started. Split multi-line selects and
-    // unified del+add ranges often intersect both sides; bail only on multi-file.
-    const preferredSide = preferredSideFromNode(range.startContainer);
+    // Prefer the side where the user started dragging (anchorNode). Range
+    // startContainer is document-order and wrong for reverse selections.
+    // Split multi-line / unified del+add often intersect both sides.
+    let preferredSide = preferredSideFromNode(selection.anchorNode);
+    if (preferredSide === undefined) {
+      preferredSide = preferredSideFromNode(range.startContainer);
+    }
     return resolveTextSelectionLineRange(candidates, preferredSide);
   }
 
@@ -9744,6 +9749,11 @@
             }
           });
         }
+        // Prefer text clipped to side-filtered contentEls so unified del+add
+        // selections don't pollute the quote with the opposite side.
+        const clipped = selectedTextWithinElements(selection, contentEls);
+        if (clipped) selectedText = clipped;
+
         const normalizedSelected = selectedText.replace(/\s+/g, ' ');
         const normalizedFull = fullText.trim().replace(/\s+/g, ' ');
         if (normalizedSelected !== normalizedFull && selectedText.length <= 300) {

--- a/web/app.js
+++ b/web/app.js
@@ -3551,6 +3551,8 @@
   const buildHunkWordDiffs = window.crit.diffRenderer.buildHunkWordDiffs;
   const buildSplitChangeRows = window.crit.diffRenderer.buildSplitChangeRows;
   const resolveUnifiedDragFormRange = window.crit.diffRenderer.resolveUnifiedDragFormRange;
+  const resolveTextSelectionLineRange = window.crit.diffRenderer.resolveTextSelectionLineRange;
+  const preferredSideFromNode = window.crit.diffRenderer.preferredSideFromNode;
 
 
   // ===== Diff Gutter Drag (multi-line comment selection) =====
@@ -5051,33 +5053,17 @@
         startLine: ln,
         endLine: ln,
         blockIndex: null,
-        side: el.dataset.diffSide || undefined,
+        // Keep '' for new-side so mixed-side resolution can filter ('' vs 'old').
+        side: el.dataset.diffSide || '',
       });
     });
 
     if (candidates.length === 0) return null;
 
-    // All candidates must share filePath and side. If the selection straddles
-    // multiple files or diff sides, bail out rather than guess.
-    const filePath = candidates[0].filePath;
-    const side = candidates[0].side;
-    for (let i = 1; i < candidates.length; i++) {
-      if (candidates[i].filePath !== filePath) return null;
-      if (candidates[i].side !== side) return null;
-    }
-
-    let startLine = Infinity;
-    let endLine = -Infinity;
-    let afterBlockIndex = null;
-    for (const c of candidates) {
-      if (c.startLine < startLine) startLine = c.startLine;
-      if (c.endLine > endLine) endLine = c.endLine;
-      if (c.blockIndex !== null && (afterBlockIndex === null || c.blockIndex > afterBlockIndex)) {
-        afterBlockIndex = c.blockIndex;
-      }
-    }
-
-    return { filePath, startLine, endLine, afterBlockIndex, side };
+    // Prefer the side where the selection started. Split multi-line selects and
+    // unified del+add ranges often intersect both sides; bail only on multi-file.
+    const preferredSide = preferredSideFromNode(range.startContainer);
+    return resolveTextSelectionLineRange(candidates, preferredSide);
   }
 
   function closeEmptyReviewForm() {

--- a/web/crit-diff-renderer.js
+++ b/web/crit-diff-renderer.js
@@ -309,6 +309,80 @@
     };
   }
 
+  // Text select-to-comment can intersect both diff sides (split DOM-order
+  // bleed; unified del+add). Prefer the selection-start side and keep only
+  // that side's line numbers so the form attaches under the intended change.
+  // candidates: [{ filePath, startLine, endLine, blockIndex, side }, ...]
+  // preferredSide: side from the selection start ('old' | '' | undefined).
+  function resolveTextSelectionLineRange(candidates, preferredSide) {
+    if (!candidates || candidates.length === 0) return null;
+
+    var filePath = candidates[0].filePath;
+    for (var i = 1; i < candidates.length; i++) {
+      if (candidates[i].filePath !== filePath) return null;
+    }
+
+    // Classify sides. Markdown line-blocks use undefined; diff new uses ''.
+    var sideKeys = {};
+    for (var d = 0; d < candidates.length; d++) {
+      var raw = candidates[d].side;
+      var key = raw === undefined ? '__md__' : (raw || '');
+      sideKeys[key] = true;
+    }
+    var keys = Object.keys(sideKeys);
+
+    var side;
+    if (keys.length === 1 && keys[0] === '__md__') {
+      side = undefined;
+    } else if (preferredSide !== undefined && preferredSide !== null) {
+      side = preferredSide || '';
+    } else if (keys.length === 1) {
+      side = keys[0] === '__md__' ? undefined : keys[0];
+    } else {
+      // Mixed diff sides with no preferred side — don't guess (DOM order is
+      // left-first and would bias toward old).
+      return null;
+    }
+
+    var startLine = Infinity;
+    var endLine = -Infinity;
+    var afterBlockIndex = null;
+    var matched = 0;
+    for (var j = 0; j < candidates.length; j++) {
+      var c = candidates[j];
+      if (side !== undefined && (c.side || '') !== side) continue;
+      matched++;
+      if (c.startLine < startLine) startLine = c.startLine;
+      if (c.endLine > endLine) endLine = c.endLine;
+      if (c.blockIndex !== null && c.blockIndex !== undefined &&
+          (afterBlockIndex === null || c.blockIndex > afterBlockIndex)) {
+        afterBlockIndex = c.blockIndex;
+      }
+    }
+    if (matched === 0) return null;
+
+    return {
+      filePath: filePath,
+      startLine: startLine,
+      endLine: endLine,
+      afterBlockIndex: afterBlockIndex,
+      side: side,
+    };
+  }
+
+  // Walk from a selection start node to the nearest commentable line and
+  // return its diff side ('' for new, 'old' for old, undefined for markdown).
+  function preferredSideFromNode(node) {
+    if (!node) return undefined;
+    // Element nodes (and element-like stubs) expose closest; text nodes use parent.
+    var el = typeof node.closest === 'function' ? node : node.parentElement;
+    if (!el || typeof el.closest !== 'function') return undefined;
+    var diffLine = el.closest('[data-diff-line-num]');
+    if (diffLine) return diffLine.dataset.diffSide || '';
+    if (el.closest('.line-block[data-file-path]')) return undefined;
+    return undefined;
+  }
+
   var api = {
     lineSimilarity: lineSimilarity,
     bestWordDiffPairing: bestWordDiffPairing,
@@ -319,6 +393,8 @@
     buildHunkWordDiffs: buildHunkWordDiffs,
     buildSplitChangeRows: buildSplitChangeRows,
     resolveUnifiedDragFormRange: resolveUnifiedDragFormRange,
+    resolveTextSelectionLineRange: resolveTextSelectionLineRange,
+    preferredSideFromNode: preferredSideFromNode,
   };
   if (typeof window !== 'undefined') {
     window.crit = window.crit || {};

--- a/web/crit-diff-renderer.js
+++ b/web/crit-diff-renderer.js
@@ -370,6 +370,41 @@
     };
   }
 
+  // Collect only the parts of a Selection that fall inside contentEls
+  // (side-filtered). Avoids quote pollution when the Range also spans the
+  // opposite diff side (unified del+add).
+  function selectedTextWithinElements(selection, contentEls) {
+    if (!selection || !selection.rangeCount || !contentEls || !contentEls.length) {
+      return '';
+    }
+    var selRange = selection.getRangeAt(0);
+    var parts = [];
+    for (var i = 0; i < contentEls.length; i++) {
+      var el = contentEls[i];
+      if (!selRange.intersectsNode(el)) continue;
+      var elParts = [];
+      var showText = (typeof NodeFilter !== 'undefined' && NodeFilter.SHOW_TEXT) ? NodeFilter.SHOW_TEXT : 4;
+      var walker = document.createTreeWalker(el, showText, null);
+      var tn;
+      while ((tn = walker.nextNode())) {
+        if (typeof selection.containsNode === 'function' && !selection.containsNode(tn, true)) {
+          continue;
+        }
+        var text = tn.textContent || '';
+        if (tn === selRange.startContainer && tn === selRange.endContainer) {
+          text = text.slice(selRange.startOffset, selRange.endOffset);
+        } else if (tn === selRange.startContainer) {
+          text = text.slice(selRange.startOffset);
+        } else if (tn === selRange.endContainer) {
+          text = text.slice(0, selRange.endOffset);
+        }
+        if (text) elParts.push(text);
+      }
+      if (elParts.length) parts.push(elParts.join(''));
+    }
+    return parts.join('\n').trim();
+  }
+
   // Walk from a selection start node to the nearest commentable line and
   // return its diff side ('' for new, 'old' for old, undefined for markdown).
   function preferredSideFromNode(node) {
@@ -395,6 +430,7 @@
     resolveUnifiedDragFormRange: resolveUnifiedDragFormRange,
     resolveTextSelectionLineRange: resolveTextSelectionLineRange,
     preferredSideFromNode: preferredSideFromNode,
+    selectedTextWithinElements: selectedTextWithinElements,
   };
   if (typeof window !== 'undefined') {
     window.crit = window.crit || {};


### PR DESCRIPTION
## Summary
- Select-to-comment (`c` after a text selection) no longer falls back to keyboard focus when the Range intersects both diff sides (split multi-line DOM bleed, or unified del+add).
- Prefer the selection anchor's side and attach the form to that side's line range; clip quotes to side-filtered content so the opposite column does not pollute the quote.

## Review
- [x] Code review: passed (intent clean; fixed anchor/quote warnings)
- [x] Parity audit: N/A (CLI diff-side select-to-comment only)

## Test plan
- [x] Unit tests for resolveTextSelectionLineRange / preferredSideFromNode / selectedTextWithinElements (41 pass)
- [x] Pre-commit (gofmt, golangci-lint, go test, ESLint, Stylelint)
- [ ] Manual: multi-line select on split right → `c` opens form on right lines
- [ ] Manual: unified select spanning del+add → `c` opens on drag-start side


Made with [Cursor](https://cursor.com)