### PR TITLE
fix: style horizontal rules in comment and reply bodies

### DIFF
--- a/test/e2e/tests/comment-hr.spec.ts
+++ b/test/e2e/tests/comment-hr.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, mdSection, switchToDocumentView } from './helpers';
+
+test.describe('Comment horizontal rules', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToDocumentView(page);
+  });
+
+  test('styles markdown horizontal rules in comment bodies', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlock = section.locator('.line-block').first();
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill('Above\n\n---\n\nBelow');
+    await page.locator('.comment-form .btn-primary').click();
+
+    const hr = section.locator('.comment-card .comment-body hr');
+    await expect(hr).toHaveCount(1);
+    await expect(hr).toHaveCSS('height', '1px');
+    await expect(hr).toHaveCSS('border-top-width', '0px');
+  });
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1738,6 +1738,14 @@ body.dragging { user-select: none; cursor: grabbing; }
   color: var(--crit-editor-fg-secondary);
 }
 
+.comment-body hr,
+.reply-body hr {
+  border: none;
+  height: 1px;
+  background: var(--crit-border);
+  margin: 24px 0;
+}
+
 /* Sanitized comment markdown keeps no classes, so key off the elements.
    A comment card is narrow: cells take a full border, not row rules alone. */
 .comment-body table,


### PR DESCRIPTION
## Summary
- Theme `<hr>` in `.comment-body` and `.reply-body` to match `.line-content hr`
- Add Playwright test in `comment-hr.spec.ts`

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- pre-commit hook green (gofmt, golangci-lint, go test)
- See also: tomasz-tomczyk/crit-web#382