### PR TITLE
fix: render agent-style quoted questions as comment blockquotes

### DIFF
--- a/test/e2e/tests/comment-blockquote.spec.ts
+++ b/test/e2e/tests/comment-blockquote.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { clearAllComments, loadPage, mdSection, switchToDocumentView } from './helpers';
+
+test.describe('Comment blockquotes', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await clearAllComments(request);
+    await loadPage(page);
+    await switchToDocumentView(page);
+  });
+
+  test('renders markdown blockquotes and agent-style **> question** lines', async ({ page }) => {
+    const section = mdSection(page);
+    const lineBlock = section.locator('.line-block').first();
+    await lineBlock.hover();
+    await section.locator('.line-comment-gutter').first().click();
+
+    const textarea = page.locator('.comment-form textarea');
+    await textarea.fill([
+      'Intro.',
+      '',
+      '> proper blockquote',
+      '',
+      '**> bold-wrapped quoted question?**',
+      '',
+      'Answer.',
+    ].join('\n'));
+    await page.locator('.comment-form .btn-primary').click();
+
+    const blockquotes = section.locator('.comment-card .comment-body blockquote');
+    await expect(blockquotes).toHaveCount(2);
+    await expect(blockquotes.first()).toHaveText('proper blockquote');
+    await expect(blockquotes.nth(1)).toHaveText('bold-wrapped quoted question?');
+    await expect(section.locator('.comment-card .comment-body strong')).toHaveCount(0);
+  });
+});

--- a/web/__tests__/comment-blockquote.test.js
+++ b/web/__tests__/comment-blockquote.test.js
@@ -1,0 +1,59 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const markdownit = require('markdown-it');
+
+// Keep in sync with web/comment-html.js
+const BOLD_BLOCKQUOTE_LINE = /^\*\*\s*>\s*(.+?)\s*\*\*$/gm;
+
+function normalizeCommentMarkdown(src) {
+  if (!src) return src;
+  return String(src).replace(BOLD_BLOCKQUOTE_LINE, '> $1');
+}
+
+function makeCommentMd() {
+  const md = markdownit({
+    html: true,
+    linkify: true,
+    typographer: true,
+    highlight() { return ''; },
+  });
+  md.disable('replacements');
+  return md;
+}
+
+test('normalizeCommentMarkdown converts **> question** lines to blockquotes', () => {
+  const md = makeCommentMd();
+  const body = [
+    'Intro paragraph.',
+    '',
+    '**> are the 280 jobs actually staggered or do they all fire at once anyway?**',
+    '',
+    'Answer paragraph.',
+  ].join('\n');
+
+  const html = md.render(normalizeCommentMarkdown(body));
+  assert.match(html, /<blockquote>\s*<p>are the 280 jobs/);
+  assert.doesNotMatch(html, /&gt; are the 280 jobs/);
+  assert.doesNotMatch(html, /<strong>/);
+});
+
+test('normalizeCommentMarkdown leaves proper blockquotes unchanged', () => {
+  const md = makeCommentMd();
+  const html = md.render(normalizeCommentMarkdown('> already a blockquote'));
+  assert.match(html, /<blockquote>\s*<p>already a blockquote<\/p>\s*<\/blockquote>/);
+});
+
+test('comment-html.js exports normalizeCommentMarkdown', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'comment-html.js'), 'utf8');
+  assert.match(src, /function normalizeCommentMarkdown/);
+  assert.match(src, /normalizeCommentMarkdown: normalizeCommentMarkdown/);
+});
+
+test('style.css: comment and reply blockquotes use document blockquote tokens', () => {
+  const css = fs.readFileSync(path.join(__dirname, '..', 'style.css'), 'utf8');
+  assert.match(css, /\.comment-body blockquote[\s\S]*?var\(--crit-blockquote-border\)/);
+  assert.match(css, /\.comment-body blockquote[\s\S]*?var\(--crit-blockquote-bg\)/);
+  assert.match(css, /\.reply-body blockquote[\s\S]*?var\(--crit-blockquote-border\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -247,10 +247,12 @@
   })();
   const renderCommentMarkdown = commentMd.render.bind(commentMd);
   commentMd.render = function(src, env) {
+    src = window.crit.commentHtml.normalizeCommentMarkdown(src);
     return window.crit.commentHtml.sanitize(renderCommentMarkdown(src, env));
   };
   const renderInlineCommentMarkdown = commentMd.renderInline.bind(commentMd);
   commentMd.renderInline = function(src, env) {
+    src = window.crit.commentHtml.normalizeCommentMarkdown(src);
     return window.crit.commentHtml.sanitize(renderInlineCommentMarkdown(src, env));
   };
 

--- a/web/comment-html.js
+++ b/web/comment-html.js
@@ -97,5 +97,14 @@
     });
   }
 
-  return { sanitize: sanitize };
+  // Agents often quote review questions as **> text** instead of markdown
+  // blockquotes. Normalize those lines before markdown-it runs.
+  var BOLD_BLOCKQUOTE_LINE = /^\*\*\s*>\s*(.+?)\s*\*\*$/gm;
+
+  function normalizeCommentMarkdown(src) {
+    if (!src) return src;
+    return String(src).replace(BOLD_BLOCKQUOTE_LINE, '> $1');
+  }
+
+  return { sanitize: sanitize, normalizeCommentMarkdown: normalizeCommentMarkdown };
 });

--- a/web/live-mode.panel-render.js
+++ b/web/live-mode.panel-render.js
@@ -72,6 +72,7 @@
           };
           var renderCommentMarkdown = commentMd.render.bind(commentMd);
           commentMd.render = function (src, env) {
+            src = window.crit.commentHtml.normalizeCommentMarkdown(src);
             return window.crit.commentHtml.sanitize(renderCommentMarkdown(src, env));
           };
         }

--- a/web/style.css
+++ b/web/style.css
@@ -1732,10 +1732,16 @@ body.dragging { user-select: none; cursor: grabbing; }
   border-bottom-color: var(--crit-brand-hover);
 }
 .comment-body blockquote {
-  border-left: 3px solid var(--crit-border);
-  margin: 0.5em 0;
-  padding-left: 10px;
+  margin: 6px 0;
+  padding: 8px 16px;
+  border-left: 3px solid var(--crit-blockquote-border);
+  background: var(--crit-blockquote-bg);
+  border-radius: 0 6px 6px 0;
   color: var(--crit-editor-fg-secondary);
+}
+
+.comment-body blockquote p {
+  margin: 2px 0;
 }
 
 .comment-body hr,
@@ -1829,10 +1835,16 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 
 .reply-body blockquote {
-  margin: 0.3em 0;
-  padding-left: 0.8em;
-  border-left: 3px solid var(--crit-border);
+  margin: 6px 0;
+  padding: 8px 16px;
+  border-left: 3px solid var(--crit-blockquote-border);
+  background: var(--crit-blockquote-bg);
+  border-radius: 0 6px 6px 0;
   color: var(--crit-editor-fg-secondary);
+}
+
+.reply-body blockquote p {
+  margin: 2px 0;
 }
 
 .reply-body p {


### PR DESCRIPTION
## Summary
- Normalize `**> text**` lines (common agent pattern when echoing review questions) into proper markdown blockquotes before rendering
- Style `.comment-body blockquote` and `.reply-body blockquote` to match document blockquotes
- Add unit and Playwright coverage for blockquote rendering in comments

## Review
- [x] Code review: passed
- [x] Parity audit: paired with tomasz-tomczyk/crit-web#383

## Test plan
- [x] Pre-commit hooks (gofmt, golangci-lint, go test -race, ESLint, Stylelint)
- [x] `node --test web/__tests__/comment-blockquote.test.js`
- [x] Manual eyeball on localhost demo session
- See also: tomasz-tomczyk/crit-web#383

Made with [Cursor](https://cursor.com)