### PR TITLE
fix: make live mode work behind a redirect, a subpath, and a reverse proxy

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -55,6 +55,12 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
+			// SetURL sends the upstream's own Host, so tell the app where the
+			// proxy is and let it generate URLs pointing back at us
+			pr.SetXForwarded()
+			if _, port, err := net.SplitHostPort(pr.In.Host); err == nil {
+				pr.Out.Header.Set("X-Forwarded-Port", port)
+			}
 			pr.Out.Header.Del("Accept-Encoding")
 			pr.Out.Header.Del("If-None-Match")
 			pr.Out.Header.Del("If-Modified-Since")
@@ -284,7 +290,7 @@ func rewriteRedirect(resp *http.Response, upstream *url.URL) error {
 	if locURL.Host == "" {
 		return nil // relative — already proxy-relative
 	}
-	if locURL.Host == upstream.Host {
+	if locURL.Host == upstream.Host || locURL.Host == resp.Request.Header.Get("X-Forwarded-Host") {
 		locURL.Scheme = ""
 		locURL.Host = ""
 		if locURL.Path == "" {

--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -38,9 +38,11 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream origin %q: %w", upstreamOrigin, err)
 	}
-	// Drop the path so SetURL doesn't join it onto every proxied request
+	// Keep only scheme+host so SetURL doesn't join path/query onto every request
 	target.Path = ""
 	target.RawPath = ""
+	target.RawQuery = ""
+	target.Fragment = ""
 
 	// Use a transport with DisableCompression=true so http.Transport does
 	// not silently re-add Accept-Encoding: gzip after our Rewrite strips
@@ -294,12 +296,21 @@ func rewriteRedirect(resp *http.Response, upstream *url.URL) error {
 		return nil // relative — already proxy-relative
 	}
 	if locURL.Host == upstream.Host || locURL.Host == resp.Request.Header.Get("X-Forwarded-Host") {
-		locURL.Scheme = ""
-		locURL.Host = ""
-		if locURL.Path == "" {
-			locURL.Path = "/"
+		// Build a path-absolute Location. Clearing Scheme/Host and calling
+		// String() is unsafe: a path starting with "//" (or leftover User)
+		// becomes protocol-relative and leaves the proxy origin.
+		path := locURL.EscapedPath()
+		if path == "" {
+			path = "/"
 		}
-		resp.Header.Set("Location", locURL.String())
+		for strings.HasPrefix(path, "//") {
+			path = "/" + strings.TrimLeft(path, "/")
+		}
+		loc := path
+		if locURL.RawQuery != "" {
+			loc += "?" + locURL.RawQuery
+		}
+		resp.Header.Set("Location", loc)
 		return nil
 	}
 	// Cross-origin: replace with 200 postMessage stub.

--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -30,14 +30,17 @@ var agentScriptFiles = []string{
 }
 
 // newLiveProxy builds a reverse proxy for a live-mode session.
-// upstreamOrigin is the target URL, optionally including a path prefix
-// (e.g. "http://localhost:3000" or "http://localhost:3333/live.html").
+// upstreamOrigin is the target URL. Any path on it is the iframe's initial
+// route, loaded by the frontend.
 // apiPort is the API server's port, used to construct the agent script URL.
 func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (http.Handler, error) {
 	target, err := url.Parse(upstreamOrigin)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream origin %q: %w", upstreamOrigin, err)
 	}
+	// Drop the path so SetURL doesn't join it onto every proxied request
+	target.Path = ""
+	target.RawPath = ""
 
 	// Use a transport with DisableCompression=true so http.Transport does
 	// not silently re-add Accept-Encoding: gzip after our Rewrite strips

--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -285,8 +285,11 @@ func rewriteRedirect(resp *http.Response, upstream *url.URL) error {
 		return nil // relative — already proxy-relative
 	}
 	if locURL.Host == upstream.Host {
-		locURL.Scheme = resp.Request.URL.Scheme
-		locURL.Host = resp.Request.URL.Host
+		locURL.Scheme = ""
+		locURL.Host = ""
+		if locURL.Path == "" {
+			locURL.Path = "/"
+		}
 		resp.Header.Set("Location", locURL.String())
 		return nil
 	}

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -292,6 +292,72 @@ func TestProxyModifyResponse_SameOriginRedirectRewritten(t *testing.T) {
 	}
 }
 
+func TestProxyRewrite_SendsForwardedHeaders(t *testing.T) {
+	var gotHost, gotProto, gotPort, gotFor string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Header.Get("X-Forwarded-Host")
+		gotProto = r.Header.Get("X-Forwarded-Proto")
+		gotPort = r.Header.Get("X-Forwarded-Port")
+		gotFor = r.Header.Get("X-Forwarded-For")
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	psURL, _ := url.Parse(ps.URL)
+	resp, err := http.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if gotHost != psURL.Host {
+		t.Errorf("X-Forwarded-Host = %q, want the proxy host %q", gotHost, psURL.Host)
+	}
+	if gotProto != "http" {
+		t.Errorf("X-Forwarded-Proto = %q, want %q", gotProto, "http")
+	}
+	if gotPort != psURL.Port() {
+		t.Errorf("X-Forwarded-Port = %q, want the proxy port %q", gotPort, psURL.Port())
+	}
+	if gotFor == "" {
+		t.Error("X-Forwarded-For is empty, want the client IP")
+	}
+}
+
+func TestProxyModifyResponse_ProxyOriginRedirectIsNotCrossOrigin(t *testing.T) {
+	var proxyHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// What an app generates once it trusts the forwarded headers
+		proxyHost = r.Header.Get("X-Forwarded-Host")
+		w.Header().Set("Location", "http://"+proxyHost+"/login")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	resp, err := client.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302 passed through", resp.StatusCode)
+	}
+	if strings.Contains(string(body), "cross-origin-redirect") {
+		t.Error("a redirect to the proxy's own origin was treated as cross-origin")
+	}
+	if loc := resp.Header.Get("Location"); loc != "/login" {
+		t.Errorf("Location = %q, want %q", loc, "/login")
+	}
+}
+
 func TestProxyModifyResponse_AbsoluteSameOriginRedirectRewritten(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -293,19 +293,20 @@ func TestProxyModifyResponse_SameOriginRedirectRewritten(t *testing.T) {
 }
 
 func TestProxyRewrite_TargetPathIsNotPrefixedOntoRequests(t *testing.T) {
-	var gotPaths []string
+	var gotPaths, gotQueries []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPaths = append(gotPaths, r.URL.Path)
+		gotQueries = append(gotQueries, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprintln(w, "<html><body>ok</body></html>")
 	}))
 	defer upstream.Close()
-	// A live URL with a path: the frontend requests that path as the initial
-	// route, so the proxy must not prefix it a second time
-	proxy, _ := newLiveProxy(upstream.URL+"/some/page", 9001, "")
+	// A live URL with a path+query: the frontend requests that path as the
+	// initial route, so the proxy must not prefix path or query a second time
+	proxy, _ := newLiveProxy(upstream.URL+"/some/page?tab=2", 9001, "")
 	ps := httptest.NewServer(proxy)
 	defer ps.Close()
-	for _, p := range []string{"/some/page", "/assets/app.css"} {
+	for _, p := range []string{"/some/page", "/assets/app.css?v=1"} {
 		resp, err := http.Get(ps.URL + p)
 		if err != nil {
 			t.Fatalf("request %s: %v", p, err)
@@ -313,12 +314,16 @@ func TestProxyRewrite_TargetPathIsNotPrefixedOntoRequests(t *testing.T) {
 		resp.Body.Close()
 	}
 	want := []string{"/some/page", "/assets/app.css"}
+	wantQ := []string{"", "v=1"}
 	if len(gotPaths) != len(want) {
 		t.Fatalf("upstream saw %v, want %v", gotPaths, want)
 	}
 	for i := range want {
 		if gotPaths[i] != want[i] {
 			t.Errorf("upstream path[%d] = %q, want %q", i, gotPaths[i], want[i])
+		}
+		if gotQueries[i] != wantQ[i] {
+			t.Errorf("upstream query[%d] = %q, want %q", i, gotQueries[i], wantQ[i])
 		}
 	}
 }
@@ -420,6 +425,55 @@ func TestProxyModifyResponse_AbsoluteSameOriginRedirectRewritten(t *testing.T) {
 	}
 	if loc != "/admin" {
 		t.Errorf("Location = %q, want %q", loc, "/admin")
+	}
+}
+
+func TestProxyModifyResponse_SameOriginRedirectStripsUserinfo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://user:pass@"+r.Host+"/admin")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	resp, err := client.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if loc := resp.Header.Get("Location"); loc != "/admin" {
+		t.Errorf("Location = %q, want %q (userinfo must not leave a protocol-relative URL)", loc, "/admin")
+	}
+}
+
+func TestProxyModifyResponse_SameOriginRedirectCollapsesLeadingDoubleSlash(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path "//evil.com/x" after origin-strip would be protocol-relative
+		w.Header().Set("Location", "http://"+r.Host+"//evil.com/x")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	resp, err := client.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	loc := resp.Header.Get("Location")
+	if strings.HasPrefix(loc, "//") {
+		t.Errorf("Location = %q is protocol-relative; iframe would leave the proxy origin", loc)
+	}
+	if loc != "/evil.com/x" {
+		t.Errorf("Location = %q, want %q", loc, "/evil.com/x")
 	}
 }
 

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -292,6 +292,40 @@ func TestProxyModifyResponse_SameOriginRedirectRewritten(t *testing.T) {
 	}
 }
 
+func TestProxyModifyResponse_AbsoluteSameOriginRedirectRewritten(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			// Absolute Location on the target's own origin, as Laravel's
+			// redirect()->route() emits
+			w.Header().Set("Location", "http://"+r.Host+"/admin")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>admin</body></html>")
+	}))
+	defer upstream.Close()
+	upURL, _ := url.Parse(upstream.URL)
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	resp, err := client.Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	loc := resp.Header.Get("Location")
+	if strings.Contains(loc, upURL.Host) {
+		t.Errorf("Location still points to upstream, iframe would leave the proxy origin: %s", loc)
+	}
+	if loc != "/admin" {
+		t.Errorf("Location = %q, want %q", loc, "/admin")
+	}
+}
+
 func TestProxyModifyResponse_CrossOriginRedirect200Stub(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "https://accounts.google.com/oauth", http.StatusFound)

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -292,6 +292,37 @@ func TestProxyModifyResponse_SameOriginRedirectRewritten(t *testing.T) {
 	}
 }
 
+func TestProxyRewrite_TargetPathIsNotPrefixedOntoRequests(t *testing.T) {
+	var gotPaths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+	// A live URL with a path: the frontend requests that path as the initial
+	// route, so the proxy must not prefix it a second time
+	proxy, _ := newLiveProxy(upstream.URL+"/some/page", 9001, "")
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	for _, p := range []string{"/some/page", "/assets/app.css"} {
+		resp, err := http.Get(ps.URL + p)
+		if err != nil {
+			t.Fatalf("request %s: %v", p, err)
+		}
+		resp.Body.Close()
+	}
+	want := []string{"/some/page", "/assets/app.css"}
+	if len(gotPaths) != len(want) {
+		t.Fatalf("upstream saw %v, want %v", gotPaths, want)
+	}
+	for i := range want {
+		if gotPaths[i] != want[i] {
+			t.Errorf("upstream path[%d] = %q, want %q", i, gotPaths[i], want[i])
+		}
+	}
+}
+
 func TestProxyRewrite_SendsForwardedHeaders(t *testing.T) {
 	var gotHost, gotProto, gotPort, gotFor string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Three bugs in live mode's proxy, each one only visible after the previous is fixed. Together they were enough to make live mode unusable against a Laravel app behind a reverse proxy.

One commit each.

## 1. An absolute same-origin redirect takes the iframe off the proxy origin

In live mode, if the app answers the entry request with a redirect to an **absolute** URL on its own origin, the iframe follows it and leaves crit's proxy origin. The injected agent can never reach the document there, so `AGENT_READY` never arrives and Pin stays `disabled title="Loading…"` forever.

Since the app renders fine inside the iframe after the redirect, it's confusing why you cannot click on the pin button to enter pin mode.

```bash
crit live https://myapp.test    # / responds 302 -> https://myapp.test/admin
```

```html
<iframe id="critLiveIframe" src="http://localhost:55638/">
  #document (https://myapp.test/admin)     <- different origin
</iframe>
```

`rewriteRedirect` already tries to point a same-host `Location` back at the proxy:

```go
if locURL.Host == upstream.Host {
    locURL.Scheme = resp.Request.URL.Scheme
    locURL.Host = resp.Request.URL.Host
```

In `ModifyResponse`, `resp.Request` is the *outbound* request, the one `SetURL` already retargeted at the upstream. So its scheme and host are the upstream's.

Frameworks that emit relative Locations (Go's `http.Redirect`, and most others) hit the `locURL.Host == ""` early return above and were never affected, which is why this went unnoticed. Laravel's `redirect()->route()` emits an absolute URL.

Fix: strip the origin so the `Location` is proxy-relative. The browser then resolves it against whatever port the proxy is listening on, and no part of the code needs to know that port.

## 2. No `X-Forwarded-*` headers, so the app can't generate proxy-correct URLs

Because the proxy uses `Rewrite` rather than a `Director`, `ReverseProxy` sets no `X-Forwarded` headers at all, `X-Forwarded-For` included.

`SetURL` blanks `Out.Host` so the upstream sees its own host, which is what vhost routing and TLS SNI need. The consequence is that every absolute URL the app generates points at itself rather than at the proxy. Module scripts are always fetched in CORS mode, so served from the proxy origin they're cross-origin, a plain static asset carries no `Access-Control-Allow-Origin`, and the request is blocked. An Inertia/Vite app never boots, leaving a bare `<div id="app">`.

With nothing forwarded, an app had no way to opt into generating proxy-correct URLs. Laravel's `TrustProxies` had nothing to trust.

`pr.SetXForwarded()` covers For, Host and Proto. Port needs setting by hand, for two reasons: Symfony reads `X-Forwarded-Port` ahead of the port inside `X-Forwarded-Host`, and a proxy sitting between crit and the app sets that header itself, so without ours the app builds URLs on the wrong port. That last case is not hypothetical, it's what made this fail for me: an `nginx-proxy` in front of the app injected `X-Forwarded-Port: 443` and Laravel generated `http://127.0.0.1:443/...`.

Same commit: once the app does generate proxy-correct URLs, its redirects land on the proxy's own origin, which `rewriteRedirect` measured only against the upstream's host and so replaced with the `cross-origin-redirect` stub. It now accepts either origin.

## 3. The live URL's path is prefixed onto every proxied request

The frontend already reads the path out of the live URL and loads it as the iframe's initial route, so the proxy maps paths 1:1. Leaving that path on the target made `SetURL` join it onto every request:

```
crit live https://app.test/admin/members

/admin/members          -> /admin/members/admin/members        404
/build/assets/app.css   -> /admin/members/build/assets/app.css 404
```

Only reachable once #2 lands. Before that, assets addressed the app's own origin and never met the proxy, so only the entry document hit it.

## Tests

```
TestProxyModifyResponse_AbsoluteSameOriginRedirectRewritten
TestProxyRewrite_SendsForwardedHeaders
TestProxyModifyResponse_ProxyOriginRedirectIsNotCrossOrigin
TestProxyRewrite_TargetPathIsNotPrefixedOntoRequests
```

Each was checked failing before its fix. The existing `TestProxyModifyResponse_SameOriginRedirectRewritten` uses `http.Redirect` with a relative path, so it passed via the early return and never exercised the branch in #1.

## Checks

`gofmt -l .` clean, `golangci-lint run ./...` reports 0 issues, `go test ./...` passes, and the `live-mode` Playwright project passes (102 passed, 8 skipped).

Two pre-existing failures on my machine, both reproducing on a clean `main` checkout and unrelated to this change: `TestDiscoverCodeFontFamiliesScansTheCurrentSystem`, and `internal/comment` + `internal/github` failing whenever a crit review daemon is live in the repo root (most visibly `TestResolveCommentScope`'s "no daemon" cases).

## Verified end to end

Against a real Laravel 12 + Inertia app behind `nginx-proxy`, driving Chrome over CDP: the entry redirect stays on the proxy origin, assets load same-origin (`200`, no CORS errors), the SPA boots, Pin enables, clicking an element anchors a pin and opens the composer.

## Not in this PR

Rewriting same-origin absolute URLs in proxied HTML, or injecting a `<base>`, would fix the asset problem without the app opting into trusted proxies at all. It's the more general fix and I'm happy to follow up, but it's a blunter instrument and felt like your call rather than mine.

Also untouched: Pin's `title="Loading…"` is indistinguishable from a slow page. Saying which origin the frame is on when the agent can't be reached would make this whole class of problem self-diagnosing.
