### PR TITLE
docs: note story mode LLM token cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ explicitly ask — agents will not infer it from a normal `/crit` review.
 **Alternative:** `crit story` from the terminal uses your global `agent_cmd`
 (separate LLM spend). Generation is LLM-driven exploration — cost depends on
 change complexity more than raw file/diff size, and does not scale linearly.
-See the **[story mode guide](docs/story-mode.md)** for commands, custom
-prompts, JSON shape, and token-cost notes.
+In our experience, complex PRs (~20–50 files, ~2k–5k lines) land around
+$1–$1.40 with Claude Opus 5. See the **[story mode guide](docs/story-mode.md)**
+for commands, custom prompts, JSON shape, and token-cost notes.
 
 ### Live mode
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ story in-session via `crit story --prep` / `--story-file`. Only run it when you
 explicitly ask — agents will not infer it from a normal `/crit` review.
 
 **Alternative:** `crit story` from the terminal uses your global `agent_cmd`
-(separate LLM spend). See the **[story mode guide](docs/story-mode.md)** for
-commands, custom prompts, and JSON shape.
+(separate LLM spend). Generation is LLM-driven exploration — cost depends on
+change complexity more than raw file/diff size, and does not scale linearly.
+See the **[story mode guide](docs/story-mode.md)** for commands, custom
+prompts, JSON shape, and token-cost notes.
 
 ### Live mode
 

--- a/docs/story-mode.md
+++ b/docs/story-mode.md
@@ -64,8 +64,10 @@ Spend depends more on **how complex and multi-theme the change is** — and how
 much the model explores — than on raw file count or diff size. Cost does
 **not** scale linearly with files or lines changed. Tiny diffs are cheap;
 large multi-theme PRs cost more, but two big diffs can land in a similar
-ballpark if exploration depth is similar. Models and pricing move quickly, so
-treat any numbers as a rough indication only.
+ballpark if exploration depth is similar.
+
+In our experience, complex PRs (~20–50 files, ~2k–5k lines changed) cost about
+**$1–$1.40** with Claude Opus 5 via `/crit-story`.
 
 ## Common commands
 

--- a/docs/story-mode.md
+++ b/docs/story-mode.md
@@ -53,6 +53,20 @@ and opens the browser at the story view.
 generation is prompt-by-reference: Crit writes the full prep file to disk and
 tells the agent to read it. The diff is not pasted into the prompt.
 
+## Token cost
+
+Story generation is **LLM-driven exploration**: the agent reads the prep file,
+may open related source for context, and writes the chapter JSON. That uses
+your agent's tokens (in-session with `/crit-story`, or a separate spawn with
+`agent_cmd`). Crit itself does not bill for stories.
+
+Spend depends more on **how complex and multi-theme the change is** — and how
+much the model explores — than on raw file count or diff size. Cost does
+**not** scale linearly with files or lines changed. Tiny diffs are cheap;
+large multi-theme PRs cost more, but two big diffs can land in a similar
+ballpark if exploration depth is similar. Models and pricing move quickly, so
+treat any numbers as a rough indication only.
+
 ## Common commands
 
 | Command | Use |


### PR DESCRIPTION
## Summary
- Document that story generation is LLM-driven exploration on the agent's model (not billed by Crit)
- Clarify spend tracks change complexity / exploration more than raw file or diff size, and does not scale linearly

## Test plan
- [ ] Skim README Story mode blurb and `docs/story-mode.md` Token cost section for clarity

Made with [Cursor](https://cursor.com)