### PR TITLE
fix: accept --session on crit push and pull (#873)

### DIFF
--- a/cmd/crit/cli_dispatch.go
+++ b/cmd/crit/cli_dispatch.go
@@ -54,7 +54,7 @@ Open a GitHub pull request for review.`},
 	{name: "mr", handler: runMR, help: `Usage: crit mr <iid|url>
 
 Open a GitLab merge request for review.`},
-	{name: "pull", handler: runPull, help: `Usage: crit pull [--output <dir>] [number|url]
+	{name: "pull", handler: runPull, help: `Usage: crit pull [--session <id>] [--output <dir>] [number|url]
 
 Fetch PR/MR comments into the local review file.`},
 	{name: "push", handler: runPush, help: `Usage: crit push [options] [number|url]
@@ -62,6 +62,7 @@ Fetch PR/MR comments into the local review file.`},
 Post local comments as a PR/MR review.
 
 Options:
+      --session <id>     Target an active review session
       --dry-run          Preview without posting
   -e, --event <type>     comment, approve, or request-changes
   -m, --message <text>   Review-level message
@@ -304,8 +305,8 @@ Sharing:
   crit unpublish [file...]                   Remove a shared review from crit-web
 
 Remote review sync (provider auto-detected, or set "forge" in config):
-  crit pull [number|url]                     Fetch PR/MR comments into the review file
-  crit push [--dry-run] [number|url]         Post review comments to a PR/MR
+  crit pull [--session <id>] [number|url]    Fetch PR/MR comments into the review file
+  crit push [--session <id>] [--dry-run] [number|url]  Post review comments to a PR/MR
 
 Setup & management:
   crit install <agent>                       Install integration for an AI coding tool

--- a/internal/forge/cli.go
+++ b/internal/forge/cli.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
 )
 
 // SelectProviderFn and ReviewFn are wired by cmd/crit, where concrete
@@ -142,14 +144,22 @@ func parsePullRequest(args []string) (PullRequest, error) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--output", "-o":
-			if i+1 >= len(args) {
-				return request, fmt.Errorf("%s requires a value", args[i])
+			val, next, err := requireFlagValue(args, i)
+			if err != nil {
+				return request, err
 			}
-			i++
-			request.OutputDir = args[i]
+			i = next
+			request.OutputDir = val
+		case "--session":
+			id, next, err := parseSessionFlag(args, i)
+			if err != nil {
+				return request, err
+			}
+			i = next
+			request.SessionID = id
 		default:
 			if request.ChangeSpec != "" {
-				return request, fmt.Errorf("usage: crit pull [--forge <provider>] [--output <dir>] [number|url]")
+				return request, fmt.Errorf("usage: crit pull [--forge <provider>] [--session <id>] [--output <dir>] [number|url]")
 			}
 			request.ChangeSpec = args[i]
 		}
@@ -164,26 +174,36 @@ func parsePushRequest(args []string) (PushRequest, error) {
 		case "--dry-run":
 			request.DryRun = true
 		case "--message", "-m":
-			if i+1 >= len(args) {
-				return request, fmt.Errorf("%s requires a value", args[i])
+			val, next, err := requireFlagValue(args, i)
+			if err != nil {
+				return request, err
 			}
-			i++
-			request.Message = args[i]
+			i = next
+			request.Message = val
 		case "--output", "-o":
-			if i+1 >= len(args) {
-				return request, fmt.Errorf("%s requires a value", args[i])
+			val, next, err := requireFlagValue(args, i)
+			if err != nil {
+				return request, err
 			}
-			i++
-			request.OutputDir = args[i]
+			i = next
+			request.OutputDir = val
+		case "--session":
+			id, next, err := parseSessionFlag(args, i)
+			if err != nil {
+				return request, err
+			}
+			i = next
+			request.SessionID = id
 		case "--event", "-e":
-			if i+1 >= len(args) {
-				return request, fmt.Errorf("%s requires a value", args[i])
+			val, next, err := requireFlagValue(args, i)
+			if err != nil {
+				return request, err
 			}
-			i++
-			request.Event = strings.ToLower(args[i])
+			i = next
+			request.Event = strings.ToLower(val)
 		default:
 			if request.ChangeSpec != "" {
-				return request, fmt.Errorf("usage: crit push [--forge <provider>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [number|url]")
+				return request, fmt.Errorf("usage: crit push [--forge <provider>] [--session <id>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [number|url]")
 			}
 			request.ChangeSpec = args[i]
 		}
@@ -197,4 +217,22 @@ func parsePushRequest(args []string) (PushRequest, error) {
 		return request, fmt.Errorf("--event request-changes requires --message")
 	}
 	return request, nil
+}
+
+func requireFlagValue(args []string, i int) (string, int, error) {
+	if i+1 >= len(args) {
+		return "", i, fmt.Errorf("%s requires a value", args[i])
+	}
+	return args[i+1], i + 1, nil
+}
+
+func parseSessionFlag(args []string, i int) (string, int, error) {
+	id, next, err := requireFlagValue(args, i)
+	if err != nil {
+		return "", i, err
+	}
+	if !daemon.ValidSessionKey(id) {
+		return "", i, daemon.InvalidSessionIDError(id)
+	}
+	return id, next, nil
 }

--- a/internal/forge/cli_test.go
+++ b/internal/forge/cli_test.go
@@ -72,6 +72,23 @@ func TestParsePullRequest(t *testing.T) {
 	}
 }
 
+func TestParsePullRequestSession(t *testing.T) {
+	request, err := parsePullRequest([]string{"--session", "aaaaaaaaaaaa", "42"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.SessionID != "aaaaaaaaaaaa" || request.ChangeSpec != "42" {
+		t.Fatalf("request = %+v", request)
+	}
+	_, err = parsePullRequest([]string{"--session", "abc"})
+	if err == nil || !strings.Contains(err.Error(), "invalid session ID") {
+		t.Fatalf("invalid session error = %v", err)
+	}
+	if _, err := parsePullRequest([]string{"--session"}); err == nil || !strings.Contains(err.Error(), "--session requires a value") {
+		t.Fatalf("missing session value error = %v", err)
+	}
+}
+
 func TestParsePushRequest(t *testing.T) {
 	request, err := parsePushRequest([]string{"--dry-run", "--event", "request-changes", "-m", "please fix", "42"})
 	if err != nil {
@@ -79,6 +96,23 @@ func TestParsePushRequest(t *testing.T) {
 	}
 	if !request.DryRun || request.Event != "request-changes" || request.Message != "please fix" || request.ChangeSpec != "42" {
 		t.Fatalf("request = %+v", request)
+	}
+}
+
+func TestParsePushRequestSession(t *testing.T) {
+	request, err := parsePushRequest([]string{"--session", "bbbbbbbbbbbb", "--dry-run", "7"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.SessionID != "bbbbbbbbbbbb" || !request.DryRun || request.ChangeSpec != "7" {
+		t.Fatalf("request = %+v", request)
+	}
+	_, err = parsePushRequest([]string{"--session", "not-hex"})
+	if err == nil || !strings.Contains(err.Error(), "invalid session ID") {
+		t.Fatalf("invalid session error = %v", err)
+	}
+	if _, err := parsePushRequest([]string{"--session"}); err == nil || !strings.Contains(err.Error(), "--session requires a value") {
+		t.Fatalf("missing session value error = %v", err)
 	}
 }
 
@@ -228,14 +262,34 @@ func TestCLIParsingRejectsMissingAndDuplicateValues(t *testing.T) {
 			t.Errorf("extractKindFlag(%v) unexpectedly succeeded", args)
 		}
 	}
-	for _, args := range [][]string{{"--output"}, {"1", "2"}} {
+	for _, args := range [][]string{{"--output"}, {"1", "2"}, {"--session"}} {
 		if _, err := parsePullRequest(args); err == nil {
 			t.Errorf("parsePullRequest(%v) unexpectedly succeeded", args)
 		}
 	}
-	for _, args := range [][]string{{"--message"}, {"--output"}, {"--event"}, {"1", "2"}, {"--event", "bogus"}} {
+	for _, args := range [][]string{{"--message"}, {"--output"}, {"--event"}, {"1", "2"}, {"--event", "bogus"}, {"--session"}} {
 		if _, err := parsePushRequest(args); err == nil {
 			t.Errorf("parsePushRequest(%v) unexpectedly succeeded", args)
 		}
+	}
+}
+
+func TestRunPullAndPushForwardSession(t *testing.T) {
+	provider := &cliTestProvider{kind: GitHub}
+	withCLIProvider(t, provider)
+
+	if err := RunPull([]string{"--session", "cccccccccccc", "9"}); err != nil {
+		t.Fatal(err)
+	}
+	if provider.pullRequest.SessionID != "cccccccccccc" || provider.pullRequest.ChangeSpec != "9" {
+		t.Fatalf("pull request = %+v", provider.pullRequest)
+	}
+
+	if err := RunPush([]string{"--session", "dddddddddddd", "--dry-run", "11"}); err != nil {
+		t.Fatal(err)
+	}
+	want := PushRequest{ChangeSpec: "11", SessionID: "dddddddddddd", DryRun: true, Event: "comment"}
+	if !reflect.DeepEqual(provider.pushRequest, want) {
+		t.Fatalf("push request = %+v, want %+v", provider.pushRequest, want)
 	}
 }

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -90,6 +90,7 @@ type PullRequest struct {
 	Repo       RepoContext
 	ChangeSpec string
 	OutputDir  string
+	SessionID  string
 	Args       []string // compatibility path for direct provider callers
 }
 
@@ -97,6 +98,7 @@ type PushRequest struct {
 	Repo       RepoContext
 	ChangeSpec string
 	OutputDir  string
+	SessionID  string
 	DryRun     bool
 	Message    string
 	Event      string

--- a/internal/github/provider.go
+++ b/internal/github/provider.go
@@ -81,6 +81,9 @@ func githubPullArgs(request forge.PullRequest) ([]string, error) {
 		return request.Args, nil
 	}
 	args := []string{}
+	if request.SessionID != "" {
+		args = append(args, "--session", request.SessionID)
+	}
 	if request.OutputDir != "" {
 		args = append(args, "--output", request.OutputDir)
 	}
@@ -98,7 +101,11 @@ func githubPushArgs(request forge.PushRequest) ([]string, error) {
 	if request.Args != nil {
 		return request.Args, nil
 	}
-	args, err := githubPullArgs(forge.PullRequest{ChangeSpec: request.ChangeSpec, OutputDir: request.OutputDir})
+	args, err := githubPullArgs(forge.PullRequest{
+		ChangeSpec: request.ChangeSpec,
+		OutputDir:  request.OutputDir,
+		SessionID:  request.SessionID,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/provider_test.go
+++ b/internal/github/provider_test.go
@@ -110,6 +110,13 @@ func TestGitHubProviderArgumentTranslation(t *testing.T) {
 	if !reflect.DeepEqual(pull, []string{"--output", "reviews", "12"}) {
 		t.Fatalf("pull args = %v", pull)
 	}
+	pull, err = githubPullArgs(forge.PullRequest{ChangeSpec: "12", SessionID: "aaaaaaaaaaaa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pull, []string{"--session", "aaaaaaaaaaaa", "12"}) {
+		t.Fatalf("session pull args = %v", pull)
+	}
 	compat := []string{"--output", "legacy", "3"}
 	pull, err = githubPullArgs(forge.PullRequest{Args: compat})
 	if err != nil || !reflect.DeepEqual(pull, compat) {
@@ -122,6 +129,14 @@ func TestGitHubProviderArgumentTranslation(t *testing.T) {
 	wantPush := []string{"--dry-run", "--event", "approve", "--message", "ship", "--output", "reviews", "12"}
 	if !reflect.DeepEqual(push, wantPush) {
 		t.Fatalf("push args = %v, want %v", push, wantPush)
+	}
+	push, err = githubPushArgs(forge.PushRequest{ChangeSpec: "12", SessionID: "bbbbbbbbbbbb", DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSessionPush := []string{"--dry-run", "--session", "bbbbbbbbbbbb", "12"}
+	if !reflect.DeepEqual(push, wantSessionPush) {
+		t.Fatalf("session push args = %v, want %v", push, wantSessionPush)
 	}
 	if _, err := githubPullArgs(forge.PullRequest{ChangeSpec: "bad"}); err == nil {
 		t.Fatal("invalid pull spec unexpectedly accepted")

--- a/internal/gitlab/pull.go
+++ b/internal/gitlab/pull.go
@@ -23,6 +23,7 @@ import (
 type pullFlags struct {
 	spec      string
 	outputDir string
+	sessionID string
 }
 
 func parsePullFlags(args []string) (pullFlags, error) {
@@ -35,6 +36,12 @@ func parsePullFlags(args []string) (pullFlags, error) {
 			}
 			i++
 			flags.outputDir = args[i]
+		case "--session":
+			if i+1 >= len(args) {
+				return flags, fmt.Errorf("--session requires a value")
+			}
+			i++
+			flags.sessionID = args[i]
 		default:
 			if flags.spec != "" {
 				return flags, usagePullError()
@@ -46,7 +53,7 @@ func parsePullFlags(args []string) (pullFlags, error) {
 }
 
 func usagePullError() error {
-	fmt.Fprintln(os.Stderr, "Usage: crit pull [--output <dir>] [mr-iid|url]")
+	fmt.Fprintln(os.Stderr, "Usage: crit pull [--session <id>] [--output <dir>] [mr-iid|url]")
 	return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
 }
 
@@ -92,7 +99,7 @@ type gitlabDiscussion struct {
 }
 
 func runPull(ctx context.Context, request forge.PullRequest) (forge.PullResult, error) {
-	flags := pullFlags{spec: request.ChangeSpec, outputDir: request.OutputDir}
+	flags := pullFlags{spec: request.ChangeSpec, outputDir: request.OutputDir, sessionID: request.SessionID}
 	if request.Args != nil {
 		var err error
 		flags, err = parsePullFlags(request.Args)
@@ -115,7 +122,7 @@ func runPull(ctx context.Context, request forge.PullRequest) (forge.PullResult, 
 		return forge.PullResult{}, err
 	}
 
-	critPath, err := review.ResolveReviewPath(flags.outputDir)
+	critPath, err := resolvePushPullReviewPath(flags.sessionID, flags.outputDir)
 	if err != nil {
 		return forge.PullResult{}, err
 	}

--- a/internal/gitlab/pull_test.go
+++ b/internal/gitlab/pull_test.go
@@ -38,13 +38,34 @@ func TestParseGitLabPullFlags(t *testing.T) {
 	if flags.outputDir != "reviews" || flags.spec == "" {
 		t.Fatalf("flags = %+v", flags)
 	}
+	flags, err = parsePullFlags([]string{"--session", "aaaaaaaaaaaa", "7"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags.sessionID != "aaaaaaaaaaaa" || flags.spec != "7" {
+		t.Fatalf("session flags = %+v", flags)
+	}
 	if _, err := parsePullFlags([]string{"--output"}); err == nil {
 		t.Fatal("missing output value unexpectedly accepted")
+	}
+	if _, err := parsePullFlags([]string{"--session"}); err == nil {
+		t.Fatal("missing session value unexpectedly accepted")
 	}
 	_, err = parsePullFlags([]string{"1", "2"})
 	var exitErr clicmd.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("duplicate specs error = %v", err)
+	}
+}
+
+func TestResolvePushPullReviewPathSession(t *testing.T) {
+	_, err := resolvePushPullReviewPath("abc", "")
+	if err == nil || !strings.Contains(err.Error(), "invalid session ID") {
+		t.Fatalf("invalid session error = %v", err)
+	}
+	_, err = resolvePushPullReviewPath("aaaaaaaaaaaa", "/tmp/out")
+	if err == nil || !strings.Contains(err.Error(), "--session cannot be used with --output") {
+		t.Fatalf("session+output error = %v", err)
 	}
 }
 

--- a/internal/gitlab/push.go
+++ b/internal/gitlab/push.go
@@ -23,6 +23,7 @@ type pushFlags struct {
 	dryRun    bool
 	message   string
 	outputDir string
+	sessionID string
 	event     string
 }
 
@@ -44,6 +45,12 @@ func parsePushFlags(args []string) (pushFlags, error) {
 			}
 			i++
 			flags.outputDir = args[i]
+		case "--session":
+			if i+1 >= len(args) {
+				return flags, fmt.Errorf("--session requires a value")
+			}
+			i++
+			flags.sessionID = args[i]
 		case "--event", "-e":
 			if i+1 >= len(args) {
 				return flags, fmt.Errorf("%s requires a value", args[i])
@@ -69,7 +76,7 @@ func parsePushFlags(args []string) (pushFlags, error) {
 }
 
 func usagePushError() error {
-	fmt.Fprintln(os.Stderr, "Usage: crit push [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [mr-iid|url]")
+	fmt.Fprintln(os.Stderr, "Usage: crit push [--session <id>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [mr-iid|url]")
 	return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
 }
 
@@ -115,7 +122,7 @@ func splitLocalMarker(body string) (string, string) {
 }
 
 func runPush(ctx context.Context, request forge.PushRequest) (forge.PushResult, error) { //nolint:gocyclo
-	flags := pushFlags{spec: request.ChangeSpec, dryRun: request.DryRun, message: request.Message, outputDir: request.OutputDir, event: request.Event}
+	flags := pushFlags{spec: request.ChangeSpec, dryRun: request.DryRun, message: request.Message, outputDir: request.OutputDir, sessionID: request.SessionID, event: request.Event}
 	if flags.event == "" {
 		flags.event = "comment"
 	}
@@ -135,7 +142,7 @@ func runPush(ctx context.Context, request forge.PushRequest) (forge.PushResult, 
 	if err := requireGLab(ctx, repo); err != nil {
 		return forge.PushResult{}, err
 	}
-	critPath, cj, err := loadPushReview(flags.outputDir)
+	critPath, cj, err := loadPushReview(flags.sessionID, flags.outputDir)
 	if err != nil {
 		return forge.PushResult{}, err
 	}
@@ -266,8 +273,8 @@ func savePartialGitLabPush(path string, cj session.CritJSON, operationErr error)
 	return operationErr
 }
 
-func loadPushReview(outputDir string) (string, session.CritJSON, error) {
-	critPath, err := review.ResolveReviewPath(outputDir)
+func loadPushReview(sessionID, outputDir string) (string, session.CritJSON, error) {
+	critPath, err := resolvePushPullReviewPath(sessionID, outputDir)
 	if err != nil {
 		return "", session.CritJSON{}, err
 	}
@@ -283,6 +290,13 @@ func loadPushReview(outputDir string) (string, session.CritJSON, error) {
 		return "", cj, fmt.Errorf("invalid review file: %w", err)
 	}
 	return critPath, cj, nil
+}
+
+func resolvePushPullReviewPath(sessionID, outputDir string) (string, error) {
+	if sessionID != "" {
+		return review.ResolveCommandReviewPathWithSession(sessionID, outputDir, "")
+	}
+	return review.ResolveReviewPath(outputDir)
 }
 
 func fetchMRRaw(ctx context.Context, repo forge.RepoContext, id forge.ChangeID) (mrRaw, error) {

--- a/internal/gitlab/push_operations_test.go
+++ b/internal/gitlab/push_operations_test.go
@@ -36,7 +36,14 @@ func TestParseGitLabPushFlags(t *testing.T) {
 	if !flags.dryRun || flags.event != "request-changes" || flags.message != "fix it" || flags.outputDir != "reviews" || flags.spec != "7" {
 		t.Fatalf("flags = %+v", flags)
 	}
-	for _, args := range [][]string{{"--message"}, {"--output"}, {"--event"}, {"--event", "bad"}, {"--event", "request-changes", "7"}} {
+	flags, err = parsePushFlags([]string{"--session", "bbbbbbbbbbbb", "--dry-run", "9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags.sessionID != "bbbbbbbbbbbb" || !flags.dryRun || flags.spec != "9" {
+		t.Fatalf("session flags = %+v", flags)
+	}
+	for _, args := range [][]string{{"--message"}, {"--output"}, {"--event"}, {"--event", "bad"}, {"--event", "request-changes", "7"}, {"--session"}} {
 		if _, err := parsePushFlags(args); err == nil {
 			t.Errorf("parsePushFlags(%v) unexpectedly succeeded", args)
 		}
@@ -289,7 +296,7 @@ func TestPushHelpers(t *testing.T) {
 
 func TestLoadPushReviewErrors(t *testing.T) {
 	outputDir := isolatedReviewOutput(t)
-	if _, _, err := loadPushReview(outputDir); err == nil || !strings.Contains(err.Error(), "no review file found") {
+	if _, _, err := loadPushReview("", outputDir); err == nil || !strings.Contains(err.Error(), "no review file found") {
 		t.Fatalf("missing review error = %v", err)
 	}
 	identity, err := review.ResolveReviewPath(outputDir)
@@ -303,7 +310,7 @@ func TestLoadPushReviewErrors(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := loadPushReview(outputDir); err == nil || !strings.Contains(err.Error(), "invalid review file") {
+	if _, _, err := loadPushReview("", outputDir); err == nil || !strings.Contains(err.Error(), "invalid review file") {
 		t.Fatalf("invalid review error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Parse and validate `--session` (12-char hex) in neutral forge push/pull parsers; plumb `SessionID` on `PullRequest`/`PushRequest`.
- Forward session through GitHub arg translation into existing session-aware CLIs.
- Resolve sessions in GitLab push/pull via `ResolveCommandReviewPathWithSession`.
- Update usage/help; cover parser, forwarding, and session/output conflict.

## Review
- [x] Code review: passed (land)
- [x] Intent audit: clean
- [x] Parity audit: N/A (CLI/forge only)

## Test plan
- [x] `mise exec -- go test ./internal/forge/... ./internal/github/... ./internal/gitlab/... ./cmd/crit/...`
- [ ] CI green

Closes #873

Made with [Cursor](https://cursor.com)