### PR TITLE
fix: draw a border on tables in comment and reply bodies

### DIFF
--- a/test/e2e/tests/comment-tables.spec.ts
+++ b/test/e2e/tests/comment-tables.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Locator } from '@playwright/test';
+import { addComment, clearAllComments, getMdPath, goSection, loadPage, mdSection, switchToDocumentView } from './helpers';
+
+// A markdown table reaches a comment body through the sanitizer with its
+// classes removed, so only element rules can draw it. Without them the browser
+// default applies and the cells run together with no border at all.
+const TABLE_MD = [
+  '| Field | Type | Notes |',
+  '| --- | --- | --- |',
+  '| id | string | primary key |',
+  '| name | string | display name |',
+].join('\n');
+
+async function expectCellBorder(cell: Locator) {
+  for (const side of ['top', 'right', 'bottom', 'left']) {
+    await expect(cell).toHaveCSS(`border-${side}-style`, 'solid');
+    await expect(cell).toHaveCSS(`border-${side}-width`, '1px');
+  }
+}
+
+test.describe('Comment tables', () => {
+  test.beforeEach(async ({ request }) => {
+    await clearAllComments(request);
+  });
+
+  test('a table in a diff comment draws a border on every cell', async ({ page }) => {
+    await loadPage(page);
+    const section = goSection(page);
+
+    const additionSide = section.locator('.diff-split-side.addition').first();
+    await additionSide.hover();
+    await additionSide.locator('.diff-comment-btn').click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill(TABLE_MD);
+    await page.locator('.comment-form .btn-primary').click();
+
+    const table = section.locator('.comment-body table');
+    await expect(table).toBeVisible();
+    await expect(table).toHaveCSS('border-collapse', 'collapse');
+    await expect(table.locator('th')).toHaveCount(3);
+    await expect(table.locator('tbody tr')).toHaveCount(2);
+
+    await expectCellBorder(table.locator('th').first());
+    await expectCellBorder(table.locator('td').first());
+  });
+
+  test('a table in a reply draws a border on every cell', async ({ page, request }) => {
+    const mdPath = await getMdPath(request);
+    const comment = await addComment(request, mdPath, 1, 'Which fields does this cover?');
+    const reply = await request.post(`/api/comment/${comment.id}/replies?path=${encodeURIComponent(mdPath)}`, {
+      data: { body: TABLE_MD, author: 'agent' },
+    });
+    expect(reply.status()).toBe(201);
+
+    await loadPage(page);
+    await switchToDocumentView(page);
+
+    const table = mdSection(page).locator('.reply-body table');
+    await expect(table).toBeVisible();
+    await expect(table.locator('th')).toHaveCount(3);
+
+    await expectCellBorder(table.locator('th').first());
+    await expectCellBorder(table.locator('td').first());
+  });
+});

--- a/test/shell/test-diff.sh
+++ b/test/shell/test-diff.sh
@@ -795,6 +795,34 @@ curl -sf -X POST "http://127.0.0.1:$WORD_DIFF_PORT/api/comment/$FOLDED_C/replies
     "author": "agent"
   }' > /dev/null
 
+# --- Markdown table in a diff comment and in a reply ---
+# A table is how an agent lists the call sites it checked. Both bodies must
+# render with a border on every cell; without one the columns run together.
+# The rows sit one per line so the table reads as a table in this file too.
+TABLE_C=$(curl -sf -X POST "http://127.0.0.1:$WORD_DIFF_PORT/api/file/comments?path=main.go" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_line": 10, "end_line": 10,
+    "body": "The handler answers three probes. Here is what each one gets today:\n\n'\
+'| Probe | Path | Body |\n'\
+'| --- | --- | --- |\n'\
+'| kubelet | `/health` | `{\"status\":\"ok\"}` |\n'\
+'| load balancer | `/ready` | 404 |\n'\
+'| operator | `/version` | 404 |\n\n'\
+'The last two need a route."
+  }' | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+
+curl -sf -X POST "http://127.0.0.1:$WORD_DIFF_PORT/api/comment/$TABLE_C/replies?path=main.go" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "body": "| Route | Handler | Status |\n'\
+'| --- | --- | --- |\n'\
+'| `/health` | healthHandler | done |\n'\
+'| `/ready` | readyHandler | open |\n'\
+'| `/version` | versionHandler | open |",
+    "author": "agent"
+  }' > /dev/null
+
 # --- Instance 5: seed two layer-scope comments on b.txt + verify stamping ---
 curl -sf -X DELETE "http://127.0.0.1:$RANGE_PORT/api/comments" > /dev/null
 
@@ -920,6 +948,11 @@ echo "  spacer gap between the /health and startup-code hunks. The spacer should
 echo "  auto-expand so the comment + agent reply are visible inline."
 echo "  The first spacer (respondJSON/logRequest) stays folded — no comments there."
 echo "  Open the All Comments panel (Shift+C) and click the comment to scroll to it."
+echo ""
+echo "Instance 2 — table in a comment and in a reply:"
+echo "  main.go line 10 carries a comment whose body is a markdown table, and a"
+echo "  reply that is a table as well. Every cell draws a border, the header row"
+echo "  sits on a raised background, and the columns stay apart in both themes."
 echo ""
 echo "Carry-forward comments placed on v1 content (instances 3 & 4):"
 echo "  C1 (lines 31-32): sessions table description"

--- a/test/shell/test-diff.sh
+++ b/test/shell/test-diff.sh
@@ -583,8 +583,15 @@ curl -sf -X POST "http://127.0.0.1:$PORT/api/comments" \
     "author": "reviewer"
   }' > /dev/null
 
-# Finish the review to write the review file
-REVIEW_FILE=$(curl -sf -X POST "http://127.0.0.1:$PORT/api/finish" | python3 -c "import json, sys; print(json.load(sys.stdin)['review_file'])")
+# Finish the review to write the review file. /api/finish reports the review
+# itself and not where it landed, so read the path from /api/config: review_path
+# names the identity folder that holds review.json.
+curl -sf -X POST "http://127.0.0.1:$PORT/api/finish" > /dev/null
+REVIEW_FILE=$(curl -sf "http://127.0.0.1:$PORT/api/config" | python3 -c "
+import json, os, sys
+path = json.load(sys.stdin)['review_path']
+print(path if path.endswith('review.json') else os.path.join(path, 'review.json'))
+")
 
 # --- Seed GitHub-synced comments (issue #370) ---
 # The POST API has no `github_id` field (synced comments normally arrive via

--- a/web/style.css
+++ b/web/style.css
@@ -1737,6 +1737,35 @@ body.dragging { user-select: none; cursor: grabbing; }
   color: var(--crit-editor-fg-secondary);
 }
 
+/* Sanitized comment markdown keeps no classes, so key off the elements.
+   A comment card is narrow: cells take a full border, not row rules alone. */
+.comment-body table,
+.reply-body table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  font-size: 0.95em;
+}
+
+.comment-body th,
+.comment-body td,
+.reply-body th,
+.reply-body td {
+  border: 1px solid var(--crit-border);
+  padding: 4px 10px;
+  text-align: left;
+}
+
+.comment-body th,
+.reply-body th {
+  font-weight: 600;
+  background: var(--crit-editor-bg-elevated);
+}
+
+.comment-body tbody tr:nth-child(even) td,
+.reply-body tbody tr:nth-child(even) td {
+  background: var(--crit-table-stripe);
+}
+
 .comment-time {
   font-size: 11px;
   color: var(--crit-editor-fg-muted);


### PR DESCRIPTION
## Summary

- Give markdown tables inside `.comment-body` and `.reply-body` a border, padding and a header background. A table reaches a comment body through the sanitizer with its classes removed, and those bodies styled every other block element but the table, so the browser default applied: no border, no padding, and columns that run together.
- Every cell takes a full border rather than the document renderer's row separators alone: a comment card is narrow, so the columns need a vertical edge to stay apart. The colours come from `--crit-border`, `--crit-editor-bg-elevated` and `--crit-table-stripe`, so no new variable, and both themes are covered.
- Both bodies share one selector list, so the pair cannot drift apart.
- Seed a table comment and a table reply on instance 2 of `test/shell/test-diff.sh`.
- Fix that harness first. `/api/finish` reports the review and not where it landed, which is deliberate: 72d2cdc (#678) dropped `review_file` from the agent payload and added a test that holds the response to it. That same PR moved `test/e2e/tests/helpers.ts` onto `/api/config`'s `review_path`, but `test/shell/test-diff.sh` was not in it — the script's previous change, 9dc81e7, lands nine days earlier. So the harness has read a key that is not there since 2026-06-22: `set -e` stopped it at instance 1, and instances 2 through 6 kept their servers, never got their comments, and printed none of their guidance. This gives the shell harness the same `/api/config` treatment the E2E helper already got.

## Screenshots

A markdown table in a diff comment and in an agent reply, seeded on `test/shell/test-diff.sh` instance 2. On the left a build without the CSS, on the right the same review with it.

**Light**

![A crit diff comment holding a markdown table, before and after this change, light theme](https://raw.githubusercontent.com/meganemura/crit/c4ce5504d65567b28e73c49a392dfa5790ea514d/comment-table-borders-light.png)

**Dark**

![The same comparison in the dark theme](https://raw.githubusercontent.com/meganemura/crit/c4ce5504d65567b28e73c49a392dfa5790ea514d/comment-table-borders-dark.png)

## Test plan

- `cd test/e2e && npx playwright test tests/comment-tables.spec.ts` — 2 passed
- The same spec against a build with `web/style.css` reverted to `HEAD~1` — 2 failed: `border-collapse` was `separate` and the cell border was `none`
- `npx stylelint "web/*.css"` — clean
- `bash scripts/check-css-vars.sh` — clean
- `./test/shell/test-diff.sh` — instance 2 shows the table comment and the table reply, and both survive the round-complete step

The local Playwright runs used the Chromium build already on this machine, not the 1217 build the repository pins: that download does not complete on my connection. CI runs the pinned build.

## Parity

crit-web renders a shared review from its own stylesheet, so the same rule belongs there — `web/comment-html.js` carries the keep-in-sync header for that reason. It is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
