### PR TITLE
chore: remove forge focus / pending-delete legacy JSON aliases (#818)

### DIFF
--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -6,17 +6,15 @@ import (
 	"testing"
 )
 
-func TestFocusUnmarshalNormalizesChangeIdentity(t *testing.T) {
+func TestFocusUnmarshalChangeIdentity(t *testing.T) {
 	tests := []struct {
 		name       string
 		payload    string
 		wantForge  string
 		wantNumber int
 	}{
-		{"canonical gitlab", `{"kind":"range","forge":"gitlab","change_number":17}`, "gitlab", 17},
-		{"canonical github", `{"kind":"range","forge":"github","change_number":42}`, "github", 42},
-		{"legacy gitlab", `{"kind":"range","mr_number":17}`, "gitlab", 17},
-		{"legacy github", `{"kind":"range","pr_number":42}`, "github", 42},
+		{"gitlab", `{"kind":"range","forge":"gitlab","change_number":17}`, "gitlab", 17},
+		{"github", `{"kind":"range","forge":"github","change_number":42}`, "github", 42},
 		{"unknown forge is preserved", `{"kind":"range","forge":"other","change_number":9}`, "other", 9},
 	}
 	for _, tt := range tests {

--- a/internal/session/gitlab_persistence_test.go
+++ b/internal/session/gitlab_persistence_test.go
@@ -1,9 +1,6 @@
 package session
 
 import (
-	"encoding/json"
-	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -16,36 +13,5 @@ func TestReconcilePendingRemoteDeletesDoesNotResurrectDrained(t *testing.T) {
 	)
 	if len(got) != 1 || got[0] != fresh {
 		t.Fatalf("reconciled = %+v, want only fresh", got)
-	}
-}
-
-func TestCritJSONMigratesLegacyProviderDeleteQueues(t *testing.T) {
-	var cj CritJSON
-	err := json.Unmarshal([]byte(`{
-		"files": {},
-		"pending_github_deletes": [7],
-		"pending_gitlab_deletes": [{"note_id": 8, "discussion_id": "d8"}]
-	}`), &cj)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []RemoteRef{
-		{Forge: "github", CommentID: 7},
-		{Forge: "gitlab", CommentID: 8, ThreadID: "d8"},
-	}
-	if !reflect.DeepEqual(cj.PendingRemoteDeletes, want) {
-		t.Fatalf("migrated deletes = %+v, want %+v", cj.PendingRemoteDeletes, want)
-	}
-	encoded, err := json.Marshal(cj)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(encoded) == "" || !json.Valid(encoded) {
-		t.Fatalf("invalid migrated JSON: %q", encoded)
-	}
-	for _, legacyField := range []string{"pending_github_deletes", "pending_gitlab_deletes"} {
-		if strings.Contains(string(encoded), legacyField) {
-			t.Fatalf("new review JSON re-emitted legacy field %q: %s", legacyField, encoded)
-		}
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -532,42 +532,6 @@ type CritJSON struct {
 	Story *Story `json:"story,omitempty"`
 }
 
-// UnmarshalJSON provides read compatibility for review files written before
-// the provider-neutral PendingRemoteDeletes queue existed. New review files
-// only write PendingRemoteDeletes; on read, the legacy GitHub and GitLab queues
-// are folded into it while every other field is decoded unchanged.
-func (cj *CritJSON) UnmarshalJSON(data []byte) error {
-	type plain CritJSON
-	var payload struct {
-		*plain
-		PendingGitHubDeletes []int64 `json:"pending_github_deletes"`
-		PendingGitLabDeletes []struct {
-			NoteID       int64  `json:"note_id"`
-			DiscussionID string `json:"discussion_id"`
-		} `json:"pending_gitlab_deletes"`
-	}
-	payload.plain = (*plain)(cj)
-	if err := json.Unmarshal(data, &payload); err != nil {
-		return err
-	}
-	for _, id := range payload.PendingGitHubDeletes {
-		cj.PendingRemoteDeletes = appendUniqueRemoteRef(cj.PendingRemoteDeletes, RemoteRef{Forge: forge.GitHub, CommentID: id})
-	}
-	for _, ref := range payload.PendingGitLabDeletes {
-		cj.PendingRemoteDeletes = appendUniqueRemoteRef(cj.PendingRemoteDeletes, RemoteRef{Forge: forge.GitLab, CommentID: ref.NoteID, ThreadID: ref.DiscussionID})
-	}
-	return nil
-}
-
-func appendUniqueRemoteRef(refs []RemoteRef, ref RemoteRef) []RemoteRef {
-	for _, existing := range refs {
-		if existing == ref {
-			return refs
-		}
-	}
-	return append(refs, ref)
-}
-
 // RemoteDeletesFor returns one provider's pending delete operations.
 func RemoteDeletesFor(cj CritJSON, provider forge.Kind) []RemoteRef {
 	var refs []RemoteRef

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -67,38 +67,6 @@ type Focus struct {
 	IsStacked         bool      `json:"is_stacked,omitempty"`
 }
 
-// UnmarshalJSON is a backward-compatibility boundary. Canonical payloads use
-// Forge + ChangeNumber; older sessions and clients may still provide the
-// provider-specific pr_number/mr_number aliases.
-func (f *Focus) UnmarshalJSON(data []byte) error {
-	type plain Focus
-	var wire struct {
-		*plain
-		PRNumber int `json:"pr_number,omitempty"`
-		MRNumber int `json:"mr_number,omitempty"`
-	}
-	wire.plain = (*plain)(f)
-	if err := json.Unmarshal(data, &wire); err != nil {
-		return err
-	}
-	if f.Forge == "" {
-		switch {
-		case wire.MRNumber > 0:
-			f.Forge = "gitlab"
-		case wire.PRNumber > 0:
-			f.Forge = "github"
-		}
-	}
-	if f.ChangeNumber == 0 {
-		if f.Forge == "gitlab" {
-			f.ChangeNumber = wire.MRNumber
-		} else if f.Forge == "github" {
-			f.ChangeNumber = wire.PRNumber
-		}
-	}
-	return nil
-}
-
 // ReadOnly reports whether comments may be added/edited in this focus.
 // v1: always false. Range mode is fully writable so users can annotate;
 // pushes to GitHub are gated separately (see runPush).


### PR DESCRIPTION
## Summary
- Drop `Focus.UnmarshalJSON` read-compat for `pr_number` / `mr_number`; Focus is plain `forge` + `change_number` only.
- Drop `CritJSON.UnmarshalJSON` fold of `pending_github_deletes` / `pending_gitlab_deletes`; keep `pending_remote_deletes` only.
- Remove legacy-only tests; keep canonical Focus unmarshal coverage.
- Leave `github_id` / `gitlab_note_id`, `--output` paths, and `APIVersion` unchanged (HTTP already canonical).

**Cadence note:** Issue #818 targeted ≥ v0.21.0; shipping early by explicit decision. Pre-#816 on-disk shapes will silently ignore those alias fields.

## Review
- [x] Code review: passed (SHIP IT)
- [x] Intent audit: clean
- [x] Parity audit: N/A

## Test plan
- [x] `mise exec -- go test ./internal/session ./internal/server ./internal/github ./internal/gitlab`
- [ ] CI green

Closes #818

Made with [Cursor](https://cursor.com)