### PR TITLE
fix: keep reply body font when editing a comment with replies

### DIFF
--- a/web/__tests__/edit-reply-font.test.js
+++ b/web/__tests__/edit-reply-font.test.js
@@ -1,0 +1,36 @@
+'use strict';
+// Regression: editing a comment with replies nests .comment-replies inside
+// .comment-form. Replies no longer inherit body font from .comment-card, so
+// .reply-body must declare it explicitly (matching .comment-body).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function replyBodyRule(css) {
+  const match = css.match(/\.reply-body\s*\{[^}]+\}/);
+  assert.ok(match, 'expected a .reply-body rule');
+  return match[0];
+}
+
+function assertReplyBodyUsesBodyFont(css, label) {
+  const rule = replyBodyRule(css);
+  assert.match(
+    rule,
+    /font-family:\s*var\(--crit-font-body\)/,
+    `${label}: .reply-body must set body font so replies stay proportional when nested in .comment-form during edit`
+  );
+}
+
+test('style.css: .reply-body declares body font', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../style.css'), 'utf8');
+  assertReplyBodyUsesBodyFont(css, 'crit/web/style.css');
+});
+
+test('crit-web app.css parity: .reply-body declares body font', () => {
+  const webCss = path.resolve(__dirname, '../../../crit-web/assets/css/app.css');
+  assert.ok(fs.existsSync(webCss), 'expected crit-web CSS at ' + webCss);
+  const css = fs.readFileSync(webCss, 'utf8');
+  assertReplyBodyUsesBodyFont(css, 'crit-web/assets/css/app.css');
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1779,6 +1779,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 
 .reply-body {
+  font-family: var(--crit-font-body);
   font-size: 14px;
   line-height: 1.6;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Set explicit `font-family: var(--crit-font-body)` on `.reply-body` so thread replies stay in proportional body font when nested inside `.comment-form` during parent comment edit
- Add regression test (`edit-reply-font.test.js`) asserting body font on `.reply-body` in both crit and crit-web CSS

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- [x] `node --test web/__tests__/edit-reply-font.test.js`
- [x] crit pre-commit hook (gofmt, golangci-lint, go test)
- [ ] CI

See also: tomasz-tomczyk/crit-web#365

Made with [Cursor](https://cursor.com)