### PR TITLE
perf: benchmarks, budgets, and guardrails for large reviews

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,81 @@ jobs:
         run: npm ci
       - name: Run frontend smoke tests
         run: make test-frontend
+      - name: Run frontend perf microbenchmarks
+        run: npm run test:perf
+
+  asset-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Check embedded asset + binary size budgets
+        run: bash scripts/check-asset-budget.sh
+
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go build cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: go-build-${{ runner.os }}-
+
+      - name: Install benchstat
+        # x/perf ships no versioned releases, so @latest tracks the Go
+        # toolchain; benchstat's comparison output format is stable.
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Run benchmarks (PR head)
+        run: go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ | tee bench-new.txt
+
+      - name: Run benchmarks (base)
+        id: base
+        # Resolve the base commit directly: on fork PRs origin/$BASE_REF may
+        # not exist, but the base SHA is always present in a full clone.
+        # A missing baseline fails the job — a silently-skipped gate is worse
+        # than a noisy one, and this step only fails on real infra problems.
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE_SHA" ] || ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+            BASE_REF="${{ github.base_ref }}"
+            [ -z "$BASE_REF" ] && BASE_REF="main"
+            git fetch origin "$BASE_REF" 2>/dev/null || true
+            BASE_SHA="origin/$BASE_REF"
+          fi
+          git worktree add /tmp/crit-base "$BASE_SHA"
+          cd /tmp/crit-base
+          go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ > "$GITHUB_WORKSPACE/bench-old.txt"
+
+      - name: Remove base worktree
+        if: always()
+        run: git worktree remove --force /tmp/crit-base || true
+
+      - name: Self-test the bench gate
+        # The gate can't detect its own parser regressions — lock the contract.
+        run: python3 scripts/bench-compare_test.py
+
+      - name: Compare with benchstat
+        run: |
+          benchstat bench-old.txt bench-new.txt | tee benchstat.txt
+          python3 scripts/bench-compare.py benchstat.txt
 
   nix:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - gocritic
     - errorlint
     - unparam
+    - perfsprint
   settings:
     gocyclo:
       min-complexity: 15
@@ -19,6 +20,11 @@ linters:
     rules:
       - linters: [staticcheck]
         text: "QF"
+      # perfsprint's error-format (fmt.Errorf → errors.New on static strings)
+      # is style churn with zero perf value; the format/integer/hex/concat
+      # checks it also runs are the ones that buy real ns/op and allocs.
+      - linters: [perfsprint]
+        text: "error-format"
       - linters: [gocyclo]
         text: "runComment|mergeExternalCritJSON|bulkAddCommentsToCritJSONScoped|runPush|runServe|runDesign|handleFileComments"
       - linters: [gocyclo]

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,18 @@ test:
 test-frontend:
 	npm run test:frontend
 
+# Run Go benchmarks locally. Compare against a base with:
+#   git worktree add /tmp/crit-base origin/main
+#   go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ > old.txt  (in /tmp/crit-base)
+#   go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ > new.txt  (here)
+#   benchstat old.txt new.txt   (go install golang.org/x/perf/cmd/benchstat@latest)
+bench:
+	go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/
+
+bench-compare:
+	benchstat bench-old.txt bench-new.txt | tee benchstat.txt
+	python3 scripts/bench-compare.py benchstat.txt
+
 setup-hooks:
 	git config core.hooksPath .githooks
 

--- a/asset-budget.json
+++ b/asset-budget.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Perf budgets for embedded frontend assets and the Go binary (which embeds web/ via embed.FS). Sizes are gzip bytes for JS, raw bytes for the binary. Caps sit ~15-20% above 2026-09 main so legitimate growth has room but accidental bloat (unminified vendor, new heavy dep, committed fixture) fails CI. Recalibrate quarterly or after intentional vendor bumps: run scripts/check-asset-budget.sh, verify the growth is intended, then update caps here.",
+  "files": [
+    { "path": "web/mermaid.min.js", "gzipBytes": 1180000, "note": "largest vendor dep (~70% of shipped JS); any mermaid bump shows here" },
+    { "path": "web/highlight.min.js", "gzipBytes": 430000, "note": "highlight.js vendor bundle" },
+    { "path": "web/app.js", "gzipBytes": 155000, "note": "main review UI; catches unbounded app.js growth" },
+    { "path": "web/markdown-it.min.js", "gzipBytes": 60000 },
+    { "path": "web/dompurify.min.js", "gzipBytes": 15000 },
+    { "path": "web/diff-match-patch.min.js", "gzipBytes": 6000 },
+    { "path": "web/live-mode.js", "gzipBytes": 31000 },
+    { "path": "web/style.css", "gzipBytes": 41000, "note": "review page styles; homepage/legal pages use Tailwind, not this file" }
+  ],
+  "globs": [
+    { "pattern": "web/crit-*.js", "gzipBytes": 85000, "note": "shared renderer/comment/diff modules; catches module sprawl" }
+  ],
+  "totalJsGzipBytes": 1950000,
+  "binaryBytes": 25165824
+}

--- a/cmd/crit/cli_install.go
+++ b/cmd/crit/cli_install.go
@@ -463,7 +463,7 @@ func installIntegration(name string, force bool) error {
 		if err := installCodexPluginActivation(global, home, codexMarketplaceName); err != nil {
 			return err
 		}
-		hints = append(hints, fmt.Sprintf("The Crit Codex plugin is enabled as crit@%s", codexMarketplaceName))
+		hints = append(hints, "The Crit Codex plugin is enabled as crit@"+codexMarketplaceName)
 	}
 	if name == "hermes" && !global {
 		fmt.Println()
@@ -1030,7 +1030,7 @@ func installCodexPluginActivation(global bool, home, marketplaceName string) err
 	fmt.Printf("  Installed: %s\n", cacheRoot)
 
 	configPath := filepath.Join(codexRoot, "config.toml")
-	if err := installCodexPluginConfig(configPath, fmt.Sprintf("crit@%s", marketplaceName)); err != nil {
+	if err := installCodexPluginConfig(configPath, "crit@"+marketplaceName); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/crit/integrations.go
+++ b/cmd/crit/integrations.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -18,7 +19,7 @@ import (
 // computeFileHash returns the hex-encoded SHA256 hash of data.
 func computeFileHash(data []byte) string {
 	h := sha256.Sum256(data)
-	return fmt.Sprintf("%x", h)
+	return hex.EncodeToString(h[:])
 }
 
 // latestCacheDir returns the lexicographically last subdirectory name
@@ -351,7 +352,7 @@ func checkCodexPluginInstallCompleteness(projectDir, homeDir string) []staleFile
 			marketplaceName = "local"
 		}
 
-		pluginKey := fmt.Sprintf("crit@%s", marketplaceName)
+		pluginKey := "crit@" + marketplaceName
 		configPath := filepath.Join(codexHome(homeDir), "config.toml")
 		if !codexPluginConfigReady(configPath, pluginKey) {
 			results = append(results, staleFile{

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,155 @@
+# Performance: benchmarks, budgets, and guardrails
+
+crit has no production profiler running anywhere — it's a localhost CLI — so
+perf is guarded by benchmarks and budgets in CI, not by dashboards. This doc
+lists what exists, how to run it, and when to recalibrate.
+
+## Go benchmarks
+
+Located next to the code they cover; all use `b.Loop()` + `b.ReportAllocs()`.
+
+| Benchmark | File | What it covers |
+| --- | --- | --- |
+| `BenchmarkComputeLineDiff` (100–10k lines) | `internal/diff/diff_test.go` | Myers/Hirschberg diff over plan-sized inputs |
+| `BenchmarkDiffEntriesToHunks` | `internal/diff/diff_test.go` | Hunk grouping over 10k entries / ~500 hunks |
+| `BenchmarkReviewSaveLoad` (10×10, 50×50) | `internal/session/review_bench_test.go` | Full review-file roundtrip (marshal + atomic write + read + unmarshal) on every debounced save |
+| `BenchmarkCarryForward` | `internal/session/review_bench_test.go` | Round-complete comment remap for one 10k-line plan + 50 comments (diff + anchor remap, on the server before `file-changed`) |
+| `BenchmarkVisibleInFocus` (n=10–1000) | `internal/session/focus_test.go` | Comment visibility filter behind every `GetComments` call |
+
+Run:
+
+```bash
+make bench   # count=6, ./internal/diff/ ./internal/session/
+```
+
+Compare a branch against a base (same machine, back to back):
+
+```bash
+git worktree add /tmp/crit-base origin/main
+(cd /tmp/crit-base && go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ > ../bench-old.txt)
+go test -run='^$' -bench=. -benchmem -count=6 ./internal/diff/ ./internal/session/ > bench-new.txt
+make bench-compare   # benchstat + scripts/bench-compare.py gating
+```
+
+Reference numbers (M4 Max, 2026-09; CI runners are slower — never gate on
+absolute ns/op, only on deltas):
+
+- `ComputeLineDiff/10000_lines`: ~250ms/op — the worst-case large-plan cost.
+- `ReviewSaveLoad/50x50`: ~13ms/op — per debounced save at 2500 comments.
+- `CarryForward`: ~370ms/op — per 10k-line plan on round-complete (stacks with N large plans).
+- `VisibleInFocus/n=1000`: ~15µs/op, 2 allocs (one hoisted focus-key format).
+
+### CI `bench` job
+
+`.github/workflows/test.yml` runs head-vs-base on the same runner and fails
+only on (see `scripts/bench-compare.py`):
+
+- time/op: statistically significant slowdown **≥ 20%** (benchstat `~` rows ignored).
+- allocs/op: **any** significant increase — allocs are deterministic, so 0→N
+  means a heap escape worth a look. B/op regressions are reported, not gated.
+
+New benchmarks appear in the comparison with no baseline — they report without
+gating until they exist on both sides. A missing baseline fails the job
+rather than skipping the gate. The gate's own parser is locked by
+`scripts/bench-compare_test.py` (run as a CI step before comparing).
+
+## Frontend perf microbenchmarks
+
+`web/__tests__/perf/*.perf.test.mjs`, run with `npm run test:perf` (also in the
+`test-frontend` CI job). Deterministic seeded fixtures, median-of-5, generous
+budgets (10–50× measured) that only fail on algorithmic regressions:
+
+- markdown-it parse + `buildLineBlocks` on a 10k-line plan fixture.
+- `splitHighlightedCode` on a 2000-line highlighted block.
+- `bestWordDiffPairing` (capped 4×4) + `wordDiff` (capped ~500-char lines).
+
+Each bench asserts its fixture does real work (e.g. `wordDiff` returns
+non-null) so budgets can't silently assert against an early-out path.
+
+## Playwright perf specs
+
+`test/e2e/tests/large-review.perf.spec.ts` (project `perf`, port 3134,
+fixture `test/e2e/setup-fixtures-perf.sh`: 300 files / ~9k changed lines +
+one large markdown, mirroring the 27f33c8 measurement). Wired into `run.sh`
+like every other project. Asserts structural invariants, not wall clock:
+
+- mounted `.file-body` sections ≤ 40 (eager set is 25).
+- DOM nodes < 200,000.
+- longtask TBT (Σ(duration − 50ms)) < 8000ms for load and for a full scroll.
+
+Measured steady state: 25 mounted bodies, ~12k DOM nodes, 0ms TBT.
+
+## Asset + binary budgets
+
+crit embeds all of `web/` in the binary, so a vendor bump inflates page
+weight and binary size together. Caps live in `asset-budget.json`
+(~15–20% above measured); `scripts/check-asset-budget.sh` enforces them in
+the `asset-budget` CI job:
+
+- per-file gzip caps (mermaid, highlight, app.js, live-mode.js, style.css,
+  markdown-it, …),
+- glob totals (`web/crit-*.js` shared modules),
+- total `web/*.js` gzip cap,
+- linux/amd64 binary cap (trimpath, `-s -w`).
+
+If growth is intentional (e.g. a vendor major bump), run the script, verify
+the delta, and update the caps in `asset-budget.json`.
+
+## Lint
+
+- `perfsprint` is enabled in `.golangci.yml` (Sprintf→concat/Itoa,
+  hex formatting, concat-in-loop). Its `error-format` check is excluded as
+  style churn with zero perf value.
+- No ESLint perf plugins: nothing published applies to vanilla DOM code.
+  The rule that matters is architectural — event listeners are delegated per
+  container (`attachDiffMouseHandler`, `attachDocGutterMouseHandler`), never
+  per line — and it is covered by the perf E2E spec, not by lint.
+
+## Known hot paths and past fixes
+
+- Focus-key formatting is hoisted out of per-comment loops
+  (`visibleInFocusKey`; `BenchmarkVisibleInFocus` locks the assumption).
+  Don't call `focusKeyFor` per comment.
+- Document-view comment gutters use one delegated mousedown per container
+  (same bug class as #657 for diff buttons: ~10k listeners on a 10k-line file).
+- `highlightQuotesInSection` indexes content elements once per mount instead
+  of scanning the section per quoted line.
+- `getFormsForFile` results are threaded down from top-level renders, not
+  recomputed per block/line/drag-frame.
+- `ComputeLineDiff` at 10k lines costs ~250ms: keep large-markdown work off
+  the critical render path (lazy bodies already do this).
+
+## Deferred follow-ups (reviewed, not yet done)
+
+From external review of this branch; each needs its own PR with measurements:
+
+1. **Full `renderFileByPath` on gutter mousedown.** Delegation removed the
+   listener cost, but the first click on a 10k-line plan still pays a full
+   file remount to start a selection (`beginDocGutterDrag`). Highest remaining
+   interaction cost for large markdown — update drag visuals without a full
+   remount, or defer non-selection work.
+2. **Mermaid on mount paths.** `renderMermaidBlocks()` runs after many
+   remounts with no budget; diagrams on large plans can dominate TBT.
+   Consider lazy-rendering mermaid (only when `code.language-mermaid`
+   exists) and a perf-E2E fixture with diagrams.
+3. **Session-init bench.** Myers and review JSON are benched; `NewSessionFromGit`
+   / `RefreshFileList` (eager ×25 + numstat for N files, gating daemon
+   readiness) is not. Needs a temp-git-repo fixture — keep it out of the
+   hermetic bench set until readiness latency shows up in practice.
+4. **Progressive mount after "Load diff".** The `diffTooLarge` placeholder is
+   good, but clicking it mounts all hunk DOM synchronously. Progressive
+   append (rAF batches) or in-file IntersectionObserver for the loaded path.
+5. **`file-changed` full reload.** The handler re-fetches everything; lazy
+   stubs soften it, but nothing asserts files past the threshold stay
+   `lazy: true` after round-complete. A Go unit test on the refresh path
+   (no new browser minutes) is the cheap guardrail.
+
+## Recalibration
+
+- Budgets: quarterly, or after an intentional vendor bump / feature that
+  legitimately moves them. Measure on `main`, set caps ~1.2× measured,
+  note the reason in the PR.
+- The `bench` CI job starts strict from day one on allocs (deterministic)
+  and ≥20%-significant on time. If it ever false-positives on a PR, don't
+  bump the threshold silently — link the run in `docs/performance.md` or the
+  PR and adjust with evidence.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bufio"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -163,7 +164,7 @@ func SessionKey(cwd string, branch string, args []string) string {
 		h.Write([]byte{0})
 		h.Write([]byte(a))
 	}
-	return fmt.Sprintf("%x", h.Sum(nil))[:12]
+	return hex.EncodeToString(h.Sum(nil))[:12]
 }
 
 // LiveSessionKey returns the session/review key for a live-mode session.
@@ -175,7 +176,7 @@ func LiveSessionKey(cwd, origin string) string {
 	h.Write([]byte(cwd))
 	h.Write([]byte("\x00live\x00"))
 	h.Write([]byte(origin))
-	return fmt.Sprintf("%x", h.Sum(nil))[:12]
+	return hex.EncodeToString(h.Sum(nil))[:12]
 }
 
 // ValidSessionKey reports whether key looks like a crit session ID (12 lowercase hex chars).

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1210,7 +1211,7 @@ func TestLiveSessionKey_MatchesSpec(t *testing.T) {
 	h.Write([]byte(cwd))
 	h.Write([]byte("\x00live\x00"))
 	h.Write([]byte(origin))
-	want := fmt.Sprintf("%x", h.Sum(nil))[:12]
+	want := hex.EncodeToString(h.Sum(nil))[:12]
 	if got != want {
 		t.Errorf("key = %q, want %q", got, want)
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -253,6 +253,9 @@ func BenchmarkComputeLineDiff(b *testing.B) {
 		{"100_lines", 100},
 		{"1000_lines", 1000},
 		{"5000_lines", 5000},
+		// 10000 lines is the stated worst case for AI-generated plans;
+		// keep it so regressions on large markdown show up here first.
+		{"10000_lines", 10000},
 	}
 
 	for _, sz := range sizes {
@@ -263,11 +266,44 @@ func BenchmarkComputeLineDiff(b *testing.B) {
 
 		b.Run(sz.name, func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				ComputeLineDiff(oldContent, newContent)
 			}
 		})
+	}
+}
+
+// BenchmarkDiffEntriesToHunks measures hunk grouping over a synthetic entry
+// list with many small changes spread across a large file. It isolates the
+// grouping pass from the Myers diff itself, so a regression in either stage
+// points at the right function.
+//
+// Run: go test -run='^$' -bench=. -benchmem ./internal/diff/
+func BenchmarkDiffEntriesToHunks(b *testing.B) {
+	// 10k entries with a change every ~20 lines (~500 hunks): the shape of
+	// a large review where grouping cost matters more than diff cost.
+	const n = 10000
+	entries := make([]DiffEntry, 0, n)
+	oldNum, newNum := 1, 1
+	for i := 1; i <= n; i++ {
+		if i%20 == 0 {
+			entries = append(entries, DiffEntry{Type: "removed", OldLine: oldNum, Text: "old line"})
+			oldNum++
+			entries = append(entries, DiffEntry{Type: "added", NewLine: newNum, Text: "new line"})
+			newNum++
+			continue
+		}
+		entries = append(entries, DiffEntry{Type: "unchanged", OldLine: oldNum, NewLine: newNum, Text: "same"})
+		oldNum++
+		newNum++
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		hunks := DiffEntriesToHunks(entries)
+		if len(hunks) == 0 {
+			b.Fatal("expected non-empty hunks")
+		}
 	}
 }
 

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"os"
@@ -21,7 +22,7 @@ func PreviewSessionKey(cwd, absPath string) string {
 	h.Write([]byte(cwd))
 	h.Write([]byte("\x00preview\x00"))
 	h.Write([]byte(absPath))
-	return fmt.Sprintf("%x", h.Sum(nil))[:12]
+	return hex.EncodeToString(h.Sum(nil))[:12]
 }
 
 // LooksLikePreviewArgs returns true when args is a single .html/.htm file path.

--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -30,8 +30,8 @@ func (s *Server) buildPromptContext(sess *Session, approved bool, stats map[stri
 	quoted := shellQuoteArg(reviewPath)
 	ctx := prompt.Context{
 		ReviewPath:          reviewPath,
-		CommentsCmd:         fmt.Sprintf("crit comments --json %s", quoted),
-		CommentsAllCmd:      fmt.Sprintf("crit comments --json --all %s", quoted),
+		CommentsCmd:         "crit comments --json " + quoted,
+		CommentsAllCmd:      "crit comments --json --all " + quoted,
 		NextRoundCmd:        session.NextRoundCommand(sess),
 		SessionKey:          sess.SessionKey,
 		Mode:                mode,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2438,7 +2438,7 @@ func listComments(sess *Session, unresolvedOnly bool) []comment.ListedComment {
 }
 
 func buildCommentsListCommand(sess *Session) string {
-	return fmt.Sprintf("crit comments --json %s", shellQuoteArg(sess.CritJSONPath()))
+	return "crit comments --json " + shellQuoteArg(sess.CritJSONPath())
 }
 
 // APIVersion is the HTTP API protocol version returned by GET /api/health as
@@ -3006,7 +3006,7 @@ func buildAgentPrompt(c Comment, filePath string) string {
 	if filePath == "" {
 		b.WriteString("A reviewer left a general comment on this review")
 	} else {
-		b.WriteString(fmt.Sprintf("A reviewer left a comment on %s", filePath))
+		b.WriteString("A reviewer left a comment on " + filePath)
 		if c.StartLine > 0 {
 			if c.EndLine > c.StartLine {
 				b.WriteString(fmt.Sprintf(" (lines %d-%d)", c.StartLine, c.EndLine))

--- a/internal/session/focus_session_test.go
+++ b/internal/session/focus_session_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -398,13 +399,15 @@ func TestGetFileDiffSnapshot_RangeLazy_UsesBetweenSHADiff(t *testing.T) {
 	if len(hunks) == 0 {
 		t.Fatal("expected between-SHA hunks for modified lazy file")
 	}
-	joined := ""
+	var sb strings.Builder
 	for _, h := range hunks {
 		for _, l := range h.Lines {
-			joined += l.Content + "\n"
+			sb.WriteString(l.Content)
+			sb.WriteByte('\n')
 		}
 	}
-	if !strings.Contains(joined, "head "+fmt.Sprint(lazyFileThreshold)) {
+	joined := sb.String()
+	if !strings.Contains(joined, "head "+strconv.Itoa(lazyFileThreshold)) {
 		t.Fatalf("hunks missing HeadSHA content; got %q", joined)
 	}
 	if strings.Contains(joined, "dirty") || strings.Contains(joined, "entirely different") {

--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -283,8 +283,10 @@ func TestCarryForwardComment_PreservesScope(t *testing.T) {
 }
 
 // BenchmarkVisibleInFocus measures the cost of the linear filter scan that
-// every GetComments call runs. visibleInFocus is a pure pointer comparison +
-// two string compares, so we expect single-digit ns per call. Locking in this
+// every GetComments call runs, via countVisibleComments (the real path,
+// with the focus key hoisted out of the loop). visibleInFocus itself is a
+// pure pointer comparison + two string compares once the key is hoisted, so
+// we expect single-digit ns per comment and zero allocs. Locking in this
 // assumption makes "should we add an index?" decisions evidence-based.
 //
 // Run: go test -bench=BenchmarkVisibleInFocus -benchmem
@@ -294,14 +296,8 @@ func BenchmarkVisibleInFocus(b *testing.B) {
 		f := Focus{Kind: FocusRange, Forge: "github", ChangeNumber: 295, DiffScope: DiffScopeLayer}
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				count := 0
-				for _, c := range comments {
-					if visibleInFocus(c, f) {
-						count++
-					}
-				}
-				if count == 0 {
+			for b.Loop() {
+				if count := countVisibleComments(comments, f); count == 0 {
 					b.Fatal("expected non-zero matches")
 				}
 			}

--- a/internal/session/plans.go
+++ b/internal/session/plans.go
@@ -2,12 +2,14 @@ package session
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +34,7 @@ func PlanSessionKey(cwd, slug string) string {
 	h.Write([]byte(cwd))
 	h.Write([]byte{0})
 	h.Write([]byte("__plan:" + slug))
-	return fmt.Sprintf("%x", h.Sum(nil))[:12]
+	return hex.EncodeToString(h.Sum(nil))[:12]
 }
 
 var nonAlphaNum = regexp.MustCompile(`[^a-z0-9]+`)
@@ -115,7 +117,7 @@ func BuildPlanDaemonArgs(currentPath, storageDir, slug string, flags PlanDaemonF
 
 func appendPlanDaemonFlags(args []string, f PlanDaemonFlags) []string {
 	if f.Port != 0 {
-		args = append(args, "--port", fmt.Sprintf("%d", f.Port))
+		args = append(args, "--port", strconv.Itoa(f.Port))
 	}
 	if f.Host != "" && f.Host != "127.0.0.1" {
 		args = append(args, "--host", f.Host)

--- a/internal/session/review_bench_test.go
+++ b/internal/session/review_bench_test.go
@@ -1,0 +1,162 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeBenchCritJSON builds a review shaped like a large session: nFiles files
+// with nComments comments each. Bodies are ~200 bytes so the payload is
+// dominated by structure, not by a single giant string — matching real
+// reviews where JSON churn comes from comment count, not comment size.
+func makeBenchCritJSON(nFiles, nComments int) CritJSON {
+	cj := CritJSON{
+		Branch:      "feature/bench",
+		BaseRef:     "main",
+		UpdatedAt:   "2026-09-04T00:00:00Z",
+		ReviewRound: 2,
+		Files:       make(map[string]CritJSONFile, nFiles),
+	}
+	body := "This is a review comment body with enough text to be realistic. " +
+		"It spans a couple of sentences so marshal cost resembles production. "
+	for f := 0; f < nFiles; f++ {
+		path := fmt.Sprintf("pkg/file%03d.go", f)
+		comments := make([]Comment, nComments)
+		for i := range comments {
+			comments[i] = Comment{
+				ID:        fmt.Sprintf("c-%d-%d", f, i),
+				StartLine: i*10 + 1,
+				EndLine:   i*10 + 3,
+				Body:      body,
+				Author:    "reviewer",
+				CreatedAt: "2026-09-04T00:00:00Z",
+				UpdatedAt: "2026-09-04T00:00:00Z",
+			}
+		}
+		cj.Files[path] = CritJSONFile{
+			Status:   "modified",
+			FileHash: "abc123",
+			Comments: comments,
+		}
+	}
+	return cj
+}
+
+// BenchmarkReviewSaveLoad measures the full review-file roundtrip
+// (marshal + atomic write + read + unmarshal) that runs on every debounced
+// save. This is the highest-risk Go-side regression surface: comment-count
+// growth hits this path on every keystroke-debounced write.
+//
+// Run: go test -run='^$' -bench=BenchmarkReviewSaveLoad -benchmem ./internal/session/
+func BenchmarkReviewSaveLoad(b *testing.B) {
+	for _, tc := range []struct {
+		name      string
+		nFiles    int
+		nComments int
+	}{
+		{"10x10", 10, 10},
+		{"50x50", 50, 50},
+	} {
+		cj := makeBenchCritJSON(tc.nFiles, tc.nComments)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			dir := b.TempDir()
+			// NOTE: b.N is the run's total iteration count, not a loop index —
+			// use an explicit counter so each iteration gets a fresh identity
+			// (fresh atomic-write + rename) instead of overwriting one path.
+			i := 0
+			for b.Loop() {
+				// Each iteration writes to a fresh identity so AtomicWriteFile
+				// rename cost is included and iterations don't share state.
+				identity := filepath.Join(dir, fmt.Sprintf("review-%d", i))
+				i++
+				if err := SaveCritJSON(identity, cj); err != nil {
+					b.Fatalf("SaveCritJSON: %v", err)
+				}
+				loaded, err := readCritJSONFromDisk(identity)
+				if err != nil {
+					b.Fatalf("readCritJSONFromDisk: %v", err)
+				}
+				if len(loaded.Files) != tc.nFiles {
+					b.Fatalf("loaded %d files, want %d", len(loaded.Files), tc.nFiles)
+				}
+			}
+		})
+	}
+}
+
+// makeBenchPlanContent builds deterministic prev/curr content pairs shaped like
+// a large AI-generated plan: n lines with every ~15th line changed.
+func makeBenchPlanContent(n int) (prev, curr string) {
+	prevLines := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		switch i % 15 {
+		case 3:
+			prevLines = append(prevLines, fmt.Sprintf("## Section %d original title", i))
+		case 7:
+			prevLines = append(prevLines, fmt.Sprintf("- old item %d with some detail text", i))
+		default:
+			prevLines = append(prevLines, fmt.Sprintf("This is body line %d with enough text to look realistic.", i))
+		}
+	}
+	prev = strings.Join(prevLines, "\n")
+	currLines := make([]string, 0, n+10)
+	for i, l := range prevLines {
+		switch i % 15 {
+		case 3:
+			currLines = append(currLines, fmt.Sprintf("## Section %d revised title", i))
+		case 7:
+			currLines = append(currLines, fmt.Sprintf("- new item %d with some detail text", i))
+			currLines = append(currLines, fmt.Sprintf("- inserted follow-up %d", i))
+		default:
+			currLines = append(currLines, l)
+		}
+	}
+	return prev, strings.Join(currLines, "\n")
+}
+
+// BenchmarkCarryForward measures the round-complete comment remap for one
+// large markdown file: ComputeLineDiff over prev/curr plus anchor remapping
+// for every comment. This runs on the server before clients get file-changed,
+// so one 10k-line plan costs ~one diff here (~250ms) and N large plans stack.
+// A second accidental LCS pass (or heavier remap) shows up here first.
+//
+// Run: go test -run='^$' -bench=BenchmarkCarryForward -benchmem ./internal/session/
+func BenchmarkCarryForward(b *testing.B) {
+	prev, curr := makeBenchPlanContent(10000)
+	comments := make([]Comment, 50)
+	for i := range comments {
+		comments[i] = Comment{
+			ID:        fmt.Sprintf("c-%d", i),
+			StartLine: i*100 + 1,
+			EndLine:   i*100 + 3,
+			Body:      "carried comment",
+			Quote:     fmt.Sprintf("body line %d", i*100+1),
+			CreatedAt: "2026-09-04T00:00:00Z",
+			UpdatedAt: "2026-09-04T00:00:00Z",
+		}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		// Fresh entry per iteration (carry-forward mutates in place). The
+		// struct setup is nanoseconds against a ~250ms diff — negligible
+		// pollution, and it keeps the b.Loop timer contract intact
+		// (no StopTimer/StartTimer across iterations).
+		f := &FileEntry{
+			Path:             "plan.md",
+			Status:           "modified",
+			FileType:         "markdown",
+			Content:          curr,
+			PreviousContent:  prev,
+			PreviousComments: comments,
+		}
+		s := &Session{}
+		s.CarryForwardFileComments(f)
+		if len(f.Comments) != len(comments) {
+			b.Fatalf("carried %d comments, want %d", len(f.Comments), len(comments))
+		}
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,7 +37,7 @@ const lazyFileThreshold = 25
 // computeFileHash returns the hex-encoded SHA256 hash of data.
 func computeFileHash(data []byte) string {
 	h := sha256.Sum256(data)
-	return fmt.Sprintf("%x", h)
+	return hex.EncodeToString(h[:])
 }
 
 // fileHash returns a stable, prefixed hash string for file content tracking.
@@ -1363,8 +1363,9 @@ func (s *Session) GetReviewComments() []Comment {
 	defer s.mu.RUnlock()
 	out := make([]Comment, 0, len(s.reviewComments))
 	seen := make(map[string]struct{}, len(s.reviewComments))
+	focusKey := focusKeyFor(s.Focus)
 	for _, c := range s.reviewComments {
-		if !visibleInFocus(c, s.Focus) {
+		if !visibleInFocusKey(c, focusKey, s.Focus) {
 			continue
 		}
 		if c.ID != "" {
@@ -1803,8 +1804,9 @@ func (s *Session) GetComments(filePath string) []Comment {
 		return []Comment{}
 	}
 	result := make([]Comment, 0, len(f.Comments))
+	focusKey := focusKeyFor(s.Focus)
 	for _, c := range f.Comments {
-		if !visibleInFocus(c, s.Focus) {
+		if !visibleInFocusKey(c, focusKey, s.Focus) {
 			continue
 		}
 		if len(c.Replies) > 0 {
@@ -2861,8 +2863,9 @@ func (s *Session) GetSessionInfo() SessionInfo {
 	defer s.mu.RUnlock()
 
 	reviewComments := make([]Comment, 0, len(s.reviewComments))
+	focusKey := focusKeyFor(s.Focus)
 	for _, c := range s.reviewComments {
-		if !visibleInFocus(c, s.Focus) {
+		if !visibleInFocusKey(c, focusKey, s.Focus) {
 			continue
 		}
 		reviewComments = append(reviewComments, c)

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -158,7 +158,15 @@ func MRFocusKey(number int, project, host string) string {
 // FocusKey. Within a range focus, the layer/full-stack DiffScope filter
 // also applies. Pure function — no I/O, no locks.
 func visibleInFocus(c Comment, f Focus) bool {
-	if c.FocusKey != focusKeyFor(f) {
+	return visibleInFocusKey(c, focusKeyFor(f), f)
+}
+
+// visibleInFocusKey is visibleInFocus with a precomputed focus key. Use it in
+// per-comment loops: focusKeyFor allocates (Sprintf) on every call, so
+// calling visibleInFocus per comment pays one allocation per comment.
+// Hoisting the key out of the loop makes the scan allocation-free.
+func visibleInFocusKey(c Comment, key string, f Focus) bool {
+	if c.FocusKey != key {
 		return false
 	}
 	if f.Kind == FocusRange {
@@ -195,9 +203,10 @@ func StampWithFocus(c Comment, f Focus) Comment {
 
 // countVisibleComments returns the count of comments visible in the given focus.
 func countVisibleComments(comments []Comment, f Focus) int {
+	key := focusKeyFor(f)
 	n := 0
 	for _, c := range comments {
-		if visibleInFocus(c, f) {
+		if visibleInFocusKey(c, key, f) {
 			n++
 		}
 	}
@@ -768,11 +777,12 @@ func (s *Session) snapshotForScoped() scopedSessionSnapshot {
 		}
 	}
 	rc := make([]Comment, 0, len(s.reviewComments))
+	focusKey := focusKeyFor(s.Focus)
 	for _, c := range s.reviewComments {
 		if !c.Resolved {
 			totalUnresolved++
 		}
-		if !visibleInFocus(c, s.Focus) {
+		if !visibleInFocusKey(c, focusKey, s.Focus) {
 			continue
 		}
 		rc = append(rc, c)

--- a/internal/session/watch.go
+++ b/internal/session/watch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -228,7 +229,7 @@ func (s *Session) watchGit(stop <-chan struct{}) {
 			s.IncrementEdits()
 			s.notify(SSEEvent{
 				Type:    "edit-detected",
-				Content: fmt.Sprintf("%d", s.GetPendingEdits()),
+				Content: strconv.Itoa(s.GetPendingEdits()),
 			})
 		case <-s.roundComplete:
 			s.handleRoundCompleteGit()
@@ -300,7 +301,7 @@ func (s *Session) watchFileMtimes(stop <-chan struct{}) {
 				s.IncrementEdits()
 				s.notify(SSEEvent{
 					Type:    "edit-detected",
-					Content: fmt.Sprintf("%d", s.GetPendingEdits()),
+					Content: strconv.Itoa(s.GetPendingEdits()),
 				})
 			}
 		case <-s.roundComplete:

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -574,7 +574,7 @@ func buildLocalFingerprintIndex(cj session.CritJSON) (map[string]bool, map[strin
 		}
 	}
 	for _, c := range cj.ReviewComments {
-		key := fmt.Sprintf("%s||0|0", c.Body)
+		key := c.Body + "||0|0"
 		fps[key] = true
 		if c.ID != "" {
 			ids[key] = c.ID

--- a/internal/story/ingest.go
+++ b/internal/story/ingest.go
@@ -6,6 +6,7 @@ package story
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
@@ -104,7 +105,7 @@ func Fingerprint(hunks []HunkID) string {
 		sum.Write([]byte(id))
 		sum.Write([]byte{0})
 	}
-	return fmt.Sprintf("%x", sum.Sum(nil))
+	return hex.EncodeToString(sum.Sum(nil))
 }
 
 // Run validates and (per §8 policy) repairs a story against the live diff.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "update-deps": "node copy-deps.js",
-    "test:frontend": "node web/__tests__/markdown-patch.test.mjs && node web/__tests__/vue-astro-highlight.test.mjs && node web/__tests__/crit-diff-renderer.test.js && node web/__tests__/markdown-replacements.test.js && node web/test-diff-render.mjs"
+    "test:frontend": "node web/__tests__/markdown-patch.test.mjs && node web/__tests__/vue-astro-highlight.test.mjs && node web/__tests__/crit-diff-renderer.test.js && node web/__tests__/markdown-replacements.test.js && node web/test-diff-render.mjs",
+    "test:perf": "node --test web/__tests__/perf/*.perf.test.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.28.2",

--- a/scripts/bench-compare.py
+++ b/scripts/bench-compare.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Gate CI on Go benchmark regressions.
+
+Reads benchstat output (from `benchstat old.txt new.txt` where both files are
+`go test -bench=. -benchmem` results) and fails only on:
+  - time/op: statistically significant slowdown >= TIME_THRESHOLD_PCT (default 20).
+    benchstat marks insignificant rows with `~`; those are ignored.
+  - allocs/op: ANY significant increase. Allocs are deterministic (unlike
+    ns/op on shared runners), so 0 -> N allocs/op always means a heap escape
+    worth a look. Note benchstat prints 0 -> N as `+Inf%`, which counts.
+
+B/op regressions are printed as warnings but never fail (they usually track
+allocs, which already gate).
+
+Usage:
+    benchstat old.txt new.txt | tee benchstat.txt
+    python3 scripts/bench-compare.py benchstat.txt [--time-pct 20]
+
+Exit 0 = no actionable regression, 1 = regression found, 2 = usage/input error.
+"""
+
+import re
+import sys
+
+TIME_THRESHOLD_PCT = 20.0
+
+
+def parse_threshold(args: list) -> float:
+    if "--time-pct" in args:
+        i = args.index("--time-pct")
+        if i + 1 >= len(args):
+            print("error: --time-pct requires a value", file=sys.stderr)
+            sys.exit(2)
+        try:
+            return float(args[i + 1])
+        except ValueError:
+            print(f"error: invalid --time-pct value: {args[i + 1]!r}", file=sys.stderr)
+            sys.exit(2)
+    return TIME_THRESHOLD_PCT
+
+
+def delta_pct(line: str) -> float | None:
+    """Return the delta percent of a benchstat row, or None if no delta.
+
+    Handles benchstat's `+Inf%` for 0 -> N transitions (e.g. 0 -> 2 allocs).
+    """
+    m = re.search(r"\+(\d+(?:\.\d+)?)%", line)
+    if m:
+        return float(m.group(1))
+    if re.search(r"\+Inf%", line, re.IGNORECASE):
+        return float("inf")
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} benchstat.txt [--time-pct 20]", file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    threshold = parse_threshold(sys.argv[1:])
+    time_regs: list = []
+    alloc_regs: list = []
+    mem_warn: list = []
+    table = None  # 'time' | 'alloc' | 'mem' | None
+    saw_table = False
+
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError as e:
+        print(f"error: cannot read {path}: {e}", file=sys.stderr)
+        return 2
+    if not any(line.strip() for line in lines):
+        print(f"error: {path} is empty — no benchstat output to gate on", file=sys.stderr)
+        return 2
+
+    for line in lines:
+        low = line.lower()
+        if "old time/op" in low or "old ns/op" in low:
+            table = "time"
+            saw_table = True
+            continue
+        if "old allocs/op" in low or "old alloc/op" in low:
+            table = "alloc"
+            saw_table = True
+            continue
+        if "old b/op" in low:
+            table = "mem"
+            saw_table = True
+            continue
+        if low.startswith("name ") or not line.strip():
+            if low.startswith("name "):
+                table = None
+            continue
+        if table is None or "~" in line:
+            continue
+        pct = delta_pct(line)
+        if pct is None:
+            continue
+        if table == "time" and pct >= threshold:
+            time_regs.append(line.rstrip())
+        elif table == "alloc" and pct > 0:
+            alloc_regs.append(line.rstrip())
+        elif table == "mem" and pct > 0:
+            mem_warn.append(line.rstrip())
+
+    if not saw_table:
+        print(f"error: {path} contains no benchstat tables — refusing to pass blind", file=sys.stderr)
+        return 2
+
+    failed = False
+    if time_regs:
+        print(f"::error::Significant time/op regression (>= {threshold:g}%):")
+        for r in time_regs:
+            print(f"::error::{r}")
+        failed = True
+    if alloc_regs:
+        print("::error::allocs/op regression (deterministic — likely heap escape):")
+        for r in alloc_regs:
+            print(f"::error::{r}")
+        failed = True
+    for r in mem_warn:
+        print(f"::warning::B/op increase (informational): {r}")
+    if not failed:
+        print("bench check passed: no significant time/op or allocs/op regressions")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-compare.py
+++ b/scripts/bench-compare.py
@@ -76,15 +76,18 @@ def main() -> int:
 
     for line in lines:
         low = line.lower()
-        if "old time/op" in low or "old ns/op" in low:
+        # Benchstat output format varies by version: older versions emit
+        # "old time/op" / "old allocs/op" / "old b/op" headers, newer
+        # versions emit just the unit ("sec/op", "allocs/op", "b/op").
+        if "time/op" in low or "sec/op" in low or "ns/op" in low:
             table = "time"
             saw_table = True
             continue
-        if "old allocs/op" in low or "old alloc/op" in low:
+        if "allocs/op" in low or "alloc/op" in low:
             table = "alloc"
             saw_table = True
             continue
-        if "old b/op" in low:
+        if "b/op" in low:
             table = "mem"
             saw_table = True
             continue

--- a/scripts/bench-compare_test.py
+++ b/scripts/bench-compare_test.py
@@ -82,6 +82,26 @@ class GateTest(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
         self.assertIn("B/op increase", r.stdout)
 
+    def test_new_benchstat_format_time_regression_fails(self):
+        # Newer benchstat versions omit the "old/new" prefix and "name" row.
+        content = (
+            "                               │ bench-old.txt │           bench-new.txt           │\n"
+            "                               │    sec/op     │   sec/op     vs base              │\n"
+            "ComputeLineDiff/100_lines-4      102.25µ ± 1%   130.00µ ± 1%  +27.13% (p=0.002 n=6)\n"
+        )
+        r = run_gate(content)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("time/op regression", r.stdout)
+
+    def test_new_benchstat_format_alloc_regression_fails(self):
+        content = (
+            "                               │   allocs/op   │  allocs/op   vs base                │\n"
+            "ComputeLineDiff/100_lines-4        597.0 ± 0%    600.0 ± 0%   +0.50%  (p=0.002 n=6)\n"
+        )
+        r = run_gate(content)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("allocs/op regression", r.stdout)
+
     def test_missing_file_exits_2(self):
         r = subprocess.run(
             [sys.executable, str(SCRIPT), "/nonexistent/benchstat.txt"],

--- a/scripts/bench-compare_test.py
+++ b/scripts/bench-compare_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression tests for bench-compare.py (the CI bench gate).
+
+The gate cannot detect its own parser regressions, so checked-in benchstat
+samples lock the parsing contract: significant time slowdowns fail, noise
+(~) and sub-threshold deltas pass, ANY allocs increase (including 0 -> N
+rendered as +Inf%) fails, B/op only warns, and malformed input exits 2.
+
+Run: python3 scripts/bench-compare_test.py
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("bench-compare.py")
+
+
+def run_gate(content: str, *args: str) -> subprocess.CompletedProcess:
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        path = f.name
+    try:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), path, *args],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(path).unlink()
+
+
+TIME_TABLE = """\
+name                  old time/op    new time/op    delta
+ComputeLineDiff-8     1.00µs ± 2%    {new}           {delta}
+"""
+
+ALLOC_TABLE = """\
+name                  old allocs/op  new allocs/op  delta
+VisibleInFocus-8      {old}          {new}           {delta}
+"""
+
+
+class GateTest(unittest.TestCase):
+    def test_significant_time_regression_fails(self):
+        r = run_gate(TIME_TABLE.format(new="1.26µs ± 2%", delta="+26.00%  (p=0.008 n=6+6)"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("time/op regression", r.stdout)
+
+    def test_subthreshold_time_passes(self):
+        r = run_gate(TIME_TABLE.format(new="1.05µs ± 2%", delta="+5.00%  (p=0.010 n=6+6)"))
+        self.assertEqual(r.returncode, 0)
+
+    def test_insignificant_row_passes(self):
+        r = run_gate(TIME_TABLE.format(new="1.30µs ±20%", delta="~     (p=0.300 n=6+6)"))
+        self.assertEqual(r.returncode, 0)
+
+    def test_alloc_increase_fails(self):
+        r = run_gate(ALLOC_TABLE.format(old="100 ± 0%", new="130 ± 0%", delta="+30.00%  (p=0.008 n=6+6)"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("allocs/op regression", r.stdout)
+
+    def test_alloc_zero_to_n_fails(self):
+        # benchstat renders 0 -> N as +Inf% — the heap-escape case that must fail.
+        r = run_gate(ALLOC_TABLE.format(old="0.00 ± 0%", new="2.00 ± 0%", delta="+Inf%  (p=0.008 n=6+6)"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("allocs/op regression", r.stdout)
+
+    def test_alloc_stable_passes(self):
+        r = run_gate(ALLOC_TABLE.format(old="100 ± 0%", new="100 ± 0%", delta="~     (all equal)"))
+        self.assertEqual(r.returncode, 0)
+
+    def test_bop_only_warns(self):
+        content = (
+            TIME_TABLE.format(new="1.01µs ± 2%", delta="~     (p=0.300 n=6+6)")
+            + "\nname                  old B/op       new B/op      delta\n"
+            + "VisibleInFocus-8        0.00 ± 0%     16.00 ± 0%   +Inf%  (p=0.008 n=6+6)\n"
+        )
+        r = run_gate(content)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("B/op increase", r.stdout)
+
+    def test_missing_file_exits_2(self):
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "/nonexistent/benchstat.txt"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(r.returncode, 2)
+
+    def test_empty_input_exits_2(self):
+        r = run_gate("")
+        self.assertEqual(r.returncode, 2)
+
+    def test_no_tables_exits_2(self):
+        r = run_gate("some log output without any benchstat tables\n")
+        self.assertEqual(r.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-asset-budget.sh
+++ b/scripts/check-asset-budget.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check-asset-budget.sh — fail CI when embedded assets or the binary blow past budget.
+#
+# crit ships every file in web/ inside the Go binary (embed.FS), so a heavy
+# vendor bump or an accidentally committed fixture inflates both page weight
+# and binary size. This script checks gzip sizes from asset-budget.json
+# plus a linux/amd64 binary build. No bundler involved — plain file sizes.
+#
+# Usage: bash scripts/check-asset-budget.sh [--binary-only|--web-only]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUDGET="$ROOT/asset-budget.json"
+MODE="${1:-all}"
+FAIL=0
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 2; }; }
+need node
+need gzip
+
+get() { node -e "const b=require('$BUDGET'); process.stdout.write(String($1));"; }
+
+check_file() {
+  local rel="$1" cap="$2"
+  local f="$ROOT/$rel"
+  if [ ! -f "$f" ]; then echo "MISS  $rel (not found)"; FAIL=1; return; fi
+  local size
+  size=$(gzip -9 -c "$f" | wc -c | tr -d ' ')
+  if [ "$size" -gt "$cap" ]; then
+    echo "OVER  $rel gzip=${size}B cap=${cap}B (+$((size - cap))B)"
+    FAIL=1
+  else
+    echo "ok    $rel gzip=${size}B cap=${cap}B"
+  fi
+}
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "--web-only" ]; then
+  echo "== web assets (gzip) =="
+  while IFS= read -r row; do
+    check_file "$(echo "$row" | cut -d' ' -f1)" "$(echo "$row" | cut -d' ' -f2)"
+  done < <(node -e "const b=require('$BUDGET'); for (const f of b.files) console.log(f.path+' '+f.gzipBytes);")
+
+  total_cap=$(get 'b.totalJsGzipBytes')
+  total=$(cat "$ROOT"/web/*.js | gzip -9 -c | wc -c | tr -d ' ')
+  if [ "$total" -gt "$total_cap" ]; then
+    echo "OVER  web/*.js (total) gzip=${total}B cap=${total_cap}B (+$((total - total_cap))B)"
+    FAIL=1
+  else
+    echo "ok    web/*.js (total) gzip=${total}B cap=${total_cap}B"
+  fi
+
+  echo "== module globs (gzip) =="
+  while IFS= read -r row; do
+    pattern=$(echo "$row" | cut -d' ' -f1)
+    cap=$(echo "$row" | cut -d' ' -f2)
+    # shellcheck disable=SC2086 — glob must expand unquoted by design
+    size=$(cat $ROOT/$pattern | gzip -9 -c | wc -c | tr -d ' ')
+    if [ "$size" -gt "$cap" ]; then
+      echo "OVER  $pattern (total) gzip=${size}B cap=${cap}B (+$((size - cap))B)"
+      FAIL=1
+    else
+      echo "ok    $pattern (total) gzip=${size}B cap=${cap}B"
+    fi
+  done < <(node -e "const b=require('$BUDGET'); for (const g of (b.globs || [])) console.log(g.pattern+' '+g.gzipBytes);")
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "--binary-only" ]; then
+  echo "== binary =="
+  need go
+  bin_cap=$(get 'b.binaryBytes')
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+  out="$tmpdir/crit-sizeprobe"
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o "$out" ./cmd/crit
+  size=$(wc -c < "$out" | tr -d ' ')
+  rm -rf "$tmpdir"
+  trap - EXIT
+  if [ "$size" -gt "$bin_cap" ]; then
+    echo "OVER  crit binary (linux/amd64) ${size}B cap=${bin_cap}B (+$((size - bin_cap))B)"
+    FAIL=1
+  else
+    echo "ok    crit binary (linux/amd64) ${size}B cap=${bin_cap}B"
+  fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "asset budget exceeded — if the growth is intentional, update caps in asset-budget.json" >&2
+  exit 1
+fi
+echo "asset budget: all within caps"

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -13,6 +13,8 @@ const SHARE_PORT = process.env.CRIT_TEST_SHARE_PORT || '3132';
 // Stub crit-web backing the share-transport project. The spec talks to it
 // directly for seeding and assertions, so it needs the port too.
 const STUB_PORT = process.env.CRIT_TEST_STUB_PORT || '3133';
+// Large-review perf fixture (300 files / ~9k changed lines + big markdown).
+const PERF_PORT = process.env.CRIT_TEST_PERF_PORT || '3134';
 // Mobile project re-uses the git-mode fixture — no separate server needed.
 const MOBILE_PORT = GIT_PORT;
 const debug = !!process.env.E2E_DEBUG;
@@ -46,7 +48,7 @@ export default defineConfig({
   projects: [
     {
       name: 'git-mode',
-      testMatch: /^(?!.*\.(filemode|singlefile|multifile|nogit|rangemode|mobile|livemode|sharetransport)\.).*\.spec\.ts$/,
+      testMatch: /^(?!.*\.(filemode|singlefile|multifile|nogit|rangemode|mobile|livemode|sharetransport|perf)\.).*\.spec\.ts$/,
       use: {
         browserName: 'chromium',
         baseURL: `http://localhost:${GIT_PORT}`,
@@ -131,6 +133,17 @@ export default defineConfig({
         baseURL: `http://localhost:${SHARE_PORT}`,
       },
     },
+    {
+      // Perf guardrails against a 300-file / ~9k-line review. Asserts
+      // structural budgets (mounted bodies, DOM nodes, longtask TBT), not
+      // wall-clock time, so it stays green on slow runners.
+      name: 'perf',
+      testMatch: /\.perf\.spec\.ts$/,
+      use: {
+        browserName: 'chromium',
+        baseURL: `http://localhost:${PERF_PORT}`,
+      },
+    },
   ],
 
   webServer: [
@@ -188,6 +201,15 @@ export default defineConfig({
       url: `http://localhost:${SHARE_PORT}/api/session`,
       reuseExistingServer: true,
       timeout: 60_000,
+      stdout: 'pipe',
+    },
+    {
+      command: `bash setup-fixtures-perf.sh ${PERF_PORT}`,
+      url: `http://localhost:${PERF_PORT}/api/session`,
+      reuseExistingServer: true,
+      // Fixture generates 300 files (+ optional go build when CRIT_BIN is
+      // unset, e.g. cold local runs outside run.sh which prebuilds).
+      timeout: 120_000,
       stdout: 'pipe',
     },
   ],

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -15,6 +15,7 @@ RANGE_PORT="${CRIT_TEST_RANGE_PORT:-3128}"
 LIVE_PORT="${CRIT_TEST_LIVE_PORT:-3129}"
 SHARE_PORT="${CRIT_TEST_SHARE_PORT:-3132}"
 STUB_PORT="${CRIT_TEST_STUB_PORT:-3133}"
+PERF_PORT="${CRIT_TEST_PERF_PORT:-3134}"
 
 # Build crit once (skip if CRIT_BIN already points to an existing binary, e.g. CI coverage builds)
 if [ -n "${CRIT_BIN:-}" ] && [ -f "$CRIT_BIN" ]; then
@@ -35,7 +36,7 @@ fi
 (cd "$SCRIPT_DIR" && npx playwright install chromium)
 
 # Kill any stale processes on our test ports before starting fresh
-for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT" "$STUB_PORT"; do
+for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT" "$STUB_PORT" "$PERF_PORT"; do
   e2e_kill_port "$port"
 done
 
@@ -59,10 +60,12 @@ bash setup-fixtures-livemode.sh "$LIVE_PORT" &
 LIVE_PID=$!
 bash setup-fixtures-sharetransport.sh "$SHARE_PORT" "$STUB_PORT" &
 SHARE_PID=$!
+bash setup-fixtures-perf.sh "$PERF_PORT" &
+PERF_PID=$!
 
 cleanup() {
-  kill "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" 2>/dev/null || true
-  wait "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" 2>/dev/null || true
+  kill "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" "$PERF_PID" 2>/dev/null || true
+  wait "$GIT_PID" "$GIT2_PID" "$FILE_PID" "$SINGLE_PID" "$NOGIT_PID" "$MULTI_PID" "$RANGE_PID" "$LIVE_PID" "$SHARE_PID" "$PERF_PID" 2>/dev/null || true
   # On Git Bash `kill <bash-pid>` doesn't reap the spawned crit.exe child;
   # taskkill /T flushes the whole tree.
   e2e_kill_stray_crit
@@ -71,7 +74,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Wait for servers to be ready
-for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT"; do
+for port in "$GIT_PORT" "$GIT2_PORT" "$FILE_PORT" "$SINGLE_PORT" "$NOGIT_PORT" "$MULTI_PORT" "$RANGE_PORT" "$LIVE_PORT" "$SHARE_PORT" "$PERF_PORT"; do
   while ! curl -sf "http://localhost:$port/api/session" >/dev/null 2>&1; do
     sleep 0.1
   done
@@ -101,6 +104,8 @@ if [ $# -eq 0 ]; then
   PW_LIVE=$!
   npx playwright test --project=share-transport > "$PWLOGS/share.log" 2>&1 &
   PW_SHARE=$!
+  npx playwright test --project=perf > "$PWLOGS/perf.log" 2>&1 &
+  PW_PERF=$!
 
   # Mobile shares the git-mode fixture (port 3123) and both projects call
   # DELETE /api/comments in beforeEach, so they must not overlap. Wait for
@@ -122,6 +127,7 @@ if [ $# -eq 0 ]; then
   wait $PW_RANGE  || FAILED=1
   wait $PW_LIVE   || FAILED=1
   wait $PW_SHARE  || FAILED=1
+  wait $PW_PERF   || FAILED=1
   if [ -n "${PW_MOBILE:-}" ]; then
     wait $PW_MOBILE || FAILED=1
   fi

--- a/test/e2e/setup-fixtures-perf.sh
+++ b/test/e2e/setup-fixtures-perf.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Perf fixture: a 300-file review (~9k changed lines) plus one large markdown
+# file, mirroring the shape measured in the lazy-loading fix (27f33c8:
+# 300 files / 9,000 changed lines, 999k DOM nodes before the fix).
+#
+# Serves git mode on the given port for *.perf.spec.ts (perf project).
+# Files beyond lazyFileThreshold (25) stay lazy until scrolled near.
+set -euo pipefail
+
+PORT="${1:-3134}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CRIT_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+DIR=$(e2e_native_tempdir)
+BIN_DIR=$(e2e_native_tempdir)
+trap 'rm -rf "$DIR" "$BIN_DIR" "${FAKE_HOME:-}"' EXIT
+
+cd "$DIR"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config core.autocrlf false
+git config core.eol lf
+
+# === Initial commit: 300 small code files + one markdown file ===
+for i in $(seq 1 300); do
+  cat > "file$i.go" << GOFILE
+package perf$i
+
+// Doc comment for file $i.
+func Hello$i() string {
+	return "hello $i"
+}
+
+func Add$i(a, b int) int {
+	return a + b
+}
+GOFILE
+done
+
+# Large markdown, initial version (~1200 lines).
+{
+  echo "# Perf Plan"
+  echo ""
+  for i in $(seq 1 200); do
+    echo "## Section $i"
+    echo ""
+    echo "This section describes part $i of the plan with some detail."
+    echo ""
+    echo "- item one for $i"
+    echo "- item two for $i"
+    echo ""
+  done
+} > plan-big.md
+
+git add -A
+git commit -q -m "initial commit"
+
+# === Feature branch: touch every file ===
+git checkout -q -b perf/large-review
+
+for i in $(seq 1 300); do
+  cat >> "file$i.go" << GOFILE
+
+// Goodbye$i is new on the branch.
+func Goodbye$i() string {
+	return "goodbye $i"
+}
+GOFILE
+done
+
+# Grow the markdown to ~3000 lines with mixed block types.
+{
+  echo "# Perf Plan"
+  echo ""
+  for i in $(seq 1 400); do
+    echo "## Section $i"
+    echo ""
+    echo "This section describes part $i of the plan with some detail."
+    echo ""
+    echo "- item one for $i"
+    echo "  - nested item for $i"
+    echo "- item two for $i"
+    echo ""
+    echo '```go'
+    echo "func Section$i() {}"
+    echo '```'
+    echo ""
+  done
+} > plan-big.md
+
+git add -A
+git commit -q -m "perf: large review fixture"
+
+# Build crit binary outside the repo (skip if CRIT_BIN is set)
+if [ -z "${CRIT_BIN:-}" ]; then
+  CRIT_BIN="$BIN_DIR/$(e2e_bin_name)"
+  (cd "$CRIT_SRC" && go build -o "$CRIT_BIN" ./cmd/crit)
+fi
+
+FAKE_HOME=$(e2e_native_tempdir)
+e2e_export_fake_home "$FAKE_HOME"
+
+STATE_FILE="$(e2e_state_file "$PORT")"
+{
+  echo "CRIT_BIN=$CRIT_BIN"
+  echo "CRIT_FIXTURE_DIR=$DIR"
+  echo "FAKE_HOME=$FAKE_HOME"
+} > "$STATE_FILE"
+
+echo '{"agent_cmd": "echo"}' > "$FAKE_HOME/.crit.config.json"
+
+# Run crit in the fixture repo (git mode: branch diff vs default branch)
+exec "$CRIT_BIN" _serve --no-open --port "$PORT"

--- a/test/e2e/tests/large-review.perf.spec.ts
+++ b/test/e2e/tests/large-review.perf.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loadPage, clearAllComments } from './helpers';
+
+// Perf guardrails for large reviews (300 files / ~9k changed lines fixture).
+//
+// These assert structural invariants — mounted body count, DOM size, and
+// longtask-blocked main thread — rather than wall-clock time, so they only
+// fail on real regressions (e.g. mounting every file eagerly, the bug class
+// fixed in 27f33c8) and not on runner noise. Wall clock is logged, not gated.
+//
+// Budgets carry 2-4x headroom over the post-lazy-loading steady state
+// (25 mounted bodies, ~93k DOM nodes, ~0ms blocked on the reference
+// 300-file measurement).
+
+test.beforeEach(async ({ request }) => {
+  await clearAllComments(request);
+});
+
+// Total Blocking Time (sum of longtask duration beyond 50ms each).
+async function installLongtaskObserver(page: Page) {
+  await page.addInitScript(() => {
+    (window as unknown as { __longtasks: number[] }).__longtasks = [];
+    try {
+      new PerformanceObserver((list) => {
+        const acc = (window as unknown as { __longtasks: number[] }).__longtasks;
+        for (const entry of list.getEntries()) acc.push(entry.duration);
+      }).observe({ type: 'longtask', buffered: true });
+    } catch {
+      // PerformanceObserver/longtask unavailable — metrics read as zero.
+    }
+  });
+}
+
+async function longtaskTBT(page: Page): Promise<number> {
+  const durations = await page.evaluate(
+    () => (window as unknown as { __longtasks?: number[] }).__longtasks ?? []
+  );
+  return durations.reduce((sum, d) => sum + Math.max(0, d - 50), 0);
+}
+
+async function domNodeCount(page: Page): Promise<number> {
+  return page.evaluate(() => document.getElementsByTagName('*').length);
+}
+
+function mountedBodies(page: Page) {
+  return page.locator('.file-body:not([data-body-deferred])');
+}
+
+test('large review initial render stays within DOM and longtask budgets', async ({ page }) => {
+  await installLongtaskObserver(page);
+  await loadPage(page);
+
+  // All 301 files render as sections (headers are cheap; bodies defer).
+  await expect(page.locator('.file-section')).toHaveCount(301);
+
+  // Only the eager set (~25) plus viewport slack is ever mounted. Polled,
+  // not snapshotted: mount/defer settles asynchronously after load.
+  await expect.poll(() => mountedBodies(page).count()).toBeLessThanOrEqual(40);
+  const mounted = await mountedBodies(page).count();
+
+  const nodes = await domNodeCount(page);
+  console.log(`initial render: mounted=${mounted} domNodes=${nodes}`);
+  expect(nodes).toBeLessThan(200_000);
+
+  const tbt = await longtaskTBT(page);
+  console.log(`initial render: longtaskTBT=${Math.round(tbt)}ms`);
+  expect(tbt).toBeLessThan(8000);
+});
+
+test('scrolling a large review keeps bodies deferred and main thread free', async ({ page }) => {
+  await installLongtaskObserver(page);
+  await loadPage(page);
+  await expect(page.locator('.file-section')).toHaveCount(301);
+
+  const tbtBefore = await longtaskTBT(page);
+  const wallStart = Date.now();
+
+  // Scripted top-down scroll in viewport steps, yielding two frames per step
+  // so the IntersectionObserver mounter runs as it would for a human reader.
+  await page.evaluate(async () => {
+    const height = () => document.documentElement.scrollHeight;
+    for (let y = 0; y < height(); y += 600) {
+      window.scrollTo(0, y);
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    }
+    window.scrollTo(0, 0);
+  });
+
+  const wallMs = Date.now() - wallStart;
+  const scrollTBT = (await longtaskTBT(page)) - tbtBefore;
+
+  // Steady state after a full pass: back near the eager set, not 300 mounted.
+  // Polled: far-offscreen bodies defer asynchronously after scrolling stops.
+  await expect.poll(() => mountedBodies(page).count()).toBeLessThanOrEqual(40);
+  const mounted = await mountedBodies(page).count();
+  const nodes = await domNodeCount(page);
+  console.log(`scroll: wall=${wallMs}ms scrollTBT=${Math.round(scrollTBT)}ms mounted=${mounted} domNodes=${nodes}`);
+
+  expect(nodes).toBeLessThan(200_000);
+  expect(scrollTBT).toBeLessThan(8000);
+});

--- a/web/__tests__/perf/bench-utils.mjs
+++ b/web/__tests__/perf/bench-utils.mjs
@@ -1,0 +1,49 @@
+// Shared helpers for frontend perf microbenchmarks (node --test).
+//
+// Pattern: deterministic seeded fixture -> warmup -> median-of-N -> budget
+// assert. Budgets are generous (10-50x measured) on purpose: these guard
+// against algorithmic regressions (accidental quadratic, lost early-out),
+// not against 5% noise. Tight timing gates belong in local benchstat-style
+// comparison, not in CI asserts.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Deterministic PRNG (mulberry32) so fixtures are stable across runs without
+// checking in multi-thousand-line files.
+export function mulberry32(seed) {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Run `fn` (sync) after `warmup` untimed iterations, then return the median
+// of `iters` timed iterations in milliseconds.
+export function medianMs(fn, { warmup = 3, iters = 5 } = {}) {
+  for (let i = 0; i < warmup; i++) fn();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    fn();
+    samples.push(performance.now() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  return samples[Math.floor(samples.length / 2)];
+}
+
+// Define a budget test: measures medianMs(fn) and fails if it exceeds budgetMs.
+export function budgetTest(name, fn, budgetMs, opts) {
+  test(name, () => {
+    const median = medianMs(fn, opts);
+    console.log(`  ${name}: median ${median.toFixed(1)}ms (budget ${budgetMs}ms)`);
+    assert.ok(
+      median < budgetMs,
+      `${name}: median ${median.toFixed(1)}ms exceeds budget ${budgetMs}ms`
+    );
+  });
+}

--- a/web/__tests__/perf/highlight-split.perf.test.mjs
+++ b/web/__tests__/perf/highlight-split.perf.test.mjs
@@ -1,0 +1,57 @@
+// Perf: splitHighlightedCode on a 2000-line highlighted code block.
+// Run: npm run test:perf.
+//
+// splitHighlightedCode tracks open <span> tags across lines to preserve
+// syntax highlighting when fences are split per-line. A 2000-line fence is
+// the realistic worst case (large generated code blocks in plans).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { medianMs } from './bench-utils.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'crit-line-blocks.js'), 'utf8');
+
+function loadLineBlocks() {
+  const sandbox = {
+    window: {
+      crit: {
+        commentCardHelpers: {
+          escapeHtml: (s) =>
+            String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+        },
+      },
+      hljs: null,
+    },
+    document: {},
+  };
+  const fn = new Function('window', 'document', src + '\nreturn window;');
+  fn(sandbox.window, sandbox.document);
+  return sandbox.window.crit.lineBlocks;
+}
+
+const lineBlocks = loadLineBlocks();
+
+// Simulate hljs output: every line wrapped in spans, some spans left open
+// across lines (multi-line strings/comments) to exercise the tag tracker.
+let highlighted = '';
+for (let i = 0; i < 2000; i++) {
+  if (i % 50 === 0) highlighted += '<span class="hljs-comment">/* multi-line comment starts ' + i + '\n';
+  else if (i % 50 === 25) highlighted += 'comment ends ' + i + ' */</span>\n';
+  else
+    highlighted +=
+      '<span class="hljs-keyword">const</span> x' + i + ' = <span class="hljs-string">"value ' + i + '"</span>;\n';
+}
+
+test('perf: splitHighlightedCode on 2000-line block stays within budget', () => {
+  let n = 0;
+  const median = medianMs(() => {
+    n = lineBlocks.splitHighlightedCode(highlighted).length;
+  });
+  console.log(`  splitHighlightedCode: median ${median.toFixed(1)}ms for ${n} lines (budget 1000ms)`);
+  assert.ok(n >= 2000, `expected >= 2000 lines, got ${n}`);
+  assert.ok(median < 1000, `splitHighlightedCode median ${median.toFixed(1)}ms exceeds 1000ms`);
+});

--- a/web/__tests__/perf/line-blocks.perf.test.mjs
+++ b/web/__tests__/perf/line-blocks.perf.test.mjs
@@ -1,0 +1,128 @@
+// Perf: markdown parse + buildLineBlocks on a 10k-line plan fixture.
+// Run: npm run test:perf (also runs under plain node --test discovery).
+//
+// This is the core document-render path for large AI-generated plans.
+// Budgets are ~50x measured (parse ~35ms, blocks ~10ms on M4) so CI only
+// fails on algorithmic regressions, never on runner noise.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { mulberry32, medianMs } from './bench-utils.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const markdownit = require('markdown-it');
+
+const src = readFileSync(resolve(__dirname, '..', '..', 'crit-line-blocks.js'), 'utf8');
+
+function loadLineBlocks() {
+  const sandbox = {
+    window: {
+      crit: {
+        commentCardHelpers: {
+          escapeHtml: (s) =>
+            String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+        },
+      },
+      hljs: {
+        getLanguage: () => false,
+        highlight: (content) => ({ value: content }),
+      },
+    },
+    document: {},
+  };
+  const fn = new Function('window', 'document', src + '\nreturn window;');
+  fn(sandbox.window, sandbox.document);
+  return sandbox.window.crit.lineBlocks;
+}
+
+// Deterministic 10k-line markdown mixing every block type the splitter drills
+// into: headings, paragraphs, lists (nested), fences, tables, blockquotes.
+function buildFixture() {
+  const rand = mulberry32(42);
+  const pick = (arr) => arr[Math.floor(rand() * arr.length)];
+  const words = [
+    'review', 'session', 'diff', 'hunk', 'comment', 'focus', 'range', 'stack',
+    'markdown', 'render', 'lazy', 'threshold', 'viewport', 'gutter', 'syntax',
+    'highlight', 'token', 'block', 'quote', 'table',
+  ];
+  const sentence = () => {
+    const n = 5 + Math.floor(rand() * 12);
+    const out = [];
+    for (let i = 0; i < n; i++) out.push(pick(words));
+    return out.join(' ') + '.';
+  };
+  const lines = [];
+  let i = 0;
+  while (i < 10000) {
+    const r = rand();
+    if (r < 0.35) {
+      lines.push('## Section ' + i + ' ' + sentence());
+      i++;
+      const n = 3 + Math.floor(rand() * 6);
+      for (let k = 0; k < n && i < 10000; k++, i++) lines.push(sentence());
+    } else if (r < 0.5) {
+      lines.push('- ' + sentence());
+      i++;
+      const n = 2 + Math.floor(rand() * 6);
+      for (let k = 0; k < n && i < 10000; k++, i++)
+        lines.push((rand() < 0.3 ? '  - ' : '- ') + sentence());
+    } else if (r < 0.6) {
+      lines.push('```js');
+      i++;
+      const n = 5 + Math.floor(rand() * 20);
+      for (let k = 0; k < n && i < 10000; k++, i++)
+        lines.push('const x' + k + ' = "' + sentence() + '";');
+      lines.push('```');
+      i++;
+    } else if (r < 0.68) {
+      lines.push('| a | b | c |');
+      lines.push('|---|---|---|');
+      i += 2;
+      const n = 3 + Math.floor(rand() * 5);
+      for (let k = 0; k < n && i < 10000; k++, i++)
+        lines.push('| ' + sentence() + ' | ' + sentence() + ' | ' + sentence() + ' |');
+    } else if (r < 0.74) {
+      lines.push('> ' + sentence());
+      i++;
+      if (rand() < 0.5) {
+        lines.push('> ' + sentence());
+        i++;
+      }
+    } else {
+      lines.push(sentence());
+      i++;
+      if (rand() < 0.3) {
+        lines.push('');
+        i++;
+      }
+    }
+  }
+  return lines.slice(0, 10000).join('\n');
+}
+
+const content = buildFixture();
+const md = markdownit({ html: true });
+const lineBlocks = loadLineBlocks();
+
+test('perf: markdown-it parse of 10k-line fixture stays within budget', () => {
+  const median = medianMs(() => md.parse(content, {}));
+  console.log(`  parse: median ${median.toFixed(1)}ms (budget 2000ms)`);
+  assert.ok(median < 2000, `parse median ${median.toFixed(1)}ms exceeds 2000ms`);
+});
+
+test('perf: buildLineBlocks on 10k-line fixture stays within budget', () => {
+  const tokens = md.parse(content, {});
+  let nBlocks = 0;
+  const median = medianMs(() => {
+    const blocks = lineBlocks.buildLineBlocks(tokens, md, content);
+    nBlocks = blocks.length;
+  });
+  console.log(`  buildLineBlocks: median ${median.toFixed(1)}ms for ${nBlocks} blocks (budget 2000ms)`);
+  assert.ok(nBlocks > 1000, `expected thousands of blocks, got ${nBlocks}`);
+  assert.ok(median < 2000, `buildLineBlocks median ${median.toFixed(1)}ms exceeds 2000ms`);
+});

--- a/web/__tests__/perf/word-diff.perf.test.mjs
+++ b/web/__tests__/perf/word-diff.perf.test.mjs
@@ -1,0 +1,102 @@
+// Perf: word-diff pairing + intra-line diff on realistic hunk shapes.
+// Run: npm run test:perf.
+//
+// Production caps bound this path (pairing skipped past 8 del+add lines,
+// wordDiff skipped past 500 chars), so these benches lock the capped worst
+// case: a 4x4 pairing set and 500-char lines. If someone loosens a cap, the
+// bench — not a user's tab — finds out first.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { mulberry32, medianMs } from './bench-utils.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'crit-diff-renderer.js'), 'utf8');
+
+function loadDiffRenderer() {
+  const mockDMP = {
+    DIFF_EQUAL: 0,
+    DIFF_DELETE: -1,
+    DIFF_INSERT: 1,
+    makeDiff(a, b) {
+      if (a === b) return [[0, a]];
+      let i = 0;
+      while (i < a.length && i < b.length && a[i] === b[i]) i++;
+      let j = 0;
+      while (j < a.length - i && j < b.length - i && a[a.length - 1 - j] === b[b.length - 1 - j]) j++;
+      const out = [];
+      if (i > 0) out.push([0, a.slice(0, i)]);
+      const del = a.slice(i, a.length - j);
+      const ins = b.slice(i, b.length - j);
+      if (del) out.push([-1, del]);
+      if (ins) out.push([1, ins]);
+      if (j > 0) out.push([0, a.slice(a.length - j)]);
+      return out;
+    },
+    cleanupSemantic(diffs) {
+      return diffs;
+    },
+  };
+  const sandbox = {
+    window: {
+      crit: {
+        commentCardHelpers: {
+          escapeHtml: (s) =>
+            String(s)
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;'),
+        },
+      },
+      DiffMatchPatch: mockDMP,
+    },
+    document: {},
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+  const fn = new Function('window', 'document', 'NodeFilter', src + '\nreturn window;');
+  fn(sandbox.window, sandbox.document, sandbox.NodeFilter);
+  return sandbox.window.crit.diffRenderer;
+}
+
+const diffRenderer = loadDiffRenderer();
+const rand = mulberry32(7);
+const words = ['function', 'return', 'const', 'process', 'value', 'offset', 'delta', 'result', 'index', 'length'];
+
+function codeLine(n) {
+  const parts = [];
+  while (parts.join(' ').length < n) parts.push(words[Math.floor(rand() * words.length)] + '_' + Math.floor(rand() * 1000));
+  return parts.join(' ').slice(0, n);
+}
+
+// Max-capped pairing shape: 4 removed + 4 added lines (del+add == 8).
+const removed = [codeLine(120), codeLine(120), codeLine(120), codeLine(120)];
+const added = removed.map((l) => l.replace(/_\d+/, '_changed'));
+
+test('perf: bestWordDiffPairing on capped 4x4 hunk stays within budget', () => {
+  let pairs = 0;
+  const median = medianMs(() => {
+    for (let i = 0; i < 500; i++) pairs = diffRenderer.bestWordDiffPairing(removed, added).length;
+  });
+  console.log(`  bestWordDiffPairing x500: median ${median.toFixed(1)}ms (budget 1000ms)`);
+  assert.ok(pairs > 0, 'expected non-empty pairing');
+  assert.ok(median < 1000, `pairing median ${median.toFixed(1)}ms exceeds 1000ms`);
+});
+
+test('perf: wordDiff on capped 500-char lines stays within budget', () => {
+  // 480 chars: stays under the 500-char wordDiff perf guard even after the
+  // single-token substitution below makes `b` a few chars longer.
+  const a = codeLine(480);
+  const b = a.replace(/_\d+/, '_changed');
+  // Guard the bench itself: at least one call must do real diff work
+  // (non-null) or the budget asserts against an early-out path.
+  assert.ok(diffRenderer.wordDiff(a, b) !== null, 'fixture lines must produce a real word diff');
+  const median = medianMs(() => {
+    for (let i = 0; i < 100; i++) diffRenderer.wordDiff(a, b);
+  });
+  console.log(`  wordDiff x100: median ${median.toFixed(1)}ms (budget 1000ms)`);
+  assert.ok(median < 1000, `wordDiff median ${median.toFixed(1)}ms exceeds 1000ms`);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3070,6 +3070,7 @@
 
     // Two-pointer merge for horizontal alignment
     const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
+    const fileForms = getFormsForFile(file.path);
     let oldIdx = 0, newIdx = 0;
 
     while (oldIdx < prevBlocks.length || newIdx < currBlocks.length) {
@@ -3080,30 +3081,30 @@
 
       if (oldIdx >= prevBlocks.length) {
         // Old exhausted — remaining new blocks are additions
-        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet));
+        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         newIdx++;
       } else if (newIdx >= currBlocks.length) {
         // New exhausted — remaining old blocks are deletions
-        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null));
+        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null, fileForms));
         oldIdx++;
       } else if (prevBlocks[oldIdx].isDiff && currBlocks[newIdx].isDiff) {
         // Both changed — paired change
-        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null));
-        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet));
+        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null, fileForms));
+        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         oldIdx++;
         newIdx++;
       } else if (prevBlocks[oldIdx].isDiff) {
         // Old removed only — spacer on right
-        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null));
+        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null, fileForms));
         oldIdx++;
       } else if (currBlocks[newIdx].isDiff) {
         // New added only — spacer on left
-        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet));
+        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         newIdx++;
       } else {
         // Both unchanged — render both, advance both
-        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], null, file, false, oldIdx, null, null));
-        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], null, file, true, newIdx, commentsMap, commentRangeSet));
+        leftCell.appendChild(renderUnifiedBlock(prevBlocks[oldIdx], null, file, false, oldIdx, null, null, fileForms));
+        rightCell.appendChild(renderUnifiedBlock(currBlocks[newIdx], null, file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         oldIdx++;
         newIdx++;
       }
@@ -3112,6 +3113,7 @@
       container.appendChild(rightCell);
     }
 
+    attachDocGutterMouseHandler(container);
     return container;
   }
 
@@ -3124,7 +3126,9 @@
 
   // Render a single block for the unified diff view.
   // When commentable=true, includes gutter, keyboard nav, comments. Otherwise read-only.
-  function renderUnifiedBlock(block, diffClass, file, commentable, blockIndex, commentsMap, commentRangeSet) {
+  // fileForms is threaded down from the top-level render (one filtered array
+  // per file render instead of one per block); callers must pass it.
+  function renderUnifiedBlock(block, diffClass, file, commentable, blockIndex, commentsMap, commentRangeSet, fileForms) {
     const frag = document.createDocumentFragment();
 
     const lineBlockEl = document.createElement('div');
@@ -3158,7 +3162,8 @@
       lineAdd.className = 'line-add';
       lineAdd.textContent = '+';
       commentGutter.appendChild(lineAdd);
-      commentGutter.addEventListener('mousedown', handleGutterMouseDown);
+      // Mousedown is delegated once per container (attachDocGutterMouseHandler),
+      // not per gutter — see #657 for the diff-button equivalent.
       lineBlockEl.appendChild(commentGutter);
     } else {
       // Non-commentable block: still add gutter but mark as read-only
@@ -3195,10 +3200,10 @@
           frag.appendChild(createCommentElement(blockComments[ci], file.path));
         }
       }
-      const fileForms = getFormsForFile(file.path);
-      for (let fi = 0; fi < fileForms.length; fi++) {
-        if (!fileForms[fi].editingId && fileForms[fi].afterBlockIndex === blockIndex) {
-          frag.appendChild(createCommentForm(fileForms[fi]));
+      const forms = fileForms || getFormsForFile(file.path);
+      for (let fi = 0; fi < forms.length; fi++) {
+        if (!forms[fi].editingId && forms[fi].afterBlockIndex === blockIndex) {
+          frag.appendChild(createCommentForm(forms[fi]));
         }
       }
     }
@@ -3215,6 +3220,7 @@
     const newBlocks = file.lineBlocks;
 
     const { commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
+    const fileForms = getFormsForFile(file.path);
 
     // Two-pointer merge: walk both block lists simultaneously
     let oldIdx = 0;
@@ -3223,11 +3229,11 @@
     while (oldIdx < oldBlocks.length || newIdx < newBlocks.length) {
       if (oldIdx >= oldBlocks.length) {
         // Old exhausted — remaining new blocks are additions
-        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet));
+        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         newIdx++;
       } else if (newIdx >= newBlocks.length) {
         // New exhausted — remaining old blocks are deletions
-        container.appendChild(renderUnifiedBlock(oldBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null));
+        container.appendChild(renderUnifiedBlock(oldBlocks[oldIdx], 'diff-removed', file, false, oldIdx, null, null, fileForms));
         oldIdx++;
       } else if (classifyBlock(oldBlocks[oldIdx], lineSets.removed)) {
         // Collect consecutive removed blocks
@@ -3251,23 +3257,24 @@
         }
         // Emit all removed then all added
         for (let ri = 0; ri < removedRun.length; ri++) {
-          container.appendChild(renderUnifiedBlock(oldBlocks[removedRun[ri]], 'diff-removed', file, false, removedRun[ri], null, null));
+          container.appendChild(renderUnifiedBlock(oldBlocks[removedRun[ri]], 'diff-removed', file, false, removedRun[ri], null, null, fileForms));
         }
         for (let ai = 0; ai < addedRun.length; ai++) {
-          container.appendChild(renderUnifiedBlock(newBlocks[addedRun[ai]], 'diff-added', file, true, addedRun[ai], commentsMap, commentRangeSet));
+          container.appendChild(renderUnifiedBlock(newBlocks[addedRun[ai]], 'diff-added', file, true, addedRun[ai], commentsMap, commentRangeSet, fileForms));
         }
       } else if (classifyBlock(newBlocks[newIdx], lineSets.added)) {
         // New block is added (no preceding removal) — emit with green highlight + comments
-        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet));
+        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], 'diff-added', file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         newIdx++;
       } else {
         // Both unchanged — emit new block once (with comments), advance both
-        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], null, file, true, newIdx, commentsMap, commentRangeSet));
+        container.appendChild(renderUnifiedBlock(newBlocks[newIdx], null, file, true, newIdx, commentsMap, commentRangeSet, fileForms));
         newIdx++;
         oldIdx++;
       }
     }
 
+    attachDocGutterMouseHandler(container);
     return container;
   }
 
@@ -3360,10 +3367,13 @@
       section.appendChild(row);
     }
 
+    // Hoisted: one filtered array per render instead of one per block
+    // (activeForms is stable within a synchronous render pass).
+    const docFileForms = getFormsForFile(file.path);
+
     for (let bi = 0; bi < file.lineBlocks.length; bi++) {
       const block = file.lineBlocks[bi];
       const isTableBlock = !!block.tableId;
-
       if (isTableBlock && block.tableId !== activeTableId) {
         const wrapper = document.createElement('div');
         wrapper.className = 'native-table-wrapper';
@@ -3450,7 +3460,7 @@
       lineAdd.className = 'line-add';
       lineAdd.textContent = '+';
       commentGutter.appendChild(lineAdd);
-      commentGutter.addEventListener('mousedown', handleGutterMouseDown);
+      // Mousedown is delegated once per container (attachDocGutterMouseHandler).
 
       gutter.appendChild(commentGutter);
       if (isTableBlock) {
@@ -3526,16 +3536,16 @@
       }
 
       // Comment form
-      const fileForms = getFormsForFile(file.path);
-      for (let fi = 0; fi < fileForms.length; fi++) {
-        if (!fileForms[fi].editingId && fileForms[fi].afterBlockIndex === bi) {
-          const formEl = createCommentForm(fileForms[fi]);
+      for (let fi = 0; fi < docFileForms.length; fi++) {
+        if (!docFileForms[fi].editingId && docFileForms[fi].afterBlockIndex === bi) {
+          const formEl = createCommentForm(docFileForms[fi]);
           if (isTableBlock) appendTableAnnotation(tableSection, formEl);
           else container.appendChild(formEl);
         }
       }
     }
 
+    attachDocGutterMouseHandler(container);
     return container;
   }
 
@@ -4106,11 +4116,13 @@
     }
   }
 
-  // Helper: append comment form if it targets this line and side
-  function appendDiffForm(container, filePath, lineNum, side) {
-    const fileForms = getFormsForFile(filePath);
-    for (let fi = 0; fi < fileForms.length; fi++) {
-      const form = fileForms[fi];
+  // Helper: append comment form if it targets this line and side.
+  // fileForms is threaded down from the top-level diff renders
+  // (renderDiffUnified/renderDiffSplit) — one filtered array per render.
+  function appendDiffForm(container, filePath, lineNum, side, fileForms) {
+    const forms = fileForms || getFormsForFile(filePath);
+    for (let fi = 0; fi < forms.length; fi++) {
+      const form = forms[fi];
       const formSide = form.side || '';
       if (!form.editingId && form.endLine === lineNum && formSide === (side || '')) {
         const el = createCommentForm(form);
@@ -4261,6 +4273,8 @@
 
     const { diffCommentsMap: commentsMap } = buildCommentIndices(file.comments);
     const commentVisualSet = buildUnifiedCommentVisualSet(hunks, file.comments);
+    // Hoisted: one filtered array per render instead of one per diff line.
+    const fileForms = getFormsForFile(file.path);
     let visualIdx = 0; // sequential index for unified drag (old/new nums are different spaces)
 
     // Leading spacer before first hunk (includes hunk header text)
@@ -4315,7 +4329,7 @@
             const inCurrentForm = !diffDragState && selectionStart !== null && selectionEnd !== null &&
                 relevantNum > 0 && relevantNum >= selectionStart && relevantNum <= selectionEnd;
             const inCurrentSelUnified = inCurrentDrag || inCurrentForm;
-            const hasFormUnified = getFormsForFile(file.path).some(function(f) {
+            const hasFormUnified = fileForms.some(function(f) {
               const fSide = f.side || '';
               const fNum = fSide === 'old' ? line.OldNum : line.NewNum;
               return !f.editingId && fNum > 0 && fNum >= f.startLine && fNum <= f.endLine;
@@ -4358,7 +4372,7 @@
         container.appendChild(lineEl);
 
         appendDiffComments(container, file.path, commentLineNum, lineSide, commentsMap);
-        appendDiffForm(container, file.path, commentLineNum, lineSide);
+        appendDiffForm(container, file.path, commentLineNum, lineSide, fileForms);
         visualIdx++;
       }
     }
@@ -4390,6 +4404,8 @@
     autoExpandSmallGaps(file);
 
     const { diffCommentsMap: commentsMap, rangeSet: commentRangeSet } = buildCommentIndices(file.comments);
+    // Hoisted: one filtered array per render instead of one per diff line.
+    const fileForms = getFormsForFile(file.path);
 
     // Leading spacer before first hunk (includes hunk header text)
     const leadingSpacerSplit = renderLeadingSpacer(hunks[0], file);
@@ -4456,8 +4472,8 @@
             el.classList.add('diff-comment-right');
             container.appendChild(el);
           }
-          appendDiffForm(container, file.path, line.OldNum, 'old');
-          appendDiffForm(container, file.path, line.NewNum, '');
+          appendDiffForm(container, file.path, line.OldNum, 'old', fileForms);
+          appendDiffForm(container, file.path, line.NewNum, '', fileForms);
         } else {
           // Positional alignment (GitHub-style): del[i] beside add[i], surplus single-sided.
           const splitRows = buildSplitChangeRows(seg.dels, seg.adds, wordDiff);
@@ -4477,8 +4493,8 @@
             if (del) appendDiffComments(container, file.path, del.OldNum, 'old', commentsMap);
             if (add) appendDiffComments(container, file.path, add.NewNum, '', commentsMap);
             // Form: render for whichever side was clicked
-            if (del) appendDiffForm(container, file.path, del.OldNum, 'old');
-            if (add) appendDiffForm(container, file.path, add.NewNum, '');
+            if (del) appendDiffForm(container, file.path, del.OldNum, 'old', fileForms);
+            if (add) appendDiffForm(container, file.path, add.NewNum, '', fileForms);
           }
         }
       }
@@ -4516,7 +4532,7 @@
       const selSide = diffDragState ? diffDragState.side : (activeForms.length > 0 ? activeForms[activeForms.length - 1].side : null);
       const inCurrentSelLeft = activeFilePath === file.path && selectionStart !== null && selectionEnd !== null &&
           left.num >= selectionStart && left.num <= selectionEnd && selSide === 'old';
-      const hasFormLeft = getFormsForFile(file.path).some(function(f) {
+      const hasFormLeft = fileForms.some(function(f) {
         return !f.editingId && left.num >= f.startLine && left.num <= f.endLine && (f.side || '') === 'old';
       });
       if (inCurrentSelLeft) { leftEl.classList.add('selected'); }
@@ -4558,7 +4574,7 @@
       const selSideR = diffDragState ? diffDragState.side : (activeForms.length > 0 ? activeForms[activeForms.length - 1].side : null);
       const inCurrentSelRight = activeFilePath === file.path && selectionStart !== null && selectionEnd !== null &&
           right.num >= selectionStart && right.num <= selectionEnd && (selSideR || '') === '';
-      const hasFormRight = getFormsForFile(file.path).some(function(f) {
+      const hasFormRight = fileForms.some(function(f) {
         return !f.editingId && right.num >= f.startLine && right.num <= f.endLine && (f.side || '') === '';
       });
       if (inCurrentSelRight) { rightEl.classList.add('selected'); }
@@ -4829,9 +4845,24 @@
   // ===== Gutter Drag Selection =====
   let dragState = null;
 
-  function handleGutterMouseDown(e) {
-    e.preventDefault();
-    const gutter = e.currentTarget;
+  // Desktop mouse path for document/markdown gutters, delegated: a single
+  // mousedown on the file container instead of one listener per
+  // .line-comment-gutter. A 10k-line markdown file renders ~10k gutters and
+  // the per-gutter approach stalled the main thread on mount — the same bug
+  // class as #657 (fixed for diff buttons via attachDiffMouseHandler).
+  // One delegated handler is O(1) regardless of file size.
+  function attachDocGutterMouseHandler(container) {
+    container.addEventListener('mousedown', function(e) {
+      const gutter = e.target.closest('.line-comment-gutter');
+      if (!gutter || !container.contains(gutter)) return;
+      // Read-only gutters never had a listener; they carry no line dataset.
+      if (gutter.classList.contains('diff-no-comment')) return;
+      e.preventDefault();
+      beginDocGutterDrag(gutter, e.shiftKey);
+    });
+  }
+
+  function beginDocGutterDrag(gutter, shiftKey) {
     const startLine = parseInt(gutter.dataset.startLine);
     const endLine = parseInt(gutter.dataset.endLine);
     const filePath = gutter.dataset.filePath;
@@ -4839,7 +4870,7 @@
     const blockIndex = parseInt(blockEl.dataset.blockIndex);
 
     // Shift+click: extend selection
-    if (e.shiftKey && selectionStart !== null && activeFilePath === filePath) {
+    if (shiftKey && selectionStart !== null && activeFilePath === filePath) {
       const rangeStart = Math.min(selectionStart, startLine);
       const rangeEnd = Math.max(selectionEnd, endLine);
       const file = getFileByPath(filePath);
@@ -4878,6 +4909,10 @@
     const section = currentRenderedFileSection(filePath);
     if (!section) return;
 
+    // Hoisted: one filtered array per pass instead of one per line per
+    // mousemove frame (activeForms is stable within a synchronous pass).
+    const fileForms = getFormsForFile(filePath);
+
     // Markdown line blocks: toggle .selected on line-block, update comment gutter drag classes
     const lineBlocks = section.querySelectorAll('.line-block[data-file-path="' + filePath + '"]');
     for (let i = 0; i < lineBlocks.length; i++) {
@@ -4910,7 +4945,7 @@
                         uVisualIdx >= unifiedVisualStart && uVisualIdx <= unifiedVisualEnd;
         const uLineNum = parseInt(uLine.dataset.diffLineNum);
         const uSide = uLine.dataset.diffSide || '';
-        const uHasForm = getFormsForFile(filePath).some(function(f) {
+        const uHasForm = fileForms.some(function(f) {
           return !f.editingId && uLineNum >= f.startLine && uLineNum <= f.endLine && (f.side || '') === uSide;
         });
         uLine.classList.toggle('selected', uSelected);
@@ -4926,7 +4961,7 @@
         const sSideMatch = diffDragState.side === sSideVal;
         const sSelected = sSideMatch && selectionStart !== null && selectionEnd !== null &&
                         sLineNum >= selectionStart && sLineNum <= selectionEnd;
-        const sHasForm = getFormsForFile(filePath).some(function(f) {
+        const sHasForm = fileForms.some(function(f) {
           return !f.editingId && sLineNum >= f.startLine && sLineNum <= f.endLine && (f.side || '') === sSideVal;
         });
         sSide.classList.toggle('selected', sSelected);
@@ -6191,31 +6226,70 @@
     const allQuoted = quotedComments.concat(formQuotes);
     if (allQuoted.length === 0) return;
 
+    // Index content elements once per mount. The old code ran two
+    // full-section querySelectorAll scans per quoted line (O(Q × L) DOM
+    // queries), which dominated mount time on large files with quoted
+    // comments. One pass here, O(1) map lookups per quoted line below.
+    const pathEsc = CSS.escape(file.path);
+    const docLineMap = new Map(); // source line -> .line-content elements
+    sectionEl.querySelectorAll('.line-block[data-file-path="' + pathEsc + '"]').forEach(function(el) {
+      const s = parseInt(el.dataset.startLine);
+      const e = parseInt(el.dataset.endLine);
+      // Native table rows have one content element per cell. Other
+      // blocks have one content div.
+      const contents = [];
+      el.querySelectorAll('.line-content').forEach(function(content) {
+        contents.push(content);
+      });
+      if (contents.length === 0) return;
+      for (let ln = s; ln <= e; ln++) {
+        let arr = docLineMap.get(ln);
+        if (!arr) {
+          arr = [];
+          docLineMap.set(ln, arr);
+        }
+        for (let ci = 0; ci < contents.length; ci++) {
+          if (arr.indexOf(contents[ci]) === -1) arr.push(contents[ci]);
+        }
+      }
+    });
+    const diffLineMap = new Map(); // lineNum + side -> .diff-content elements
+    sectionEl.querySelectorAll('[data-diff-file-path="' + pathEsc + '"]').forEach(function(el) {
+      // Elements without data-diff-side never matched (undefined !== any
+      // comment side string), so they are left out of the index entirely.
+      if (el.dataset.diffSide === undefined) return;
+      const key = el.dataset.diffLineNum + '' + el.dataset.diffSide;
+      const content = el.querySelector('.diff-content');
+      if (!content) return;
+      let arr = diffLineMap.get(key);
+      if (!arr) {
+        arr = [];
+        diffLineMap.set(key, arr);
+      }
+      if (arr.indexOf(content) === -1) arr.push(content);
+    });
+
     allQuoted.forEach(function(comment) {
       // Find the content elements in this comment's line range
       const contentEls = [];
+      // Filter by side to avoid matching the wrong line in unified diff
+      // (deleted and added lines can share the same line number)
+      const commentSide = comment.side || '';
       for (let ln = comment.start_line; ln <= comment.end_line; ln++) {
         // Document view: line-blocks with data-file-path
-        sectionEl.querySelectorAll('.line-block[data-file-path="' + CSS.escape(file.path) + '"]').forEach(function(el) {
-          const s = parseInt(el.dataset.startLine);
-          const e = parseInt(el.dataset.endLine);
-          if (s <= ln && e >= ln) {
-            // Native table rows have one content element per cell. Other
-            // blocks have one content div.
-            el.querySelectorAll('.line-content').forEach(function(content) {
-              if (contentEls.indexOf(content) === -1) contentEls.push(content);
-            });
+        const docEls = docLineMap.get(ln);
+        if (docEls) {
+          for (let di = 0; di < docEls.length; di++) {
+            if (contentEls.indexOf(docEls[di]) === -1) contentEls.push(docEls[di]);
           }
-        });
+        }
         // Diff view: diff lines with data-diff-line-num
-        // Filter by side to avoid matching the wrong line in unified diff
-        // (deleted and added lines can share the same line number)
-        const commentSide = comment.side || '';
-        sectionEl.querySelectorAll('[data-diff-file-path="' + CSS.escape(file.path) + '"][data-diff-line-num="' + ln + '"]').forEach(function(el) {
-          if (el.dataset.diffSide !== commentSide) return;
-          const content = el.querySelector('.diff-content');
-          if (content && contentEls.indexOf(content) === -1) contentEls.push(content);
-        });
+        const diffEls = diffLineMap.get(ln + '' + commentSide);
+        if (diffEls) {
+          for (let fi = 0; fi < diffEls.length; fi++) {
+            if (contentEls.indexOf(diffEls[fi]) === -1) contentEls.push(diffEls[fi]);
+          }
+        }
       }
 
       if (contentEls.length === 0) return;

--- a/web/app.js
+++ b/web/app.js
@@ -4456,7 +4456,7 @@
           const row = makeSplitRow(
             { num: line.OldNum, content: line.Content, type: 'context' },
             { num: line.NewNum, content: line.Content, type: 'context' },
-            file, commentRangeSet
+            file, commentRangeSet, fileForms
           );
           container.appendChild(row.el);
           // Context lines: form appears where clicked (left or right),
@@ -4486,7 +4486,7 @@
             const row = makeSplitRow(
               del ? { num: del.OldNum, content: del.Content, type: 'del', wordRanges: wd ? wd.oldRanges : null } : null,
               add ? { num: add.NewNum, content: add.Content, type: 'add', wordRanges: wd ? wd.newRanges : null } : null,
-              file, commentRangeSet
+              file, commentRangeSet, fileForms
             );
             container.appendChild(row.el);
             // Comments for both sides (different keys)
@@ -4511,7 +4511,7 @@
 
   // Build one split row: left (old) side + right (new) side
   // left/right: { num, content, type } or null for empty
-  function makeSplitRow(left, right, file, commentRangeSet) {
+  function makeSplitRow(left, right, file, commentRangeSet, fileForms) {
     const row = document.createElement('div');
     row.className = 'diff-split-row';
 


### PR DESCRIPTION
Adds performance benchmarks, CI guardrails, and targeted CPU/allocation wins in the hot paths that show up on large AI-generated plans and reviews.

## Backend wins
- Hoist `focusKeyFor` out of per-comment loops via `visibleInFocusKey`; `BenchmarkVisibleInFocus` drops ~70% time and ~99% allocations.
- Replace `fmt.Sprintf` for hex hashes, decimal ints, and static strings with `hex.EncodeToString`, `strconv.Itoa`, and string concatenation across session/daemon/preview/share/story/plans/server/install paths.
- Add Go benchmarks: review save/load roundtrip, carry-forward on a 10k-line plan, hunk grouping, and extend diff to 10k lines.

## Frontend wins
- Thread `getFormsForFile` down from top-level renders instead of recomputing per block/line/drag-frame.
- Delegate document-view gutter `mousedown` to one listener per file container (~10k fewer listeners on a 10k-line markdown file).
- Index content elements once in `highlightQuotesInSection` instead of scanning the section per quoted line.
- Add frontend microbenchmarks for markdown parse, line blocks, highlight split, and word diff.

## CI & budgets
- New `asset-budget` job enforcing gzip caps on embedded JS/CSS and a linux/amd64 binary-size cap.
- New `bench` job comparing head vs base with benchstat; fails on significant ≥20% time slowdown or any allocs/op increase.
- Wire `npm run test:perf` into the frontend test job.
- Enable `perfsprint` linter (excluding `error-format`).

## E2E guardrail
- New `perf` project with a 300-file / ~9k-line fixture, asserting mounted body count, DOM node count, and longtask TBT.

## Docs
- Add `docs/performance.md` with runbook, reference numbers, and deferred follow-ups.

## Test plan
- `go test ./...` passes.
- `golangci-lint run ./...` passes.
- `npm run test:frontend` and `npm run test:perf` pass.
- `bash scripts/check-asset-budget.sh` passes.
- Note: `go test -race ./internal/session/` has pre-existing failures on `main` in lazy-file snapshot tests (race in `snapshotForWrite`); not introduced by this branch.