### PR TITLE
fix: align test review paths with ResolveReviewPath

### DIFF
--- a/internal/comment/comment_scope_test.go
+++ b/internal/comment/comment_scope_test.go
@@ -1,14 +1,11 @@
 package comment
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
-	"github.com/tomasz-tomczyk/crit/internal/vcs"
 )
 
 func withDaemonFocus(t *testing.T, f *Focus) {
@@ -25,17 +22,14 @@ func withDaemonFocus(t *testing.T, f *Focus) {
 
 func writeReviewFileWithScope(t *testing.T, dir, scope string) {
 	t.Helper()
-	cwd, err := daemon.ResolvedCWD()
+	// Use ResolveReviewPath so the fixture key matches production path
+	// resolution (including a live daemon session key for this cwd).
+	critPath, err := review.ResolveReviewPath(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	branch := ""
-	if vc := vcs.DetectVCS(""); vc != nil {
-		branch = vc.CurrentBranch()
-	}
-	key := daemon.SessionKey(cwd, branch, nil)
 	cj := CritJSON{ActiveDiffScope: scope, Files: map[string]CritJSONFile{}}
-	if err := saveCritJSON(filepath.Join(dir, "reviews", key), cj); err != nil {
+	if err := saveCritJSON(critPath, cj); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tomasz-tomczyk/crit/internal/daemon"
 	"github.com/tomasz-tomczyk/crit/internal/review"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/testutil"
@@ -23,17 +22,17 @@ func init() {
 	fetchGHUserName = func(login string) (string, error) { return "", nil }
 }
 
+// outputDataRootIdentity returns the review identity folder under dataRoot,
+// matching review.ResolveReviewPath so fixtures land where production code
+// reads them. When a live daemon owns the test cwd, identityUnderDataRoot
+// prefers that session key over a locally re-derived git-mode key.
 func outputDataRootIdentity(t *testing.T, dataRoot string) string {
 	t.Helper()
-	cwd, err := daemon.ResolvedCWD()
+	path, err := review.ResolveReviewPath(dataRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	branch := ""
-	if vc := vcs.DetectVCS(""); vc != nil {
-		branch = vc.CurrentBranch()
-	}
-	return filepath.Join(dataRoot, "reviews", daemon.SessionKey(cwd, branch, nil))
+	return path
 }
 
 func TestMergeGHComments_BasicConversion(t *testing.T) {
@@ -902,16 +901,7 @@ func TestAddCommentToCritJSON_OutputDir(t *testing.T) {
 		t.Error(".crit.json should not be written to repo root when --output is set")
 	}
 
-	cwd, err := daemon.ResolvedCWD()
-	if err != nil {
-		t.Fatal(err)
-	}
-	branch := ""
-	if vc := vcs.DetectVCS(""); vc != nil {
-		branch = vc.CurrentBranch()
-	}
-	key := daemon.SessionKey(cwd, branch, nil)
-	data, err := os.ReadFile(filepath.Join(outputDir, "reviews", key, "review.json"))
+	data, err := os.ReadFile(filepath.Join(outputDataRootIdentity(t, outputDir), "review.json"))
 	if err != nil {
 		t.Fatalf("expected review under output data root: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Test helpers for review fixtures were re-deriving git-mode session keys while `review.ResolveReviewPath` prefers a live daemon session key for the same cwd.
- That path mismatch made `internal/comment` and `internal/github` unit tests fail whenever a crit daemon was running in the worktree (e.g. during pre-commit on feature branches).
- Helpers now call `ResolveReviewPath` so fixtures land where production code reads them.

## Test plan
- [x] `mise exec -- go test -count=1 ./internal/comment/ ./internal/github/`
- [x] `mise exec -- go test -count=1 ./...`
- [x] Reproduced failure under live daemon cwd with unfixed helpers; fixed test binaries pass in that cwd


Made with [Cursor](https://cursor.com)