### PR TITLE
fix: resolve full GitHub PR URLs against their owner/repo

### DIFF
--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -119,8 +119,8 @@ func listOpenGitLabChanges(ctx context.Context) ([]forge.ChangeSummary, error) {
 func init() {
 	forge.SelectProviderFn = selectProvider
 	forge.ReviewFn = session.RunReview
-	session.InvalidatePRCache = func(number int, project string) {
-		github.InvalidatePR(forge.ChangeID{Number: number, Project: project})
+	session.InvalidatePRCache = func(number int, project, host string) {
+		github.InvalidatePR(forge.ChangeID{Number: number, Project: project, Host: host})
 	}
 	session.FetchMRFileContent = func(f session.Focus, sha, path string) ([]byte, error) {
 		project := f.RemoteProject

--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -119,7 +119,9 @@ func listOpenGitLabChanges(ctx context.Context) ([]forge.ChangeSummary, error) {
 func init() {
 	forge.SelectProviderFn = selectProvider
 	forge.ReviewFn = session.RunReview
-	session.InvalidatePRCache = github.InvalidatePRCache
+	session.InvalidatePRCache = func(number int, project string) {
+		github.InvalidatePR(forge.ChangeID{Number: number, Project: project})
+	}
 	session.FetchMRFileContent = func(f session.Focus, sha, path string) ([]byte, error) {
 		project := f.RemoteProject
 		if sha == f.BaseSHA && f.RemoteBaseProject != "" {

--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -198,9 +198,18 @@ func init() {
 			IgnorePatterns: sc.IgnorePatterns,
 		})
 	}
+	wirePRResolveHooks()
+	wireMRResolveHooks()
+}
+
+func wirePRResolveHooks() {
 	focus.SetPRResolveHooks(
-		func(prNum int) (focus.ChangeResolveInfo, error) {
-			info, err := github.FetchPRByNumber(prNum)
+		func(spec string) (focus.ChangeResolveInfo, error) {
+			id, err := github.ParsePRSpec(spec)
+			if err != nil {
+				return focus.ChangeResolveInfo{}, err
+			}
+			info, err := github.FetchPR(id)
 			if err != nil {
 				return focus.ChangeResolveInfo{}, err
 			}
@@ -213,6 +222,9 @@ func init() {
 				BaseRefName:       info.BaseRefName,
 				HeadRefName:       info.HeadRefName,
 				HeadRepoURL:       info.HeadRepoURL,
+				BaseRepoProject:   id.Project, // only URL-derived; bare --pr stays checkout-scoped
+				HeadRepoProject:   github.ProjectFromRemoteURL(info.HeadRepoURL),
+				HeadRepoHost:      id.Host,
 				IsCrossRepository: info.IsCrossRepository,
 			}, nil
 		},
@@ -230,6 +242,9 @@ func init() {
 			}, v)
 		},
 	)
+}
+
+func wireMRResolveHooks() {
 	focus.SetMRResolveHooks(
 		func(spec string) (focus.ChangeResolveInfo, error) {
 			id, err := gitlab.ParseMRSpec(spec)

--- a/cmd/crit/wire_test.go
+++ b/cmd/crit/wire_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tomasz-tomczyk/crit/internal/focus"
 	"github.com/tomasz-tomczyk/crit/internal/forge"
 	"github.com/tomasz-tomczyk/crit/internal/github"
 	"github.com/tomasz-tomczyk/crit/internal/gitlab"
@@ -236,5 +237,79 @@ func TestWiredForgeDetectionFallsBackToGitHubOnConfigError(t *testing.T) {
 	writeWireConfig(t, homeDir, `{"forge":"invalid"}`)
 	if got := server.DetectForgeKindFn(); got != forge.GitHub {
 		t.Fatalf("detected forge = %q, want github fallback", got)
+	}
+}
+
+func TestWirePRResolveHooks_PreservesURLProject(t *testing.T) {
+	prevFetch, prevStacked := focus.FetchPRHook, focus.IsStackedPRHook
+	t.Cleanup(func() { focus.SetPRResolveHooks(prevFetch, prevStacked) })
+
+	restore := github.SwapFetchPRByNumberForTest(func(n int) (*github.PRInfo, error) {
+		if n == 99 {
+			return nil, errors.New("fetch boom")
+		}
+		return &github.PRInfo{
+			URL:               "https://github.com/myorg/repo-b/pull/1",
+			Number:            n,
+			Title:             "Cross-repo",
+			BaseRefOid:        "base",
+			HeadRefOid:        "head",
+			BaseRefName:       "main",
+			HeadRefName:       "feat",
+			HeadRepoURL:       "https://github.com/fork/repo-b.git",
+			IsCrossRepository: true,
+		}, nil
+	})
+	t.Cleanup(restore)
+
+	wirePRResolveHooks()
+
+	info, err := focus.FetchPRHook("https://github.com/myorg/repo-b/pull/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.BaseRepoProject != "myorg/repo-b" {
+		t.Errorf("BaseRepoProject = %q", info.BaseRepoProject)
+	}
+	if info.HeadRepoProject != "fork/repo-b" {
+		t.Errorf("HeadRepoProject = %q", info.HeadRepoProject)
+	}
+	if info.HeadRepoHost != "github.com" {
+		t.Errorf("HeadRepoHost = %q", info.HeadRepoHost)
+	}
+
+	bare, err := focus.FetchPRHook("7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bare.BaseRepoProject != "" {
+		t.Errorf("bare --pr BaseRepoProject = %q want empty", bare.BaseRepoProject)
+	}
+
+	if _, err := focus.FetchPRHook("not-a-pr"); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if _, err := focus.FetchPRHook("99"); err == nil || !strings.Contains(err.Error(), "fetch boom") {
+		t.Fatalf("fetch error = %v", err)
+	}
+	if focus.IsStackedPRHook == nil || focus.IsStackedPRHook(info, nil) {
+		t.Fatal("IsStackedPRHook(nil vcs) should be false")
+	}
+}
+
+func TestWireMRResolveHooks_InvalidSpecAndStackedGuard(t *testing.T) {
+	prevFetch, prevStacked := focus.FetchMRHook, focus.IsStackedMRHook
+	t.Cleanup(func() { focus.SetMRResolveHooks(prevFetch, prevStacked) })
+
+	wireMRResolveHooks()
+
+	if _, err := focus.FetchMRHook("not-an-mr"); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if focus.IsStackedMRHook == nil {
+		t.Fatal("IsStackedMRHook not wired")
+	}
+	if focus.IsStackedMRHook(focus.ChangeResolveInfo{BaseRefName: "feature"}, nil) {
+		t.Fatal("nil vcs should not be stacked")
 	}
 }

--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -169,10 +169,10 @@ func resolveFocusFromPR(prSpec string, scope DiffScope, remoteFiles bool, v vcs.
 	if err != nil {
 		return nil, err
 	}
-	if FetchPRByNumberHook == nil {
+	if FetchPRHook == nil {
 		return nil, fmt.Errorf("resolving PR #%d: PR fetch not wired", prNum)
 	}
-	info, err := FetchPRByNumberHook(prNum)
+	info, err := FetchPRHook(prSpec)
 	if err != nil {
 		return nil, fmt.Errorf("resolving PR #%d: %w", prNum, err)
 	}

--- a/internal/focus/focus_pr_mergebase_test.go
+++ b/internal/focus/focus_pr_mergebase_test.go
@@ -13,10 +13,10 @@ import (
 func TestResolveFocusFromPR_UsesMergeBaseNotBaseTip(t *testing.T) {
 	vcs.ClearGitEnvForTest(t) // robust under git hooks that export GIT_DIR
 
-	prevFetch := FetchPRByNumberHook
+	prevFetch := FetchPRHook
 	prevStack := IsStackedPRHook
 	t.Cleanup(func() {
-		FetchPRByNumberHook = prevFetch
+		FetchPRHook = prevFetch
 		IsStackedPRHook = prevStack
 	})
 
@@ -30,7 +30,7 @@ func TestResolveFocusFromPR_UsesMergeBaseNotBaseTip(t *testing.T) {
 	vcs.GitRun(t, dir, "checkout", "main")
 	baseTip := vcs.CommitAtForTest(t, dir, "drift.txt", "drift\n", "base branch drift")
 
-	FetchPRByNumberHook = func(int) (ChangeResolveInfo, error) {
+	FetchPRHook = func(string) (ChangeResolveInfo, error) {
 		return ChangeResolveInfo{
 			Number:      7,
 			Title:       "drifted PR",

--- a/internal/focus/focus_pr_test.go
+++ b/internal/focus/focus_pr_test.go
@@ -7,23 +7,13 @@ import (
 )
 
 func TestResolveFocusFromPR(t *testing.T) {
-	prevFetch := FetchPRByNumberHook
+	prevFetch := FetchPRHook
 	prevStack := IsStackedPRHook
 	t.Cleanup(func() {
-		FetchPRByNumberHook = prevFetch
+		FetchPRHook = prevFetch
 		IsStackedPRHook = prevStack
 	})
 
-	FetchPRByNumberHook = func(prNum int) (ChangeResolveInfo, error) {
-		return ChangeResolveInfo{
-			Number:      prNum,
-			Title:       "Test PR",
-			BaseRefOid:  "base1234567890",
-			HeadRefOid:  "head1234567890",
-			BaseRefName: "main",
-			HeadRefName: "feature",
-		}, nil
-	}
 	IsStackedPRHook = func(ChangeResolveInfo, vcs.VCS) bool { return false }
 
 	dir := vcs.InitTestRepo(t)
@@ -32,33 +22,37 @@ func TestResolveFocusFromPR(t *testing.T) {
 	base := vcs.GitRun(t, dir, "rev-parse", "HEAD")
 	head := vcs.CommitAtForTest(t, dir, "pr.txt", "x", "pr change")
 
-	FetchPRByNumberHook = func(prNum int) (ChangeResolveInfo, error) {
+	FetchPRHook = func(spec string) (ChangeResolveInfo, error) {
 		return ChangeResolveInfo{
-			Number:      prNum,
-			Title:       "Test PR",
-			BaseRefOid:  base,
-			HeadRefOid:  head,
-			BaseRefName: "main",
-			HeadRefName: "feature",
+			Number:          42,
+			Title:           "Test PR",
+			BaseRefOid:      base,
+			HeadRefOid:      head,
+			BaseRefName:     "main",
+			HeadRefName:     "feature",
+			BaseRepoProject: "myorg/repo-b",
 		}, nil
 	}
 
 	// remoteFiles skips EnsureSHAFetched; this test wires PR hooks, not git fetch.
-	f, err := ResolveFocus(ChangeSpec{Forge: "github", Value: "42"}, "", "", true, v, dir)
+	f, err := ResolveFocus(ChangeSpec{Forge: "github", Value: "https://github.com/myorg/repo-b/pull/42"}, "", "", true, v, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if f == nil || f.Forge != "github" || f.ChangeNumber != 42 || f.HeadSHA != head {
 		t.Errorf("got %+v", f)
 	}
+	if f.RemoteBaseProject != "myorg/repo-b" {
+		t.Errorf("RemoteBaseProject=%q want myorg/repo-b", f.RemoteBaseProject)
+	}
 }
 
 func TestSetPRResolveHooks(t *testing.T) {
 	SetPRResolveHooks(
-		func(int) (ChangeResolveInfo, error) { return ChangeResolveInfo{Number: 1}, nil },
+		func(string) (ChangeResolveInfo, error) { return ChangeResolveInfo{Number: 1}, nil },
 		func(ChangeResolveInfo, vcs.VCS) bool { return true },
 	)
-	if FetchPRByNumberHook == nil || IsStackedPRHook == nil {
+	if FetchPRHook == nil || IsStackedPRHook == nil {
 		t.Fatal("hooks not wired")
 	}
 }

--- a/internal/focus/pr_hooks.go
+++ b/internal/focus/pr_hooks.go
@@ -20,18 +20,20 @@ type ChangeResolveInfo struct {
 }
 
 var (
-	FetchPRByNumberHook func(prNum int) (ChangeResolveInfo, error)
-	IsStackedPRHook     func(info ChangeResolveInfo, v vcs.VCS) bool
-	FetchMRHook         func(spec string) (ChangeResolveInfo, error)
-	IsStackedMRHook     func(info ChangeResolveInfo, v vcs.VCS) bool
+	// FetchPRHook resolves a --pr <num|url> spec. The raw CLI value is passed
+	// through so URL-derived owner/repo survives (mirrors FetchMRHook).
+	FetchPRHook     func(spec string) (ChangeResolveInfo, error)
+	IsStackedPRHook func(info ChangeResolveInfo, v vcs.VCS) bool
+	FetchMRHook     func(spec string) (ChangeResolveInfo, error)
+	IsStackedMRHook func(info ChangeResolveInfo, v vcs.VCS) bool
 )
 
 // SetPRResolveHooks wires PR resolution from cmd/crit to break focus↔github cycles.
 func SetPRResolveHooks(
-	fetch func(prNum int) (ChangeResolveInfo, error),
+	fetch func(spec string) (ChangeResolveInfo, error),
 	stacked func(info ChangeResolveInfo, v vcs.VCS) bool,
 ) {
-	FetchPRByNumberHook = fetch
+	FetchPRHook = fetch
 	IsStackedPRHook = stacked
 }
 

--- a/internal/github/export.go
+++ b/internal/github/export.go
@@ -1,6 +1,9 @@
 package github
 
-import "github.com/tomasz-tomczyk/crit/internal/session"
+import (
+	"github.com/tomasz-tomczyk/crit/internal/forge"
+	"github.com/tomasz-tomczyk/crit/internal/session"
+)
 
 type (
 	GhReplyForPush = ghReplyForPush
@@ -107,12 +110,16 @@ func RenderOrphanMarkdown(prNum int, b PushBuckets) string {
 }
 
 // SwapFetchPRByNumberForTest replaces the PR fetch function for the duration of a test.
+// The stub receives the PR number only; Project from ChangeID is ignored (tests that
+// need project-aware stubs should assign fetchPRFn directly).
 func SwapFetchPRByNumberForTest(fn func(int) (*PRInfo, error)) func() {
-	prev := fetchPRByNumberFn
-	fetchPRByNumberFn = fn
+	prev := fetchPRFn
+	fetchPRFn = func(id forge.ChangeID) (*PRInfo, error) {
+		return fn(id.Number)
+	}
 	prMetaCache.reset()
 	return func() {
-		fetchPRByNumberFn = prev
+		fetchPRFn = prev
 		prMetaCache.reset()
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -300,30 +300,40 @@ func parsePRViewJSON(b []byte) (*PRInfo, error) {
 	}, nil
 }
 
-// fetchPRByNumberFn is the live function that hits `gh`. Indirected through a
+// fetchPRFn is the live function that hits `gh`. Indirected through a
 // package var so tests can stub it without a real gh dependency. Tests that
 // swap this should also reset prMetaCache (see withFetchPRByNumber) or the
 // new stub will be shadowed by a previous test's cached PRInfo.
-var fetchPRByNumberFn = fetchPRByNumberReal
+var fetchPRFn = fetchPRReal
 
-// fetchPRByNumber resolves a PR by explicit number using `gh pr view <num>`,
-// memoized for the daemon's lifetime via prMetaCache so repeated focus
-// switches return instantly. Unlike detectPRInfo, this does not filter
-// MERGED/CLOSED — a user explicitly asking to review --pr <num> can review a
-// merged PR (the comment-anchoring rules still apply because the head SHA is
-// fixed). The cache is invalidated by invalidatePRCache after force-push
-// detection (Session.SetFocus) and `crit pull`.
-func FetchPRByNumber(num int) (*PRInfo, error) {
-	return prMetaCache.get(num)
+// FetchPR resolves a PR by ChangeID using `gh pr view`, memoized for the
+// daemon's lifetime via prMetaCache. When id.Project is set, the lookup is
+// pinned with `gh -R` so a full PR URL cannot resolve against the wrong
+// checkout (#870). Unlike detectPRInfo, this does not filter MERGED/CLOSED —
+// a user explicitly asking to review --pr <num> can review a merged PR.
+func FetchPR(id forge.ChangeID) (*PRInfo, error) {
+	if id.Number <= 0 {
+		return nil, fmt.Errorf("invalid PR number %d", id.Number)
+	}
+	return prMetaCache.get(id)
 }
 
-func fetchPRByNumberReal(num int) (*PRInfo, error) {
+// FetchPRByNumber resolves a PR by number against the current checkout.
+// Prefer FetchPR when a URL-derived Project is known.
+func FetchPRByNumber(num int) (*PRInfo, error) {
+	return FetchPR(forge.ChangeID{Number: num})
+}
+
+func fetchPRReal(id forge.ChangeID) (*PRInfo, error) {
 	if err := requireGH(); err != nil {
 		return nil, err
 	}
-	out, err := exec.Command("gh", "pr", "view", strconv.Itoa(num), "--json", prJSONFields).Output()
+	out, err := exec.Command("gh", prViewArgs(id)...).Output()
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view %d: %w", num, err)
+		if id.Project != "" {
+			return nil, fmt.Errorf("gh pr view %d -R %s: %w", id.Number, id.Project, err)
+		}
+		return nil, fmt.Errorf("gh pr view %d: %w", id.Number, err)
 	}
 	return parsePRViewJSON(out)
 }

--- a/internal/github/pr_cache.go
+++ b/internal/github/pr_cache.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -110,6 +112,20 @@ func (c *prMetadataCache) invalidate(id forge.ChangeID) {
 	c.mu.Unlock()
 }
 
+// invalidateNumber drops the bare-number entry and every project-qualified
+// entry for num. Used when only the PR number is known (e.g. crit pull).
+func (c *prMetadataCache) invalidateNumber(num int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, strconv.Itoa(num))
+	suffix := "#" + strconv.Itoa(num)
+	for key := range c.entries {
+		if strings.HasSuffix(key, suffix) {
+			delete(c.entries, key)
+		}
+	}
+}
+
 // reset clears the entire cache. Used by tests to isolate one fixture's
 // fetchFn from the next; production code should prefer invalidate.
 func (c *prMetadataCache) reset() {
@@ -124,13 +140,14 @@ func (c *prMetadataCache) reset() {
 // (including the CLI `crit pull` path) don't always have a Server in hand.
 var prMetaCache = newPRMetadataCache()
 
-// InvalidatePRCache drops the cached PRInfo for a bare PR number (current
-// checkout). Prefer InvalidatePR when the owning project is known.
+// InvalidatePRCache drops every cached PRInfo for num — both the bare-number
+// key (checkout-scoped --pr) and any project-qualified keys (URL-scoped).
+// Used by `crit pull`, which only knows the PR number.
 func InvalidatePRCache(num int) {
 	if num <= 0 {
 		return
 	}
-	prMetaCache.invalidate(forge.ChangeID{Number: num})
+	prMetaCache.invalidateNumber(num)
 }
 
 // InvalidatePR drops the cached PRInfo for id (project-qualified when set).

--- a/internal/github/pr_cache.go
+++ b/internal/github/pr_cache.go
@@ -3,6 +3,8 @@ package github
 import (
 	"sync"
 	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/forge"
 )
 
 // prMetadataCacheCap caps prMetadataCache size to bound memory growth in
@@ -18,41 +20,43 @@ type prCacheEntry struct {
 	access time.Time
 }
 
-// prMetadataCache memoizes PRInfo lookups by PR number for the lifetime of the
-// daemon process. Switching back to a previously-visited PR feels instant when
-// this metadata is held in memory; the alternative is a 1-3s `gh pr view`
-// round trip on every focus change. Capacity-bounded LRU; entries also
-// invalidate on force-push and `crit pull`.
+// prMetadataCache memoizes PRInfo lookups by ChangeID (number, optionally
+// qualified by owner/repo) for the lifetime of the daemon process. Switching
+// back to a previously-visited PR feels instant when this metadata is held in
+// memory; the alternative is a 1-3s `gh pr view` round trip on every focus
+// change. Capacity-bounded LRU; entries also invalidate on force-push and
+// `crit pull`.
 type prMetadataCache struct {
 	mu      sync.Mutex
-	entries map[int]*prCacheEntry
+	entries map[string]*prCacheEntry
 	cap     int
 
 	// fetchFn fetches a PR on cache miss. Indirected so tests can drive the
-	// cache without shelling `gh`. Defaults to fetchPRByNumberFn (the same
+	// cache without shelling `gh`. Defaults to fetchPRFn (the same
 	// indirection point the rest of the codebase uses for test stubs).
-	fetchFn func(int) (*PRInfo, error)
+	fetchFn func(forge.ChangeID) (*PRInfo, error)
 }
 
 // newPRMetadataCache constructs a cache wired to the live fetcher.
 func newPRMetadataCache() *prMetadataCache {
 	return &prMetadataCache{
-		entries: make(map[int]*prCacheEntry),
+		entries: make(map[string]*prCacheEntry),
 		cap:     prMetadataCacheCap,
-		fetchFn: func(num int) (*PRInfo, error) { return fetchPRByNumberFn(num) },
+		fetchFn: func(id forge.ChangeID) (*PRInfo, error) { return fetchPRFn(id) },
 	}
 }
 
-// get returns the cached PRInfo for num, populating it on miss. Concurrent
+// get returns the cached PRInfo for id, populating it on miss. Concurrent
 // callers requesting the same uncached PR may all observe the miss and call
 // fetchFn — the second-arrival check after the fetch ensures the map only
 // stores the first successful result, so callers see a consistent value
 // without the complexity of a full singleflight.Group. The duplicate `gh`
 // invocation is acceptable: focus switches are user-driven and rarely hit the
 // same uncached PR from multiple goroutines.
-func (c *prMetadataCache) get(num int) (*PRInfo, error) {
+func (c *prMetadataCache) get(id forge.ChangeID) (*PRInfo, error) {
+	key := prCacheKey(id)
 	c.mu.Lock()
-	if e, ok := c.entries[num]; ok {
+	if e, ok := c.entries[key]; ok {
 		e.access = time.Now()
 		info := e.data
 		c.mu.Unlock()
@@ -60,14 +64,14 @@ func (c *prMetadataCache) get(num int) (*PRInfo, error) {
 	}
 	c.mu.Unlock()
 
-	info, err := c.fetchFn(num)
+	info, err := c.fetchFn(id)
 	if err != nil {
 		return nil, err
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if existing, ok := c.entries[num]; ok {
+	if existing, ok := c.entries[key]; ok {
 		// Race: another goroutine populated while we were fetching.
 		// Prefer the existing entry so all callers converge on one pointer.
 		existing.access = time.Now()
@@ -76,7 +80,7 @@ func (c *prMetadataCache) get(num int) (*PRInfo, error) {
 	if c.cap > 0 && len(c.entries) >= c.cap {
 		c.evictOldestLocked()
 	}
-	c.entries[num] = &prCacheEntry{data: info, access: time.Now()}
+	c.entries[key] = &prCacheEntry{data: info, access: time.Now()}
 	return info, nil
 }
 
@@ -84,25 +88,25 @@ func (c *prMetadataCache) get(num int) (*PRInfo, error) {
 // Linear scan is fine: cap is small (64) and evictions only happen on cache miss
 // after the cap is reached.
 func (c *prMetadataCache) evictOldestLocked() {
-	var oldestNum int
+	var oldestKey string
 	var oldestAt time.Time
 	first := true
-	for num, e := range c.entries {
+	for key, e := range c.entries {
 		if first || e.access.Before(oldestAt) {
-			oldestNum = num
+			oldestKey = key
 			oldestAt = e.access
 			first = false
 		}
 	}
 	if !first {
-		delete(c.entries, oldestNum)
+		delete(c.entries, oldestKey)
 	}
 }
 
-// invalidate drops the cache entry for num. Safe to call when num is absent.
-func (c *prMetadataCache) invalidate(num int) {
+// invalidate drops the cache entry for id. Safe to call when absent.
+func (c *prMetadataCache) invalidate(id forge.ChangeID) {
 	c.mu.Lock()
-	delete(c.entries, num)
+	delete(c.entries, prCacheKey(id))
 	c.mu.Unlock()
 }
 
@@ -110,22 +114,29 @@ func (c *prMetadataCache) invalidate(num int) {
 // fetchFn from the next; production code should prefer invalidate.
 func (c *prMetadataCache) reset() {
 	c.mu.Lock()
-	c.entries = make(map[int]*prCacheEntry)
+	c.entries = make(map[string]*prCacheEntry)
 	c.mu.Unlock()
 }
 
-// prMetaCache is the package-level singleton consulted by fetchPRByNumber and
+// prMetaCache is the package-level singleton consulted by FetchPR and
 // the focus/pull invalidation hooks. Mirrors the singleton shape of
 // PRListCache (held on Server) but lives at package scope because callers
 // (including the CLI `crit pull` path) don't always have a Server in hand.
 var prMetaCache = newPRMetadataCache()
 
-// InvalidatePRCache drops the cached PRInfo for num. Call after operations
-// that may have made the cached metadata stale: force-push detection in
-// SetFocus and after `crit pull` (which is the most common refresh trigger).
+// InvalidatePRCache drops the cached PRInfo for a bare PR number (current
+// checkout). Prefer InvalidatePR when the owning project is known.
 func InvalidatePRCache(num int) {
 	if num <= 0 {
 		return
 	}
-	prMetaCache.invalidate(num)
+	prMetaCache.invalidate(forge.ChangeID{Number: num})
+}
+
+// InvalidatePR drops the cached PRInfo for id (project-qualified when set).
+func InvalidatePR(id forge.ChangeID) {
+	if id.Number <= 0 {
+		return
+	}
+	prMetaCache.invalidate(id)
 }

--- a/internal/github/pr_cache_test.go
+++ b/internal/github/pr_cache_test.go
@@ -196,6 +196,24 @@ func TestPRMetadataCache_ConcurrentGetSinglePopulation(t *testing.T) {
 	}
 }
 
+func TestInvalidatePR_DropsProjectQualifiedKey(t *testing.T) {
+	prev := prMetaCache
+	prMetaCache = newPRMetadataCache()
+	t.Cleanup(func() { prMetaCache = prev })
+
+	id := forge.ChangeID{Number: 1, Project: "org/repo-b"}
+	prMetaCache.entries[prCacheKey(id)] = &prCacheEntry{data: &PRInfo{Number: 1}, access: time.Now()}
+	prMetaCache.entries["1"] = &prCacheEntry{data: &PRInfo{Number: 1, Title: "bare"}, access: time.Now()}
+
+	InvalidatePR(id)
+	if _, ok := prMetaCache.entries[prCacheKey(id)]; ok {
+		t.Error("InvalidatePR failed to drop project-qualified entry")
+	}
+	if _, ok := prMetaCache.entries["1"]; !ok {
+		t.Error("InvalidatePR wrongly dropped bare-number entry")
+	}
+}
+
 func TestInvalidatePRCache_IgnoresNonPositive(t *testing.T) {
 	prev := prMetaCache
 	prMetaCache = newPRMetadataCache()

--- a/internal/github/pr_cache_test.go
+++ b/internal/github/pr_cache_test.go
@@ -214,6 +214,28 @@ func TestInvalidatePR_DropsProjectQualifiedKey(t *testing.T) {
 	}
 }
 
+func TestInvalidatePRCache_DropsBareAndQualified(t *testing.T) {
+	prev := prMetaCache
+	prMetaCache = newPRMetadataCache()
+	t.Cleanup(func() { prMetaCache = prev })
+
+	id := forge.ChangeID{Number: 7, Project: "org/repo-b", Host: "github.example.com"}
+	prMetaCache.entries[prCacheKey(id)] = &prCacheEntry{data: &PRInfo{Number: 7}, access: time.Now()}
+	prMetaCache.entries["7"] = &prCacheEntry{data: &PRInfo{Number: 7}, access: time.Now()}
+	prMetaCache.entries["8"] = &prCacheEntry{data: &PRInfo{Number: 8}, access: time.Now()}
+
+	InvalidatePRCache(7)
+	if _, ok := prMetaCache.entries[prCacheKey(id)]; ok {
+		t.Error("InvalidatePRCache left project-qualified entry")
+	}
+	if _, ok := prMetaCache.entries["7"]; ok {
+		t.Error("InvalidatePRCache left bare entry")
+	}
+	if _, ok := prMetaCache.entries["8"]; !ok {
+		t.Error("InvalidatePRCache wrongly dropped unrelated PR")
+	}
+}
+
 func TestInvalidatePRCache_IgnoresNonPositive(t *testing.T) {
 	prev := prMetaCache
 	prMetaCache = newPRMetadataCache()

--- a/internal/github/pr_cache_test.go
+++ b/internal/github/pr_cache_test.go
@@ -2,30 +2,35 @@ package github
 
 import (
 	"errors"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/tomasz-tomczyk/crit/internal/forge"
 )
 
 // newTestCache builds an isolated cache wired to a counting fetchFn so the
 // production singleton is untouched between tests.
-func newTestCache(fn func(int) (*PRInfo, error)) *prMetadataCache {
+func newTestCache(fn func(forge.ChangeID) (*PRInfo, error)) *prMetadataCache {
 	return &prMetadataCache{
-		entries: make(map[int]*prCacheEntry),
+		entries: make(map[string]*prCacheEntry),
 		cap:     prMetadataCacheCap,
 		fetchFn: fn,
 	}
 }
 
+func numID(n int) forge.ChangeID { return forge.ChangeID{Number: n} }
+
 func TestPRMetadataCache_FirstGetIsMiss(t *testing.T) {
 	var calls int32
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
-		return &PRInfo{Number: num, Title: "first"}, nil
+		return &PRInfo{Number: id.Number, Title: "first"}, nil
 	})
 
-	info, err := c.get(42)
+	info, err := c.get(numID(42))
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -39,15 +44,15 @@ func TestPRMetadataCache_FirstGetIsMiss(t *testing.T) {
 
 func TestPRMetadataCache_SecondGetIsHit(t *testing.T) {
 	var calls int32
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
-		return &PRInfo{Number: num}, nil
+		return &PRInfo{Number: id.Number}, nil
 	})
 
-	if _, err := c.get(42); err != nil {
+	if _, err := c.get(numID(42)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.get(42); err != nil {
+	if _, err := c.get(numID(42)); err != nil {
 		t.Fatal(err)
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
@@ -57,15 +62,15 @@ func TestPRMetadataCache_SecondGetIsHit(t *testing.T) {
 
 func TestPRMetadataCache_DistinctPRsAreIndependent(t *testing.T) {
 	var calls int32
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
-		return &PRInfo{Number: num}, nil
+		return &PRInfo{Number: id.Number}, nil
 	})
 
-	if _, err := c.get(1); err != nil {
+	if _, err := c.get(numID(1)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.get(2); err != nil {
+	if _, err := c.get(numID(2)); err != nil {
 		t.Fatal(err)
 	}
 	if got := atomic.LoadInt32(&calls); got != 2 {
@@ -73,18 +78,43 @@ func TestPRMetadataCache_DistinctPRsAreIndependent(t *testing.T) {
 	}
 }
 
-func TestPRMetadataCache_InvalidateRemovesEntry(t *testing.T) {
+func TestPRMetadataCache_SameNumberDifferentProjectsAreIndependent(t *testing.T) {
 	var calls int32
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
-		return &PRInfo{Number: num}, nil
+		return &PRInfo{Number: id.Number, URL: "https://github.com/" + id.Project + "/pull/" + strconv.Itoa(id.Number)}, nil
 	})
 
-	if _, err := c.get(42); err != nil {
+	a := forge.ChangeID{Number: 1, Project: "org/repo-a"}
+	b := forge.ChangeID{Number: 1, Project: "org/repo-b"}
+	infoA, err := c.get(a)
+	if err != nil {
 		t.Fatal(err)
 	}
-	c.invalidate(42)
-	if _, err := c.get(42); err != nil {
+	infoB, err := c.get(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if infoA.URL == infoB.URL {
+		t.Fatalf("same-number PRs in different repos collided: %q", infoA.URL)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("fetchFn calls=%d want 2", got)
+	}
+}
+
+func TestPRMetadataCache_InvalidateRemovesEntry(t *testing.T) {
+	var calls int32
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		return &PRInfo{Number: id.Number}, nil
+	})
+
+	if _, err := c.get(numID(42)); err != nil {
+		t.Fatal(err)
+	}
+	c.invalidate(numID(42))
+	if _, err := c.get(numID(42)); err != nil {
 		t.Fatal(err)
 	}
 	if got := atomic.LoadInt32(&calls); got != 2 {
@@ -93,26 +123,25 @@ func TestPRMetadataCache_InvalidateRemovesEntry(t *testing.T) {
 }
 
 func TestPRMetadataCache_InvalidateMissingNumberIsNoOp(t *testing.T) {
-	c := newTestCache(func(int) (*PRInfo, error) { return &PRInfo{}, nil })
-	c.invalidate(99) // must not panic
+	c := newTestCache(func(forge.ChangeID) (*PRInfo, error) { return &PRInfo{}, nil })
+	c.invalidate(numID(99)) // must not panic
 }
 
 func TestPRMetadataCache_FetchErrorNotCached(t *testing.T) {
 	var calls int32
 	wantErr := errors.New("boom")
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
 		if atomic.LoadInt32(&calls) == 1 {
 			return nil, wantErr
 		}
-		return &PRInfo{Number: num}, nil
+		return &PRInfo{Number: id.Number}, nil
 	})
 
-	if _, err := c.get(7); !errors.Is(err, wantErr) {
+	if _, err := c.get(numID(7)); !errors.Is(err, wantErr) {
 		t.Fatalf("first get err=%v want %v", err, wantErr)
 	}
-	// Second call must hit fetchFn again because errors don't populate the cache.
-	info, err := c.get(7)
+	info, err := c.get(numID(7))
 	if err != nil {
 		t.Fatalf("second get: %v", err)
 	}
@@ -124,17 +153,11 @@ func TestPRMetadataCache_FetchErrorNotCached(t *testing.T) {
 	}
 }
 
-// TestPRMetadataCache_ConcurrentGetSinglePopulation verifies that even if N
-// goroutines race past the initial miss check, only one entry survives in
-// the cache — all callers converge on a single *PRInfo. We tolerate up to N
-// fetchFn invocations (no full singleflight), but post-fetch deduping must
-// hand back the same pointer to every caller.
 func TestPRMetadataCache_ConcurrentGetSinglePopulation(t *testing.T) {
 	var calls int32
-	c := newTestCache(func(num int) (*PRInfo, error) {
+	c := newTestCache(func(id forge.ChangeID) (*PRInfo, error) {
 		atomic.AddInt32(&calls, 1)
-		// Fresh pointer each call — only post-fetch dedupe ensures convergence.
-		return &PRInfo{Number: num, Title: "v"}, nil
+		return &PRInfo{Number: id.Number, Title: "v"}, nil
 	})
 
 	const goroutines = 32
@@ -144,7 +167,7 @@ func TestPRMetadataCache_ConcurrentGetSinglePopulation(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			info, err := c.get(99)
+			info, err := c.get(numID(99))
 			if err != nil {
 				t.Errorf("goroutine %d: %v", idx, err)
 				return
@@ -163,38 +186,33 @@ func TestPRMetadataCache_ConcurrentGetSinglePopulation(t *testing.T) {
 			t.Errorf("goroutine %d returned %p, want %p (all callers must converge)", i, r, first)
 		}
 	}
-	// Cache must hold exactly one entry post-race.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.entries) != 1 {
 		t.Errorf("entries=%d want 1", len(c.entries))
 	}
-	if c.entries[99].data != first {
-		t.Errorf("cached entry %p != returned %p", c.entries[99].data, first)
+	if c.entries["99"].data != first {
+		t.Errorf("cached entry %p != returned %p", c.entries["99"].data, first)
 	}
 }
 
 func TestInvalidatePRCache_IgnoresNonPositive(t *testing.T) {
-	// Snapshot then restore the singleton so we don't bleed state into other tests.
 	prev := prMetaCache
 	prMetaCache = newPRMetadataCache()
 	t.Cleanup(func() { prMetaCache = prev })
 
-	prMetaCache.entries[1] = &prCacheEntry{data: &PRInfo{Number: 1}, access: time.Now()}
+	prMetaCache.entries["1"] = &prCacheEntry{data: &PRInfo{Number: 1}, access: time.Now()}
 	InvalidatePRCache(0)
 	InvalidatePRCache(-5)
-	if _, ok := prMetaCache.entries[1]; !ok {
+	if _, ok := prMetaCache.entries["1"]; !ok {
 		t.Error("InvalidatePRCache(0/-5) wrongly dropped unrelated entries")
 	}
 	InvalidatePRCache(1)
-	if _, ok := prMetaCache.entries[1]; ok {
+	if _, ok := prMetaCache.entries["1"]; ok {
 		t.Error("InvalidatePRCache(1) failed to drop entry")
 	}
 }
 
-// TestFetchPRByNumber_RoutesThroughCache verifies the package-level wiring:
-// fetchPRByNumber consults prMetaCache before invoking fetchPRByNumberFn, so
-// repeated calls with the same number hit `gh` exactly once.
 func TestFetchPRByNumber_RoutesThroughCache(t *testing.T) {
 	var calls int32
 	withFetchPRByNumber(t, func(num int) (*PRInfo, error) {
@@ -203,7 +221,7 @@ func TestFetchPRByNumber_RoutesThroughCache(t *testing.T) {
 	})
 
 	for i := 0; i < 5; i++ {
-		info, err := fetchPRByNumber(100)
+		info, err := FetchPRByNumber(100)
 		if err != nil {
 			t.Fatalf("iter %d: %v", i, err)
 		}
@@ -212,11 +230,11 @@ func TestFetchPRByNumber_RoutesThroughCache(t *testing.T) {
 		}
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Errorf("fetchPRByNumberFn calls=%d want 1 across 5 fetchPRByNumber calls", got)
+		t.Errorf("fetchPRFn calls=%d want 1 across 5 FetchPRByNumber calls", got)
 	}
 
 	InvalidatePRCache(100)
-	if _, err := fetchPRByNumber(100); err != nil {
+	if _, err := FetchPRByNumber(100); err != nil {
 		t.Fatal(err)
 	}
 	if got := atomic.LoadInt32(&calls); got != 2 {
@@ -224,32 +242,25 @@ func TestFetchPRByNumber_RoutesThroughCache(t *testing.T) {
 	}
 }
 
-// TestPRMetadataCache_EvictsOldestWhenFull populates the cache past its cap
-// and verifies that the LRU entry is evicted while the most-recently-touched
-// entries survive.
 func TestPRMetadataCache_EvictsOldestWhenFull(t *testing.T) {
 	c := &prMetadataCache{
-		entries: make(map[int]*prCacheEntry),
+		entries: make(map[string]*prCacheEntry),
 		cap:     3,
-		fetchFn: func(num int) (*PRInfo, error) { return &PRInfo{Number: num}, nil },
+		fetchFn: func(id forge.ChangeID) (*PRInfo, error) { return &PRInfo{Number: id.Number}, nil },
 	}
 
-	// Fill exactly to cap.
 	for i := 1; i <= 3; i++ {
-		if _, err := c.get(i); err != nil {
+		if _, err := c.get(numID(i)); err != nil {
 			t.Fatal(err)
 		}
-		// Stagger access times so LRU ordering is unambiguous.
 		time.Sleep(2 * time.Millisecond)
 	}
-	// Touch PR 1 so PR 2 becomes the LRU.
-	if _, err := c.get(1); err != nil {
+	if _, err := c.get(numID(1)); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(2 * time.Millisecond)
 
-	// Inserting PR 4 must evict PR 2 (the now-oldest).
-	if _, err := c.get(4); err != nil {
+	if _, err := c.get(numID(4)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -258,18 +269,18 @@ func TestPRMetadataCache_EvictsOldestWhenFull(t *testing.T) {
 	if len(c.entries) != 3 {
 		t.Errorf("entries=%d want 3 (cap)", len(c.entries))
 	}
-	if _, ok := c.entries[2]; ok {
+	if _, ok := c.entries["2"]; ok {
 		t.Errorf("PR 2 should have been evicted (LRU); entries=%v", keys(c.entries))
 	}
-	for _, want := range []int{1, 3, 4} {
+	for _, want := range []string{"1", "3", "4"} {
 		if _, ok := c.entries[want]; !ok {
-			t.Errorf("PR %d should be retained; entries=%v", want, keys(c.entries))
+			t.Errorf("PR %s should be retained; entries=%v", want, keys(c.entries))
 		}
 	}
 }
 
-func keys(m map[int]*prCacheEntry) []int {
-	out := make([]int, 0, len(m))
+func keys(m map[string]*prCacheEntry) []string {
+	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)
 	}

--- a/internal/github/pr_cache_test.go
+++ b/internal/github/pr_cache_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -279,6 +280,15 @@ func TestFetchPRByNumber_RoutesThroughCache(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Errorf("after invalidate, calls=%d want 2", got)
+	}
+}
+
+func TestFetchPR_RejectsNonPositiveNumber(t *testing.T) {
+	if _, err := FetchPR(forge.ChangeID{}); err == nil || !strings.Contains(err.Error(), "invalid PR number") {
+		t.Fatalf("FetchPR(0) err = %v", err)
+	}
+	if _, err := FetchPR(forge.ChangeID{Number: -1}); err == nil {
+		t.Fatal("FetchPR(-1) unexpectedly succeeded")
 	}
 }
 

--- a/internal/github/provider.go
+++ b/internal/github/provider.go
@@ -26,18 +26,23 @@ func (Provider) Detect(_ context.Context, _ forge.RepoContext) (forge.ChangeID, 
 }
 
 func (Provider) Get(_ context.Context, _ forge.RepoContext, id forge.ChangeID) (forge.ChangeRequest, error) {
-	info, err := FetchPRByNumber(id.Number)
+	info, err := FetchPR(id)
 	if err != nil {
 		return forge.ChangeRequest{}, err
 	}
 	if info == nil {
 		return forge.ChangeRequest{}, fmt.Errorf("PR #%d not found", id.Number)
 	}
+	baseProject := id.Project
+	if baseProject == "" {
+		baseProject = githubProject(info.URL)
+	}
 	return forge.ChangeRequest{
 		ID: id, URL: info.URL, Title: info.Title, Body: info.Body, State: info.State,
 		Draft: info.IsDraft, BaseRefName: info.BaseRefName, HeadRefName: info.HeadRefName,
 		BaseSHA: info.BaseRefOid, HeadSHA: info.HeadRefOid,
-		HeadRepo:        forge.RepoRef{Project: githubProject(info.HeadRepoURL)},
+		BaseRepo:        forge.RepoRef{Project: baseProject, Host: id.Host},
+		HeadRepo:        forge.RepoRef{Project: githubProject(info.HeadRepoURL), CloneURL: info.HeadRepoURL},
 		CrossRepository: info.IsCrossRepository, Additions: info.Additions,
 		Deletions: info.Deletions, ChangedFiles: info.ChangedFiles,
 		Author: info.AuthorLogin, CreatedAt: info.CreatedAt,
@@ -150,7 +155,7 @@ func (Provider) FetchFile(_ context.Context, _ forge.RepoContext, source forge.R
 	return session.FetchGitHubFileContent(parts[len(parts)-2], parts[len(parts)-1], sha, path)
 }
 
-func (Provider) Invalidate(id forge.ChangeID) { InvalidatePRCache(id.Number) }
+func (Provider) Invalidate(id forge.ChangeID) { InvalidatePR(id) }
 
 var _ forge.Provider = Provider{}
 
@@ -160,3 +165,6 @@ func githubProject(raw string) string {
 	}
 	return strings.TrimSuffix(strings.Trim(raw, "/"), ".git")
 }
+
+// ProjectFromRemoteURL extracts "owner/repo" from a GitHub remote or PR URL.
+func ProjectFromRemoteURL(raw string) string { return githubProject(raw) }

--- a/internal/github/provider_test.go
+++ b/internal/github/provider_test.go
@@ -172,3 +172,17 @@ func TestGitHubProjectNormalization(t *testing.T) {
 		}
 	}
 }
+
+func TestProjectFromRemoteURL(t *testing.T) {
+	tests := map[string]string{
+		"https://github.com/myorg/repo-b.git": "myorg/repo-b",
+		"https://github.com/o/r":              "o/r",
+		"acme/widget":                         "acme/widget",
+		"":                                    "",
+	}
+	for input, want := range tests {
+		if got := ProjectFromRemoteURL(input); got != want {
+			t.Errorf("ProjectFromRemoteURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/github/spec.go
+++ b/internal/github/spec.go
@@ -43,11 +43,16 @@ func invalidPRSpec(spec string) error {
 
 // prViewArgs builds the `gh pr view` argument list for id. When Project is
 // set (from a full PR URL), pin the lookup with -R so the current checkout's
-// remote cannot shadow a different owner/repo (#870).
+// remote cannot shadow a different owner/repo (#870). Non-github.com hosts
+// are included as HOST/OWNER/REPO so GitHub Enterprise URLs resolve correctly.
 func prViewArgs(id forge.ChangeID) []string {
 	args := []string{"pr", "view", strconv.Itoa(id.Number)}
 	if id.Project != "" {
-		args = append(args, "-R", id.Project)
+		repo := id.Project
+		if id.Host != "" && !strings.EqualFold(id.Host, "github.com") {
+			repo = id.Host + "/" + id.Project
+		}
+		args = append(args, "-R", repo)
 	}
 	return append(args, "--json", prJSONFields)
 }

--- a/internal/github/spec.go
+++ b/internal/github/spec.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -33,12 +34,36 @@ func ParsePRSpec(spec string) (forge.ChangeID, error) {
 	return forge.ChangeID{
 		Number:  n,
 		Project: parts[0] + "/" + parts[1],
-		Host:    u.Host,
+		Host:    normalizeGitHubHost(u.Host),
 	}, nil
 }
 
 func invalidPRSpec(spec string) error {
 	return fmt.Errorf("invalid --pr value %q (expected number or https://host/owner/repo/pull/N URL)", spec)
+}
+
+// normalizeGitHubHost collapses github.com aliases so cache/session keys and
+// -R flags stay consistent (www., ports, case).
+func normalizeGitHubHost(host string) string {
+	host = strings.TrimSpace(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if strings.EqualFold(host, "github.com") || strings.EqualFold(host, "www.github.com") {
+		return "github.com"
+	}
+	return strings.ToLower(host)
+}
+
+// prRepoRef is the -R / cache-key repository identity for id.
+func prRepoRef(id forge.ChangeID) string {
+	if id.Project == "" {
+		return ""
+	}
+	if id.Host != "" && !strings.EqualFold(id.Host, "github.com") {
+		return id.Host + "/" + id.Project
+	}
+	return id.Project
 }
 
 // prViewArgs builds the `gh pr view` argument list for id. When Project is
@@ -47,21 +72,17 @@ func invalidPRSpec(spec string) error {
 // are included as HOST/OWNER/REPO so GitHub Enterprise URLs resolve correctly.
 func prViewArgs(id forge.ChangeID) []string {
 	args := []string{"pr", "view", strconv.Itoa(id.Number)}
-	if id.Project != "" {
-		repo := id.Project
-		if id.Host != "" && !strings.EqualFold(id.Host, "github.com") {
-			repo = id.Host + "/" + id.Project
-		}
+	if repo := prRepoRef(id); repo != "" {
 		args = append(args, "-R", repo)
 	}
 	return append(args, "--json", prJSONFields)
 }
 
-// prCacheKey namespaces PR metadata by owner/repo when known so same-number
-// PRs in different repos do not collide in the daemon cache.
+// prCacheKey namespaces PR metadata by host/owner/repo when known so same-number
+// PRs in different repos (or hosts) do not collide in the daemon cache.
 func prCacheKey(id forge.ChangeID) string {
-	if id.Project == "" {
-		return strconv.Itoa(id.Number)
+	if repo := prRepoRef(id); repo != "" {
+		return repo + "#" + strconv.Itoa(id.Number)
 	}
-	return id.Project + "#" + strconv.Itoa(id.Number)
+	return strconv.Itoa(id.Number)
 }

--- a/internal/github/spec.go
+++ b/internal/github/spec.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/tomasz-tomczyk/crit/internal/forge"
+)
+
+// ParsePRSpec accepts a PR number or a canonical GitHub pull-request URL.
+// Bare numbers leave Project/Host empty (resolved against the current
+// checkout). Full URLs populate Project as "owner/repo" and Host from the URL
+// so cross-repo reviews do not collapse onto the cwd remote (#870).
+func ParsePRSpec(spec string) (forge.ChangeID, error) {
+	if n, err := strconv.Atoi(spec); err == nil && n > 0 {
+		return forge.ChangeID{Number: n}, nil
+	}
+	u, err := url.Parse(spec)
+	if err != nil || u.Hostname() == "" {
+		return forge.ChangeID{}, invalidPRSpec(spec)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// owner/repo/pull/N — optionally followed by tab suffixes (files, commits, …).
+	if len(parts) < 4 || parts[2] != "pull" {
+		return forge.ChangeID{}, invalidPRSpec(spec)
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil || n <= 0 {
+		return forge.ChangeID{}, invalidPRSpec(spec)
+	}
+	return forge.ChangeID{
+		Number:  n,
+		Project: parts[0] + "/" + parts[1],
+		Host:    u.Host,
+	}, nil
+}
+
+func invalidPRSpec(spec string) error {
+	return fmt.Errorf("invalid --pr value %q (expected number or https://host/owner/repo/pull/N URL)", spec)
+}
+
+// prViewArgs builds the `gh pr view` argument list for id. When Project is
+// set (from a full PR URL), pin the lookup with -R so the current checkout's
+// remote cannot shadow a different owner/repo (#870).
+func prViewArgs(id forge.ChangeID) []string {
+	args := []string{"pr", "view", strconv.Itoa(id.Number)}
+	if id.Project != "" {
+		args = append(args, "-R", id.Project)
+	}
+	return append(args, "--json", prJSONFields)
+}
+
+// prCacheKey namespaces PR metadata by owner/repo when known so same-number
+// PRs in different repos do not collide in the daemon cache.
+func prCacheKey(id forge.ChangeID) string {
+	if id.Project == "" {
+		return strconv.Itoa(id.Number)
+	}
+	return id.Project + "#" + strconv.Itoa(id.Number)
+}

--- a/internal/github/spec_test.go
+++ b/internal/github/spec_test.go
@@ -28,6 +28,16 @@ func TestParsePRSpec(t *testing.T) {
 			forge.ChangeID{Number: 1, Project: "myorg/repo-b", Host: "github.com"},
 			false,
 		},
+		{
+			"https://www.github.com/o/r/pull/2",
+			forge.ChangeID{Number: 2, Project: "o/r", Host: "github.com"},
+			false,
+		},
+		{
+			"https://github.example.com/acme/app/pull/9",
+			forge.ChangeID{Number: 9, Project: "acme/app", Host: "github.example.com"},
+			false,
+		},
 		{"http://github.com/o/r/pull/7", forge.ChangeID{Number: 7, Project: "o/r", Host: "github.com"}, false},
 		{"abc", forge.ChangeID{}, true},
 		{"-5", forge.ChangeID{}, true},

--- a/internal/github/spec_test.go
+++ b/internal/github/spec_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/forge"
+)
+
+func TestParsePRSpec(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    forge.ChangeID
+		wantErr bool
+	}{
+		{"295", forge.ChangeID{Number: 295}, false},
+		{
+			"https://github.com/a/b/pull/295",
+			forge.ChangeID{Number: 295, Project: "a/b", Host: "github.com"},
+			false,
+		},
+		{
+			"https://github.com/a/b/pull/295/files",
+			forge.ChangeID{Number: 295, Project: "a/b", Host: "github.com"},
+			false,
+		},
+		{
+			"https://github.com/myorg/repo-b/pull/1?diff=split",
+			forge.ChangeID{Number: 1, Project: "myorg/repo-b", Host: "github.com"},
+			false,
+		},
+		{"http://github.com/o/r/pull/7", forge.ChangeID{Number: 7, Project: "o/r", Host: "github.com"}, false},
+		{"abc", forge.ChangeID{}, true},
+		{"-5", forge.ChangeID{}, true},
+		{"0", forge.ChangeID{}, true},
+		{"", forge.ChangeID{}, true},
+		{"https://github.com/a/b/issues/295", forge.ChangeID{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := ParsePRSpec(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, c.wantErr)
+			}
+			if got != c.want {
+				t.Fatalf("got %+v want %+v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/github/spec_test.go
+++ b/internal/github/spec_test.go
@@ -39,11 +39,23 @@ func TestParsePRSpec(t *testing.T) {
 			false,
 		},
 		{"http://github.com/o/r/pull/7", forge.ChangeID{Number: 7, Project: "o/r", Host: "github.com"}, false},
+		{
+			"https://github.com:443/o/r/pull/8",
+			forge.ChangeID{Number: 8, Project: "o/r", Host: "github.com"},
+			false,
+		},
+		{
+			"https://GITHUB.COM/O/R/pull/3",
+			forge.ChangeID{Number: 3, Project: "O/R", Host: "github.com"},
+			false,
+		},
 		{"abc", forge.ChangeID{}, true},
 		{"-5", forge.ChangeID{}, true},
 		{"0", forge.ChangeID{}, true},
 		{"", forge.ChangeID{}, true},
 		{"https://github.com/a/b/issues/295", forge.ChangeID{}, true},
+		{"https://github.com/a/b/pull/0", forge.ChangeID{}, true},
+		{"https://github.com/only-one/pull/1", forge.ChangeID{}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {

--- a/internal/github/spec_view_args_test.go
+++ b/internal/github/spec_view_args_test.go
@@ -1,0 +1,35 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/forge"
+)
+
+func TestPRViewArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		id   forge.ChangeID
+		want []string
+	}{
+		{
+			name: "bare number uses current checkout",
+			id:   forge.ChangeID{Number: 42},
+			want: []string{"pr", "view", "42", "--json", prJSONFields},
+		},
+		{
+			name: "URL-derived project pins -R owner/repo",
+			id:   forge.ChangeID{Number: 1, Project: "myorg/repo-b"},
+			want: []string{"pr", "view", "1", "-R", "myorg/repo-b", "--json", prJSONFields},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := prViewArgs(c.id)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("got %v want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/github/spec_view_args_test.go
+++ b/internal/github/spec_view_args_test.go
@@ -20,8 +20,13 @@ func TestPRViewArgs(t *testing.T) {
 		},
 		{
 			name: "URL-derived project pins -R owner/repo",
-			id:   forge.ChangeID{Number: 1, Project: "myorg/repo-b"},
+			id:   forge.ChangeID{Number: 1, Project: "myorg/repo-b", Host: "github.com"},
 			want: []string{"pr", "view", "1", "-R", "myorg/repo-b", "--json", prJSONFields},
+		},
+		{
+			name: "enterprise host is included in -R",
+			id:   forge.ChangeID{Number: 9, Project: "acme/app", Host: "github.example.com"},
+			want: []string{"pr", "view", "9", "-R", "github.example.com/acme/app", "--json", prJSONFields},
 		},
 	}
 	for _, c := range cases {

--- a/internal/github/spec_view_args_test.go
+++ b/internal/github/spec_view_args_test.go
@@ -38,3 +38,14 @@ func TestPRViewArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestPRCacheKey_IncludesEnterpriseHost(t *testing.T) {
+	got := prCacheKey(forge.ChangeID{Number: 9, Project: "acme/app", Host: "github.example.com"})
+	if got != "github.example.com/acme/app#9" {
+		t.Fatalf("got %q", got)
+	}
+	dotcom := prCacheKey(forge.ChangeID{Number: 9, Project: "acme/app", Host: "github.com"})
+	if dotcom != "acme/app#9" {
+		t.Fatalf("github.com key = %q", dotcom)
+	}
+}

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -351,10 +351,7 @@ func FocusKeyArgs(sc *DaemonCLIConfig) []string {
 		if sc.Focus.Forge == "gitlab" {
 			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
 		}
-		if sc.Focus.RemoteBaseProject != "" {
-			return []string{fmt.Sprintf("pr:%s#%d", sc.Focus.RemoteBaseProject, sc.Focus.ChangeNumber)}
-		}
-		return []string{fmt.Sprintf("pr:%d", sc.Focus.ChangeNumber)}
+		return []string{session.PRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 	}
 	return []string{fmt.Sprintf("range:%s..%s", sc.Focus.BaseSHA, sc.Focus.HeadSHA)}
 }

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -351,6 +351,9 @@ func FocusKeyArgs(sc *DaemonCLIConfig) []string {
 		if sc.Focus.Forge == "gitlab" {
 			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
 		}
+		if sc.Focus.RemoteBaseProject != "" {
+			return []string{fmt.Sprintf("pr:%s#%d", sc.Focus.RemoteBaseProject, sc.Focus.ChangeNumber)}
+		}
 		return []string{fmt.Sprintf("pr:%d", sc.Focus.ChangeNumber)}
 	}
 	return []string{fmt.Sprintf("range:%s..%s", sc.Focus.BaseSHA, sc.Focus.HeadSHA)}

--- a/internal/server/daemon_cli_test.go
+++ b/internal/server/daemon_cli_test.go
@@ -56,6 +56,23 @@ func TestFocusKeyArgs_PRWithEnterpriseHost(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithGitHubDotComHostOmitsHost(t *testing.T) {
+	sc := &server.DaemonCLIConfig{Focus: &server.Focus{
+		Kind: server.FocusRange, Forge: "github", ChangeNumber: 4,
+		RemoteBaseProject: "o/r", RemoteHost: "github.com",
+	}}
+	got := server.FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:o/r#4" {
+		t.Errorf("got %v want [pr:o/r#4]", got)
+	}
+}
+
+func TestFocusKeyArgs_NilConfig(t *testing.T) {
+	if got := server.FocusKeyArgs(nil); got != nil {
+		t.Errorf("got %v want nil", got)
+	}
+}
+
 func TestFocusKeyArgs_MR(t *testing.T) {
 	sc := &server.DaemonCLIConfig{Focus: &server.Focus{Kind: server.FocusRange, Forge: "gitlab", ChangeNumber: 42}}
 	got := server.FocusKeyArgs(sc)

--- a/internal/server/daemon_cli_test.go
+++ b/internal/server/daemon_cli_test.go
@@ -45,6 +45,17 @@ func TestFocusKeyArgs_PRWithRemoteBaseProject(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithEnterpriseHost(t *testing.T) {
+	sc := &server.DaemonCLIConfig{Focus: &server.Focus{
+		Kind: server.FocusRange, Forge: "github", ChangeNumber: 9,
+		RemoteBaseProject: "acme/app", RemoteHost: "github.example.com",
+	}}
+	got := server.FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:github.example.com/acme/app#9" {
+		t.Errorf("got %v want [pr:github.example.com/acme/app#9]", got)
+	}
+}
+
 func TestFocusKeyArgs_MR(t *testing.T) {
 	sc := &server.DaemonCLIConfig{Focus: &server.Focus{Kind: server.FocusRange, Forge: "gitlab", ChangeNumber: 42}}
 	got := server.FocusKeyArgs(sc)

--- a/internal/server/daemon_cli_test.go
+++ b/internal/server/daemon_cli_test.go
@@ -34,6 +34,17 @@ func TestFocusKeyArgs_PR(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithRemoteBaseProject(t *testing.T) {
+	sc := &server.DaemonCLIConfig{Focus: &server.Focus{
+		Kind: server.FocusRange, Forge: "github", ChangeNumber: 1,
+		RemoteBaseProject: "myorg/repo-b",
+	}}
+	got := server.FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:myorg/repo-b#1" {
+		t.Errorf("got %v want [pr:myorg/repo-b#1]", got)
+	}
+}
+
 func TestFocusKeyArgs_MR(t *testing.T) {
 	sc := &server.DaemonCLIConfig{Focus: &server.Focus{Kind: server.FocusRange, Forge: "gitlab", ChangeNumber: 42}}
 	got := server.FocusKeyArgs(sc)

--- a/internal/session/focus_cli_test.go
+++ b/internal/session/focus_cli_test.go
@@ -38,6 +38,31 @@ func TestFocusKeyArgs_PRWithEnterpriseHost(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithGitHubDotComHostOmitsHost(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{
+		Kind: FocusRange, Forge: "github", ChangeNumber: 4,
+		RemoteBaseProject: "o/r", RemoteHost: "github.com",
+	}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:o/r#4" {
+		t.Errorf("got %v want [pr:o/r#4]", got)
+	}
+}
+
+func TestFocusKeyArgs_NilConfig(t *testing.T) {
+	if got := FocusKeyArgs(nil); got != nil {
+		t.Errorf("got %v want nil", got)
+	}
+}
+
+func TestFocusKeyArgs_MR(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{Kind: FocusRange, Forge: "gitlab", ChangeNumber: 42}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "mr:42" {
+		t.Errorf("got %v want [mr:42]", got)
+	}
+}
+
 func TestPRFocusKey_MatchesFocusKeyFor(t *testing.T) {
 	f := Focus{
 		Kind: FocusRange, Forge: "github", ChangeNumber: 3,

--- a/internal/session/focus_cli_test.go
+++ b/internal/session/focus_cli_test.go
@@ -27,6 +27,27 @@ func TestFocusKeyArgs_PRWithRemoteBaseProject(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithEnterpriseHost(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{
+		Kind: FocusRange, Forge: "github", ChangeNumber: 9,
+		RemoteBaseProject: "acme/app", RemoteHost: "github.example.com",
+	}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:github.example.com/acme/app#9" {
+		t.Errorf("got %v want [pr:github.example.com/acme/app#9]", got)
+	}
+}
+
+func TestPRFocusKey_MatchesFocusKeyFor(t *testing.T) {
+	f := Focus{
+		Kind: FocusRange, Forge: "github", ChangeNumber: 3,
+		RemoteBaseProject: "o/r", RemoteHost: "github.example.com",
+	}
+	if got, want := focusKeyFor(f), PRFocusKey(3, "o/r", "github.example.com"); got != want {
+		t.Fatalf("focusKeyFor=%q PRFocusKey=%q", got, want)
+	}
+}
+
 func TestFocusKeyArgs_Range(t *testing.T) {
 	sc := &CLIReviewConfig{Focus: &Focus{Kind: FocusRange, BaseSHA: "abc", HeadSHA: "def"}}
 	got := FocusKeyArgs(sc)

--- a/internal/session/focus_cli_test.go
+++ b/internal/session/focus_cli_test.go
@@ -16,6 +16,17 @@ func TestFocusKeyArgs_PR(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_PRWithRemoteBaseProject(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{
+		Kind: FocusRange, Forge: "github", ChangeNumber: 1,
+		RemoteBaseProject: "myorg/repo-b",
+	}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "pr:myorg/repo-b#1" {
+		t.Errorf("got %v want [pr:myorg/repo-b#1]", got)
+	}
+}
+
 func TestFocusKeyArgs_Range(t *testing.T) {
 	sc := &CLIReviewConfig{Focus: &Focus{Kind: FocusRange, BaseSHA: "abc", HeadSHA: "def"}}
 	got := FocusKeyArgs(sc)

--- a/internal/session/hooks.go
+++ b/internal/session/hooks.go
@@ -35,6 +35,9 @@ func FocusKeyArgs(sc *CLIReviewConfig) []string {
 		if sc.Focus.Forge == "gitlab" {
 			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
 		}
+		if sc.Focus.RemoteBaseProject != "" {
+			return []string{fmt.Sprintf("pr:%s#%d", sc.Focus.RemoteBaseProject, sc.Focus.ChangeNumber)}
+		}
 		return []string{fmt.Sprintf("pr:%d", sc.Focus.ChangeNumber)}
 	}
 	return []string{fmt.Sprintf("range:%s..%s", sc.Focus.BaseSHA, sc.Focus.HeadSHA)}

--- a/internal/session/hooks.go
+++ b/internal/session/hooks.go
@@ -35,10 +35,7 @@ func FocusKeyArgs(sc *CLIReviewConfig) []string {
 		if sc.Focus.Forge == "gitlab" {
 			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
 		}
-		if sc.Focus.RemoteBaseProject != "" {
-			return []string{fmt.Sprintf("pr:%s#%d", sc.Focus.RemoteBaseProject, sc.Focus.ChangeNumber)}
-		}
-		return []string{fmt.Sprintf("pr:%d", sc.Focus.ChangeNumber)}
+		return []string{PRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 	}
 	return []string{fmt.Sprintf("range:%s..%s", sc.Focus.BaseSHA, sc.Focus.HeadSHA)}
 }

--- a/internal/session/pr_cache_hook.go
+++ b/internal/session/pr_cache_hook.go
@@ -1,6 +1,7 @@
 package session
 
 // InvalidatePRCache drops cached PR metadata when the user switches away from a
-// PR focus. Wired from cmd/crit to github.InvalidatePRCache at startup to avoid
-// an import cycle (github imports session).
-var InvalidatePRCache func(int)
+// PR focus. project is the URL-derived "owner/repo" (empty for bare --pr).
+// Wired from cmd/crit to github.InvalidatePR at startup to avoid an import
+// cycle (github imports session).
+var InvalidatePRCache func(number int, project string)

--- a/internal/session/pr_cache_hook.go
+++ b/internal/session/pr_cache_hook.go
@@ -1,7 +1,8 @@
 package session
 
 // InvalidatePRCache drops cached PR metadata when the user switches away from a
-// PR focus. project is the URL-derived "owner/repo" (empty for bare --pr).
-// Wired from cmd/crit to github.InvalidatePR at startup to avoid an import
-// cycle (github imports session).
-var InvalidatePRCache func(number int, project string)
+// PR focus. project is the URL-derived "owner/repo" (empty for bare --pr);
+// host is the forge host (empty or github.com for github.com). Wired from
+// cmd/crit to github.InvalidatePR at startup to avoid an import cycle
+// (github imports session).
+var InvalidatePRCache func(number int, project, host string)

--- a/internal/session/pr_switch_cache_test.go
+++ b/internal/session/pr_switch_cache_test.go
@@ -1,0 +1,77 @@
+package session
+
+import "testing"
+
+func TestDropStaleCacheOnPRSwitch(t *testing.T) {
+	type call struct {
+		number  int
+		project string
+		host    string
+	}
+	var calls []call
+	prev := InvalidatePRCache
+	InvalidatePRCache = func(number int, project, host string) {
+		calls = append(calls, call{number, project, host})
+	}
+	t.Cleanup(func() { InvalidatePRCache = prev })
+
+	gh := func(num int, project, host string) Focus {
+		return Focus{Kind: FocusRange, Forge: "github", ChangeNumber: num, RemoteBaseProject: project, RemoteHost: host}
+	}
+
+	t.Run("same number and project skips", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(gh(1, "a/b", ""), gh(1, "a/b", ""))
+		if len(calls) != 0 {
+			t.Fatalf("calls=%v want none", calls)
+		}
+	})
+
+	t.Run("same number different project invalidates", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(gh(1, "org/repo-a", ""), gh(1, "org/repo-b", ""))
+		if len(calls) != 1 || calls[0] != (call{1, "org/repo-a", ""}) {
+			t.Fatalf("calls=%v", calls)
+		}
+	})
+
+	t.Run("same number different host invalidates", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(gh(9, "acme/app", "github.com"), gh(9, "acme/app", "github.example.com"))
+		if len(calls) != 1 || calls[0] != (call{9, "acme/app", "github.com"}) {
+			t.Fatalf("calls=%v", calls)
+		}
+	})
+
+	t.Run("different number invalidates", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(gh(2, "o/r", ""), gh(3, "o/r", ""))
+		if len(calls) != 1 || calls[0].number != 2 {
+			t.Fatalf("calls=%v", calls)
+		}
+	})
+
+	t.Run("non github skips", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(
+			Focus{Forge: "gitlab", ChangeNumber: 1},
+			Focus{Forge: "github", ChangeNumber: 2},
+		)
+		if len(calls) != 0 {
+			t.Fatalf("calls=%v want none", calls)
+		}
+	})
+
+	t.Run("zero change number skips", func(t *testing.T) {
+		calls = nil
+		dropStaleCacheOnPRSwitch(gh(0, "a/b", ""), gh(1, "a/b", ""))
+		if len(calls) != 0 {
+			t.Fatalf("calls=%v want none", calls)
+		}
+	})
+
+	t.Run("nil hook is safe", func(t *testing.T) {
+		InvalidatePRCache = nil
+		dropStaleCacheOnPRSwitch(gh(1, "a/b", ""), gh(2, "a/b", ""))
+	})
+}

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -115,10 +116,23 @@ func focusKeyFor(f Focus) string {
 		if f.Forge == "gitlab" {
 			return fmt.Sprintf("mr:%d", f.ChangeNumber)
 		}
-		// github or empty forge (legacy ChangeNumber without Forge) → pr:N
-		return fmt.Sprintf("pr:%d", f.ChangeNumber)
+		// github or empty forge (legacy ChangeNumber without Forge) → pr:…
+		return PRFocusKey(f.ChangeNumber, f.RemoteBaseProject, f.RemoteHost)
 	}
 	return fmt.Sprintf("range:%s..%s", f.BaseSHA, f.HeadSHA)
+}
+
+// PRFocusKey is the GitHub PR identity used for daemon session keys and
+// comment FocusKey stamping. URL-qualified reviews include owner/repo (and
+// non-github.com host) so same-number PRs do not collide (#870).
+func PRFocusKey(number int, project, host string) string {
+	if project == "" {
+		return fmt.Sprintf("pr:%d", number)
+	}
+	if host != "" && !strings.EqualFold(host, "github.com") {
+		return fmt.Sprintf("pr:%s/%s#%d", host, project, number)
+	}
+	return fmt.Sprintf("pr:%s#%d", project, number)
 }
 
 // visibleInFocus reports whether c should be shown in the given focus.
@@ -366,11 +380,13 @@ func dropStaleCacheOnPRSwitch(oldFocus, newFocus Focus) {
 	if oldFocus.Forge != "github" || newFocus.Forge != "github" || oldFocus.ChangeNumber == 0 || newFocus.ChangeNumber == 0 {
 		return
 	}
-	if oldFocus.ChangeNumber == newFocus.ChangeNumber && oldFocus.RemoteBaseProject == newFocus.RemoteBaseProject {
+	if oldFocus.ChangeNumber == newFocus.ChangeNumber &&
+		oldFocus.RemoteBaseProject == newFocus.RemoteBaseProject &&
+		oldFocus.RemoteHost == newFocus.RemoteHost {
 		return
 	}
 	if InvalidatePRCache != nil {
-		InvalidatePRCache(oldFocus.ChangeNumber, oldFocus.RemoteBaseProject)
+		InvalidatePRCache(oldFocus.ChangeNumber, oldFocus.RemoteBaseProject, oldFocus.RemoteHost)
 	}
 }
 

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -370,7 +370,7 @@ func dropStaleCacheOnPRSwitch(oldFocus, newFocus Focus) {
 		return
 	}
 	if InvalidatePRCache != nil {
-		InvalidatePRCache(oldFocus.ChangeNumber)
+		InvalidatePRCache(oldFocus.ChangeNumber, oldFocus.RemoteBaseProject)
 	}
 }
 

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -366,7 +366,7 @@ func dropStaleCacheOnPRSwitch(oldFocus, newFocus Focus) {
 	if oldFocus.Forge != "github" || newFocus.Forge != "github" || oldFocus.ChangeNumber == 0 || newFocus.ChangeNumber == 0 {
 		return
 	}
-	if oldFocus.ChangeNumber == newFocus.ChangeNumber {
+	if oldFocus.ChangeNumber == newFocus.ChangeNumber && oldFocus.RemoteBaseProject == newFocus.RemoteBaseProject {
 		return
 	}
 	if InvalidatePRCache != nil {


### PR DESCRIPTION
## Summary
- Full `crit --pr https://github.com/owner/repo/pull/N` URLs now parse into `ChangeID` with Project/Host and pin `gh pr view -R`, so same-number PRs in different repos no longer open the wrong review (closes #870).
- Bare `--pr N` stays checkout-scoped; URL reviews key sessions/comments as `pr:owner/repo#N` (enterprise: `pr:host/owner/repo#N`) and invalidate matching cache entries on focus switch.
- `crit pull` clears both bare and project-qualified cache entries for that PR number.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- [x] Unit tests for ParsePRSpec, prViewArgs (-R / enterprise host), project-qualified cache + invalidate-all-on-pull, FocusKeyArgs / PRFocusKey parity
- [x] Pre-commit (gofmt, golangci-lint, go test) passed
- [ ] Manual: from repo-a, `crit --pr https://github.com/<org>/repo-b/pull/1` opens repo-b (not repo-a)


Made with [Cursor](https://cursor.com)