### PR TITLE
fix: open a single form when editing a file-level comment

### DIFF
--- a/test/e2e/tests/file-comments.filemode.spec.ts
+++ b/test/e2e/tests/file-comments.filemode.spec.ts
@@ -70,13 +70,18 @@ test.describe('File-level comments — File Mode', () => {
 
     await card.locator('.comment-actions button[title="Edit"]').click();
 
-    const textarea = section.locator('.file-comments .comment-form textarea').first();
+    // Regression: editing must open one form, not both file compose + inline editor.
+    const forms = section.locator('.file-comments .comment-form');
+    await expect(forms).toHaveCount(1);
+    await expect(forms.locator('.comment-form-header')).toHaveText('Editing file comment');
+
+    const textarea = forms.locator('textarea');
     await expect(textarea).toBeVisible();
     await expect(textarea).toHaveValue('original');
 
     await textarea.clear();
     await textarea.fill('updated');
-    await section.locator('.file-comments .comment-form .btn-primary').first().click();
+    await forms.locator('.btn-primary').click();
 
     await expect(section.locator('.file-comments .comment-card .comment-body')).toContainText('updated');
   });

--- a/test/e2e/tests/file-comments.filemode.spec.ts
+++ b/test/e2e/tests/file-comments.filemode.spec.ts
@@ -74,6 +74,7 @@ test.describe('File-level comments — File Mode', () => {
     const forms = section.locator('.file-comments .comment-form');
     await expect(forms).toHaveCount(1);
     await expect(forms.locator('.comment-form-header')).toHaveText('Editing file comment');
+    await expect(forms.locator('.btn-primary')).toHaveText('Update Comment');
 
     const textarea = forms.locator('textarea');
     await expect(textarea).toBeVisible();

--- a/test/e2e/tests/file-comments.spec.ts
+++ b/test/e2e/tests/file-comments.spec.ts
@@ -76,13 +76,20 @@ test.describe('File-level comments — Git Mode', () => {
     // Click Edit
     await card.locator('.comment-actions button[title="Edit"]').click();
 
-    const textarea = section.locator('.file-comments .comment-form textarea').first();
+    // Regression: editing must open one form (inline editor), not both the
+    // file-scope compose form and the inline editor at once.
+    const forms = section.locator('.file-comments .comment-form');
+    await expect(forms).toHaveCount(1);
+    await expect(forms.locator('.comment-form-header')).toHaveText('Editing file comment');
+    await expect(forms.locator('.btn-primary')).toHaveText('Update Comment');
+
+    const textarea = forms.locator('textarea');
     await expect(textarea).toBeVisible();
     await expect(textarea).toHaveValue('original file comment');
 
     await textarea.clear();
     await textarea.fill('updated file comment');
-    await section.locator('.file-comments .comment-form .btn-primary').first().click();
+    await forms.locator('.btn-primary').click();
 
     await expect(section.locator('.file-comments .comment-card .comment-body')).toContainText('updated file comment');
   });

--- a/web/app.js
+++ b/web/app.js
@@ -2828,7 +2828,9 @@
         }
         fileCommentsContainer.appendChild(el);
       }
-      if (fileForm && !isOrphaned) {
+      // Edit-in-progress is rendered in place of the comment card via
+      // createInlineEditor — don't also mount the file compose form.
+      if (fileForm && !isOrphaned && !fileForm.editingId) {
         fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
       }
       section.appendChild(fileCommentsContainer);
@@ -11515,7 +11517,11 @@
         fileComments.forEach(function(comment) {
           fileCommentsContainer.appendChild(comment.resolved ? createResolvedElement(comment, file.path) : createCommentElement(comment, file.path));
         });
-        if (fileForm) fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
+        // Edit-in-progress is rendered in place of the comment card via
+        // createInlineEditor — don't also mount the file compose form.
+        if (fileForm && !fileForm.editingId) {
+          fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
+        }
         section.appendChild(fileCommentsContainer);
       }
     }

--- a/web/app.js
+++ b/web/app.js
@@ -513,6 +513,13 @@
   function findFormForEdit(commentId) {
     return activeForms.find(function(f) { return f.editingId === commentId; });
   }
+
+  // File compose only — edits use createInlineEditor in place of the card.
+  function getFileComposeForm(filePath) {
+    return getFormsForFile(filePath).find(function(f) {
+      return f.scope === 'file' && !f.editingId;
+    });
+  }
   let selectionStart = null;
   let selectionEnd = null;
   let unifiedVisualStart = null; // visual index range for unified drag (cross-number-space)
@@ -2806,9 +2813,7 @@
     const fileComments = isOrphaned
       ? file.comments
       : file.comments.filter(function(c) { return c.scope === 'file'; });
-    const fileForm = getFormsForFile(file.path).find(function(f) {
-      return f.scope === 'file' && !f.editingId;
-    });
+    const fileForm = getFileComposeForm(file.path);
     if (fileComments.length > 0 || (fileForm && !isOrphaned)) {
       const fileCommentsContainer = document.createElement('div');
       fileCommentsContainer.className = 'file-comments';
@@ -2830,8 +2835,6 @@
         }
         fileCommentsContainer.appendChild(el);
       }
-      // File-comment edits render via createInlineEditor in place of the card.
-      // Only mount the compose form here.
       if (fileForm && !isOrphaned) {
         fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
       }
@@ -5181,7 +5184,6 @@
     focusCommentTextarea(newForm.formKey);
   }
 
-  // Compose-only. File-comment edits use createInlineEditor (in place of the card).
   function createFileCommentForm(formObj) {
     return createCommentFormUI({
       formObj: formObj,
@@ -11503,17 +11505,13 @@
 
     if (file) {
       const fileComments = file.comments.filter(function(c) { return c.scope === 'file'; });
-      const fileForm = getFormsForFile(file.path).find(function(f) {
-        return f.scope === 'file' && !f.editingId;
-      });
+      const fileForm = getFileComposeForm(file.path);
       if (fileComments.length > 0 || fileForm) {
         const fileCommentsContainer = document.createElement('div');
         fileCommentsContainer.className = 'file-comments';
         fileComments.forEach(function(comment) {
           fileCommentsContainer.appendChild(comment.resolved ? createResolvedElement(comment, file.path) : createCommentElement(comment, file.path));
         });
-        // File-comment edits render via createInlineEditor in place of the card.
-        // Only mount the compose form here.
         if (fileForm) fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
         section.appendChild(fileCommentsContainer);
       }

--- a/web/app.js
+++ b/web/app.js
@@ -2806,7 +2806,9 @@
     const fileComments = isOrphaned
       ? file.comments
       : file.comments.filter(function(c) { return c.scope === 'file'; });
-    const fileForm = getFormsForFile(file.path).find(function(f) { return f.scope === 'file'; });
+    const fileForm = getFormsForFile(file.path).find(function(f) {
+      return f.scope === 'file' && !f.editingId;
+    });
     if (fileComments.length > 0 || (fileForm && !isOrphaned)) {
       const fileCommentsContainer = document.createElement('div');
       fileCommentsContainer.className = 'file-comments';
@@ -2828,9 +2830,9 @@
         }
         fileCommentsContainer.appendChild(el);
       }
-      // Edit-in-progress is rendered in place of the comment card via
-      // createInlineEditor — don't also mount the file compose form.
-      if (fileForm && !isOrphaned && !fileForm.editingId) {
+      // File-comment edits render via createInlineEditor in place of the card.
+      // Only mount the compose form here.
+      if (fileForm && !isOrphaned) {
         fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
       }
       section.appendChild(fileCommentsContainer);
@@ -5179,22 +5181,13 @@
     focusCommentTextarea(newForm.formKey);
   }
 
+  // Compose-only. File-comment edits use createInlineEditor (in place of the card).
   function createFileCommentForm(formObj) {
-    let initialBody = '';
-    if (formObj.editingId) {
-      const file = getFileByPath(formObj.filePath);
-      if (file) {
-        const existing = file.comments.find(function(c) { return c.id === formObj.editingId; });
-        if (existing) initialBody = existing.body;
-      }
-    } else if (formObj.draftBody) {
-      initialBody = formObj.draftBody;
-    }
     return createCommentFormUI({
       formObj: formObj,
-      headerText: formObj.editingId ? 'Editing comment' : 'Comment',
-      submitText: formObj.editingId ? 'Update' : 'Comment',
-      initialBody: initialBody,
+      headerText: 'Comment',
+      submitText: 'Comment',
+      initialBody: formObj.draftBody || '',
       autoFocus: false
     });
   }
@@ -11510,18 +11503,18 @@
 
     if (file) {
       const fileComments = file.comments.filter(function(c) { return c.scope === 'file'; });
-      const fileForm = getFormsForFile(file.path).find(function(f) { return f.scope === 'file'; });
+      const fileForm = getFormsForFile(file.path).find(function(f) {
+        return f.scope === 'file' && !f.editingId;
+      });
       if (fileComments.length > 0 || fileForm) {
         const fileCommentsContainer = document.createElement('div');
         fileCommentsContainer.className = 'file-comments';
         fileComments.forEach(function(comment) {
           fileCommentsContainer.appendChild(comment.resolved ? createResolvedElement(comment, file.path) : createCommentElement(comment, file.path));
         });
-        // Edit-in-progress is rendered in place of the comment card via
-        // createInlineEditor — don't also mount the file compose form.
-        if (fileForm && !fileForm.editingId) {
-          fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
-        }
+        // File-comment edits render via createInlineEditor in place of the card.
+        // Only mount the compose form here.
+        if (fileForm) fileCommentsContainer.appendChild(createFileCommentForm(fileForm));
         section.appendChild(fileCommentsContainer);
       }
     }


### PR DESCRIPTION
## Summary
- Editing a file-level comment was mounting both the inline editor and the file compose form (two Update buttons).
- Mount only the compose form from activeForms via `getFileComposeForm`; edits stay on the inline editor.
- E2E asserts exactly one form with the correct header/button labels.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web uses a different file-comment edit path)

## Test plan
- [x] Playwright: file-comments (git-mode) — can edit a file-level comment
- [x] Playwright: file-comments (file-mode) — same
- [x] Pre-commit (gofmt, golangci-lint, go test, eslint, stylelint)

Made with [Cursor](https://cursor.com)