### PR TITLE
fix: keep the referring page's path in live mode's Referer

### DIFF
--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -75,8 +75,8 @@ func newLiveProxy(upstreamOrigin string, apiPort int, upstreamCookies string) (h
 			if pr.Out.Header.Get("Origin") != "" {
 				pr.Out.Header.Set("Origin", target.Scheme+"://"+target.Host)
 			}
-			if pr.Out.Header.Get("Referer") != "" {
-				pr.Out.Header.Set("Referer", target.Scheme+"://"+target.Host+pr.Out.URL.Path)
+			if ref := pr.Out.Header.Get("Referer"); ref != "" {
+				pr.Out.Header.Set("Referer", rewriteReferer(ref, target))
 			}
 		},
 		Transport:      transport,
@@ -401,4 +401,19 @@ func BindProxyServer(upstreamOrigin string, apiPort int, upstreamCookies string)
 		IdleTimeout: 60 * time.Second,
 	}
 	return ln, srv, nil
+}
+
+// rewriteReferer swaps in the upstream origin but keeps the referring page's own path
+// and query, which frameworks read to work out where "redirect back" should land
+func rewriteReferer(ref string, upstream *url.URL) string {
+	origin := upstream.Scheme + "://" + upstream.Host
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return origin
+	}
+	out := origin + refURL.EscapedPath()
+	if refURL.RawQuery != "" {
+		out += "?" + refURL.RawQuery
+	}
+	return out
 }

--- a/internal/live/proxy.go
+++ b/internal/live/proxy.go
@@ -404,14 +404,26 @@ func BindProxyServer(upstreamOrigin string, apiPort int, upstreamCookies string)
 }
 
 // rewriteReferer swaps in the upstream origin but keeps the referring page's own path
-// and query, which frameworks read to work out where "redirect back" should land
+// and query, which frameworks read to work out where "redirect back" should land.
+// Path is built the same way as rewriteRedirect: never via url.URL.String(), and
+// leading "//" is collapsed so a forged Referer cannot become protocol-relative
+// when an app turns it into a Location.
 func rewriteReferer(ref string, upstream *url.URL) string {
 	origin := upstream.Scheme + "://" + upstream.Host
 	refURL, err := url.Parse(ref)
 	if err != nil {
 		return origin
 	}
-	out := origin + refURL.EscapedPath()
+	path := refURL.EscapedPath()
+	if path == "" {
+		path = "/"
+	} else if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	for strings.HasPrefix(path, "//") {
+		path = "/" + strings.TrimLeft(path, "/")
+	}
+	out := origin + path
 	if refURL.RawQuery != "" {
 		out += "?" + refURL.RawQuery
 	}

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -328,6 +328,57 @@ func TestProxyRewrite_TargetPathIsNotPrefixedOntoRequests(t *testing.T) {
 	}
 }
 
+func TestProxyRewrite_RefererKeepsReferringPagePath(t *testing.T) {
+	var gotReferer string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("Referer")
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	// A form on /claims/create posting to /claims: "redirect back" reads the
+	// referer, so it has to point at the create page
+	req, _ := http.NewRequest(http.MethodPost, ps.URL+"/claims", nil)
+	req.Header.Set("Referer", ps.URL+"/claims/create?step=2")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	want := upstream.URL + "/claims/create?step=2"
+	if gotReferer != want {
+		t.Errorf("Referer = %q, want %q", gotReferer, want)
+	}
+}
+
+func TestProxyRewrite_RefererDropsUserinfoAndFragment(t *testing.T) {
+	var gotReferer string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("Referer")
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, "<html><body>ok</body></html>")
+	}))
+	defer upstream.Close()
+	proxy, _ := newLiveProxy(upstream.URL, 9001, "")
+	ps := httptest.NewServer(proxy)
+	defer ps.Close()
+	psURL, _ := url.Parse(ps.URL)
+	req, _ := http.NewRequest(http.MethodPost, ps.URL+"/claims", nil)
+	req.Header.Set("Referer", "http://user:pass@"+psURL.Host+"/claims/create#section")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	want := upstream.URL + "/claims/create"
+	if gotReferer != want {
+		t.Errorf("Referer = %q, want %q (userinfo and fragment must not reach the upstream)", gotReferer, want)
+	}
+}
+
 func TestProxyRewrite_SendsForwardedHeaders(t *testing.T) {
 	var gotHost, gotProto, gotPort, gotFor string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/live/proxy_test.go
+++ b/internal/live/proxy_test.go
@@ -379,6 +379,34 @@ func TestProxyRewrite_RefererDropsUserinfoAndFragment(t *testing.T) {
 	}
 }
 
+func TestRewriteReferer(t *testing.T) {
+	upstream, err := url.Parse("http://app.test:3000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	origin := "http://app.test:3000"
+	cases := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "keeps path and query", ref: "http://127.0.0.1:9/claims/create?step=2", want: origin + "/claims/create?step=2"},
+		{name: "drops userinfo and fragment", ref: "http://user:pass@127.0.0.1:9/claims/create#x", want: origin + "/claims/create"},
+		{name: "collapses double-slash path", ref: "http://127.0.0.1:9//evil.com/x", want: origin + "/evil.com/x"},
+		{name: "relative without slash", ref: "claims/create", want: origin + "/claims/create"},
+		{name: "empty path becomes slash", ref: "http://127.0.0.1:9", want: origin + "/"},
+		{name: "unparseable falls back to origin", ref: "://bad", want: origin},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewriteReferer(tc.ref, upstream)
+			if got != tc.want {
+				t.Errorf("rewriteReferer(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProxyRewrite_SendsForwardedHeaders(t *testing.T) {
 	var gotHost, gotProto, gotPort, gotFor string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Live mode's proxy rewrites the `Referer` header using the **current** request's path instead of the referring page's, so any framework that reads `Referer` to work out where "redirect back" goes sends the user to the wrong place.

## The bug

A form on `/claims/create` posts to `/claims`. The browser sends `Referer: http://127.0.0.1:PORT/claims/create`, and the proxy replaces it:

```go
pr.Out.Header.Set("Referer", target.Scheme+"://"+target.Host+pr.Out.URL.Path)
```

`pr.Out.URL.Path` is the outbound request's path, which by then is the POST target. So the app receives `Referer: https://app.test/claims`, pointing at the list page rather than the form.

Laravel's `redirect()->back()` reads `Referer` ahead of the session's previous URL:

```php
$referrer = $this->request->headers->get('referer');
$url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
```

So a validation failure redirects to the list page, and the flashed errors land on a page the user never sees. The form looks like it silently succeeded. Inertia apps hit this on every form, since its axios POST carries the document URL as `Referer`.

It affects anything reading `Referer` for a back-redirect, and any request whose referring page differs from its target, so most non-GET traffic.

## Repro

Verified against a real Laravel/Inertia app behind a reverse proxy. Same failing `POST /login` through both builds, with `Referer` set to a different page:

```
before:  Location: /login                        <- the POST target
after:   Location: /on-track-accident-claims/create   <- the referring page
```

## Fix

Keep the referring page's path and query, and swap in only the origin.

The URL is built explicitly rather than mutating the parsed one and calling `String()`. Same reasoning as b1036eb of #860: `String()` on a mutated `url.URL` carries pieces you did not intend, here userinfo and the fragment, straight to the upstream. A `Referer` of `http://user:pass@host/x#frag` would forward those credentials to the app.

## Tests

- `TestProxyRewrite_RefererKeepsReferringPagePath` covers the reported bug, including the query string.
- `TestProxyRewrite_RefererDropsUserinfoAndFragment` covers the leak above. Confirmed it fails against the `String()` version.
