### PR TITLE
feat: add api_version to GET /api/health for client compatibility (#812)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ All routes wrapped with `s.withReady` return 503 until session init completes �
 
 Session-scoped:
 
-- `GET  /api/health` — liveness probe (no readiness gate; used for daemon health checks)
+- `GET  /api/health` — liveness probe (no readiness gate; used for daemon health checks); `{status, browser_clients, api_version}` — bump `APIVersion` only for breaking HTTP API changes; missing `api_version` = 0
 - `GET  /api/qr` — QR code for current shared URL
 - `GET  /api/session` — session metadata
 - `GET  /api/config` — `{share_url, hosted_url, delete_token, version, latest_version, ...}`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2441,6 +2441,12 @@ func buildCommentsListCommand(sess *Session) string {
 	return fmt.Sprintf("crit comments --json %s", shellQuoteArg(sess.CritJSONPath()))
 }
 
+// APIVersion is the HTTP API protocol version returned by GET /api/health as
+// api_version. Bump only for breaking changes (removed/renamed fields or
+// endpoints, changed field meaning, or changed request shape). Additive
+// changes do not require a bump. Clients treat a missing field as version 0.
+const APIVersion = 1
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -2453,6 +2459,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{
 		"status":          "ok",
 		"browser_clients": browserClients,
+		"api_version":     APIVersion,
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2281,6 +2281,16 @@ func TestHealthEndpoint(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("GET /api/health: got %d, want 200", w.Code)
 	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("status = %v, want ok", resp["status"])
+	}
+	if resp["api_version"] != float64(APIVersion) {
+		t.Errorf("api_version = %v, want %d", resp["api_version"], APIVersion)
+	}
 }
 
 // Regression: /api/review-cycle is POST-only. The frontend used to GET it
@@ -4020,6 +4030,9 @@ func TestHandleHealth_WithBrowserClients(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["browser_clients"] != true {
 		t.Errorf("browser_clients = %v, want true", resp["browser_clients"])
+	}
+	if resp["api_version"] != float64(APIVersion) {
+		t.Errorf("api_version = %v, want %d", resp["api_version"], APIVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add exported `APIVersion` (currently `1`) and return it as `api_version` on `GET /api/health` without changing existing fields.
- Document bump rules in AGENTS.md: bump only for breaking HTTP API changes; clients treat a missing field as version `0`.
- Extend health endpoint tests to assert `api_version` matches `APIVersion`.

## Review
- [x] Code review: passed (SHIP IT)
- [x] Intent audit: clean
- [x] Parity audit: N/A (server-only)

## Test plan
- [x] `mise exec -- go test ./internal/server/...`
- [ ] CI green

Closes #812

Made with [Cursor](https://cursor.com)