### PR TITLE
fix: stop word-diff spans from reopening at hljs tag boundaries

### DIFF
--- a/web/__tests__/crit-diff-renderer.test.js
+++ b/web/__tests__/crit-diff-renderer.test.js
@@ -125,6 +125,25 @@ test('applyWordDiffToHtml skips over HTML tags without counting them', function(
   assert.equal(result, '<span>a</span><span class="hl">b</span>');
 });
 
+test('applyWordDiffToHtml keeps highlight spans open across nested hljs tags', function() {
+  // highlight.js can nest many spans inside a single changed token (e.g. HEEx #{...}).
+  // Closing/reopening word-diff spans at every tag boundary creates empty highlight
+  // spans that render as phantom whitespace in the diff viewer.
+  var oldLine = '                <span class="text-gray-500 sm:text-sm" id="price-currency-for-sms">USD</span>';
+  var newLine = '                <span class="text-gray-500 sm:text-sm" id={"price-currency-for-feature-#{ef.index}"}>';
+  var hlLine =
+    '<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">span</span> ' +
+    '<span class="hljs-attr">class</span>=<span class="hljs-string">"text-gray-500 sm:text-sm"</span> ' +
+    '<span class="hljs-attr">id</span>=<span class="hljs-string">{</span></span></span>' +
+    '<span class="language-elixir"><span class="hljs-string"><span class="hljs-subst">' +
+    '<span class="hljs-string">"price-currency-for-feature-#{ef.index}"</span></span></span></span>' +
+    '<span class="language-xml"><span class="hljs-tag">}&gt;</span></span>';
+  var wd = diffRenderer.wordDiff(oldLine, newLine);
+  assert.ok(wd && wd.newRanges.length > 0);
+  var result = diffRenderer.applyWordDiffToHtml(hlLine, wd.newRanges, 'diff-word-add');
+  assert.equal(result.match(/<span class="diff-word-add"><\/span>/g), null);
+});
+
 // --- bestWordDiffPairing ---
 
 test('bestWordDiffPairing pairs similar lines together', function() {

--- a/web/crit-diff-renderer.js
+++ b/web/crit-diff-renderer.js
@@ -142,15 +142,14 @@
     var i = 0;             // position in html string
 
     while (i < html.length) {
-      // Skip HTML tags (don't count them as visible characters)
+      // Skip HTML tags (don't count them as visible characters).
+      // Keep any open word-diff span across tags — closing/reopening at each tag
+      // boundary creates empty highlight spans inside nested hljs markup.
       if (html[i] === '<') {
-        // If we're in a word-diff range, close it before the tag, reopen after
-        if (inRange) result += '</span>';
         var tagEnd = html.indexOf('>', i);
         if (tagEnd === -1) { result += html.slice(i); break; }
         result += html.slice(i, tagEnd + 1);
         i = tagEnd + 1;
-        if (inRange) result += '<span class="' + cssClass + '">';
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Keep word-diff highlight spans open across nested syntax-highlight tags in `applyWordDiffToHtml`
- Fixes phantom whitespace in HEEx/Elixir diffs where empty `diff-word-add` spans rendered inside nested hljs markup
- Adds regression test using the HEEx `price-currency-for-feature` case

## Review
- [x] Code review: passed
- [x] Parity audit: companion crit-web PR

## Test plan
- [x] `node --test web/__tests__/crit-diff-renderer.test.js` (42 tests)
- [x] Pre-commit hook (gofmt, golangci-lint, go test, eslint, stylelint)
- [x] Visual validation on PL-3727 HEEx diff at localhost:49819

See also: tomasz-tomczyk/crit-web#366

Made with [Cursor](https://cursor.com)