### PR TITLE
feat: open mermaid diagrams in fullscreen with pan/zoom

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -8307,6 +8307,9 @@
   }
 
   function renderMermaidBlocks() {
+    // Any document rebuild invalidates the detached overlay clone (and its
+    // theme) — close the overlay rather than show a stale diagram.
+    closeMermaidOverlay();
     if (typeof mermaid === 'undefined') return;
     mermaid.initialize({ startOnLoad: false, theme: getMermaidTheme() });
     const codes = document.querySelectorAll('code.language-mermaid');
@@ -8424,17 +8427,25 @@
     // Mermaid emits width="100%" + a max-width cap. Inside the overlay the
     // canvas sizes to content (width: max-content), which makes a percentage
     // width resolve circularly and the diagram collapse. Pin the clone to its
-    // natural viewBox size so fit/center math holds.
+    // natural size so fit/center math holds. Prefer the viewBox; fall back to
+    // the live source rect (the clone itself may already be collapsed).
+    let natW = 0;
+    let natH = 0;
     const vb = clone.getAttribute('viewBox');
     if (vb) {
       const parts = vb.trim().split(/[\s,]+/);
-      const w = parseFloat(parts[2]);
-      const h = parseFloat(parts[3]);
-      if (w > 0 && h > 0) {
-        clone.setAttribute('width', String(w));
-        clone.setAttribute('height', String(h));
-        if (clone.style) clone.style.removeProperty('max-width');
-      }
+      natW = parseFloat(parts[2]);
+      natH = parseFloat(parts[3]);
+    }
+    if (!(natW > 0) || !(natH > 0)) {
+      const srcRect = sourceSvg.getBoundingClientRect();
+      natW = srcRect.width;
+      natH = srcRect.height;
+    }
+    if (natW > 0 && natH > 0) {
+      clone.setAttribute('width', String(natW));
+      clone.setAttribute('height', String(natH));
+      if (clone.style) clone.style.removeProperty('max-width');
     }
     nodes.canvas.appendChild(clone);
     mermaidOverlayState.open = true;
@@ -8490,6 +8501,15 @@
     let pinchStart = 0;
     let pinchScale = 1;
 
+    // Re-anchor the pinch baseline on every pointer-count change so adding
+    // or lifting a finger mid-gesture never causes a zoom jump.
+    function capturePinchBaseline() {
+      const pts = Array.from(activePointers.values());
+      if (pts.length < 2) return;
+      pinchStart = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      pinchScale = mermaidOverlayState.scale;
+    }
+
     if (nodes.zoomIn) nodes.zoomIn.addEventListener('click', function () { mermaidOverlayZoomCenter(1.25); });
     if (nodes.zoomOut) nodes.zoomOut.addEventListener('click', function () { mermaidOverlayZoomCenter(1 / 1.25); });
     if (nodes.zoomReset) nodes.zoomReset.addEventListener('click', function () { mermaidOverlayFit(); });
@@ -8499,7 +8519,12 @@
     });
     nodes.overlay.addEventListener('keydown', mermaidOverlayTrapTab);
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && mermaidOverlayState.open) {
+      // Note: no defaultPrevented check — the app-wide keymap (below)
+      // unconditionally preventDefaults Escape, so honoring it would break
+      // Esc-to-close entirely. Esc dismissing both the overlay and any
+      // background form matches the existing "cancel whatever" convention.
+      if (e.key !== 'Escape') return;
+      if (mermaidOverlayState.open) {
         e.preventDefault();
         closeMermaidOverlay();
       }
@@ -8518,11 +8543,9 @@
       if (activePointers.size === 1) {
         panAnchor = { x: e.clientX - mermaidOverlayState.x, y: e.clientY - mermaidOverlayState.y };
         nodes.viewport.classList.add('panning');
-      } else if (activePointers.size === 2) {
-        const pts = Array.from(activePointers.values());
-        pinchStart = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
-        pinchScale = mermaidOverlayState.scale;
+      } else {
         panAnchor = null;
+        capturePinchBaseline();
       }
     });
     nodes.viewport.addEventListener('pointermove', function (e) {
@@ -8552,7 +8575,9 @@
       if (activePointers.size === 1) {
         const remaining = Array.from(activePointers.values())[0];
         panAnchor = { x: remaining.x - mermaidOverlayState.x, y: remaining.y - mermaidOverlayState.y };
-      } else if (activePointers.size === 0) {
+      } else if (activePointers.size >= 2) {
+        capturePinchBaseline();
+      } else {
         panAnchor = null;
         nodes.viewport.classList.remove('panning');
       }

--- a/web/app.js
+++ b/web/app.js
@@ -8319,6 +8319,271 @@
       pre.replaceWith(container);
     });
     try { mermaid.run(); } catch {}
+    decorateMermaidBlocks();
+  }
+
+  // ===== Mermaid fullscreen overlay (GitHub-style pan/zoom) =====
+  // Expand button on each rendered diagram opens #mermaidOverlay with a
+  // detached SVG clone. Pan via drag, zoom via wheel / pinch / buttons.
+  // Pure CSS transform — no new dependencies. The clone is detached, so
+  // inline re-renders never disturb the overlay; a theme change closes it
+  // because the clone keeps the old theme's colors.
+  const mermaidOverlayState = {
+    open: false,
+    trigger: null,
+    scale: 1,
+    x: 0,
+    y: 0,
+    installed: false
+  };
+  const MERMAID_ZOOM_MIN = 0.1;
+  const MERMAID_ZOOM_MAX = 8;
+
+  function mermaidOverlayNodes() {
+    return {
+      overlay: document.getElementById('mermaidOverlay'),
+      viewport: document.getElementById('mermaidOverlayViewport'),
+      canvas: document.getElementById('mermaidOverlayCanvas'),
+      label: document.getElementById('mermaidZoomLabel'),
+      closeBtn: document.getElementById('mermaidOverlayClose'),
+      zoomIn: document.getElementById('mermaidZoomIn'),
+      zoomOut: document.getElementById('mermaidZoomOut'),
+      zoomReset: document.getElementById('mermaidZoomReset')
+    };
+  }
+
+  function mermaidOverlayApply() {
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.canvas) return;
+    nodes.canvas.style.transform = 'translate(' + mermaidOverlayState.x + 'px, ' + mermaidOverlayState.y + 'px) scale(' + mermaidOverlayState.scale + ')';
+    if (nodes.label) nodes.label.textContent = Math.round(mermaidOverlayState.scale * 100) + '%';
+  }
+
+  function mermaidOverlayZoomAt(factor, clientX, clientY) {
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.viewport) return;
+    const rect = nodes.viewport.getBoundingClientRect();
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
+    const next = Math.min(MERMAID_ZOOM_MAX, Math.max(MERMAID_ZOOM_MIN, mermaidOverlayState.scale * factor));
+    if (next === mermaidOverlayState.scale) return;
+    const ratio = next / mermaidOverlayState.scale;
+    mermaidOverlayState.x = px - (px - mermaidOverlayState.x) * ratio;
+    mermaidOverlayState.y = py - (py - mermaidOverlayState.y) * ratio;
+    mermaidOverlayState.scale = next;
+    mermaidOverlayApply();
+  }
+
+  function mermaidOverlayZoomCenter(factor) {
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.viewport) return;
+    const rect = nodes.viewport.getBoundingClientRect();
+    mermaidOverlayZoomAt(factor, rect.left + rect.width / 2, rect.top + rect.height / 2);
+  }
+
+  // Fit the cloned SVG into the viewport (capped so tiny diagrams don't blow up).
+  function mermaidOverlayFit() {
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.viewport || !nodes.canvas) return;
+    const svg = nodes.canvas.querySelector('svg');
+    mermaidOverlayState.scale = 1;
+    mermaidOverlayState.x = 0;
+    mermaidOverlayState.y = 0;
+    if (svg) {
+      let w = 0;
+      let h = 0;
+      const vb = svg.getAttribute('viewBox');
+      if (vb) {
+        const parts = vb.trim().split(/[\s,]+/);
+        w = parseFloat(parts[2]);
+        h = parseFloat(parts[3]);
+      }
+      if (!(w > 0) || !(h > 0)) {
+        const r = svg.getBoundingClientRect();
+        w = r.width;
+        h = r.height;
+      }
+      if (w > 0 && h > 0) {
+        const vw = nodes.viewport.clientWidth - 48;
+        const vh = nodes.viewport.clientHeight - 48;
+        if (vw > 0 && vh > 0) {
+          mermaidOverlayState.scale = Math.min(vw / w, vh / h, 2);
+          mermaidOverlayState.x = (nodes.viewport.clientWidth - w * mermaidOverlayState.scale) / 2;
+          mermaidOverlayState.y = (nodes.viewport.clientHeight - h * mermaidOverlayState.scale) / 2;
+        }
+      }
+    }
+    mermaidOverlayApply();
+  }
+
+  function openMermaidOverlay(sourceSvg, trigger) {
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.overlay || !sourceSvg || !nodes.canvas) return;
+    nodes.canvas.innerHTML = '';
+    const clone = sourceSvg.cloneNode(true);
+    // Mermaid emits width="100%" + a max-width cap. Inside the overlay the
+    // canvas sizes to content (width: max-content), which makes a percentage
+    // width resolve circularly and the diagram collapse. Pin the clone to its
+    // natural viewBox size so fit/center math holds.
+    const vb = clone.getAttribute('viewBox');
+    if (vb) {
+      const parts = vb.trim().split(/[\s,]+/);
+      const w = parseFloat(parts[2]);
+      const h = parseFloat(parts[3]);
+      if (w > 0 && h > 0) {
+        clone.setAttribute('width', String(w));
+        clone.setAttribute('height', String(h));
+        if (clone.style) clone.style.removeProperty('max-width');
+      }
+    }
+    nodes.canvas.appendChild(clone);
+    mermaidOverlayState.open = true;
+    mermaidOverlayState.trigger = trigger || null;
+    installMermaidOverlay();
+    nodes.overlay.classList.add('active');
+    document.body.style.overflow = 'hidden';
+    mermaidOverlayFit();
+    if (nodes.closeBtn && nodes.closeBtn.focus) nodes.closeBtn.focus();
+  }
+
+  function closeMermaidOverlay() {
+    const nodes = mermaidOverlayNodes();
+    if (!mermaidOverlayState.open) return;
+    mermaidOverlayState.open = false;
+    if (nodes.overlay) nodes.overlay.classList.remove('active');
+    if (nodes.canvas) nodes.canvas.innerHTML = '';
+    document.body.style.overflow = '';
+    const trigger = mermaidOverlayState.trigger;
+    mermaidOverlayState.trigger = null;
+    // The trigger stays rendered (transparent until hover/focus), so focus()
+    // lands even outside hover — e.g. the keyboard flow.
+    if (trigger && document.contains(trigger) && trigger.focus) trigger.focus();
+  }
+
+  function mermaidOverlayTrapTab(e) {
+    if (e.key !== 'Tab') return;
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.overlay) return;
+    const focusables = nodes.overlay.querySelectorAll('button:not([disabled])');
+    if (!focusables || focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  // One-pointer drag pans; two-pointer pinch zooms. Installed once — the
+  // overlay shell lives in index.html and survives document re-renders.
+  function installMermaidOverlay() {
+    if (mermaidOverlayState.installed) return;
+    const nodes = mermaidOverlayNodes();
+    if (!nodes.overlay || !nodes.viewport) return;
+    mermaidOverlayState.installed = true;
+
+    const activePointers = new Map();
+    let panAnchor = null;
+    let pinchStart = 0;
+    let pinchScale = 1;
+
+    if (nodes.zoomIn) nodes.zoomIn.addEventListener('click', function () { mermaidOverlayZoomCenter(1.25); });
+    if (nodes.zoomOut) nodes.zoomOut.addEventListener('click', function () { mermaidOverlayZoomCenter(1 / 1.25); });
+    if (nodes.zoomReset) nodes.zoomReset.addEventListener('click', function () { mermaidOverlayFit(); });
+    if (nodes.closeBtn) nodes.closeBtn.addEventListener('click', function () { closeMermaidOverlay(); });
+    nodes.overlay.addEventListener('click', function (e) {
+      if (e.target === nodes.overlay) closeMermaidOverlay();
+    });
+    nodes.overlay.addEventListener('keydown', mermaidOverlayTrapTab);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && mermaidOverlayState.open) {
+        e.preventDefault();
+        closeMermaidOverlay();
+      }
+    });
+
+    nodes.viewport.addEventListener('wheel', function (e) {
+      if (!mermaidOverlayState.open) return;
+      e.preventDefault();
+      mermaidOverlayZoomAt(e.deltaY < 0 ? 1.12 : 1 / 1.12, e.clientX, e.clientY);
+    }, { passive: false });
+
+    nodes.viewport.addEventListener('pointerdown', function (e) {
+      if (!mermaidOverlayState.open) return;
+      try { nodes.viewport.setPointerCapture(e.pointerId); } catch { /* noop */ }
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (activePointers.size === 1) {
+        panAnchor = { x: e.clientX - mermaidOverlayState.x, y: e.clientY - mermaidOverlayState.y };
+        nodes.viewport.classList.add('panning');
+      } else if (activePointers.size === 2) {
+        const pts = Array.from(activePointers.values());
+        pinchStart = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+        pinchScale = mermaidOverlayState.scale;
+        panAnchor = null;
+      }
+    });
+    nodes.viewport.addEventListener('pointermove', function (e) {
+      if (!activePointers.has(e.pointerId)) return;
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (activePointers.size === 2) {
+        const pts = Array.from(activePointers.values());
+        const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+        if (pinchStart > 0 && dist > 0) {
+          const midX = (pts[0].x + pts[1].x) / 2;
+          const midY = (pts[0].y + pts[1].y) / 2;
+          // Zoom relative to the scale captured when the second pointer
+          // landed, anchored at the gesture midpoint.
+          const rel = (pinchScale * dist / pinchStart) / mermaidOverlayState.scale;
+          mermaidOverlayZoomAt(rel, midX, midY);
+        }
+        return;
+      }
+      if (panAnchor) {
+        mermaidOverlayState.x = e.clientX - panAnchor.x;
+        mermaidOverlayState.y = e.clientY - panAnchor.y;
+        mermaidOverlayApply();
+      }
+    });
+    function endMermaidPointer(e) {
+      activePointers.delete(e.pointerId);
+      if (activePointers.size === 1) {
+        const remaining = Array.from(activePointers.values())[0];
+        panAnchor = { x: remaining.x - mermaidOverlayState.x, y: remaining.y - mermaidOverlayState.y };
+      } else if (activePointers.size === 0) {
+        panAnchor = null;
+        nodes.viewport.classList.remove('panning');
+      }
+    }
+    nodes.viewport.addEventListener('pointerup', endMermaidPointer);
+    nodes.viewport.addEventListener('pointercancel', endMermaidPointer);
+  }
+
+  // Expand affordance on each rendered diagram. Idempotent — safe to run
+  // after every renderMermaidBlocks() call. The button lives on the
+  // .mermaid-block (not inside .mermaid) so mermaid re-renders never wipe
+  // it, and clicks stopPropagation so comment gestures are unaffected.
+  function decorateMermaidBlocks() {
+    installMermaidOverlay();
+    const blocks = document.querySelectorAll('.line-content.mermaid-block');
+    blocks.forEach(function (block) {
+      if (block.querySelector('.mermaid-expand')) return;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mermaid-expand';
+      btn.setAttribute('aria-label', 'Open diagram fullscreen');
+      btn.setAttribute('title', 'Open fullscreen');
+      btn.textContent = '⛶ Expand';
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const svg = block.querySelector('.mermaid svg');
+        if (!svg) return;
+        openMermaidOverlay(svg, btn);
+      });
+      block.appendChild(btn);
+    });
   }
 
   // ===== Theme =====
@@ -8333,6 +8598,8 @@
     else if (choice === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
     else document.documentElement.removeAttribute('data-theme');
 
+    // The fullscreen clone keeps the old theme's colors — close it.
+    closeMermaidOverlay();
     // Re-initialize mermaid diagrams with updated theme
     if (typeof mermaid !== 'undefined') {
       mermaid.initialize({ startOnLoad: false, theme: getMermaidTheme() });

--- a/web/index.html
+++ b/web/index.html
@@ -280,6 +280,19 @@
   </div>
 </div>
 
+<div class="mermaid-overlay" id="mermaidOverlay" role="dialog" aria-modal="true" aria-label="Diagram fullscreen view">
+  <div class="mermaid-overlay-toolbar" role="toolbar" aria-label="Diagram view controls">
+    <button class="btn btn-sm" id="mermaidZoomOut" aria-label="Zoom out" title="Zoom out">&minus;</button>
+    <span class="mermaid-overlay-zoom" id="mermaidZoomLabel" aria-live="polite">100%</span>
+    <button class="btn btn-sm" id="mermaidZoomIn" aria-label="Zoom in" title="Zoom in">+</button>
+    <button class="btn btn-sm" id="mermaidZoomReset" aria-label="Reset view" title="Reset view">Reset</button>
+    <button class="btn btn-sm" id="mermaidOverlayClose" aria-label="Close fullscreen view" title="Close (Esc)">&times;</button>
+  </div>
+  <div class="mermaid-overlay-viewport" id="mermaidOverlayViewport">
+    <div class="mermaid-overlay-canvas" id="mermaidOverlayCanvas"></div>
+  </div>
+</div>
+
 <script>
   (function () {
     // Path-based fork. The server serves this same index.html raw at /live,

--- a/web/style.css
+++ b/web/style.css
@@ -1292,10 +1292,115 @@ body.dragging { user-select: none; cursor: grabbing; }
   margin: 6px 0;
   text-align: center;
   min-height: 60px;
+  position: relative;
 }
 .mermaid svg {
   max-width: 100%;
   height: auto;
+}
+
+/* Expand affordance on rendered diagrams. Always rendered (so keyboard
+   users can Tab to it) but transparent and non-interactive until the
+   diagram is hovered or the button itself takes focus; touch gets an
+   always-visible 44px target. Absolute positioning keeps it out of the
+   document flow, so showing it never shifts diagram layout. */
+.mermaid-expand {
+  display: flex;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--crit-editor-fg-secondary);
+  background: var(--crit-editor-bg-elevated);
+  border: 1px solid var(--crit-border-strong);
+  border-radius: 6px;
+  cursor: pointer;
+  z-index: 2;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--crit-dur-fast) var(--crit-ease);
+}
+.mermaid-expand:hover {
+  color: var(--crit-editor-fg);
+  background: var(--crit-editor-bg-hover);
+}
+.mermaid-expand:focus-visible { box-shadow: var(--crit-focus); }
+.line-content.mermaid-block:hover .mermaid-expand,
+.mermaid-expand:focus,
+.mermaid-expand:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (pointer: coarse) {
+  .mermaid-expand {
+    opacity: 1;
+    pointer-events: auto;
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* ===== Mermaid fullscreen overlay (GitHub-style pan/zoom) ===== */
+.mermaid-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--crit-overlay-bg);
+  z-index: 500;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 16px;
+}
+.mermaid-overlay.active { display: flex; }
+.mermaid-overlay-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--crit-bg-card);
+  border: 1px solid var(--crit-border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  box-shadow: var(--crit-shadow);
+}
+.mermaid-overlay-zoom {
+  min-width: 52px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--crit-fg-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.mermaid-overlay-viewport {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  overflow: hidden;
+  background: var(--crit-editor-bg-card);
+  border: 1px solid var(--crit-border);
+  border-radius: 8px;
+  cursor: grab;
+  touch-action: none;
+}
+.mermaid-overlay-viewport.panning { cursor: grabbing; }
+.mermaid-overlay-canvas {
+  transform-origin: 0 0;
+  will-change: transform;
+  width: max-content;
+}
+.mermaid-overlay-canvas svg {
+  display: block;
+  max-width: none;
+  height: auto;
+}
+@media (max-width: 768px) {
+  .mermaid-overlay { padding: 8px; }
+  .mermaid-overlay-toolbar { flex-wrap: wrap; justify-content: center; }
 }
 
 /* ===== Images ===== */


### PR DESCRIPTION
Closes #861

## Summary
- Rendered Mermaid diagrams get an `⛶ Expand` affordance (hover/focus reveal on desktop, always-visible 44px target on touch) that opens a full-viewport overlay, GitHub-style
- Overlay: drag-pan, wheel-at-cursor zoom, two-finger pinch, `−`/`+`/`Reset` toolbar with live zoom %, fit-to-view on open
- Dismiss via Esc / backdrop / close button, with Tab trap and focus return; theme change or any document rebuild closes it so the detached clone never goes stale
- Pure CSS transforms on a cloned SVG — no new dependencies, no comment-model or protocol changes, comment gestures unaffected (`stopPropagation`)

## Review
- [x] Code review: fresh-eyes pass done, 4 findings fixed (close-on-rerender, pinch re-baseline, viewBox fallback, Esc convention), rest demoted with reasons
- [x] Parity audit: crit-web port NOT included — tracked as follow-up (this PR is crit/ only)
- [x] Pre-commit hooks: gofmt, golangci-lint, go tests, eslint, stylelint, CSS-vars all green

## Test plan
- Live Playwright verification against a real binary (large flowchart + sequence diagram): open, fit 32%, zoom to 50%, drag-pan, wheel zoom, Reset, Esc/backdrop/close, keyboard Enter/Esc with focus return, round-complete rebuild closes overlay — zero page errors
- `node --test web/__tests__/`: 561/562 (1 pre-existing `live-mode.panel-render` failure, also fails on clean tree)
- No committed E2E spec: every shared fixture has exact-count assertions and the audit guidance warns against expanding them; CI's full E2E suite covers existing flows
- Follow-up: port to `crit-web` (`document-renderer.js` + `app.css` + `review_live.html.heex`)