### PR TITLE
fix: load lazy file diffs in story chapter groups

### DIFF
--- a/web/__tests__/story-lazy-hunks.test.js
+++ b/web/__tests__/story-lazy-hunks.test.js
@@ -22,6 +22,9 @@ test('ensureStoryLazyFile hydrates a lazy file via loadSingleFile', () => {
   assert.match(appSrc, /function ensureStoryLazyFile\s*\(/);
   const body = sliceFunction(appSrc, 'ensureStoryLazyFile', 'cloneFileForHunks');
   assert.match(body, /loadSingleFile\s*\(/);
+  // Story-visible loads must use the same scope as eager file hydration.
+  assert.match(body, /currentFileDataScope\s*\(/);
+  assert.doesNotMatch(body, /effectiveDiffScope\s*\(/);
   assert.match(body, /file\.lazy\s*=\s*false/);
   assert.match(body, /file\.diffHunks\s*=\s*loaded\.diffHunks/);
   // Cached story clones keyed by empty lazy placeholders must not stick.
@@ -37,4 +40,6 @@ test('renderStoryFileGroup loads lazy files instead of claiming hunks are gone',
     /file\.lazy[\s\S]{0,120}Loading diff[\s\S]{0,80}These hunks are no longer in the diff\./,
   );
   assert.match(body, /ensureStoryLazyFile\(file\)\.then/);
+  // After hydrate, refresh nav / hide-resolved / mermaid like renderStoryFileByPath.
+  assert.match(body, /replaceWith\(replacement\);\s*renderMermaidBlocks\(\);\s*rebuildNavList\(\);\s*applyHideResolved\(\);\s*renderStoryRail\(\);/s);
 });

--- a/web/__tests__/story-lazy-hunks.test.js
+++ b/web/__tests__/story-lazy-hunks.test.js
@@ -1,0 +1,40 @@
+'use strict';
+// Source-contract tests for story mode + lazy file loading (#869).
+// Large reviews mark most files lazy (empty diffHunks until opened). Story
+// chapters must hydrate those diffs before claiming hunks are gone.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appSrc = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+function sliceFunction(src, name, nextName) {
+  const start = src.indexOf('function ' + name);
+  assert.notEqual(start, -1, name + ' must exist');
+  const end = nextName ? src.indexOf('function ' + nextName, start + 1) : start + 2500;
+  assert.notEqual(end, -1, nextName + ' must follow ' + name);
+  return src.slice(start, end);
+}
+
+test('ensureStoryLazyFile hydrates a lazy file via loadSingleFile', () => {
+  assert.match(appSrc, /function ensureStoryLazyFile\s*\(/);
+  const body = sliceFunction(appSrc, 'ensureStoryLazyFile', 'cloneFileForHunks');
+  assert.match(body, /loadSingleFile\s*\(/);
+  assert.match(body, /file\.lazy\s*=\s*false/);
+  assert.match(body, /file\.diffHunks\s*=\s*loaded\.diffHunks/);
+  // Cached story clones keyed by empty lazy placeholders must not stick.
+  assert.match(body, /storyExpandedFileCache/);
+});
+
+test('renderStoryFileGroup loads lazy files instead of claiming hunks are gone', () => {
+  const body = sliceFunction(appSrc, 'renderStoryFileGroup', 'storySupportReasonForFile');
+  assert.match(body, /ensureStoryLazyFile\s*\(/);
+  // Lazy placeholders show a loading state; true drift keeps the old copy.
+  assert.match(
+    body,
+    /file\.lazy[\s\S]{0,120}Loading diff[\s\S]{0,80}These hunks are no longer in the diff\./,
+  );
+  assert.match(body, /ensureStoryLazyFile\(file\)\.then/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10884,6 +10884,48 @@
     clone.viewMode = 'diff';
   }
 
+  // Story chapters render independently of the flat Diff-view <details>
+  // sections. Lazy files ship with empty diffHunks until opened there, which
+  // made Story show "These hunks are no longer in the diff." (#869). Hydrate
+  // the file data here so chapter groups can filter real hunks.
+  function ensureStoryLazyFile(file) {
+    if (!file || !file.lazy) return Promise.resolve(file);
+    if (file._storyLazyPromise) return file._storyLazyPromise;
+    file._storyLazyPromise = loadSingleFile({
+      path: file.path,
+      old_path: file.oldPath,
+      status: file.status,
+      file_type: file.fileType,
+      additions: file.additions,
+      deletions: file.deletions,
+    }, effectiveDiffScope()).then(function (loaded) {
+      file.oldPath = loaded.oldPath;
+      file.content = loaded.content;
+      file.previousContent = loaded.previousContent;
+      file.comments = loaded.comments;
+      file.diffHunks = loaded.diffHunks;
+      file._autoExpandDone = false;
+      file.lineBlocks = loaded.lineBlocks;
+      file.previousLineBlocks = loaded.previousLineBlocks;
+      file.tocItems = loaded.tocItems;
+      file.diffTooLarge = loaded.diffTooLarge;
+      file.diffLoaded = loaded.diffLoaded;
+      file.fileHash = loaded.fileHash;
+      file.lazy = false;
+      file._lazyLoading = false;
+      if (loaded.highlightCache) file.highlightCache = loaded.highlightCache;
+      if (loaded.lang) file.lang = loaded.lang;
+      delete file._storyLazyPromise;
+      // Drop clones built against the empty lazy placeholder.
+      storyExpandedFileCache.clear();
+      return file;
+    }).catch(function (err) {
+      delete file._storyLazyPromise;
+      throw err;
+    });
+    return file._storyLazyPromise;
+  }
+
   // Build a shallow file clone whose diffHunks are just the referenced ones,
   // preserving comments/path so the existing diff+comment renderer works
   // unchanged. Returns null if the file isn't loaded or has no matching hunks.
@@ -11270,8 +11312,9 @@
 
   function renderStoryFileGroup(page, filePath, oldStarts, supportReason) {
     const pid = storyPageId(page);
-    const built = cloneFileForHunks(filePath, oldStarts, pid);
     const file = getFileByPath(filePath);
+    // Lazy placeholders have empty diffHunks — don't filter/cache them as a miss.
+    const built = (file && file.lazy) ? null : cloneFileForHunks(filePath, oldStarts, pid);
     const section = document.createElement('details');
     section.className = 'file-section crit-story-file-group';
     section.id = 'story-file-section-' + pid + '-' + filePath;
@@ -11301,6 +11344,7 @@
     const total = built ? built.total : 0;
     let statText;
     if (supportReason) statText = escapeHtml(supportReason);
+    else if (file && file.lazy) statText = 'Loading\u2026';
     else if (total > 1 && shown < total) statText = 'hunk' + (shown === 1 ? ' ' : 's ') + shown + ' of ' + total;
     else statText = shown + ' hunk' + (shown === 1 ? '' : 's');
     const adds = file ? (file.additions || 0) : 0;
@@ -11404,11 +11448,26 @@
     } else {
       const empty = document.createElement('div');
       empty.className = 'crit-story-file-group__empty';
-      empty.textContent = file ? 'These hunks are no longer in the diff.' : 'File not loaded.';
+      if (!file) empty.textContent = 'File not loaded.';
+      else if (file.lazy) empty.textContent = 'Loading diff\u2026';
+      else empty.textContent = 'These hunks are no longer in the diff.';
       body.appendChild(empty);
     }
     section.appendChild(body);
     if (built && built.clone) highlightQuotesInSection(section, built.clone);
+
+    if (file && file.lazy) {
+      ensureStoryLazyFile(file).then(function () {
+        if (!section.isConnected) return;
+        const replacement = renderStoryFileGroup(page, filePath, oldStarts, supportReason);
+        replacement.open = section.open;
+        section.replaceWith(replacement);
+      }).catch(function () {
+        const emptyEl = section.querySelector('.crit-story-file-group__empty');
+        if (emptyEl) emptyEl.textContent = 'Failed to load diff.';
+      });
+    }
+
     return section;
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -10891,6 +10891,8 @@
   function ensureStoryLazyFile(file) {
     if (!file || !file.lazy) return Promise.resolve(file);
     if (file._storyLazyPromise) return file._storyLazyPromise;
+    // Match loadAllFileData: when Story is visible, file data is scoped to
+    // 'all' so chapter hunk_refs line up with the loaded diff.
     file._storyLazyPromise = loadSingleFile({
       path: file.path,
       old_path: file.oldPath,
@@ -10898,7 +10900,7 @@
       file_type: file.fileType,
       additions: file.additions,
       deletions: file.deletions,
-    }, effectiveDiffScope()).then(function (loaded) {
+    }, currentFileDataScope()).then(function (loaded) {
       file.oldPath = loaded.oldPath;
       file.content = loaded.content;
       file.previousContent = loaded.previousContent;
@@ -11462,6 +11464,10 @@
         const replacement = renderStoryFileGroup(page, filePath, oldStarts, supportReason);
         replacement.open = section.open;
         section.replaceWith(replacement);
+        renderMermaidBlocks();
+        rebuildNavList();
+        applyHideResolved();
+        renderStoryRail();
       }).catch(function () {
         const emptyEl = section.querySelector('.crit-story-file-group__empty');
         if (emptyEl) emptyEl.textContent = 'Failed to load diff.';


### PR DESCRIPTION
## Summary
- Story chapters treated unloaded lazy files as missing hunks and showed a false empty state (closes #869).
- Hydrate those files before filtering, using the same scope as story-visible eager loads, then re-render the file group.
- Add source-contract tests for the wiring.

## Review
- [x] Code review: passed (scope + post-render follow-ups applied)
- [x] Parity audit: N/A (story mode is CLI-only)

## Test plan
- [x] Source-contract tests for `ensureStoryLazyFile` / `renderStoryFileGroup`
- [x] Pre-commit (gofmt, golangci-lint, go test, eslint, stylelint)
- [x] Manual: large story review chapter with lazy files loads hunks instead of "These hunks are no longer in the diff."


Made with [Cursor](https://cursor.com)