### PR TITLE
chore: remove legacy --output /.crit compatibility path (#774)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ All keys are optional — omit any you don't need.
 | `host`                 | string   | `"127.0.0.1"`              | Listen host (global/CLI/env only). Non-loopback values also require `--allow-unauthenticated-network` / `CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1`. Prefer loopback + SSH/Tailscale/Docker host-loopback publish. |
 | `no_open`              | bool     | `false`                    | Don't auto-open the browser when starting a review.                                                                                                                                     |
 | `quiet`                | bool     | `false`                    | On success, suppress daemon connect/start lines, integration tips, and the session summary. Errors, `approved:`, and the finish prompt are unchanged. |
-| `output`               | string   | `~/.crit`                  | Crit data root for reviews. Reviews live in `<root>/reviews/<key>/` (same layout as the default). A leftover `<root>/.crit` from when `output` named a single review folder is still used (with a warning) until you move or remove it. |
+| `output`               | string   | `~/.crit`                  | Crit data root for reviews. Reviews live in `<root>/reviews/<key>/` (same layout as the default). |
 | `author`               | string   | VCS user name              | Author name shown on comments. Falls back to your configured VCS user name.                                                                                                            |
 | `forge`                | string   | `"auto"`                   | Remote review provider: `"auto"`, `"github"`, or `"gitlab"`. Auto-detection uses the repository remote; set this for ambiguous self-managed hosts. |
 | `gitlab_url`           | string   | `"https://gitlab.com"`     | GitLab base URL used for every MR operation. Set once for a self-managed instance; MR URL arguments must use the same host. |
@@ -390,7 +390,7 @@ These keys can only be set in `~/.crit.config.json` (global). Project-level `.cr
 | `--allow-unauthenticated-network` | | — | Required with non-loopback `--host` or any `--public-url` |
 | `--no-open`     |       | `no_open`             | Don't auto-open browser                |
 | `--share-url`   |       | `share_url`           | Share service URL                      |
-| `--output`      | `-o`  | `output`              | Crit data root for reviews (`<root>/reviews/<key>/`). Honors a leftover `<root>/.crit` from older crit versions until removed. |
+| `--output`      | `-o`  | `output`              | Crit data root for reviews (`<root>/reviews/<key>/`). |
 | `--quiet`       | `-q`  | `quiet`               | On success, suppress connect/start status, tips, and session summary                 |
 | `--base-branch` |       | `base_branch`         | Base branch to diff against            |
 | `--vcs`         |       | `vcs`                 | VCS backend (`git`, `sl`, or `jj`)     |

--- a/cmd/crit/cli_serve.go
+++ b/cmd/crit/cli_serve.go
@@ -90,7 +90,7 @@ func resolveServeReviewPath(outputDir, planDir, sessionKey string) (string, erro
 	switch {
 	case outputDir != "":
 		// --output / config output is a crit data root (like ~/.crit).
-		return reviewpath.IdentityUnderDataRoot(outputDir, sessionKey)
+		return reviewpath.Identity(outputDir, sessionKey)
 	case planDir != "":
 		abs, err := serveAbsPath(planDir)
 		if err != nil {

--- a/cmd/crit/cli_serve_test.go
+++ b/cmd/crit/cli_serve_test.go
@@ -117,25 +117,18 @@ func TestResolveServeReviewPath(t *testing.T) {
 		}
 	})
 
-	t.Run("outputDir keeps a legacy identity and warns", func(t *testing.T) {
+	t.Run("outputDir always keys under reviews", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(dir, ".crit"), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		stderr := captureStderr(t, func() {
-			got, err := resolveServeReviewPath(dir, "", "deadbeef1234")
-			if err != nil {
-				t.Fatalf("resolveServeReviewPath: %v", err)
-			}
-			// The daemon must land on the same folder the headless commands
-			// resolve to, or `crit comment` would write to a sibling review.
-			want := filepath.Join(dir, ".crit")
-			if got != want {
-				t.Fatalf("got %q, want %q", got, want)
-			}
-		})
-		if !strings.Contains(stderr, "legacy .crit review") {
-			t.Fatalf("stderr = %q, want legacy warning", stderr)
+		got, err := resolveServeReviewPath(dir, "", "deadbeef1234")
+		if err != nil {
+			t.Fatalf("resolveServeReviewPath: %v", err)
+		}
+		want := filepath.Join(dir, "reviews", "deadbeef1234")
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
 		}
 	})
 

--- a/internal/comment/run.go
+++ b/internal/comment/run.go
@@ -170,7 +170,7 @@ func resolveUnqualifiedCommentReviewPath(f *commentFlags) error {
 		key = keys[0]
 	}
 	if f.outputDir != "" {
-		f.reviewPath, err = reviewpath.IdentityUnderDataRoot(f.outputDir, key)
+		f.reviewPath, err = reviewpath.Identity(f.outputDir, key)
 		if len(sessions) == 1 {
 			f.sessionEntry = &sessions[0]
 		}
@@ -182,7 +182,7 @@ func resolveUnqualifiedCommentReviewPath(f *commentFlags) error {
 		return nil
 	}
 	if f.configuredOutput != "" {
-		f.reviewPath, err = reviewpath.IdentityUnderDataRoot(f.configuredOutput, key)
+		f.reviewPath, err = reviewpath.Identity(f.configuredOutput, key)
 		return err
 	}
 	f.reviewPath, err = daemon.ReviewFilePath(key)

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -35,8 +35,7 @@ Keys worth knowing:
   output <dir>
       Crit data root for reviews. Reviews live in <dir>/reviews/<key>/, keyed
       per working directory and branch, the same layout as the default
-      ~/.crit. A <dir>/.crit folder left over from when output named a single
-      review folder keeps being used, with a warning, until you move it.
+      ~/.crit.
 
   plan_approve_mode <mode>
       Claude Code permission mode to switch to after a plan-hook approval, for

--- a/internal/review/review_file.go
+++ b/internal/review/review_file.go
@@ -136,9 +136,7 @@ func ResolveReviewPathWithArgs(outputDir string, fileArgs []string) (string, err
 }
 
 // identityUnderDataRoot maps --output / config output (a crit data root) to
-// {dataRoot}/reviews/<key>, matching default ~/.crit/reviews/<key> layout. A
-// pre-data-root {dataRoot}/.crit review still wins — see
-// reviewpath.IdentityUnderDataRoot.
+// {dataRoot}/reviews/<key>, matching default ~/.crit/reviews/<key> layout.
 //
 // When a daemon is alive for this cwd, its session key wins — file/live/PR/range
 // reviews key differently from plain git mode, and re-deriving from local
@@ -153,9 +151,9 @@ func identityUnderDataRoot(dataRoot string, fileArgs []string) (string, error) {
 		return "", err
 	}
 	if key != "" {
-		return reviewpath.IdentityUnderDataRoot(dataRoot, key)
+		return reviewpath.Identity(dataRoot, key)
 	}
-	return reviewpath.IdentityUnderDataRoot(dataRoot, sessionKeyForArgs(cwd, fileArgs))
+	return reviewpath.Identity(dataRoot, sessionKeyForArgs(cwd, fileArgs))
 }
 
 // sessionKeyFromDaemon returns the registry key of the best matching live

--- a/internal/review/review_file_test.go
+++ b/internal/review/review_file_test.go
@@ -496,25 +496,18 @@ func TestResolveCommandReviewPathPrecedence(t *testing.T) {
 		}
 	})
 
-	t.Run("keeps using a legacy output layout and warns", func(t *testing.T) {
+	t.Run("ignores a leftover .crit under the data root", func(t *testing.T) {
 		dataRoot := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(dataRoot, ".crit"), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		var got string
-		stderr := captureStderr(t, func() {
-			var err error
-			got, err = ResolveReviewPathWithArgs(dataRoot, nil)
-			if err != nil {
-				t.Fatalf("ResolveReviewPathWithArgs: %v", err)
-			}
-		})
-		want := filepath.Join(dataRoot, ".crit")
-		if got != want {
-			t.Fatalf("review path = %q, want pre-existing legacy path %q", got, want)
+		got, err := ResolveReviewPathWithArgs(dataRoot, nil)
+		if err != nil {
+			t.Fatalf("ResolveReviewPathWithArgs: %v", err)
 		}
-		if !strings.Contains(stderr, "legacy .crit review") {
-			t.Fatalf("stderr = %q, want legacy warning", stderr)
+		want := filepath.Join(dataRoot, "reviews", daemon.SessionKey(resolvedCWD, "", nil))
+		if got != want {
+			t.Fatalf("review path = %q, want keyed path %q", got, want)
 		}
 	})
 }

--- a/internal/reviewpath/output.go
+++ b/internal/reviewpath/output.go
@@ -1,8 +1,6 @@
 package reviewpath
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 )
 
@@ -32,51 +30,4 @@ func Identity(dataRoot, key string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, key), nil
-}
-
-// IdentityUnderDataRoot resolves a session key under a crit data root,
-// preferring a pre-existing legacy {dataRoot}/.crit review when one is there.
-//
-// Before --output meant a data root it named one fixed review folder, so roots
-// written by older versions already hold review.json, the share URL and the
-// delete token at {dataRoot}/.crit. Keying underneath such a root would strand
-// that review: `crit share` would publish a duplicate and `crit fetch` /
-// `crit unpublish` would report no review file. The legacy folder therefore
-// keeps winning, with a warning, until the user moves or removes it.
-func IdentityUnderDataRoot(dataRoot, key string) (string, error) {
-	if HasLegacyIdentity(dataRoot) {
-		legacy, err := LegacyIdentityPath(dataRoot)
-		if err != nil {
-			return "", err
-		}
-		fmt.Fprintf(os.Stderr, "crit: warning: using the legacy .crit review in %s, from when --output named a single review folder; output is now a data root, so move or remove it to get keyed, per-branch reviews under %s\n",
-			dataRoot, filepath.Join(dataRoot, "reviews"))
-		return legacy, nil
-	}
-	return Identity(dataRoot, key)
-}
-
-// LegacyIdentityPath is the pre-data-root layout: {dataRoot}/.crit.
-func LegacyIdentityPath(dataRoot string) (string, error) {
-	abs, err := absPath(dataRoot)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(abs, ".crit"), nil
-}
-
-// HasLegacyIdentity reports whether dataRoot contains the old fixed-identity
-// folder or flat file from before output meant "data root".
-func HasLegacyIdentity(dataRoot string) bool {
-	legacy, err := LegacyIdentityPath(dataRoot)
-	if err != nil {
-		return false
-	}
-	if st, err := os.Stat(legacy); err == nil && st.IsDir() {
-		return true
-	}
-	if _, err := os.Stat(legacy + ".json"); err == nil {
-		return true
-	}
-	return false
 }

--- a/internal/reviewpath/output_test.go
+++ b/internal/reviewpath/output_test.go
@@ -2,7 +2,6 @@ package reviewpath
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,85 +31,6 @@ func TestReviewsDir(t *testing.T) {
 	}
 }
 
-func TestHasLegacyIdentity(t *testing.T) {
-	root := t.TempDir()
-	if HasLegacyIdentity(root) {
-		t.Fatal("expected no legacy identity in empty root")
-	}
-	if err := os.MkdirAll(filepath.Join(root, ".crit"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if !HasLegacyIdentity(root) {
-		t.Fatal("expected legacy .crit folder to be detected")
-	}
-}
-
-func TestHasLegacyIdentity_JSONFile(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".crit.json"), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if !HasLegacyIdentity(root) {
-		t.Fatal("expected legacy .crit.json to be detected")
-	}
-}
-
-func TestLegacyIdentityPath(t *testing.T) {
-	root := t.TempDir()
-	got, err := LegacyIdentityPath(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(root, ".crit")
-	if got != want {
-		t.Fatalf("LegacyIdentityPath = %q, want %q", got, want)
-	}
-}
-
-func TestIdentityUnderDataRoot(t *testing.T) {
-	t.Run("keys under reviews when the root is clean", func(t *testing.T) {
-		root := t.TempDir()
-		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := filepath.Join(root, "reviews", "deadbeef1234")
-		if got != want {
-			t.Fatalf("IdentityUnderDataRoot = %q, want %q", got, want)
-		}
-	})
-
-	t.Run("honors a legacy .crit folder", func(t *testing.T) {
-		root := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(root, ".crit"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := filepath.Join(root, ".crit")
-		if got != want {
-			t.Fatalf("IdentityUnderDataRoot = %q, want legacy path %q", got, want)
-		}
-	})
-
-	t.Run("honors a legacy .crit.json flat file", func(t *testing.T) {
-		root := t.TempDir()
-		if err := os.WriteFile(filepath.Join(root, ".crit.json"), []byte("{}"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		got, err := IdentityUnderDataRoot(root, "deadbeef1234")
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := filepath.Join(root, ".crit")
-		if got != want {
-			t.Fatalf("IdentityUnderDataRoot = %q, want legacy path %q", got, want)
-		}
-	})
-}
-
 func TestReviewsDirAbsError(t *testing.T) {
 	orig := absPath
 	t.Cleanup(func() { absPath = orig })
@@ -122,11 +42,5 @@ func TestReviewsDirAbsError(t *testing.T) {
 	}
 	if _, err := Identity("x", "key"); err == nil || !strings.Contains(err.Error(), "abs failed") {
 		t.Fatalf("Identity error = %v", err)
-	}
-	if _, err := LegacyIdentityPath("x"); err == nil || !strings.Contains(err.Error(), "abs failed") {
-		t.Fatalf("LegacyIdentityPath error = %v", err)
-	}
-	if HasLegacyIdentity("x") {
-		t.Fatal("HasLegacyIdentity should be false when Abs fails")
 	}
 }

--- a/internal/session/status_cli.go
+++ b/internal/session/status_cli.go
@@ -98,7 +98,7 @@ func resolveStatusReviewPath(cwd, branch string, matchedSession *daemon.SessionE
 		return "", err
 	}
 	if cfg.Output != "" {
-		return reviewpath.IdentityUnderDataRoot(cfg.Output, daemon.SessionKey(cwd, branch, nil))
+		return reviewpath.Identity(cfg.Output, daemon.SessionKey(cwd, branch, nil))
 	}
 	key := daemon.SessionKey(cwd, branch, nil)
 	return daemon.ReviewFilePath(key)

--- a/internal/share/integration_export_test.go
+++ b/internal/share/integration_export_test.go
@@ -19,16 +19,16 @@ type (
 
 var saveAuthSession = auth.SaveAuthSession
 
-// readCritJSON reads .crit/review.json from dir (integration test helper).
+// readCritJSON reads review.json from the keyed folder under --output dir.
 func readCritJSON(t *testing.T, dir string) CritJSON {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	data, err := os.ReadFile(filepath.Join(testOutputIdentity(t, dir), "review.json"))
 	if err != nil {
-		t.Fatalf("reading .crit/review.json: %v", err)
+		t.Fatalf("reading review.json: %v", err)
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
-		t.Fatalf("parsing .crit/review.json: %v", err)
+		t.Fatalf("parsing review.json: %v", err)
 	}
 	return cj
 }

--- a/internal/share/share_integration_test.go
+++ b/internal/share/share_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
@@ -159,15 +160,13 @@ func TestShareSyncIntegration(t *testing.T) {
 		t.Errorf("crit-web should have updated content, got: %s", docBody.Files[0].Content)
 	}
 
-	// g) Verify the web reviewer comment was pulled into local .crit.json
-	// (post-v4 .crit.json is a folder; the canonical review payload lives at
-	// .crit/review.json).
-	localData, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	// g) Verify the web reviewer comment was pulled into local review.json
+	localData, err := os.ReadFile(filepath.Join(testOutputIdentity(t, dir), "review.json"))
 	if err != nil {
-		t.Fatalf("reading .crit.json: %v", err)
+		t.Fatalf("reading review.json: %v", err)
 	}
 	if !strings.Contains(string(localData), "web reviewer comment") {
-		t.Errorf("expected web reviewer comment in local .crit.json, got: %s", string(localData))
+		t.Errorf("expected web reviewer comment in local review.json, got: %s", string(localData))
 	}
 
 	// h) Verify export endpoint returns .crit.json-compatible shape
@@ -339,12 +338,9 @@ func reviewRoundFromAPI(t *testing.T, baseURL, token string) int {
 	return body.ReviewRound
 }
 
-// writeTestCritJSON writes a CritJSON to .crit/review.json in dir.
+// writeTestCritJSON writes a CritJSON to the keyed review folder under dir,
+// matching `--output <dir>` resolution (`<dir>/reviews/<key>/review.json`).
 //
-// `--output <dir>` names a crit data root, so a fresh root would key the review
-// as <dir>/reviews/<key>/. Seeding <dir>/.crit puts the tests on the
-// pre-data-root layout that crit still honors for existing users, which is what
-// keeps every helper below (and readCritJSON) pointed at one review folder.
 // NOTE: readCritJSON is defined in integration_export_test.go and shared across
 // test files.
 func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
@@ -353,7 +349,7 @@ func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	identity := filepath.Join(dir, ".crit")
+	identity := testOutputIdentity(t, dir)
 	if err := os.MkdirAll(identity, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -362,9 +358,25 @@ func writeTestCritJSON(t *testing.T, dir string, cj CritJSON) {
 	}
 }
 
+// testOutputIdentity is the keyed review folder under --output data root dir.
+// Matches ResolveCommandReviewPathWithSession when cwd is dir, there is no live
+// daemon, and the directory is not a VCS checkout (integration temps aren't).
+func testOutputIdentity(t *testing.T, dir string) string {
+	t.Helper()
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd := abs
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		cwd = resolved
+	}
+	return filepath.Join(abs, "reviews", daemon.SessionKey(cwd, "", nil))
+}
+
 // critShareCmd runs `crit share` and returns stdout. Fails the test on error.
 // Uses --output to point at the temp dir seeded by writeTestCritJSON, so crit
-// reads/writes .crit/review.json there.
+// reads/writes reviews/<key>/review.json there.
 func critShareCmd(t *testing.T, binary, baseURL, dir string, files ...string) string {
 	t.Helper()
 	args := append([]string{"share", "--share-url", baseURL, "--output", dir}, files...)
@@ -2166,13 +2178,13 @@ func TestShareReceiver_LegacyShareStillWorks(t *testing.T) {
 	}
 
 	// The review file should now record the share URL + delete token.
-	data, err := os.ReadFile(filepath.Join(dir, ".crit", "review.json"))
+	data, err := os.ReadFile(filepath.Join(testOutputIdentity(t, dir), "review.json"))
 	if err != nil {
-		t.Fatalf("read .crit/review.json: %v", err)
+		t.Fatalf("read review.json: %v", err)
 	}
 	var cj CritJSON
 	if err := json.Unmarshal(data, &cj); err != nil {
-		t.Fatalf("decode .crit/review.json: %v", err)
+		t.Fatalf("decode review.json: %v", err)
 	}
 	if cj.ShareURL != "https://crit.stub/r/stubtoken" {
 		t.Errorf("share_url = %q, want https://crit.stub/r/stubtoken", cj.ShareURL)
@@ -2393,7 +2405,7 @@ func TestShareSyncOrgPersistence(t *testing.T) {
 	critShareCmdWithEnv(t, binary, baseURL, dir, []string{"--org", slug, "--visibility", "organization"}, authEnv, "readme.md")
 
 	// Read the review file and verify org fields are persisted
-	reviewPath := filepath.Join(dir, ".crit", "review.json")
+	reviewPath := filepath.Join(testOutputIdentity(t, dir), "review.json")
 	data, err := os.ReadFile(reviewPath)
 	if err != nil {
 		t.Fatalf("reading review file: %v", err)


### PR DESCRIPTION
## Summary
- Always resolve `--output` / config `output` to `<root>/reviews/<key>/` via `reviewpath.Identity`.
- Delete prefer-legacy helpers (`IdentityUnderDataRoot`, `HasLegacyIdentity`, `LegacyIdentityPath`) and related tests.
- Update README and `crit config` help to drop leftover-`.crit` wording.
- Point share integration helpers at the keyed `reviews/<key>/` layout.

**Note:** Leftover `{root}/.crit` under custom `--output` is no longer preferred (intentional). Daemon reconnect can still migrate when `review_path` ends in `/.crit`.

## Review
- [x] Code review: passed (Ship)
- [x] Parity audit: N/A

## Test plan
- [x] Unit tests on touched packages
- [x] Share package compiles with `-tags integration`
- [ ] CI green
- [ ] Optional: `make e2e-share` (needs local crit-web)

Closes #774

Made with [Cursor](https://cursor.com)