### PR TITLE
fix: pin pull/push to PR URL repo and qualify GitLab focus keys

### DIFF
--- a/cmd/crit/wire.go
+++ b/cmd/crit/wire.go
@@ -104,10 +104,6 @@ func glabOwnsHost(host string) bool {
 	return exec.CommandContext(ctx, "glab", "auth", "status", "--hostname", host).Run() == nil
 }
 
-func fetchChange(provider forge.Provider, number int) (forge.ChangeRequest, error) {
-	return provider.Get(context.Background(), forge.RepoContext{}, forge.ChangeID{Number: number})
-}
-
 func listOpenGitLabChanges(ctx context.Context) ([]forge.ChangeSummary, error) {
 	provider, err := gitlab.NewProvider(config.LoadConfig("").GitLabURL)
 	if err != nil {
@@ -119,8 +115,10 @@ func listOpenGitLabChanges(ctx context.Context) ([]forge.ChangeSummary, error) {
 func init() {
 	forge.SelectProviderFn = selectProvider
 	forge.ReviewFn = session.RunReview
-	session.InvalidatePRCache = func(number int, project, host string) {
-		github.InvalidatePR(forge.ChangeID{Number: number, Project: project, Host: host})
+	session.InvalidatePRCache = func(number int, _, _ string) {
+		// Drop bare and project-qualified sibling keys for this number —
+		// matching crit pull — so a focus switch cannot leave a stale twin.
+		github.InvalidatePRCache(number)
 	}
 	session.FetchMRFileContent = func(f session.Focus, sha, path string) ([]byte, error) {
 		project := f.RemoteProject

--- a/cmd/crit/wire_test.go
+++ b/cmd/crit/wire_test.go
@@ -201,9 +201,9 @@ func TestGlabOwnsHost(t *testing.T) {
 func TestFetchChangeUsesNormalizedChangeID(t *testing.T) {
 	wantErr := errors.New("provider failure")
 	provider := &wireTestProvider{get: forge.ChangeRequest{Title: "Feature"}, err: wantErr}
-	change, err := fetchChange(provider, 27)
+	change, err := provider.Get(context.Background(), forge.RepoContext{}, forge.ChangeID{Number: 27})
 	if change.Title != "Feature" || !errors.Is(err, wantErr) {
-		t.Fatalf("fetchChange = (%+v, %v)", change, err)
+		t.Fatalf("Get = (%+v, %v)", change, err)
 	}
 	if provider.getID != (forge.ChangeID{Number: 27}) {
 		t.Fatalf("change ID = %+v", provider.getID)

--- a/internal/github/export.go
+++ b/internal/github/export.go
@@ -24,11 +24,11 @@ func RequireGH() error {
 }
 
 func FetchPRComments(prNumber int) ([]GhComment, error) {
-	return fetchPRComments(prNumber)
+	return fetchPRComments(forge.ChangeID{Number: prNumber})
 }
 
 func FetchPRThreadResolved(prNumber int) (map[int64]bool, error) {
-	return fetchPRThreadResolved(prNumber)
+	return fetchPRThreadResolved(forge.ChangeID{Number: prNumber})
 }
 
 func MergeGHComments(cj *session.CritJSON, ghComments []GhComment) int {
@@ -44,7 +44,7 @@ func BucketsToGHComments(postable []scopedComment, rewrite bodyRewriter) []map[s
 }
 
 func CreateGHReview(prNumber int, comments []map[string]any, message, event string) (map[string]int64, error) {
-	return createGHReview(prNumber, comments, message, event)
+	return createGHReview(forge.ChangeID{Number: prNumber}, comments, message, event)
 }
 
 func CollectNewRepliesForPush(cf CritJSONFile, rewrite bodyRewriter) []GhReplyForPush {
@@ -52,7 +52,7 @@ func CollectNewRepliesForPush(cf CritJSONFile, rewrite bodyRewriter) []GhReplyFo
 }
 
 func PostPushReplies(prNumber int, allReplies []GhReplyForPush) (map[ReplyKey]int64, int, bool) {
-	return postPushReplies(prNumber, allReplies)
+	return postPushReplies(forge.ChangeID{Number: prNumber}, allReplies)
 }
 
 func ParsePushEvent(flag string) (string, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -459,13 +459,13 @@ func EnsureSHAFetchedSapling(vcsInst vcs.VCS, sha, repoRoot, forkURL string) err
 }
 
 // fetchPRComments fetches all review comments for a PR.
-func fetchPRComments(prNumber int) ([]ghComment, error) {
+func fetchPRComments(id forge.ChangeID) ([]ghComment, error) {
 	if ghSupportsAPISlurp() {
-		return fetchPRCommentsWithSlurp(prNumber)
+		return fetchPRCommentsWithSlurp(id)
 	}
 	// TODO: Remove this compatibility path once Crit requires gh v2.48.0+,
 	// which added `gh api --slurp`.
-	return fetchPRCommentsWithoutSlurp(prNumber)
+	return fetchPRCommentsWithoutSlurp(id)
 }
 
 func ghSupportsAPISlurp() bool {
@@ -511,12 +511,12 @@ func versionAtLeast(version string, wantMajor, wantMinor, wantPatch int) bool {
 	return patch >= wantPatch
 }
 
-func fetchPRCommentsWithSlurp(prNumber int) ([]ghComment, error) {
-	out, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
+func fetchPRCommentsWithSlurp(id forge.ChangeID) ([]ghComment, error) {
+	out, err := exec.Command("gh", ghAPIArgs(id,
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", id.Number),
 		"--paginate",
 		"--slurp",
-	).Output()
+	)...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("fetching PR comments: %w", err)
 	}
@@ -533,13 +533,13 @@ func fetchPRCommentsWithSlurp(prNumber int) ([]ghComment, error) {
 	return comments, nil
 }
 
-func fetchPRCommentsWithoutSlurp(prNumber int) ([]ghComment, error) {
-	out, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
+func fetchPRCommentsWithoutSlurp(id forge.ChangeID) ([]ghComment, error) {
+	out, err := exec.Command("gh", ghAPIArgs(id,
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", id.Number),
 		"--paginate",
 		"--jq",
 		".[]",
-	).Output()
+	)...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("fetching PR comments: %w", err)
 	}
@@ -594,15 +594,15 @@ func fetchCurrentRepoOwnerName() (string, string, error) {
 // crit's scale that the inner cap is acceptable. If we ever hit it, the
 // merge logic degrades gracefully — only the unseen replies miss the
 // resolved bit, the root still gets it.
-func fetchPRThreadResolved(prNumber int) (map[int64]bool, error) {
-	owner, name, err := fetchCurrentRepoOwnerName()
+func fetchPRThreadResolved(id forge.ChangeID) (map[int64]bool, error) {
+	owner, name, err := resolveRepoOwnerName(id)
 	if err != nil {
 		return nil, err
 	}
 	resolved := make(map[int64]bool)
 	cursor := ""
 	for {
-		page, nextCursor, err := fetchPRThreadResolvedPage(owner, name, prNumber, cursor)
+		page, nextCursor, err := fetchPRThreadResolvedPage(owner, name, id.Number, cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -1136,7 +1136,7 @@ func updateCritJSONWithEditedBodies(critPath string, succeeded []ghEditForPush) 
 
 // postGHReply posts a reply to an existing GitHub PR review comment.
 // Returns the GitHub ID of the newly created reply.
-func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
+func postGHReply(id forge.ChangeID, parentGHID int64, body string) (int64, error) {
 	payload, err := json.Marshal(map[string]any{
 		"body":        body,
 		"in_reply_to": parentGHID,
@@ -1144,11 +1144,11 @@ func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("marshal reply: %w", err)
 	}
-	cmd := exec.Command("gh", "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
+	cmd := exec.Command("gh", ghAPIArgs(id,
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", id.Number),
 		"--method", "POST",
 		"--input", "-",
-	)
+	)...)
 	cmd.Stdin = bytes.NewReader(payload)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1168,12 +1168,12 @@ func postGHReply(prNumber int, parentGHID int64, body string) (int64, error) {
 
 // postPushReplies posts each reply via gh api. On the first auth-rotation
 // failure (HTTP 401) it aborts the rest of the batch.
-func postPushReplies(prNumber int, allReplies []ghReplyForPush) (map[replyKey]int64, int, bool) {
+func postPushReplies(id forge.ChangeID, allReplies []ghReplyForPush) (map[replyKey]int64, int, bool) {
 	replyCount := 0
 	replyIDs := make(map[replyKey]int64)
 	authFailed := false
 	for _, reply := range allReplies {
-		replyID, err := postGHReply(prNumber, reply.ParentGHID, reply.Body)
+		replyID, err := postGHReply(id, reply.ParentGHID, reply.Body)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to post reply: %v\n", err)
 			if errors.Is(err, errGHAuthFailed) {
@@ -1261,18 +1261,18 @@ func buildReviewPayload(comments []map[string]any, message string, event string)
 // createGHReview posts a review with inline comments to a GitHub PR.
 // message is the top-level review body (empty string posts no top-level comment).
 // Returns a map of "path:endLine" -> GitHubID for each created comment.
-func createGHReview(prNumber int, comments []map[string]any, message string, event string) (map[string]int64, error) {
+func createGHReview(id forge.ChangeID, comments []map[string]any, message string, event string) (map[string]int64, error) {
 	data, err := buildReviewPayload(comments, message, event)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling review: %w", err)
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("gh", "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews", prNumber),
+	cmd := exec.Command("gh", ghAPIArgs(id,
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews", id.Number),
 		"--method", "POST",
 		"--input", "-",
-	)
+	)...)
 	cmd.Stdin = bytes.NewReader(data)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -1299,9 +1299,9 @@ func createGHReview(prNumber int, comments []map[string]any, message string, eve
 
 	// Fetch this review's comments and zip with our input to map IDs by position.
 	// We use the review-scoped endpoint (only returns this review's comments, in order).
-	commentOut, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews/%d/comments", prNumber, reviewResp.ID),
-	).Output()
+	commentOut, err := exec.Command("gh", ghAPIArgs(id,
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/reviews/%d/comments", id.Number, reviewResp.ID),
+	)...).Output()
 	if err != nil {
 		return idMap, nil //nolint:nilerr // non-fatal: review was created, comment ID mapping is best-effort
 	}

--- a/internal/github/pr_cache_test.go
+++ b/internal/github/pr_cache_test.go
@@ -215,6 +215,28 @@ func TestInvalidatePR_DropsProjectQualifiedKey(t *testing.T) {
 	}
 }
 
+func TestProviderInvalidate_DropsBareAndQualified(t *testing.T) {
+	prev := prMetaCache
+	prMetaCache = newPRMetadataCache()
+	t.Cleanup(func() { prMetaCache = prev })
+
+	id := forge.ChangeID{Number: 3, Project: "org/repo-b"}
+	prMetaCache.entries[prCacheKey(id)] = &prCacheEntry{data: &PRInfo{Number: 3}, access: time.Now()}
+	prMetaCache.entries["3"] = &prCacheEntry{data: &PRInfo{Number: 3}, access: time.Now()}
+	prMetaCache.entries["4"] = &prCacheEntry{data: &PRInfo{Number: 4}, access: time.Now()}
+
+	Provider{}.Invalidate(id)
+	if _, ok := prMetaCache.entries[prCacheKey(id)]; ok {
+		t.Error("Provider.Invalidate left project-qualified entry")
+	}
+	if _, ok := prMetaCache.entries["3"]; ok {
+		t.Error("Provider.Invalidate left bare entry")
+	}
+	if _, ok := prMetaCache.entries["4"]; !ok {
+		t.Error("Provider.Invalidate wrongly dropped unrelated PR")
+	}
+}
+
 func TestInvalidatePRCache_DropsBareAndQualified(t *testing.T) {
 	prev := prMetaCache
 	prMetaCache = newPRMetadataCache()

--- a/internal/github/provider.go
+++ b/internal/github/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/tomasz-tomczyk/crit/internal/forge"
@@ -37,11 +36,17 @@ func (Provider) Get(_ context.Context, _ forge.RepoContext, id forge.ChangeID) (
 	if baseProject == "" {
 		baseProject = githubProject(info.URL)
 	}
+	baseHost := id.Host
+	if baseHost == "" {
+		if u, err := url.Parse(info.URL); err == nil {
+			baseHost = normalizeGitHubHost(u.Host)
+		}
+	}
 	return forge.ChangeRequest{
 		ID: id, URL: info.URL, Title: info.Title, Body: info.Body, State: info.State,
 		Draft: info.IsDraft, BaseRefName: info.BaseRefName, HeadRefName: info.HeadRefName,
 		BaseSHA: info.BaseRefOid, HeadSHA: info.HeadRefOid,
-		BaseRepo:        forge.RepoRef{Project: baseProject, Host: id.Host},
+		BaseRepo:        forge.RepoRef{Project: baseProject, Host: baseHost},
 		HeadRepo:        forge.RepoRef{Project: githubProject(info.HeadRepoURL), CloneURL: info.HeadRepoURL},
 		CrossRepository: info.IsCrossRepository, Additions: info.Additions,
 		Deletions: info.Deletions, ChangedFiles: info.ChangedFiles,
@@ -93,11 +98,12 @@ func githubPullArgs(request forge.PullRequest) ([]string, error) {
 		args = append(args, "--output", request.OutputDir)
 	}
 	if request.ChangeSpec != "" {
-		n, err := githubChangeNumber(request.ChangeSpec)
-		if err != nil {
-			return nil, err
+		// Validate and preserve the original spec (number or URL) so RunPull can
+		// pin -R from ParsePRSpec — do not collapse URLs to bare numbers.
+		if _, err := ParsePRSpec(request.ChangeSpec); err != nil {
+			return nil, fmt.Errorf("invalid GitHub pull request %q (expected number or URL)", request.ChangeSpec)
 		}
-		args = append(args, fmt.Sprint(n))
+		args = append(args, request.ChangeSpec)
 	}
 	return args, nil
 }
@@ -127,25 +133,6 @@ func githubPushArgs(request forge.PushRequest) ([]string, error) {
 	return append(prefix, args...), nil
 }
 
-func githubChangeNumber(spec string) (int, error) {
-	if n, err := strconv.Atoi(spec); err == nil && n > 0 {
-		return n, nil
-	}
-	u, err := url.Parse(spec)
-	if err == nil {
-		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-		for i := 0; i+1 < len(parts); i++ {
-			if parts[i] != "pull" {
-				continue
-			}
-			if n, parseErr := strconv.Atoi(parts[i+1]); parseErr == nil && n > 0 {
-				return n, nil
-			}
-		}
-	}
-	return 0, fmt.Errorf("invalid GitHub pull request %q (expected number or URL)", spec)
-}
-
 func (Provider) FetchFile(_ context.Context, _ forge.RepoContext, source forge.RepoRef, sha, path string) ([]byte, error) {
 	project := strings.Trim(source.Project, "/")
 	parts := strings.Split(project, "/")
@@ -155,13 +142,28 @@ func (Provider) FetchFile(_ context.Context, _ forge.RepoContext, source forge.R
 	return session.FetchGitHubFileContent(parts[len(parts)-2], parts[len(parts)-1], sha, path)
 }
 
-func (Provider) Invalidate(id forge.ChangeID) { InvalidatePR(id) }
+func (Provider) Invalidate(id forge.ChangeID) {
+	// Drop bare and project-qualified sibling keys (same as crit pull).
+	InvalidatePRCache(id.Number)
+}
 
 var _ forge.Provider = Provider{}
 
 func githubProject(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// HTML PR URLs must yield owner/repo, not owner/repo/pull/N.
+	if id, err := ParsePRSpec(raw); err == nil && id.Project != "" {
+		return id.Project
+	}
 	if u, err := url.Parse(raw); err == nil && u.Host != "" {
-		return strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		path := strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		parts := strings.Split(path, "/")
+		if len(parts) >= 2 {
+			return parts[0] + "/" + parts[1]
+		}
+		return path
 	}
 	return strings.TrimSuffix(strings.Trim(raw, "/"), ".git")
 }

--- a/internal/github/provider_test.go
+++ b/internal/github/provider_test.go
@@ -34,11 +34,15 @@ esac
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-func TestGitHubChangeNumber(t *testing.T) {
+func TestGitHubPullArgsPreservesPRURL(t *testing.T) {
 	for _, input := range []string{"42", "https://github.com/acme/widget/pull/42", "https://github.example/acme/widget/pull/42/files"} {
-		got, err := githubChangeNumber(input)
-		if err != nil || got != 42 {
-			t.Errorf("githubChangeNumber(%q) = (%d, %v)", input, got, err)
+		got, err := githubPullArgs(forge.PullRequest{ChangeSpec: input})
+		if err != nil {
+			t.Errorf("githubPullArgs(%q) err = %v", input, err)
+			continue
+		}
+		if len(got) != 1 || got[0] != input {
+			t.Errorf("githubPullArgs(%q) = %v, want [%q]", input, got, input)
 		}
 	}
 }
@@ -103,11 +107,12 @@ func TestGitHubProviderGetTranslatesMetadata(t *testing.T) {
 }
 
 func TestGitHubProviderArgumentTranslation(t *testing.T) {
-	pull, err := githubPullArgs(forge.PullRequest{ChangeSpec: "https://github.com/acme/widget/pull/12/files", OutputDir: "reviews"})
+	url := "https://github.com/acme/widget/pull/12/files"
+	pull, err := githubPullArgs(forge.PullRequest{ChangeSpec: url, OutputDir: "reviews"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(pull, []string{"--output", "reviews", "12"}) {
+	if !reflect.DeepEqual(pull, []string{"--output", "reviews", url}) {
 		t.Fatalf("pull args = %v", pull)
 	}
 	pull, err = githubPullArgs(forge.PullRequest{ChangeSpec: "12", SessionID: "aaaaaaaaaaaa"})
@@ -161,10 +166,12 @@ func TestGitHubProviderMethodsRejectInvalidSpecsBeforeCLI(t *testing.T) {
 
 func TestGitHubProjectNormalization(t *testing.T) {
 	tests := map[string]string{
-		"https://github.com/acme/widget.git": "acme/widget",
-		"git@github.com:acme/widget.git":     "git@github.com:acme/widget",
-		"/acme/widget/":                      "acme/widget",
-		"":                                   "",
+		"https://github.com/acme/widget.git":          "acme/widget",
+		"https://github.com/acme/widget/pull/7":       "acme/widget",
+		"https://github.com/acme/widget/pull/7/files": "acme/widget",
+		"git@github.com:acme/widget.git":              "git@github.com:acme/widget",
+		"/acme/widget/":                               "acme/widget",
+		"":                                            "",
 	}
 	for input, want := range tests {
 		if got := githubProject(input); got != want {
@@ -173,10 +180,28 @@ func TestGitHubProjectNormalization(t *testing.T) {
 	}
 }
 
+func TestGitHubProviderGet_BaseRepoFromPRURL(t *testing.T) {
+	withFetchPRByNumber(t, func(number int) (*PRInfo, error) {
+		return &PRInfo{
+			URL: "https://github.com/acme/widget/pull/7", Title: "Feature",
+			BaseRefName: "main", HeadRefName: "feature", BaseRefOid: "base", HeadRefOid: "head",
+			HeadRepoURL: "https://github.com/alice/widget.git",
+		}, nil
+	})
+	change, err := Provider{}.Get(context.Background(), forge.RepoContext{}, forge.ChangeID{Number: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if change.BaseRepo.Project != "acme/widget" {
+		t.Fatalf("BaseRepo.Project = %q, want acme/widget", change.BaseRepo.Project)
+	}
+}
+
 func TestProjectFromRemoteURL(t *testing.T) {
 	tests := map[string]string{
 		"https://github.com/myorg/repo-b.git": "myorg/repo-b",
 		"https://github.com/o/r":              "o/r",
+		"https://github.com/o/r/pull/3":       "o/r",
 		"acme/widget":                         "acme/widget",
 		"":                                    "",
 	}

--- a/internal/github/pull_cli.go
+++ b/internal/github/pull_cli.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/config"
+	"github.com/tomasz-tomczyk/crit/internal/forge"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/share"
@@ -16,7 +16,7 @@ import (
 )
 
 type pullFlags struct {
-	prFlag           int
+	spec             string // positional number or URL (empty = detect from branch)
 	outputDir        string
 	configuredOutput string
 	sessionID        string
@@ -44,12 +44,15 @@ func parsePullFlags(args []string) (pullFlags, error) {
 			f.sessionID = args[i]
 			continue
 		}
-		n, err := strconv.Atoi(arg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Usage: crit pull [--session <id>] [--output <dir>] [pr-number]\n")
+		if f.spec != "" {
+			fmt.Fprintf(os.Stderr, "Usage: crit pull [--session <id>] [--output <dir>] [number|url]\n")
 			return f, clicmd.ExitError{Code: 1, Err: errors.New("exit")}
 		}
-		f.prFlag = n
+		if _, err := ParsePRSpec(arg); err != nil {
+			fmt.Fprintf(os.Stderr, "Usage: crit pull [--session <id>] [--output <dir>] [number|url]\n")
+			return f, clicmd.ExitError{Code: 1, Err: errors.New("exit")}
+		}
+		f.spec = arg
 	}
 	return f, nil
 }
@@ -74,8 +77,19 @@ func parseResolvedPullFlags(args []string) (pullFlags, error) {
 	return f, nil
 }
 
-func shouldRedirectReviewForPR(prFlag int, pinnedOutput bool) bool {
-	return prFlag != 0 && !pinnedOutput
+func shouldRedirectReviewForPR(explicitSpec bool, pinnedOutput bool) bool {
+	return explicitSpec && !pinnedOutput
+}
+
+func resolvePullChangeID(spec string) (forge.ChangeID, error) {
+	if spec != "" {
+		return ParsePRSpec(spec)
+	}
+	n, err := DetectPR(0)
+	if err != nil {
+		return forge.ChangeID{}, err
+	}
+	return forge.ChangeID{Number: n}, nil
 }
 
 func RunPull(args []string) error { //nolint:gocyclo
@@ -88,19 +102,19 @@ func RunPull(args []string) error { //nolint:gocyclo
 		return err
 	}
 
-	prNumber, err := DetectPR(f.prFlag)
+	id, err := resolvePullChangeID(f.spec)
 	if err != nil {
 		return err
 	}
 
-	InvalidatePRCache(prNumber)
+	InvalidatePRCache(id.Number)
 
-	ghComments, err := FetchPRComments(prNumber)
+	ghComments, err := fetchPRComments(id)
 	if err != nil {
 		return err
 	}
 
-	threadResolved, threadErr := FetchPRThreadResolved(prNumber)
+	threadResolved, threadErr := fetchPRThreadResolved(id)
 	if threadErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not fetch review-thread resolution state: %v\n", threadErr)
 		threadResolved = nil
@@ -117,8 +131,8 @@ func RunPull(args []string) error { //nolint:gocyclo
 		}
 	}
 
-	if shouldRedirectReviewForPR(f.prFlag, f.sessionID != "" || f.outputDir != "" || f.configuredOutput != "") {
-		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
+	if shouldRedirectReviewForPR(f.spec != "", f.sessionID != "" || f.outputDir != "" || f.configuredOutput != "") {
+		if altPath, altCJ, ok := review.RedirectReviewPathForPR(id.Number, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ
 		}
@@ -144,7 +158,7 @@ func RunPull(args []string) error { //nolint:gocyclo
 	added := MergeGHCommentsScoped(&cj, ghComments, scope, threadResolved)
 
 	if added == 0 {
-		fmt.Printf("No new inline comments found on PR #%d\n", prNumber)
+		fmt.Printf("No new inline comments found on PR #%d\n", id.Number)
 		return nil
 	}
 
@@ -152,7 +166,7 @@ func RunPull(args []string) error { //nolint:gocyclo
 		return err
 	}
 
-	fmt.Printf("Pulled %d comments from PR #%d into %s\n", added, prNumber, critPath)
+	fmt.Printf("Pulled %d comments from PR #%d into %s\n", added, id.Number, critPath)
 	fmt.Println("Run 'crit' to view them in the browser.")
 	return nil
 }

--- a/internal/github/pull_cli_test.go
+++ b/internal/github/pull_cli_test.go
@@ -35,11 +35,12 @@ func TestParsePullFlags(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "empty", args: nil, want: pullFlags{}},
-		{name: "pr number", args: []string{"42"}, want: pullFlags{prFlag: 42}},
+		{name: "pr number", args: []string{"42"}, want: pullFlags{spec: "42"}},
 		{name: "output long", args: []string{"--output", "/tmp/out"}, want: pullFlags{outputDir: "/tmp/out"}},
 		{name: "output short", args: []string{"-o", "/tmp/out"}, want: pullFlags{outputDir: "/tmp/out"}},
-		{name: "output and pr", args: []string{"-o", "/tmp/out", "7"}, want: pullFlags{prFlag: 7, outputDir: "/tmp/out"}},
+		{name: "output and pr", args: []string{"-o", "/tmp/out", "7"}, want: pullFlags{spec: "7", outputDir: "/tmp/out"}},
 		{name: "output missing value", args: []string{"--output"}, wantErr: true},
+		{name: "pr url", args: []string{"https://github.com/acme/widget/pull/12"}, want: pullFlags{spec: "https://github.com/acme/widget/pull/12"}},
 		{name: "non-numeric positional", args: []string{"notanumber"}, wantErr: true},
 	}
 	for _, tt := range tests {
@@ -97,7 +98,7 @@ func TestParseResolvedPullFlags(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if f.prFlag != 42 || f.configuredOutput != configuredOutput {
+		if f.spec != "42" || f.configuredOutput != configuredOutput {
 			t.Fatalf("flags = %+v, want PR 42 and configured output %q", f, configuredOutput)
 		}
 	})
@@ -112,18 +113,18 @@ func TestParseResolvedPullFlags(t *testing.T) {
 func TestShouldRedirectReviewForPR(t *testing.T) {
 	tests := []struct {
 		name         string
-		prFlag       int
+		explicitSpec bool
 		pinnedOutput bool
 		want         bool
 	}{
-		{name: "explicit PR without pinned output redirects", prFlag: 42, want: true},
+		{name: "explicit PR without pinned output redirects", explicitSpec: true, want: true},
 		{name: "auto-detected PR does not redirect", want: false},
-		{name: "explicit PR with CLI or configured output stays pinned", prFlag: 42, pinnedOutput: true, want: false},
+		{name: "explicit PR with CLI or configured output stays pinned", explicitSpec: true, pinnedOutput: true, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldRedirectReviewForPR(tt.prFlag, tt.pinnedOutput); got != tt.want {
-				t.Fatalf("shouldRedirectReviewForPR(%d, %v) = %v, want %v", tt.prFlag, tt.pinnedOutput, got, tt.want)
+			if got := shouldRedirectReviewForPR(tt.explicitSpec, tt.pinnedOutput); got != tt.want {
+				t.Fatalf("shouldRedirectReviewForPR(%v, %v) = %v, want %v", tt.explicitSpec, tt.pinnedOutput, got, tt.want)
 			}
 		})
 	}
@@ -175,7 +176,7 @@ func TestParsePullFlagsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := pullFlags{sessionID: "aaaaaaaaaaaa", prFlag: 42}
+	want := pullFlags{sessionID: "aaaaaaaaaaaa", spec: "42"}
 	if got != want {
 		t.Fatalf("got %+v, want %+v", got, want)
 	}
@@ -190,7 +191,7 @@ func TestParsePullFlagsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.sessionID != "bbbbbbbbbbbb" || got.outputDir != "/tmp/out" || got.prFlag != 7 {
+	if got.sessionID != "bbbbbbbbbbbb" || got.outputDir != "/tmp/out" || got.spec != "7" {
 		t.Fatalf("got %+v", got)
 	}
 }
@@ -201,7 +202,7 @@ func TestParseResolvedPullFlagsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if f.sessionID != "cccccccccccc" || f.prFlag != 9 {
+	if f.sessionID != "cccccccccccc" || f.spec != "9" {
 		t.Fatalf("flags = %+v", f)
 	}
 	if f.configuredOutput != configuredOutput {
@@ -211,7 +212,7 @@ func TestParseResolvedPullFlagsSession(t *testing.T) {
 
 func TestShouldRedirectReviewForPRWithSession(t *testing.T) {
 	// --session pins the review identity the same way --output does.
-	if shouldRedirectReviewForPR(42, true) {
+	if shouldRedirectReviewForPR(true, true) {
 		t.Fatal("pinned session should not redirect")
 	}
 }

--- a/internal/github/push_cli.go
+++ b/internal/github/push_cli.go
@@ -5,18 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/config"
+	"github.com/tomasz-tomczyk/crit/internal/forge"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/share"
 )
 
 type pushFlags struct {
-	prFlag           int
+	spec             string // positional number or URL (empty = detect from branch)
 	dryRun           bool
 	message          string
 	outputDir        string
@@ -65,14 +65,24 @@ func parsePushFlags(args []string) (pushFlags, error) {
 			f.eventFlag = args[i]
 			continue
 		}
-		n, err := strconv.Atoi(arg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Usage: crit push [--session <id>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [pr-number]\n")
-			return f, clicmd.ExitError{Code: 1, Err: errors.New("exit")}
+		if err := setPushSpec(&f, arg); err != nil {
+			return f, err
 		}
-		f.prFlag = n
 	}
 	return f, nil
+}
+
+func setPushSpec(f *pushFlags, arg string) error {
+	if f.spec != "" {
+		fmt.Fprintf(os.Stderr, "Usage: crit push [--session <id>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [number|url]\n")
+		return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
+	}
+	if _, err := ParsePRSpec(arg); err != nil {
+		fmt.Fprintf(os.Stderr, "Usage: crit push [--session <id>] [--dry-run] [--event <type>] [--message <msg>] [--output <dir>] [number|url]\n")
+		return clicmd.ExitError{Code: 1, Err: errors.New("exit")}
+	}
+	f.spec = arg
+	return nil
 }
 
 func resolvePushFlags(f *pushFlags) error {
@@ -108,19 +118,19 @@ func parseResolvedPushFlags(args []string) (pushFlags, error) {
 // On dry-run with a fetch error, surfaces a stderr note so the user knows the
 // stale-head check was skipped — silent skipping makes the dry-run plan
 // misleading.
-func resolveCurrentPRHead(prNumber int, inRange, dryRun bool) (string, error) {
+func resolveCurrentPRHead(id forge.ChangeID, inRange, dryRun bool) (string, error) {
 	if !inRange {
 		return "", nil
 	}
-	info, err := FetchPRByNumber(prNumber)
+	info, err := FetchPR(id)
 	if err != nil {
 		if dryRun {
 			fmt.Fprintf(os.Stderr,
 				"Note: could not resolve current PR #%d head; stale-head check not enforced in this dry-run: %v\n",
-				prNumber, err)
+				id.Number, err)
 			return "", nil
 		}
-		return "", fmt.Errorf("fetching PR #%d for stale-head check: %w", prNumber, err)
+		return "", fmt.Errorf("fetching PR #%d for stale-head check: %w", id.Number, err)
 	}
 	if info == nil {
 		return "", nil
@@ -134,12 +144,13 @@ func resolveCurrentPRHead(prNumber int, inRange, dryRun bool) (string, error) {
 type pushContext struct {
 	flags    pushFlags
 	event    string
-	prNumber int
+	id       forge.ChangeID
+	prNumber int // id.Number; kept for call sites that only need the number
 	critPath string
 	cj       session.CritJSON
 }
 
-// loadPushContext parses flags, validates them, resolves the PR number, and
+// loadPushContext parses flags, validates them, resolves the PR, and
 // reads + parses the review file.
 func loadPushContext(args []string) (pushContext, error) {
 	if err := RequireGH(); err != nil {
@@ -160,27 +171,27 @@ func loadPushContext(args []string) (pushContext, error) {
 		return pushContext{}, clicmd.ExitError{Code: 1, Err: errors.New("--event request-changes requires --message")}
 	}
 
-	prNumber, err := DetectPR(f.prFlag)
+	id, err := resolvePullChangeID(f.spec)
 	if err != nil {
 		return pushContext{}, err
 	}
 
-	critPath, cj, err := loadPushReview(f, prNumber)
+	critPath, cj, err := loadPushReview(f, id)
 	if err != nil {
 		return pushContext{}, err
 	}
 
-	return pushContext{flags: f, event: event, prNumber: prNumber, critPath: critPath, cj: cj}, nil
+	return pushContext{flags: f, event: event, id: id, prNumber: id.Number, critPath: critPath, cj: cj}, nil
 }
 
-func loadPushReview(f pushFlags, prNumber int) (string, session.CritJSON, error) {
+func loadPushReview(f pushFlags, id forge.ChangeID) (string, session.CritJSON, error) {
 	critPath, err := review.ResolveCommandReviewPathWithSession(f.sessionID, f.outputDir, f.configuredOutput)
 	if err != nil {
 		return "", session.CritJSON{}, err
 	}
 
 	// Read the cwd-resolved file first (best-effort) so we know its branch.
-	// We tolerate "not found" here so an explicit `--pr N` from a clean
+	// We tolerate "not found" here so an explicit PR number/URL from a clean
 	// checkout can still find the right file by branch via the redirect.
 	var cj session.CritJSON
 	cwdFileExists := true
@@ -194,13 +205,13 @@ func loadPushReview(f pushFlags, prNumber int) (string, session.CritJSON, error)
 		return "", session.CritJSON{}, fmt.Errorf("invalid review file: %w", err)
 	}
 
-	// Redirect when the user passed an explicit PR number and the cwd-resolved
+	// Redirect when the user passed an explicit PR number/URL and the cwd-resolved
 	// review file is for a different branch (or is missing) — pushing the wrong
 	// comments to a PR is destructive, so honor the explicit intent first. Same
 	// pattern as PR #424's findReviewFileByCommentID fallback for `crit comment`.
 	pinned := f.sessionID != "" || f.outputDir != "" || f.configuredOutput != ""
-	if shouldRedirectReviewForPR(f.prFlag, pinned) {
-		if altPath, altCJ, ok := review.RedirectReviewPathForPR(prNumber, cj.Branch, critPath); ok {
+	if shouldRedirectReviewForPR(f.spec != "", pinned) {
+		if altPath, altCJ, ok := review.RedirectReviewPathForPR(id.Number, cj.Branch, critPath); ok {
 			critPath = altPath
 			cj = altCJ
 			cwdFileExists = true
@@ -245,7 +256,7 @@ func RunPushLive(ctx pushContext, b PushBuckets) int { //nolint:gocyclo // CLI p
 			allReplies = append(allReplies, CollectNewRepliesForPush(cf, rewrite)...)
 		}
 		var replyIDs map[ReplyKey]int64
-		replyIDs, postedReplies, replyAuthFailed = PostPushReplies(ctx.prNumber, allReplies)
+		replyIDs, postedReplies, replyAuthFailed = postPushReplies(ctx.id, allReplies)
 		if len(commentIDs) > 0 || len(replyIDs) > 0 {
 			if uerr := UpdateCritJSONWithGitHubIDs(ctx.critPath, commentIDs, replyIDs); uerr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update review file with GitHub IDs: %v\n", uerr)
@@ -317,7 +328,7 @@ func runPushPostReview(ctx pushContext, b PushBuckets, rewrite BodyRewriter) (in
 		return 0, false, false, nil
 	}
 	ghComments := BucketsToGHComments(b.Postable, rewrite)
-	ids, err := CreateGHReview(ctx.prNumber, ghComments, ctx.flags.message, ctx.event)
+	ids, err := createGHReview(ctx.id, ghComments, ctx.flags.message, ctx.event)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error posting review: %v\n", err)
 		return 0, true, errors.Is(err, ErrGHAuthFailed), nil
@@ -472,7 +483,7 @@ func RunPush(args []string) error {
 	}
 
 	inRange := ctx.cj.ActiveDiffScope != ""
-	currentHead, err := resolveCurrentPRHead(ctx.prNumber, inRange, ctx.flags.dryRun)
+	currentHead, err := resolveCurrentPRHead(ctx.id, inRange, ctx.flags.dryRun)
 	if err != nil {
 		return err
 	}

--- a/internal/github/push_cli_flags_test.go
+++ b/internal/github/push_cli_flags_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/tomasz-tomczyk/crit/internal/clicmd"
 	"github.com/tomasz-tomczyk/crit/internal/daemon"
+	"github.com/tomasz-tomczyk/crit/internal/forge"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
 )
@@ -31,11 +32,11 @@ func TestParsePushFlags(t *testing.T) {
 		{name: "message short", args: []string{"-m", "hi"}, want: pushFlags{message: "hi"}},
 		{name: "output", args: []string{"-o", "/tmp/x"}, want: pushFlags{outputDir: "/tmp/x"}},
 		{name: "event", args: []string{"-e", "approve"}, want: pushFlags{eventFlag: "approve"}},
-		{name: "pr number", args: []string{"99"}, want: pushFlags{prFlag: 99}},
+		{name: "pr number", args: []string{"99"}, want: pushFlags{spec: "99"}},
 		{
 			name: "all flags",
 			args: []string{"--dry-run", "--event", "request-changes", "-m", "msg", "-o", "/d", "12"},
-			want: pushFlags{prFlag: 12, dryRun: true, message: "msg", outputDir: "/d", eventFlag: "request-changes"},
+			want: pushFlags{spec: "12", dryRun: true, message: "msg", outputDir: "/d", eventFlag: "request-changes"},
 		},
 		{name: "message missing value", args: []string{"--message"}, wantErr: true},
 		{name: "output missing value", args: []string{"--output"}, wantErr: true},
@@ -97,7 +98,7 @@ func TestParseResolvedPushFlags(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !f.dryRun || f.prFlag != 42 {
+		if !f.dryRun || f.spec != "42" {
 			t.Fatalf("flags = %+v, want dry-run PR 42", f)
 		}
 		if f.configuredOutput != configuredOutput {
@@ -124,7 +125,7 @@ func TestParsePushFlags_NonNumericExitCode(t *testing.T) {
 }
 
 func TestResolveCurrentPRHead_NotInRange(t *testing.T) {
-	sha, err := resolveCurrentPRHead(5, false, false)
+	sha, err := resolveCurrentPRHead(forge.ChangeID{Number: 5}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -139,7 +140,7 @@ func TestResolveCurrentPRHead_InRange(t *testing.T) {
 	})
 	defer restore()
 
-	sha, err := resolveCurrentPRHead(5, true, false)
+	sha, err := resolveCurrentPRHead(forge.ChangeID{Number: 5}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestResolveCurrentPRHead_FetchError(t *testing.T) {
 	defer restore()
 
 	// Live mode: a fetch failure is fatal because the stale-head check must run.
-	if _, err := resolveCurrentPRHead(5, true, false); err == nil {
+	if _, err := resolveCurrentPRHead(forge.ChangeID{Number: 5}, true, false); err == nil {
 		t.Error("resolveCurrentPRHead live mode = nil error, want error on fetch failure")
 	}
 
@@ -163,7 +164,7 @@ func TestResolveCurrentPRHead_FetchError(t *testing.T) {
 	var sha string
 	stderr := captureStderr(t, func() {
 		var err error
-		sha, err = resolveCurrentPRHead(5, true, true)
+		sha, err = resolveCurrentPRHead(forge.ChangeID{Number: 5}, true, true)
 		if err != nil {
 			t.Errorf("dry-run should tolerate fetch error, got %v", err)
 		}
@@ -211,7 +212,7 @@ func TestParsePushFlagsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := pushFlags{sessionID: "aaaaaaaaaaaa", dryRun: true, prFlag: 12}
+	want := pushFlags{sessionID: "aaaaaaaaaaaa", dryRun: true, spec: "12"}
 	if got != want {
 		t.Fatalf("got %+v, want %+v", got, want)
 	}
@@ -222,14 +223,14 @@ func TestParsePushFlagsSession(t *testing.T) {
 
 func TestLoadPushReview(t *testing.T) {
 	t.Run("session and output conflict", func(t *testing.T) {
-		_, _, err := loadPushReview(pushFlags{sessionID: "aaaaaaaaaaaa", outputDir: "/tmp/out"}, 1)
+		_, _, err := loadPushReview(pushFlags{sessionID: "aaaaaaaaaaaa", outputDir: "/tmp/out"}, forge.ChangeID{Number: 1})
 		if err == nil || !strings.Contains(err.Error(), "--session cannot be used with --output") {
 			t.Fatalf("error = %v, want session/output conflict", err)
 		}
 	})
 
 	t.Run("invalid session id", func(t *testing.T) {
-		_, _, err := loadPushReview(pushFlags{sessionID: "bad"}, 1)
+		_, _, err := loadPushReview(pushFlags{sessionID: "bad"}, forge.ChangeID{Number: 1})
 		if err == nil || !strings.Contains(err.Error(), "expected 12-character hex") {
 			t.Fatalf("error = %v, want invalid session id", err)
 		}
@@ -239,7 +240,7 @@ func TestLoadPushReview(t *testing.T) {
 		projectDir := t.TempDir()
 		testutil.SetHome(t, t.TempDir())
 		t.Chdir(projectDir)
-		_, _, err := loadPushReview(pushFlags{}, 1)
+		_, _, err := loadPushReview(pushFlags{}, forge.ChangeID{Number: 1})
 		if err == nil || !strings.Contains(err.Error(), "no review file found") {
 			t.Fatalf("error = %v, want missing review file", err)
 		}
@@ -266,7 +267,7 @@ func TestLoadPushReview(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotPath, cj, err := loadPushReview(pushFlags{}, 0)
+		gotPath, cj, err := loadPushReview(pushFlags{}, forge.ChangeID{Number: 0})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -296,7 +297,7 @@ func TestLoadPushReview(t *testing.T) {
 		if err := os.WriteFile(session.ReviewPathsFor(identity).Review, []byte("{"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		_, _, err = loadPushReview(pushFlags{}, 0)
+		_, _, err = loadPushReview(pushFlags{}, forge.ChangeID{Number: 0})
 		if err == nil || !strings.Contains(err.Error(), "invalid review file") {
 			t.Fatalf("error = %v, want invalid review file", err)
 		}
@@ -337,7 +338,7 @@ func TestLoadPushReview(t *testing.T) {
 		}
 		t.Cleanup(func() { daemon.RemoveSessionFile(key) })
 
-		gotPath, cj, err := loadPushReview(pushFlags{sessionID: key}, 99)
+		gotPath, cj, err := loadPushReview(pushFlags{sessionID: key}, forge.ChangeID{Number: 99})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/github/push_partial_failure_test.go
+++ b/internal/github/push_partial_failure_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/tomasz-tomczyk/crit/internal/forge"
+
 	"github.com/tomasz-tomczyk/crit/internal/session"
 )
 
@@ -66,7 +68,7 @@ esac
 		{ParentGHID: 300, Body: "third reply"},
 	}
 
-	got, _, _ := postPushReplies(42, replies)
+	got, _, _ := postPushReplies(forge.ChangeID{Number: 42}, replies)
 
 	// First reply: parent 100 → id 1001.
 	k1 := replyKey{ParentGHID: 100, BodyPrefix: truncateStr("first reply", 60)}

--- a/internal/github/spec.go
+++ b/internal/github/spec.go
@@ -86,3 +86,27 @@ func prCacheKey(id forge.ChangeID) string {
 	}
 	return strconv.Itoa(id.Number)
 }
+
+// ghAPIArgs builds a `gh api` argument list. When id.Project is set, pins with
+// -R so {owner}/{repo} placeholders (and GraphQL via explicit owner/name) resolve
+// against the URL-qualified repo rather than the current checkout (#870 class).
+func ghAPIArgs(id forge.ChangeID, endpointAndFlags ...string) []string {
+	args := []string{"api"}
+	if repo := prRepoRef(id); repo != "" {
+		args = append(args, "-R", repo)
+	}
+	return append(args, endpointAndFlags...)
+}
+
+// resolveRepoOwnerName returns owner/name for GraphQL. URL-qualified ChangeIDs
+// use id.Project; bare numbers fall back to the current checkout.
+func resolveRepoOwnerName(id forge.ChangeID) (string, string, error) {
+	if id.Project != "" {
+		parts := strings.SplitN(id.Project, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("invalid GitHub project %q", id.Project)
+		}
+		return parts[0], parts[1], nil
+	}
+	return fetchCurrentRepoOwnerName()
+}

--- a/internal/github/spec_view_args_test.go
+++ b/internal/github/spec_view_args_test.go
@@ -49,3 +49,14 @@ func TestPRCacheKey_IncludesEnterpriseHost(t *testing.T) {
 		t.Fatalf("github.com key = %q", dotcom)
 	}
 }
+
+func TestGHAPIArgs(t *testing.T) {
+	bare := ghAPIArgs(forge.ChangeID{Number: 5}, "repos/{owner}/{repo}/pulls/5/comments")
+	if !reflect.DeepEqual(bare, []string{"api", "repos/{owner}/{repo}/pulls/5/comments"}) {
+		t.Fatalf("bare = %#v", bare)
+	}
+	pinned := ghAPIArgs(forge.ChangeID{Number: 5, Project: "acme/widget"}, "repos/{owner}/{repo}/pulls/5/comments")
+	if !reflect.DeepEqual(pinned, []string{"api", "-R", "acme/widget", "repos/{owner}/{repo}/pulls/5/comments"}) {
+		t.Fatalf("pinned = %#v", pinned)
+	}
+}

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -349,7 +349,7 @@ func FocusKeyArgs(sc *DaemonCLIConfig) []string {
 	}
 	if sc.Focus.ChangeNumber > 0 {
 		if sc.Focus.Forge == "gitlab" {
-			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
+			return []string{session.MRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 		}
 		return []string{session.PRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 	}

--- a/internal/server/daemon_cli_test.go
+++ b/internal/server/daemon_cli_test.go
@@ -81,6 +81,17 @@ func TestFocusKeyArgs_MR(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_MRWithRemoteBaseProject(t *testing.T) {
+	sc := &server.DaemonCLIConfig{Focus: &server.Focus{
+		Kind: server.FocusRange, Forge: "gitlab", ChangeNumber: 7,
+		RemoteBaseProject: "acme/widget",
+	}}
+	got := server.FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "mr:acme/widget#7" {
+		t.Errorf("got %v want [mr:acme/widget#7]", got)
+	}
+}
+
 func TestFocusKeyArgs_Range(t *testing.T) {
 	sc := &server.DaemonCLIConfig{Focus: &server.Focus{Kind: server.FocusRange, BaseSHA: "abc", HeadSHA: "def"}}
 	got := server.FocusKeyArgs(sc)

--- a/internal/session/focus_cli_test.go
+++ b/internal/session/focus_cli_test.go
@@ -63,6 +63,28 @@ func TestFocusKeyArgs_MR(t *testing.T) {
 	}
 }
 
+func TestFocusKeyArgs_MRWithRemoteBaseProject(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{
+		Kind: FocusRange, Forge: "gitlab", ChangeNumber: 7,
+		RemoteBaseProject: "acme/widget",
+	}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "mr:acme/widget#7" {
+		t.Errorf("got %v want [mr:acme/widget#7]", got)
+	}
+}
+
+func TestFocusKeyArgs_MRWithSelfManagedHost(t *testing.T) {
+	sc := &CLIReviewConfig{Focus: &Focus{
+		Kind: FocusRange, Forge: "gitlab", ChangeNumber: 9,
+		RemoteBaseProject: "group/app", RemoteHost: "gitlab.example.com",
+	}}
+	got := FocusKeyArgs(sc)
+	if len(got) != 1 || got[0] != "mr:gitlab.example.com/group/app#9" {
+		t.Errorf("got %v want [mr:gitlab.example.com/group/app#9]", got)
+	}
+}
+
 func TestPRFocusKey_MatchesFocusKeyFor(t *testing.T) {
 	f := Focus{
 		Kind: FocusRange, Forge: "github", ChangeNumber: 3,
@@ -70,6 +92,16 @@ func TestPRFocusKey_MatchesFocusKeyFor(t *testing.T) {
 	}
 	if got, want := focusKeyFor(f), PRFocusKey(3, "o/r", "github.example.com"); got != want {
 		t.Fatalf("focusKeyFor=%q PRFocusKey=%q", got, want)
+	}
+}
+
+func TestMRFocusKey_MatchesFocusKeyFor(t *testing.T) {
+	f := Focus{
+		Kind: FocusRange, Forge: "gitlab", ChangeNumber: 3,
+		RemoteBaseProject: "g/p", RemoteHost: "gitlab.example.com",
+	}
+	if got, want := focusKeyFor(f), MRFocusKey(3, "g/p", "gitlab.example.com"); got != want {
+		t.Fatalf("focusKeyFor=%q MRFocusKey=%q", got, want)
 	}
 }
 

--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -150,6 +150,7 @@ func TestFocusKeyFor(t *testing.T) {
 		{"empty kind", Focus{}, ""},
 		{"range with GitHub change", Focus{Kind: FocusRange, Forge: "github", ChangeNumber: 42, BaseSHA: "aaaaaaa", HeadSHA: "bbbbbbb"}, "pr:42"},
 		{"range with GitLab change", Focus{Kind: FocusRange, Forge: "gitlab", ChangeNumber: 17, BaseSHA: "aaaaaaa", HeadSHA: "bbbbbbb"}, "mr:17"},
+		{"range with GitLab project", Focus{Kind: FocusRange, Forge: "gitlab", ChangeNumber: 17, RemoteBaseProject: "acme/widget", BaseSHA: "aaaaaaa", HeadSHA: "bbbbbbb"}, "mr:acme/widget#17"},
 		{"range with empty forge + change", Focus{Kind: FocusRange, ChangeNumber: 9, BaseSHA: "aaaaaaa", HeadSHA: "bbbbbbb"}, "pr:9"},
 		{"range with unknown forge", Focus{Kind: FocusRange, Forge: "other", ChangeNumber: 9, BaseSHA: "aaaaaaa", HeadSHA: "bbbbbbb"}, "pr:9"},
 		{"range without PR", Focus{Kind: FocusRange, BaseSHA: "aaaaaaa1234", HeadSHA: "bbbbbbb1234"}, "range:aaaaaaa1234..bbbbbbb1234"},

--- a/internal/session/hooks.go
+++ b/internal/session/hooks.go
@@ -33,7 +33,7 @@ func FocusKeyArgs(sc *CLIReviewConfig) []string {
 	}
 	if sc.Focus.ChangeNumber > 0 {
 		if sc.Focus.Forge == "gitlab" {
-			return []string{fmt.Sprintf("mr:%d", sc.Focus.ChangeNumber)}
+			return []string{MRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 		}
 		return []string{PRFocusKey(sc.Focus.ChangeNumber, sc.Focus.RemoteBaseProject, sc.Focus.RemoteHost)}
 	}

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -102,6 +102,9 @@ func (f Focus) PickerVisible() bool {
 // focusKeyFor returns the per-view key used to scope comment visibility.
 //
 //	pr:<num>                       — range focus with PR number
+//	pr:<project>#<num>             — URL-qualified GitHub PR
+//	mr:<num>                       — range focus with MR IID (checkout-scoped)
+//	mr:<project>#<num>             — URL-qualified GitLab MR
 //	range:<baseSHA>..<headSHA>     — range focus without PR number
 //	""                             — working-tree (and unknown)
 //
@@ -114,7 +117,7 @@ func focusKeyFor(f Focus) string {
 	}
 	if f.ChangeNumber > 0 {
 		if f.Forge == "gitlab" {
-			return fmt.Sprintf("mr:%d", f.ChangeNumber)
+			return MRFocusKey(f.ChangeNumber, f.RemoteBaseProject, f.RemoteHost)
 		}
 		// github or empty forge (legacy ChangeNumber without Forge) → pr:…
 		return PRFocusKey(f.ChangeNumber, f.RemoteBaseProject, f.RemoteHost)
@@ -125,6 +128,8 @@ func focusKeyFor(f Focus) string {
 // PRFocusKey is the GitHub PR identity used for daemon session keys and
 // comment FocusKey stamping. URL-qualified reviews include owner/repo (and
 // non-github.com host) so same-number PRs do not collide (#870).
+// Bare numbers (empty project) keep the legacy "pr:N" form so existing
+// checkout-scoped sessions continue to match.
 func PRFocusKey(number int, project, host string) string {
 	if project == "" {
 		return fmt.Sprintf("pr:%d", number)
@@ -133,6 +138,19 @@ func PRFocusKey(number int, project, host string) string {
 		return fmt.Sprintf("pr:%s/%s#%d", host, project, number)
 	}
 	return fmt.Sprintf("pr:%s#%d", project, number)
+}
+
+// MRFocusKey is the GitLab MR identity used for daemon session keys and
+// comment FocusKey stamping. Mirrors PRFocusKey: bare IIDs stay "mr:N";
+// URL-qualified reviews include project (and non-gitlab.com host).
+func MRFocusKey(number int, project, host string) string {
+	if project == "" {
+		return fmt.Sprintf("mr:%d", number)
+	}
+	if host != "" && !strings.EqualFold(host, "gitlab.com") {
+		return fmt.Sprintf("mr:%s/%s#%d", host, project, number)
+	}
+	return fmt.Sprintf("mr:%s#%d", project, number)
 }
 
 // visibleInFocus reports whether c should be shown in the given focus.


### PR DESCRIPTION
## Summary
- Pass ParsePRSpec through pull/push so cross-repo PR URLs pin `-R` (same class of fix as URL-aware pr view)
- Derive BaseRepo owner/repo from PR HTML URLs; add MRFocusKey mirroring GitHub; invalidate all PR cache keys on focus switch

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (Go-only)

## Test plan
- [x] gofmt, golangci-lint, go test (packages)
- [x] e2e-roundtrip
- See also: tomasz-tomczyk/crit-web#385 (mermaid overlay companion)

## Notes
- `go test -race` range-lazy flakes reproduce on origin/main; not introduced here


Made with [Cursor](https://cursor.com)