### PR TITLE
test: isolate TestNewSessionFromGitLazyThreshold from ambient git config

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3151,6 +3151,11 @@ func TestNewSessionFromGitLazyThreshold(t *testing.T) {
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
+	// Isolate git commands from ambient config (e.g. runner-level .gitconfig,
+	// credentials helpers, or external diff tools) that can leak extra files into
+	// the detected change set on CI.
+	t.Setenv("HOME", dir)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 
 	s, err := NewSessionFromGit(nil)
 	if err != nil {
@@ -3158,7 +3163,17 @@ func TestNewSessionFromGitLazyThreshold(t *testing.T) {
 	}
 
 	if len(s.Files) != 120 {
-		t.Fatalf("expected 120 files, got %d", len(s.Files))
+		want := make(map[string]bool, 120)
+		for i := 0; i < 120; i++ {
+			want[fmt.Sprintf("file%03d.go", i)] = true
+		}
+		var unexpected []string
+		for _, f := range s.Files {
+			if !want[f.Path] {
+				unexpected = append(unexpected, f.Path)
+			}
+		}
+		t.Fatalf("expected 120 files, got %d; unexpected: %v", len(s.Files), unexpected)
 	}
 
 	eagerCount, lazyCount := 0, 0


### PR DESCRIPTION
Fixes the flaky coverage-run failure reported in https://github.com/tomasz-tomczyk/crit/actions/runs/33956805844/job/101281494330 where "TestNewSessionFromGitLazyThreshold" intermittently returned 121 files instead of 120 on the Ubuntu runner.

The test now sets HOME to the temporary repo and disables system git config before invoking NewSessionFromGit, so the git commands use the same isolated environment as the fixture setup and are not affected by runner-level .gitconfig, credential helpers, or external diff tools.

Also improves the failure message to list any unexpected file paths so future diagnoses are easier.