### PR TITLE
fix: derive settings Account status from share targets

### DIFF
--- a/web/__tests__/crit-share.test.js
+++ b/web/__tests__/crit-share.test.js
@@ -80,11 +80,26 @@ test('create() wires a click handler onto shareBtnEl', () => {
   assert.equal((btn._listeners.click || []).length, 1);
 });
 
-test('reveal() shows the button when shareURL && canShare', () => {
+test('reveal() shows the button when (shareURL || shareTargets) && canShare', () => {
   const btn = wireButton(makeButton());
   installDomStub({ shareBtn: btn });
   share = require('../crit-share.js');
   const ctl = share.create({ shareBtnEl: btn, shareURL: 'https://crit.md', canShare: true });
+  assert.equal(btn.style.display, 'none');
+  ctl.reveal();
+  assert.equal(btn.style.display, '');
+});
+
+test('reveal() shows the button when shareTargets is non-empty even if shareURL is empty', () => {
+  const btn = wireButton(makeButton());
+  installDomStub({ shareBtn: btn });
+  share = require('../crit-share.js');
+  const ctl = share.create({
+    shareBtnEl: btn,
+    shareURL: '',
+    shareTargets: [{ name: 'crit.md', url: 'https://crit.md', default: true }],
+    canShare: true,
+  });
   assert.equal(btn.style.display, 'none');
   ctl.reveal();
   assert.equal(btn.style.display, '');
@@ -99,7 +114,7 @@ test('reveal() does NOT show the button when canShare is false (e.g. git mode)',
   assert.equal(btn.style.display, 'none');
 });
 
-test('reveal() does NOT show the button when shareURL is empty', () => {
+test('reveal() does NOT show the button when shareURL and shareTargets are empty', () => {
   const btn = wireButton(makeButton());
   installDomStub({ shareBtn: btn });
   share = require('../crit-share.js');

--- a/web/app.js
+++ b/web/app.js
@@ -898,8 +898,8 @@
     //
     // Share is available in files + preview review, but not vcs/diff (git):
     // canShare = session.mode !== 'git'. The controller's reveal() shows the
-    // button iff (shareURL && canShare) and sets the 'shared' state when a
-    // hosted URL already exists.
+    // button iff (hostedURL || shareTargets.length > 0) && canShare and sets
+    // the 'shared' state when a hosted URL already exists.
     shareCtl = window.crit.share.create({
       shareURL: shareURL,
       shareTargets: configuredShareTargets,

--- a/web/crit-settings-panes.js
+++ b/web/crit-settings-panes.js
@@ -420,11 +420,23 @@
         html += '</div></div></div>';
       }
 
-      var settingsTargets = Array.isArray(cfg.share_targets) ? cfg.share_targets : (cfg.share_url ? [{ url: cfg.share_url, auth_logged_in: cfg.auth_logged_in, auth_user_email: cfg.auth_user_email, auth_user_name: cfg.auth_user_name }] : []);
-      // Account card
+      // Legacy share_url-only configs have no per-target auth; top-level cfg.auth_*
+      // still applies. Modern share_targets carry auth_logged_in per target.
+      var settingsTargets = Array.isArray(cfg.share_targets) ? cfg.share_targets : (cfg.share_url ? [{ url: cfg.share_url }] : []);
+      // Account card — logged-in if ANY target is authenticated (localhost CLI).
       if (show.account && settingsTargets.length > 0) {
-        if (cfg.auth_logged_in) {
-          var display = cfg.auth_user_email || cfg.auth_user_name || 'Logged in';
+        var loggedInTarget = null;
+        for (var ti = 0; ti < settingsTargets.length; ti++) {
+          if (settingsTargets[ti].auth_logged_in) {
+            loggedInTarget = settingsTargets[ti];
+            break;
+          }
+        }
+        if (!loggedInTarget && !Array.isArray(cfg.share_targets) && cfg.auth_logged_in) {
+          loggedInTarget = { auth_user_email: cfg.auth_user_email, auth_user_name: cfg.auth_user_name };
+        }
+        if (loggedInTarget) {
+          var display = loggedInTarget.auth_user_email || loggedInTarget.auth_user_name || 'Logged in';
           html += '<div class="config-card config-card--green"><div class="config-card-header">';
           html += '<span class="config-card-icon" style="color:var(--crit-green)">&#10003;</span>';
           html += '<span class="config-card-title">Account</span>';

--- a/web/crit-share.js
+++ b/web/crit-share.js
@@ -22,7 +22,8 @@
 //             needsShareConsent, authUserName, proxyAuth, reviewType,
 //             sharedOrg, sharedVisibility
 //   shareBtnEl: the #shareBtn element (click handler attached internally)
-//   canShare:  bool — reveal() shows the button iff (shareURL && canShare).
+//   canShare:  bool — reveal() shows the button iff
+//              (hostedURL || shareTargets.length > 0) && canShare.
 //              code-review passes session.mode !== 'git'; preview passes true.
 //   adapters:
 //     onCommentsRefreshed():        re-render the comments UI after a merge
@@ -236,7 +237,7 @@
     }
 
     async function fetchOrgs() {
-	  const key = shareURL;
+      const key = shareURL;
       if (cachedOrgs.has(key)) return cachedOrgs.get(key);
       if (fetchOrgsPromise.has(key)) return fetchOrgsPromise.get(key);
       const pending = (async function() {
@@ -284,7 +285,7 @@
     }
 
     async function fetchSharePolicy(popupSession) {
-	  const key = shareURL;
+      const key = shareURL;
       if (cachedSharePolicy.has(key)) return cachedSharePolicy.get(key);
       if (fetchSharePolicyPromise.has(key)) return fetchSharePolicyPromise.get(key);
       const pending = (async function() {
@@ -771,7 +772,7 @@
           '</div>';
 
       let subtitleText = 'Anyone with the link can read it. The page works without an account.';
-	  if (!shareURL && shareBaseURL) subtitleText = 'The originating instance (' + escapeHtml(shareBaseURL) + ') is no longer configured. The existing link is preserved.';
+      if (!shareURL && shareBaseURL) subtitleText = 'The originating instance (' + escapeHtml(shareBaseURL) + ') is no longer configured. The existing link is preserved.';
       const missingOrigin = !shareURL && !!shareBaseURL;
       let orgStripHtml = '';
       if (sharedOrg) {
@@ -911,7 +912,7 @@
     async function handlePullComments() {
       const btn = document.getElementById('modalPullBtn');
       if (!btn) return;
-	  if (!shareURL) { showShareError(new Error('originating Crit instance is no longer configured')); return; }
+      if (!shareURL) { showShareError(new Error('originating Crit instance is no longer configured')); return; }
       btn.disabled = true;
       const origLabel = btn.textContent;
       btn.textContent = 'Pulling…';
@@ -971,7 +972,7 @@
     async function handleReshare() {
       const btn = document.getElementById('modalReshareBtn');
       if (!btn) return;
-	  if (!shareURL) { showShareError(new Error('originating Crit instance is no longer configured')); return; }
+      if (!shareURL) { showShareError(new Error('originating Crit instance is no longer configured')); return; }
       btn.disabled = true;
       const origLabel = btn.textContent;
       btn.textContent = 'Re-sharing…';
@@ -1095,7 +1096,7 @@
     }
 
     async function handleUnpublish() {
-	  if (!shareURL) { closeShareModal(); showShareError(new Error('originating Crit instance is no longer configured')); return; }
+      if (!shareURL) { closeShareModal(); showShareError(new Error('originating Crit instance is no longer configured')); return; }
       const btn = document.getElementById('confirmUnpublishBtn');
       if (btn) { btn.textContent = 'Unpublishing…'; btn.disabled = true; }
 
@@ -1276,7 +1277,8 @@
     }
 
     return {
-      // reveal() shows the share button iff (shareURL && canShare), and sets
+      // reveal() shows the share button iff
+      // (hostedURL || shareTargets.length > 0) && canShare, and sets
       // the button to the 'shared' state if there's already a hosted URL.
       reveal: function reveal() {
         if ((hostedURL || shareTargets.length > 0) && options.canShare) {

--- a/web/style.css
+++ b/web/style.css
@@ -835,8 +835,7 @@ body {
 .sd-org-body { padding: 20px; display: flex; flex-direction: column; gap: 20px; }
 .sd-org-label { display: block; font-size: 12px; font-weight: 600; color: var(--crit-fg-primary); margin-bottom: 8px; letter-spacing: 0.01em; }
 /* Owner radio list */
-.sd-org-owner-list { display: flex; flex-direction: column; border: 1px solid var(--crit-border); border-radius: 8px; overflow: hidden; }
-.sd-target-list { display: flex; flex-direction: column; border: 1px solid var(--crit-border); border-radius: 8px; overflow: hidden; }
+.sd-org-owner-list, .sd-target-list { display: flex; flex-direction: column; border: 1px solid var(--crit-border); border-radius: 8px; overflow: hidden; }
 .sd-target-option { display: flex; align-items: center; justify-content: space-between; gap: 16px; width: 100%; padding: 12px; border: 0; background: transparent; color: var(--crit-fg-primary); text-align: left; cursor: pointer; font: inherit; }
 .sd-target-option + .sd-target-option { border-top: 1px solid var(--crit-border); }
 .sd-target-option:hover, .sd-target-option:focus-visible { background: var(--crit-option-hover); outline: none; }


### PR DESCRIPTION
## Summary
- Settings Account card reads auth from share_targets[] instead of top-level cfg.auth_* only.
- Align reveal() docs/tests with multi-target gate; tidy share list CSS.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (CLI settings UI)

## Test plan
- [x] node --test crit-share + crit-settings-panes (39 pass)
- [x] pre-commit gofmt/lint/tests

Companion release-audit PRs: tomasz-tomczyk/crit#913, tomasz-tomczyk/crit-web#394