### PR TITLE
fix: resolve preview share URL from share_targets

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -372,9 +372,9 @@ func runAuthLogout(args []string) {
 
 	serverURL := target.URL
 	// Revoke server-side first while the token is still valid, then clear
-	// local credentials. clearAuthIdentity() removes the token and all
-	// cached identity fields in a single write — keep this in sync with
-	// the 401-handling paths that also call it.
+	// local credentials for this target. ClearTargetAuth removes the token
+	// and cached identity fields for one deployment — keep this in sync with
+	// the 401-handling paths that clear auth.
 	revoked := revokeToken(serverURL, token)
 	ClearTargetAuth(serverURL)
 

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -145,8 +145,18 @@ func buildPreviewStartArgs(absPath string, port int, host, publicURL string, all
 		AllowUnauthenticatedNetwork: allowUnauthNet,
 		NoOpen:                      noOpen,
 		Quiet:                       quiet,
-		ShareURL:                    config.ResolveShareURL(shareURL, cfg, config.DefaultShareURL),
+		ShareURL:                    resolvePreviewShareURL(shareURL, cfg),
 	})
+}
+
+// resolvePreviewShareURL mirrors daemon_cli / SelectShareTarget so share_targets-only
+// config (post-migrate, share_url deleted) reaches the daemon instead of forcing crit.md.
+func resolvePreviewShareURL(flagValue string, cfg config.Config) string {
+	target, ok, err := config.SelectShareTarget(flagValue, flagValue != "", cfg)
+	if err != nil || !ok {
+		return ""
+	}
+	return target.URL
 }
 
 func installDaemonSignalHandler(pid int) {

--- a/internal/preview/preview_daemon_args_test.go
+++ b/internal/preview/preview_daemon_args_test.go
@@ -1,12 +1,14 @@
 package preview
 
 import (
+	"os"
 	"testing"
 
 	"github.com/tomasz-tomczyk/crit/internal/config"
 )
 
 func TestBuildPreviewStartArgs_PublicURL(t *testing.T) {
+	unsetEnvForTest(t, "CRIT_SHARE_URL")
 	cfg := config.Config{PublicURL: "https://config.ts.net"}
 	args := buildPreviewStartArgsForTest("/tmp/page.html", 0, "", "https://cli.ts.net", false, true, false, "", cfg)
 	want := []string{
@@ -28,4 +30,47 @@ func TestBuildPreviewStartArgs_PublicURL(t *testing.T) {
 	if len(fromCfg) != 6 || fromCfg[2] != "--public-url" || fromCfg[3] != "https://config.ts.net" {
 		t.Fatalf("config public-url: got %v", fromCfg)
 	}
+}
+
+func TestBuildPreviewStartArgs_ShareTargetsOnly(t *testing.T) {
+	unsetEnvForTest(t, "CRIT_SHARE_URL")
+	cfg := config.Config{
+		ShareTargets: []config.ShareTarget{
+			{Name: "acme", URL: "https://crit.acme.example", Default: true},
+		},
+	}
+	args := buildPreviewStartArgsForTest("/tmp/page.html", 0, "", "", false, true, false, "", cfg)
+	want := []string{
+		"--preview-file", "/tmp/page.html",
+		"--no-open",
+		"--share-url", "https://crit.acme.example",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("got %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("arg[%d]: got %q, want %q", i, args[i], want[i])
+		}
+	}
+	for _, a := range args {
+		if a == "https://crit.md" {
+			t.Fatalf("share_targets-only config must not inject DefaultShareURL; got %v", args)
+		}
+	}
+}
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	old, existed := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
 }

--- a/internal/server/daemon_cli.go
+++ b/internal/server/daemon_cli.go
@@ -196,12 +196,13 @@ func applyDaemonConfigDefaults(sf *daemonFlagSet, cfg config.Config) { //nolint:
 		}
 	}
 	if sf.shareURLSet || func() bool { _, ok := os.LookupEnv("CRIT_SHARE_URL"); return ok }() {
+		// cfg is passed by value; ShareTargets narrowing happens in
+		// ResolveDaemonCLIConfig on the real Config. Only resolve flag/env
+		// into sf.shareURL / sf.proxyAuth here.
 		target, ok, err := config.SelectShareTarget(sf.shareURL, true, cfg)
 		if err == nil && ok {
-			cfg.ShareTargets = []config.ShareTarget{target}
 			sf.shareURL, sf.proxyAuth = target.URL, target.ProxyAuth
 		} else if !ok {
-			cfg.ShareTargets = []config.ShareTarget{}
 			sf.shareURL, sf.proxyAuth = "", false
 		}
 	} else if target, ok, _ := config.SelectShareTarget("", false, cfg); ok {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tomasz-tomczyk/crit/internal/auth"
 	"github.com/tomasz-tomczyk/crit/internal/config"
 	"github.com/tomasz-tomczyk/crit/internal/session"
 	"github.com/tomasz-tomczyk/crit/internal/share"
@@ -82,8 +81,6 @@ func commentsAtOrBeforeRound(comments []Comment, round int) []Comment {
 func recordSessionStats(sess *Session, author string, startedAt time.Time) {
 	session.RecordSessionStats(sess, author, startedAt)
 }
-
-func clearAuthIdentity() { auth.ClearAuthIdentity() }
 
 func filterPathsIgnored(paths []string, patterns []string) []string {
 	return config.FilterPathsIgnored(paths, patterns)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -793,7 +793,10 @@ func (s *Server) handleShareConsent(w http.ResponseWriter, r *http.Request) {
 		TargetURL string `json:"target_url"`
 	}
 	if r.Body != nil && r.ContentLength > 0 {
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
 	}
 	if body.TargetURL == "" && !s.configConfigured {
 		body.TargetURL = config.DefaultShareURL

--- a/internal/server/share_targets.go
+++ b/internal/server/share_targets.go
@@ -30,7 +30,11 @@ func (s *Server) freshShareConfig() config.Config {
 			cfg.RuntimeShareURL = &override
 			if override == "" {
 				cfg.ShareTargets = []config.ShareTarget{}
-			} else if target, ok, err := config.SelectShareTarget(override, true, cfg); err == nil && ok {
+			} else if target, ok, err := config.SelectShareTarget(override, true, cfg); err != nil || !ok {
+				// Invalid/failed override must not leave RuntimeShareURL pointing
+				// at the full configured target list (same outcome as disable).
+				cfg.ShareTargets = []config.ShareTarget{}
+			} else {
 				cfg.ShareTargets = []config.ShareTarget{target}
 			}
 		}
@@ -41,6 +45,8 @@ func (s *Server) freshShareConfig() config.Config {
 
 func (s *Server) resolvedShareTargets() ([]config.ShareTarget, error) {
 	if !s.configConfigured {
+		// NewServer's legacy constructor is widely used by embedders/tests.
+		// Treat its explicit URL as one ephemeral target when daemon config is absent.
 		if s.shareURL == "" {
 			return []config.ShareTarget{}, nil
 		}
@@ -51,32 +57,7 @@ func (s *Server) resolvedShareTargets() ([]config.ShareTarget, error) {
 		return []config.ShareTarget{{Name: canonical, URL: canonical, Default: true, ProxyAuth: s.proxyAuth, ShareConsented: s.cfg.ShareConsented, Auth: config.TargetAuth{Token: s.authTokenSnapshot(), UserID: s.cfg.AuthUserID, UserName: s.cfg.AuthUserName, UserEmail: s.cfg.AuthUserEmail}}}, nil
 	}
 	cfg := s.freshShareConfig()
-	targets, err := config.ResolveShareTargets(cfg)
-	if err != nil {
-		return nil, err
-	}
-	// NewServer's legacy constructor is widely used by embedders/tests. Treat
-	// its explicit URL as one ephemeral target when daemon config is absent.
-	if !s.configConfigured && s.shareURL != "" {
-		canonical, canonicalErr := config.CanonicalShareURL(s.shareURL)
-		if canonicalErr != nil {
-			return nil, canonicalErr
-		}
-		found := false
-		for i := range targets {
-			if targets[i].URL == canonical {
-				targets[i].ProxyAuth = s.proxyAuth
-				if targets[i].Auth.Token == "" {
-					targets[i].Auth.Token = s.authTokenSnapshot()
-				}
-				found = true
-			}
-		}
-		if !found {
-			targets = []config.ShareTarget{{Name: canonical, URL: canonical, Default: true, ProxyAuth: s.proxyAuth, Auth: config.TargetAuth{Token: s.authTokenSnapshot(), UserID: s.cfg.AuthUserID, UserName: s.cfg.AuthUserName, UserEmail: s.cfg.AuthUserEmail}, ShareConsented: s.cfg.ShareConsented}}
-		}
-	}
-	return targets, nil
+	return config.ResolveShareTargets(cfg)
 }
 
 func (s *Server) targetForRequest(requested string) (config.ShareTarget, error) { //nolint:gocyclo // Bound, requested, and default target rules are intentionally explicit.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2026,12 +2026,9 @@ func (s *Session) GetToken() string {
 }
 
 // SetSharedURLAndToken atomically updates both the shared URL and delete token.
+// Prefer SetSharedTarget when the deployment base URL is known.
 func (s *Session) SetSharedURLAndToken(url, token string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.sharedURL = url
-	s.deleteToken = token
-	s.scheduleWrite()
+	s.SetSharedTarget(url, "", token)
 }
 
 // SetSharedTarget binds the remote URL and delete token to the deployment that


### PR DESCRIPTION
## Summary
- crit preview no longer injects https://crit.md when config only has share_targets.
- Clean up multi-target leftovers (dead resolvedShareTargets branch, SetSharedURLAndToken, consent decode, freshShareConfig).

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (CLI share resolution)

## Test plan
- [x] go vet / golangci-lint / unit tests (pre-commit)
- [x] share_targets-only preview daemon args test
- [x] make e2e-share

Companion release-audit PRs: tomasz-tomczyk/crit#914, tomasz-tomczyk/crit-web#394