### PR TITLE
fix: quote jj paths as filesets so bracketed paths diff

### DIFF
--- a/internal/vcs/jj.go
+++ b/internal/vcs/jj.go
@@ -572,9 +572,9 @@ func jjCommitRevset(sha string) string {
 // jjFileset wraps a path in jj's file: pattern. jj parses path arguments as
 // fileset expressions even after "--", so a bare path containing an operator
 // character either fails to parse ("(") or silently matches nothing ("["),
-// and the file renders as unchanged. Next.js route groups and dynamic
-// segments — "(group)", "[slug]" — hit this on every path. file: keeps the
-// cwd-relative resolution a bare path already had.
+// and the file renders as unchanged (issue #858). Next.js route groups and
+// dynamic segments hit this on every path. file: keeps the cwd-relative
+// resolution a bare path already had.
 func jjFileset(path string) string {
 	return fmt.Sprintf("file:%q", path)
 }

--- a/internal/vcs/jj.go
+++ b/internal/vcs/jj.go
@@ -200,7 +200,7 @@ func (j *JJVCS) FileDiffUnifiedCtx(ctx context.Context, path, baseRef, dir strin
 		}
 		args = append(args, "--from", jjCommitRevset(base), "--to", "@")
 	}
-	args = append(args, "--", path)
+	args = append(args, "--", jjFileset(path))
 	out, err := jjCommandInDirCtx(ctx, dir, args...)
 	if err != nil {
 		return nil, err
@@ -220,7 +220,7 @@ func (j *JJVCS) FileDiffForCommit(path, sha, dir string, ignoreWhitespace bool) 
 	if err != nil {
 		return nil, err
 	}
-	args := append(jjDiffArgs(ignoreWhitespace), "-r", jjCommitRevset(rev), "--", path)
+	args := append(jjDiffArgs(ignoreWhitespace), "-r", jjCommitRevset(rev), "--", jjFileset(path))
 	out, err := JJCommandInDir(dir, args...)
 	if err != nil {
 		return nil, err
@@ -380,7 +380,7 @@ func (j *JJVCS) FileDiffBetweenSHAs(path, _ string, baseSHA, headSHA, dir string
 	if err != nil {
 		return nil, err
 	}
-	args := append(jjDiffArgs(ignoreWhitespace), "--from", jjCommitRevset(base), "--to", jjCommitRevset(head), "--", path)
+	args := append(jjDiffArgs(ignoreWhitespace), "--from", jjCommitRevset(base), "--to", jjCommitRevset(head), "--", jjFileset(path))
 	out, err := JJCommandInDir(dir, args...)
 	if err != nil {
 		return nil, err
@@ -393,7 +393,7 @@ func (j *JJVCS) ReadFileAtSHA(sha, path, dir string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := jjCommandBytesInDir(dir, "file", "show", "-r", jjCommitRevset(rev), "--", path)
+	out, err := jjCommandBytesInDir(dir, "file", "show", "-r", jjCommitRevset(rev), "--", jjFileset(path))
 	if err != nil {
 		return nil, nil //nolint:nilerr // a missing path at a valid commit is not an error for callers
 	}
@@ -567,6 +567,16 @@ func JJCommitSubject(dir, sha string) string {
 
 func jjCommitRevset(sha string) string {
 	return fmt.Sprintf("commit_id(%q)", strings.TrimSpace(sha))
+}
+
+// jjFileset wraps a path in jj's file: pattern. jj parses path arguments as
+// fileset expressions even after "--", so a bare path containing an operator
+// character either fails to parse ("(") or silently matches nothing ("["),
+// and the file renders as unchanged. Next.js route groups and dynamic
+// segments — "(group)", "[slug]" — hit this on every path. file: keeps the
+// cwd-relative resolution a bare path already had.
+func jjFileset(path string) string {
+	return fmt.Sprintf("file:%q", path)
 }
 
 func isJJRootCommitID(sha string) bool {

--- a/internal/vcs/jj_methods_test.go
+++ b/internal/vcs/jj_methods_test.go
@@ -560,3 +560,56 @@ func TestIsSimpleJJBookmarkName(t *testing.T) {
 		}
 	}
 }
+
+// jj parses path arguments as fileset expressions even after "--", so a path
+// containing an operator character used to fail to parse and the file rendered
+// as unchanged. Next.js route groups and dynamic segments hit this constantly.
+func TestJJVCS_PathsWithFilesetOperators(t *testing.T) {
+	for _, dirName := range []string{"(group)", "[dynamic]", "(group)/[dynamic]"} {
+		t.Run(dirName, func(t *testing.T) {
+			dir := initTestJJRepoWithLocalMain(t)
+			j := &JJVCS{}
+			base := runJJ(t, dir, "log", "-r", "bookmarks(exact:\"main\")", "--no-graph", "-T", "commit_id")
+
+			rel := filepath.Join("src", dirName, "page.tsx")
+			if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, rel)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, rel), []byte("export const a = 1;\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			withCwd(t, dir)
+
+			changes, err := j.ChangedFilesFromBaseInDir(base, dir)
+			if err != nil {
+				t.Fatalf("ChangedFilesFromBaseInDir: %v", err)
+			}
+			if len(changes) == 0 {
+				t.Fatalf("no changed files reported for %q", rel)
+			}
+
+			hunks, err := j.FileDiffUnified(rel, base, dir, false)
+			if err != nil {
+				t.Fatalf("FileDiffUnified(%q): %v", rel, err)
+			}
+			if len(hunks) == 0 {
+				t.Errorf("FileDiffUnified(%q) returned no hunks; the path was parsed as a fileset expression", rel)
+			}
+		})
+	}
+}
+
+func TestJJFileset(t *testing.T) {
+	cases := map[string]string{
+		"src/plain/page.tsx":      `file:"src/plain/page.tsx"`,
+		"src/(group)/page.tsx":    `file:"src/(group)/page.tsx"`,
+		"src/[slug]/page.tsx":     `file:"src/[slug]/page.tsx"`,
+		`src/od"d/page.tsx`:       `file:"src/od\"d/page.tsx"`,
+		`src/back\slash/page.tsx`: `file:"src/back\\slash/page.tsx"`,
+	}
+	for in, want := range cases {
+		if got := jjFileset(in); got != want {
+			t.Errorf("jjFileset(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/vcs/jj_methods_test.go
+++ b/internal/vcs/jj_methods_test.go
@@ -561,9 +561,9 @@ func TestIsSimpleJJBookmarkName(t *testing.T) {
 	}
 }
 
-// jj parses path arguments as fileset expressions even after "--", so a path
-// containing an operator character used to fail to parse and the file rendered
-// as unchanged. Next.js route groups and dynamic segments hit this constantly.
+// Regression test for issue #858. Both operators are covered because they
+// failed differently: "(" errored, "[" matched nothing and returned no diff
+// with no error at all.
 func TestJJVCS_PathsWithFilesetOperators(t *testing.T) {
 	for _, dirName := range []string{"(group)", "[dynamic]", "(group)/[dynamic]"} {
 		t.Run(dirName, func(t *testing.T) {


### PR DESCRIPTION
Fixes #858.

## The bug

jj parses path arguments as [fileset expressions](https://docs.jj-vcs.dev/latest/filesets/) **even after `--`**, so a bare path containing a fileset operator never reaches jj as a literal. Files render as "No changes" while the sidebar still shows them as *New File* / *Modified*.

The two characters fail differently, which is what made it hard to spot:

- `(` — hard syntax error, swallowed by the caller
- `[` — parses as a *valid* fileset that matches nothing, so it fails **silently** with no error at all

Next.js App Router paths hit this on essentially every file, since route groups `(marketing)` and dynamic segments `[slug]` are the convention. Git repositories are unaffected.

## The fix

A small helper alongside the existing `jjCommitRevset`:

```go
func jjFileset(path string) string {
	return fmt.Sprintf("file:%q", path)
}
```

Applied at the four sites that pass a path to a jj subcommand — three `jj diff` variants and `jj file show`.

`file:` keeps the cwd-relative resolution a bare path already had, so this is a faithful drop-in rather than a semantic change, and `%q` matches how `jjCommitRevset` already quotes. Git pathspec handling is untouched.

## Tests

Both in `internal/vcs/jj_methods_test.go`:

- `TestJJVCS_PathsWithFilesetOperators` — table-driven over `(group)`, `[dynamic]` and `(group)/[dynamic]`, asserting `ChangedFilesFromBaseInDir` sees the file *and* `FileDiffUnified` returns real hunks. I confirmed each case fails without the fix; that is where the silent-vs-error distinction above came from.
- `TestJJFileset` — the quoting helper, including embedded `"` and `\`.

`go build ./...`, `gofmt -l .` and the full `go test ./...` (25 packages) are green.

## Verification

Beyond the unit tests, I built the patched binary and ran it against the real-world repository from the issue — a 9-file range where 6 files previously rendered as "No changes". All nine now render.

I did not add a `test/shell/test-diff.sh` scenario: this is a VCS-layer fix with Go coverage rather than a review-UI feature. Happy to add one if you would prefer it.
