### PR TITLE
fix: preserve scoped diff revisions for staged/unstaged (#915)

### DIFF
--- a/internal/session/issue_915_test.go
+++ b/internal/session/issue_915_test.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
+)
+
+// Regression test for #915: after a renamed file is edited between review
+// rounds, staged and unstaged views must not fall back to the combined "all"
+// diff and mix the two rounds together.
+func TestGetFileDiffSnapshotScoped_RenamedFileAfterRoundCompleteKeepsScopesSeparate(t *testing.T) {
+	dir := initTestRepo(t)
+	setHome(t, t.TempDir())
+
+	oldPath := filepath.Join(dir, "old.go")
+	baseContent := `package sample
+
+func moved() {
+	println("base version")
+}
+
+func stableOne() {}
+func stableTwo() {}
+func stableThree() {}
+func stableFour() {}
+func stableFive() {}
+func stableSix() {}
+func stableSeven() {}
+func stableEight() {}
+`
+	writeFile(t, oldPath, baseContent)
+	gitT(t, dir, "add", "old.go")
+	gitT(t, dir, "commit", "-m", "add source file")
+	gitT(t, dir, "checkout", "-b", "feature")
+
+	// Round 1 renames the file and stages an edit at the original location.
+	gitT(t, dir, "mv", "old.go", "new.go")
+	newPath := filepath.Join(dir, "new.go")
+	roundOneContent := strings.Replace(baseContent, "base version", "round one", 1)
+	writeFile(t, newPath, roundOneContent)
+	gitT(t, dir, "add", "-A")
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+
+	sess, err := NewGitSession(&vcs.GitVCS{}, nil)
+	if err != nil {
+		t.Fatalf("NewGitSession: %v", err)
+	}
+	if len(sess.Files) != 1 || sess.Files[0].Status != "renamed" {
+		t.Fatalf("round 1 must begin with one renamed file, got %+v", sess.Files)
+	}
+
+	// Round 2 moves the edited block below the stable code and changes it again,
+	// but leaves that second edit unstaged. The index is still the Round 1 state.
+	roundTwoContent := `package sample
+
+func stableOne() {}
+func stableTwo() {}
+func stableThree() {}
+func stableFour() {}
+func stableFive() {}
+func stableSix() {}
+func stableSeven() {}
+func stableEight() {}
+
+func moved() {
+	println("round two")
+}
+`
+	writeFile(t, newPath, roundTwoContent)
+	sess.handleRoundCompleteGit()
+
+	if len(sess.Files) != 1 || sess.Files[0].Status != "renamed" {
+		t.Fatalf("round 2 must retain the renamed file, got %+v", sess.Files)
+	}
+
+	diffText := func(scope string) string {
+		t.Helper()
+		snapshot, ok := sess.GetFileDiffSnapshotScoped("new.go", scope, "", false)
+		if !ok {
+			t.Fatalf("GetFileDiffSnapshotScoped(%q) returned ok=false", scope)
+		}
+		hunks, ok := snapshot["hunks"].([]vcs.DiffHunk)
+		if !ok {
+			t.Fatalf("GetFileDiffSnapshotScoped(%q) hunks have type %T", scope, snapshot["hunks"])
+		}
+		var lines []string
+		for _, hunk := range hunks {
+			for _, line := range hunk.Lines {
+				lines = append(lines, line.Content)
+			}
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	staged := diffText("staged")
+	if strings.Contains(staged, "round two") {
+		t.Errorf("staged diff leaked the unstaged Round 2 version:\n%s", staged)
+	}
+	if !strings.Contains(staged, "round one") {
+		t.Errorf("staged diff omitted the staged Round 1 version:\n%s", staged)
+	}
+
+	unstaged := diffText("unstaged")
+	if strings.Contains(unstaged, "base version") {
+		t.Errorf("unstaged diff leaked the pre-Round 1 base version:\n%s", unstaged)
+	}
+	if !strings.Contains(unstaged, "round one") || !strings.Contains(unstaged, "round two") {
+		t.Errorf("unstaged diff must compare Round 1 index to Round 2 worktree:\n%s", unstaged)
+	}
+
+	all := diffText("all")
+	if !strings.Contains(all, "round two") {
+		t.Errorf("all diff omitted the Round 2 worktree version:\n%s", all)
+	}
+	if strings.Contains(all, "round one") {
+		t.Errorf("all diff unexpectedly exposed the intermediate Round 1 version:\n%s", all)
+	}
+}

--- a/internal/session/session_focus.go
+++ b/internal/session/session_focus.go
@@ -816,30 +816,39 @@ func addedFileRendersWhole(scope string) bool {
 	return scope != "staged" && scope != "unstaged"
 }
 
-func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v vcs.VCS, ignoreWhitespace bool) []vcs.DiffHunk {
-	if v == nil {
-		return nil
+// scopedHunksForCommit returns hunks when a commit (or commit range) pin is set.
+// ok is false when commit is empty and the caller should use scope-based diffs.
+func scopedHunksForCommit(fc vcs.FileChange, commit, repoRoot string, v vcs.VCS, ignoreWhitespace bool) (hunks []vcs.DiffHunk, ok bool) {
+	if commit == "" {
+		return nil, false
 	}
 	if commit == virtualWorkingTreeCommitSHA {
 		h, err := v.FileDiffUnified(fc.Path, "HEAD", repoRoot, ignoreWhitespace)
 		if err == nil {
-			return h
+			return h, true
 		}
-		return nil
+		return nil, true
 	}
-	if base, head, ok := vcs.SplitCommitRange(commit); ok {
+	if base, head, rangeOK := vcs.SplitCommitRange(commit); rangeOK {
 		h, err := v.FileDiffBetweenSHAs(fc.Path, fc.OldPath, base, head, repoRoot, ignoreWhitespace)
 		if err == nil {
-			return h
+			return h, true
 		}
+		return nil, true
+	}
+	h, err := v.FileDiffForCommit(fc.Path, commit, repoRoot, ignoreWhitespace)
+	if err == nil {
+		return h, true
+	}
+	return nil, true
+}
+
+func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v vcs.VCS, ignoreWhitespace bool) []vcs.DiffHunk {
+	if v == nil {
 		return nil
 	}
-	if commit != "" {
-		h, err := v.FileDiffForCommit(fc.Path, commit, repoRoot, ignoreWhitespace)
-		if err == nil {
-			return h
-		}
-		return nil
+	if hunks, ok := scopedHunksForCommit(fc, commit, repoRoot, v, ignoreWhitespace); ok {
+		return hunks
 	}
 	showWholeFile := fc.Status == "untracked"
 	if fc.Status == "added" {
@@ -852,7 +861,7 @@ func scopedHunks(fc vcs.FileChange, scope, commit, baseRef, repoRoot string, v v
 		}
 		return nil
 	}
-	if fc.Status == "renamed" && fc.OldPath != "" {
+	if fc.Status == "renamed" && fc.OldPath != "" && (scope == "" || scope == "all" || scope == "branch") {
 		h, err := diffHunksForFile(fc.Path, fc.OldPath, fc.Status, baseRef, repoRoot, ignoreWhitespace, v)
 		if err == nil {
 			return h
@@ -1058,6 +1067,31 @@ func computeScopedDiffHunks(path, scope, commit, status, oldPath, content, baseR
 	return scopedHunks(vcs.FileChange{Path: path, OldPath: oldPath, Status: status}, scope, commit, baseRef, repoRoot, v, ignoreWhitespace)
 }
 
+// scopedDiffContents returns the old- and new-side content paired with a Git
+// index diff. Other VCS backends do not expose staged/unstaged scopes.
+func scopedDiffContents(path, scope, repoRoot, worktreeContent string, v vcs.VCS) (previousContent, content string, ok bool) {
+	content = worktreeContent
+	if v == nil || v.Name() != "git" {
+		return "", content, false
+	}
+
+	switch scope {
+	case "staged":
+		previousContent, _ = v.FileContentAtRef(path, "HEAD", repoRoot)
+		content, _ = v.FileContentAtRef(path, ":0", repoRoot)
+	case "unstaged":
+		previousContent, _ = v.FileContentAtRef(path, ":0", repoRoot)
+		if data, err := os.ReadFile(filepath.Join(repoRoot, path)); err == nil {
+			content = string(data)
+		} else if os.IsNotExist(err) {
+			content = ""
+		}
+	default:
+		return "", content, false
+	}
+	return previousContent, content, true
+}
+
 // GetFileDiffSnapshotScoped returns diff data for a file filtered by scope.
 // When scope is "" or in file mode (scopes only apply to git), delegates to GetFileDiffSnapshot.
 // When commit is non-empty, returns the diff for that single commit.
@@ -1080,5 +1114,12 @@ func (s *Session) GetFileDiffSnapshotScoped(path, scope, commit string, ignoreWh
 	if hunks == nil {
 		hunks = []vcs.DiffHunk{}
 	}
-	return map[string]any{"hunks": hunks}, true
+	result := map[string]any{"hunks": hunks}
+	if commit == "" {
+		if previousContent, scopedContent, ok := scopedDiffContents(path, scope, repoRoot, content, vc); ok {
+			result["previous_content"] = previousContent
+			result["content"] = scopedContent
+		}
+	}
+	return result, true
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1085,6 +1085,180 @@ func TestGetFileDiffSnapshotScoped_UntrackedFileUnstagedScope(t *testing.T) {
 	}
 }
 
+func TestGetFileDiffSnapshotScoped_UnstagedDeletionHasEmptyContent(t *testing.T) {
+	dir := initTestRepo(t)
+	gitT(t, dir, "checkout", "-b", "feature")
+	path := filepath.Join(dir, "main.go")
+	committedContent := "package main\n\nfunc main() {}\n"
+	writeFile(t, path, committedContent)
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "add main")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Session{
+		Mode:     "git",
+		RepoRoot: dir,
+		BaseRef:  "main",
+		VCS:      &vcs.GitVCS{},
+		Files: []*FileEntry{{
+			Path:     "main.go",
+			AbsPath:  path,
+			Status:   "deleted",
+			FileType: "code",
+			Content:  committedContent,
+		}},
+	}
+
+	result, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "", false)
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+	if result["previous_content"] != committedContent {
+		t.Errorf("previous_content = %q, want index content", result["previous_content"])
+	}
+	if result["content"] != "" {
+		t.Errorf("content = %q, want empty deleted-file content", result["content"])
+	}
+}
+
+// TestGetFileDiffSnapshotScoped_CodeMoveAfterRound_Repro915 reproduces issue #915:
+// after a feedback round moves code around, the staged/unstaged scoped diff must
+// include the content of the revision it is diffed against so the UI can expand
+// context lines correctly. Without that base content, the frontend fills gaps
+// between hunks from the working tree file using line numbers that belong to the
+// index/HEAD, producing a correct changed hunk followed by an incorrect block of
+// unchanged context.
+func TestGetFileDiffSnapshotScoped_CodeMoveAfterRound_Repro915(t *testing.T) {
+	dir := initTestRepo(t)
+	gitT(t, dir, "checkout", "-b", "feature")
+
+	// Round 1: commit a file with helper() above foo().
+	round1 := "package main\n\nfunc helper() {\n\t// helper body\n}\n\nfunc foo() {\n\thelper()\n\t// foo body\n}\n\nfunc bar() {\n\t// bar body\n}\n"
+	writeFile(t, filepath.Join(dir, "main.go"), round1)
+	gitT(t, dir, "add", "main.go")
+	gitT(t, dir, "commit", "-m", "round 1")
+
+	// Round 2: stage a move of helper() below foo(), then add an unstaged tweak
+	// on a different line so the staged diff's new-side line numbers diverge from
+	// the working tree content.
+	round2Staged := "package main\n\nfunc foo() {\n\thelper()\n\t// foo body\n}\n\nfunc helper() {\n\t// helper body\n}\n\nfunc bar() {\n\t// bar body\n}\n"
+	writeFile(t, filepath.Join(dir, "main.go"), round2Staged)
+	gitT(t, dir, "add", "main.go")
+
+	round2Working := "package main\n\nfunc foo() {\n\thelper()\n\t// foo body tweaked\n}\n\nfunc helper() {\n\t// helper body\n}\n\nfunc bar() {\n\t// bar body\n}\n"
+	writeFile(t, filepath.Join(dir, "main.go"), round2Working)
+
+	// Simulate the session state at the end of Round 1.
+	s := &Session{
+		Mode:        "git",
+		RepoRoot:    dir,
+		BaseRef:     "main",
+		VCS:         &vcs.GitVCS{},
+		ReviewRound: 1,
+		subscribers: make(map[chan SSEEvent]struct{}),
+		Files: []*FileEntry{{
+			Path:     "main.go",
+			AbsPath:  filepath.Join(dir, "main.go"),
+			Status:   "added",
+			FileType: "code",
+			Content:  round1,
+			Comments: []Comment{},
+		}},
+	}
+
+	// Round-complete refreshes the file list, content, and cached DiffHunks.
+	s.handleRoundCompleteGit()
+
+	// The hunks themselves must match real git output.
+	for _, scope := range []string{"unstaged", "staged"} {
+		result, ok := s.GetFileDiffSnapshotScoped("main.go", scope, "", false)
+		if !ok {
+			t.Fatalf("scope=%s: expected snapshot", scope)
+		}
+		hunks := result["hunks"].([]vcs.DiffHunk)
+
+		wantHunks, err := vcs.FileDiffScoped("main.go", scope, "main", dir, false)
+		if err != nil {
+			t.Fatalf("scope=%s: real git diff failed: %v", scope, err)
+		}
+		if !hunksEqual(hunks, wantHunks) {
+			t.Errorf("scope=%s: scoped diff does not match real git diff\nscoped: %s\ngit:    %s", scope, formatHunks(hunks), formatHunks(wantHunks))
+		}
+	}
+
+	// Issue #915: scoped diffs must also expose the base content so the frontend
+	// can expand context lines using the correct revision. Without this, the UI
+	// fills small inter-hunk gaps from the working tree file using line numbers
+	// that belong to the index (staged) or HEAD (branch), producing wrong context.
+	stagedResult, ok := s.GetFileDiffSnapshotScoped("main.go", "staged", "", false)
+	if !ok {
+		t.Fatal("scope=staged: expected snapshot")
+	}
+	if stagedResult["previous_content"] != round1 {
+		t.Errorf("scope=staged: expected previous_content to be HEAD (Round 1) content for correct context expansion; got %q", stagedResult["previous_content"])
+	}
+	if stagedResult["content"] != round2Staged {
+		t.Errorf("scope=staged: expected content to be the index (Round 2 staged) content; got %q", stagedResult["content"])
+	}
+
+	unstagedResult, ok := s.GetFileDiffSnapshotScoped("main.go", "unstaged", "", false)
+	if !ok {
+		t.Fatal("scope=unstaged: expected snapshot")
+	}
+	if unstagedResult["previous_content"] != round2Staged {
+		t.Errorf("scope=unstaged: expected previous_content to be index content for correct context expansion; got %q", unstagedResult["previous_content"])
+	}
+	if unstagedResult["content"] != round2Working {
+		t.Errorf("scope=unstaged: expected content to be current worktree content; got %q", unstagedResult["content"])
+	}
+}
+
+// hunksEqual reports whether two parsed hunks slices are equivalent for test
+// assertions (headers, line counts, types, and content).
+func hunksEqual(a, b []vcs.DiffHunk) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Header != b[i].Header || a[i].OldStart != b[i].OldStart || a[i].OldCount != b[i].OldCount || a[i].NewStart != b[i].NewStart || a[i].NewCount != b[i].NewCount {
+			return false
+		}
+		if len(a[i].Lines) != len(b[i].Lines) {
+			return false
+		}
+		for j := range a[i].Lines {
+			if a[i].Lines[j].Type != b[i].Lines[j].Type || a[i].Lines[j].Content != b[i].Lines[j].Content {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// formatHunks renders parsed hunks as a compact string for test failure output.
+func formatHunks(hunks []vcs.DiffHunk) string {
+	var b strings.Builder
+	for _, h := range hunks {
+		b.WriteString(h.Header)
+		b.WriteString("\n")
+		for _, l := range h.Lines {
+			switch l.Type {
+			case "add":
+				b.WriteString("+")
+			case "del":
+				b.WriteString("-")
+			default:
+				b.WriteString(" ")
+			}
+			b.WriteString(l.Content)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
 func TestSession_GlobalCommentIDs(t *testing.T) {
 	s := newTestSession(t)
 	c1, _ := s.AddComment("plan.md", 1, 1, "", "md comment", "", "", "")

--- a/web/__tests__/range-focus-diff-scope.test.js
+++ b/web/__tests__/range-focus-diff-scope.test.js
@@ -10,6 +10,48 @@ const path = require('node:path');
 
 const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
 
+function extractFunction(name) {
+  const start = appJs.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} must exist`);
+  const bodyStart = appJs.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < appJs.length; i++) {
+    if (appJs[i] === '{') depth++;
+    if (appJs[i] === '}') {
+      depth--;
+      if (depth === 0) return appJs.slice(start, i + 1);
+    }
+  }
+  throw new Error(`could not extract ${name}`);
+}
+
+const loadSingleFile = new Function(`
+  let diffCommit = '';
+  let ignoreWhitespace = false;
+  const session = { mode: 'git' };
+  function enc(value) { return value; }
+  function preHighlightFile() { return null; }
+  function langFromPath() { return ''; }
+  function buildCodeLineBlocks() { return []; }
+  function parseMarkdown() { return { blocks: [], tocItems: [] }; }
+  ${extractFunction('loadSingleFile').replace(/^function /, 'async function ')}
+  return loadSingleFile;
+`)();
+
+async function loadWithDiff(diff) {
+  const originalFetch = global.fetch;
+  global.fetch = async function(url) {
+    if (url.startsWith('/api/file?')) return { ok: true, json: async function() { return { content: 'worktree' }; } };
+    if (url.startsWith('/api/file/comments')) return { ok: true, json: async function() { return []; } };
+    return { ok: true, json: async function() { return diff; } };
+  };
+  try {
+    return await loadSingleFile({ path: 'main.go', status: 'modified', file_type: 'code' }, 'staged');
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
 test('range focus forces diffScope to all on init', () => {
   assert.match(
     appJs,
@@ -29,4 +71,10 @@ test('file diff loads use the story-aware file data scope helper', () => {
     /loadAllFileData\(session\.files[^)]*currentFileDataScope\(\)/,
     'loadAllFileData must use currentFileDataScope so story and range scopes agree'
   );
+});
+
+test('scoped diff content overrides worktree content for context expansion', async () => {
+  assert.equal((await loadWithDiff({ hunks: [], content: 'index' })).content, 'index');
+  assert.equal((await loadWithDiff({ hunks: [] })).content, 'worktree');
+  assert.equal((await loadWithDiff({ hunks: [], content: '' })).content, '');
 });

--- a/web/app.js
+++ b/web/app.js
@@ -659,13 +659,16 @@
       fetch('/api/file/comments?path=' + enc(fi.path)).then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
       fetch(diffUrl).then(function(r) { return r.ok ? r.json() : { hunks: [] }; }).catch(function() { return { hunks: [] }; }),
     ]);
+    const content = Object.prototype.hasOwnProperty.call(diffRes, 'content')
+      ? diffRes.content
+      : (fileRes.content || '');
 
     const f = {
       path: fi.path,
       oldPath: fi.old_path || '',
       status: fi.status,
       fileType: fi.file_type,
-      content: fileRes.content || '',
+      content: content,
       previousContent: diffRes.previous_content || '',
       comments: Array.isArray(commentsRes) ? commentsRes : [],
       diffHunks: diffRes.hunks || [],


### PR DESCRIPTION
## Summary
- Staged/unstaged views for renamed files now use FileDiffScoped instead of the full base→worktree rename diff
- Scoped snapshots return the matching old/new content revisions so gap-fill no longer uses mismatched worktree bytes
- Frontend prefers diff response content when present

Closes #915

## Review
- [x] Code review: passed (intent + parity N/A)
- [x] Parity audit: N/A (CLI git scopes)

## Test plan
- [x] `TestGetFileDiffSnapshotScoped_RenamedFileAfterRoundCompleteKeepsScopesSeparate`
- [x] `TestGetFileDiffSnapshotScoped_CodeMoveAfterRound_Repro915`
- [x] `node --test web/__tests__/range-focus-diff-scope.test.js`
- [ ] CI full suite


Made with [Cursor](https://cursor.com)