### PR TITLE
fix: carry comments across file renames (#917)

### DIFF
--- a/internal/session/issue917_rename_test.go
+++ b/internal/session/issue917_rename_test.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tomasz-tomczyk/crit/internal/vcs"
+)
+
+// TestHandleRoundCompleteGit_RenameFollowsPersistedComments reproduces #917.
+//
+// Comments are keyed by path string. When the agent renames a file
+// (old.go -> new.go) git reports Status="renamed" with OldPath="old.go".
+// A comment that was already persisted under old.go in the review JSON
+// (the debounced writer flushes on every change) must follow the rename and
+// land on the new.go entry after round-complete.
+//
+// Today it does not: RefreshFileList only reuses an entry when
+// existing[fc.Path] matches the NEW path, so new.go is created with empty
+// Comments and the old.go entry is dropped. restoreOrphanedComments then reads
+// the still-old.go-keyed review JSON and re-materialises the thread as an
+// orphaned/removed phantom under old.go. The net effect is the review thread
+// sticks to a dead path instead of the renamed file.
+func TestHandleRoundCompleteGit_RenameFollowsPersistedComments(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []vcs.FileChange{
+			{Path: "new.go", OldPath: "old.go", Status: "renamed"},
+		},
+		diffs: map[string][]vcs.DiffHunk{
+			"new.go": {{OldStart: 1, NewStart: 1}},
+		},
+	}
+	s := newWatchSession(t, v)
+	s.Mode = "git"
+	s.Branch = "feature"
+	s.ReviewRound = 1
+	s.subscribers = make(map[chan SSEEvent]struct{})
+
+	// Post-rename, only new.go exists on disk; old.go is gone.
+	if err := os.WriteFile(filepath.Join(s.RepoRoot, "new.go"), []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The review JSON still keys the thread under the OLD path — this is what
+	// the writer flushed before the rename was observed.
+	critPath := s.critJSONPath()
+	cj := CritJSON{
+		Branch:      "feature",
+		ReviewRound: 1,
+		Files: map[string]CritJSONFile{
+			"old.go": {
+				Status: "modified",
+				Comments: []Comment{
+					{ID: "c1", Body: "this thread must follow the rename", Scope: "line", StartLine: 1, EndLine: 1, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(cj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mustMkdirAll(ReviewPathsFor(critPath).Review), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// In-memory the session still knows the file by its pre-rename path.
+	s.Files = []*FileEntry{
+		{Path: "old.go", AbsPath: filepath.Join(s.RepoRoot, "old.go"), Status: "modified"},
+	}
+
+	s.handleRoundCompleteGit()
+
+	byPath := map[string]*FileEntry{}
+	for _, f := range s.Files {
+		byPath[f.Path] = f
+	}
+
+	// The renamed-into entry must exist and carry the persisted thread.
+	newEntry := byPath["new.go"]
+	if newEntry == nil {
+		t.Fatalf("new.go missing from file list after rename round-complete")
+	}
+	if len(newEntry.Comments) == 0 {
+		t.Errorf("new.go has 0 comments; the persisted thread from old.go should have followed the rename (#917)")
+	}
+
+	// And it must not be stranded as an orphaned phantom under the dead path.
+	if old := byPath["old.go"]; old != nil && old.Orphaned && len(old.Comments) > 0 {
+		t.Errorf("old.go was restored as an orphaned phantom holding %d comment(s); the thread should have moved to new.go instead (#917)", len(old.Comments))
+	}
+}

--- a/internal/session/issue917_rename_test.go
+++ b/internal/session/issue917_rename_test.go
@@ -94,3 +94,124 @@ func TestHandleRoundCompleteGit_RenameFollowsPersistedComments(t *testing.T) {
 		t.Errorf("old.go was restored as an orphaned phantom holding %d comment(s); the thread should have moved to new.go instead (#917)", len(old.Comments))
 	}
 }
+
+func TestMergeCommentSlices_DedupsByID(t *testing.T) {
+	base := []Comment{{ID: "a", Body: "keep"}, {ID: "b", Body: "also"}}
+	extra := []Comment{{ID: "b", Body: "dup"}, {ID: "c", Body: "new"}}
+	got := mergeCommentSlices(base, extra)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[2].ID != "c" || got[1].Body != "also" {
+		t.Errorf("unexpected merge result: %+v", got)
+	}
+	if mergeCommentSlices(base, nil) == nil {
+		t.Error("nil extra should return base")
+	}
+}
+
+func TestRewriteReviewJSONRenames_MovesAndMerges(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "review-id")
+	if err := os.MkdirAll(identity, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	reviewPath := ReviewPathsFor(identity).Review
+	cj := CritJSON{
+		Files: map[string]CritJSONFile{
+			"old.go": {
+				Status:   "modified",
+				Comments: []Comment{{ID: "from-old", Body: "old", Scope: "line"}},
+			},
+			"new.go": {
+				Status:   "renamed",
+				Comments: []Comment{{ID: "from-new", Body: "new", Scope: "line"}},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reviewPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rewriteReviewJSONRenames(identity, []pathRename{{from: "old.go", to: "new.go"}})
+
+	raw, err := os.ReadFile(reviewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got CritJSON
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Files["old.go"]; ok {
+		t.Error("old.go key should be removed")
+	}
+	nf, ok := got.Files["new.go"]
+	if !ok {
+		t.Fatal("new.go key missing")
+	}
+	ids := map[string]bool{}
+	for _, c := range nf.Comments {
+		ids[c.ID] = true
+	}
+	if !ids["from-old"] || !ids["from-new"] {
+		t.Errorf("merged comments = %+v, want both IDs", nf.Comments)
+	}
+}
+
+func TestAppendOrphanedFiles_AttachesViaOldPath(t *testing.T) {
+	s := &Session{
+		Files: []*FileEntry{
+			{Path: "new.go", OldPath: "old.go", Status: "renamed", Comments: nil},
+		},
+	}
+	s.appendOrphanedFiles(map[string]CritJSONFile{
+		"old.go": {
+			Comments: []Comment{{ID: "c1", Body: "follow me", Scope: ""}},
+		},
+	})
+	if len(s.Files) != 1 {
+		t.Fatalf("want 1 file (no phantom), got %d", len(s.Files))
+	}
+	if len(s.Files[0].Comments) != 1 || s.Files[0].Comments[0].ID != "c1" {
+		t.Errorf("comments not attached via OldPath: %+v", s.Files[0].Comments)
+	}
+	if s.Files[0].Comments[0].Scope != "line" {
+		t.Errorf("empty Scope should default to line, got %q", s.Files[0].Comments[0].Scope)
+	}
+	if s.Files[0].Orphaned {
+		t.Error("renamed target must not be marked orphaned")
+	}
+}
+
+func TestRefreshFileList_SetsOldPathWhenNewPathAlreadyPresent(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []vcs.FileChange{
+			{Path: "new.go", OldPath: "old.go", Status: "renamed"},
+		},
+	}
+	s := newWatchSession(t, v)
+	newAbs := filepath.Join(s.RepoRoot, "new.go")
+	if err := os.WriteFile(newAbs, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.Files = []*FileEntry{
+		{Path: "new.go", AbsPath: newAbs, Status: "added", Comments: []Comment{{ID: "keep", Body: "x"}}},
+	}
+	s.RefreshFileList()
+	if len(s.Files) != 1 || s.Files[0].Path != "new.go" {
+		t.Fatalf("unexpected files: %+v", s.Files)
+	}
+	if s.Files[0].OldPath != "old.go" {
+		t.Errorf("OldPath = %q, want old.go", s.Files[0].OldPath)
+	}
+	if len(s.Files[0].Comments) != 1 {
+		t.Errorf("comments should be preserved, got %d", len(s.Files[0].Comments))
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2467,6 +2467,9 @@ func (s *Session) restoreShareStateLocked(cj *CritJSON) {
 func (s *Session) restoreFileCommentsLocked(cj *CritJSON) {
 	for _, f := range s.Files {
 		cf, ok := cj.Files[f.Path]
+		if !ok && f.OldPath != "" {
+			cf, ok = cj.Files[f.OldPath]
+		}
 		if !ok {
 			continue
 		}
@@ -2624,11 +2627,25 @@ func (s *Session) restoreOrphanedComments() {
 // s.mu held or during init (before concurrent access).
 func (s *Session) appendOrphanedFiles(critFiles map[string]CritJSONFile) {
 	knownPaths := make(map[string]bool, len(s.Files))
+	byOldPath := make(map[string]*FileEntry)
 	for _, f := range s.Files {
 		knownPaths[f.Path] = true
+		if f.OldPath != "" {
+			byOldPath[f.OldPath] = f
+		}
 	}
 	for path, cf := range critFiles {
 		if knownPaths[path] || len(cf.Comments) == 0 {
+			continue
+		}
+		// #917: comments keyed under a pre-rename path belong on the renamed entry.
+		if f, ok := byOldPath[path]; ok {
+			f.Comments = mergeCommentSlices(f.Comments, cf.Comments)
+			for i := range f.Comments {
+				if f.Comments[i].Scope == "" {
+					f.Comments[i].Scope = "line"
+				}
+			}
 			continue
 		}
 		fe := &FileEntry{

--- a/internal/session/watch.go
+++ b/internal/session/watch.go
@@ -117,54 +117,178 @@ func (s *Session) RefreshFileList() {
 		}
 	}
 
-	// Build new file list, doing I/O (os.ReadFile, sha256) without holding the lock.
-	// Status updates for existing entries are deferred to the write-lock section
-	// to avoid racing with concurrent readers.
-	type existingUpdate struct {
-		entry  *FileEntry
-		status string
-	}
-	var newFiles []*FileEntry
-	var updates []existingUpdate
-	for i, fc := range changes {
-		if f, ok := existing[fc.Path]; ok {
-			updates = append(updates, existingUpdate{f, fc.Status})
-			newFiles = append(newFiles, f)
-		} else {
-			absPath := filepath.Join(repoRoot, fc.Path)
-			fe := &FileEntry{
-				Path:     fc.Path,
-				AbsPath:  absPath,
-				Status:   fc.Status,
-				FileType: detectFileType(fc.Path),
-				Comments: []Comment{},
-			}
-
-			// Apply lazy threshold for newly discovered files
-			if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
-				fe.Lazy = true
-				if ns, ok := numstats[fc.Path]; ok {
-					fe.LazyAdditions = ns.Additions
-					fe.LazyDeletions = ns.Deletions
-				}
-			} else if fc.Status != "deleted" {
-				if data, err := os.ReadFile(absPath); err == nil {
-					fe.Content = string(data)
-					fe.FileHash = fileHash(data)
-				}
-			}
-
-			newFiles = append(newFiles, fe)
-		}
-	}
+	built := buildRefreshedFileList(existing, changes, repoRoot, numstats)
 
 	// Assign under write lock
 	s.mu.Lock()
-	for _, u := range updates {
+	for _, u := range built.updates {
 		u.entry.Status = u.status
+		if u.oldPath != "" {
+			u.entry.OldPath = u.oldPath
+		}
+		if u.newPath != "" {
+			u.entry.Path = u.newPath
+			u.entry.AbsPath = u.absPath
+		}
 	}
-	s.Files = newFiles
+	s.Files = built.files
+	critPath := s.critJSONPath()
 	s.mu.Unlock()
+
+	// Rewrite review-JSON path keys so persisted threads follow the rename
+	// and restoreOrphanedComments does not resurrect a phantom under OldPath.
+	if len(built.renames) > 0 {
+		rewriteReviewJSONRenames(critPath, built.renames)
+	}
+}
+
+// fileListUpdate defers Path/Status/OldPath mutation until the write lock.
+type fileListUpdate struct {
+	entry   *FileEntry
+	status  string
+	oldPath string // set FileEntry.OldPath when non-empty (rename)
+	newPath string // when set, retarget Path/AbsPath (rename handoff)
+	absPath string
+}
+
+type refreshedFileList struct {
+	files   []*FileEntry
+	updates []fileListUpdate
+	renames []pathRename
+}
+
+// buildRefreshedFileList maps VCS changes onto existing FileEntries, carrying
+// comments across renames via OldPath (#917). Pure aside from reading new
+// file contents from disk for newly discovered paths.
+func buildRefreshedFileList(existing map[string]*FileEntry, changes []vcs.FileChange, repoRoot string, numstats map[string]vcs.NumstatEntry) refreshedFileList {
+	var out refreshedFileList
+	for i, fc := range changes {
+		absPath := filepath.Join(repoRoot, fc.Path)
+		if f, ok := existing[fc.Path]; ok {
+			out.updates = append(out.updates, fileListUpdate{entry: f, status: fc.Status, oldPath: fc.OldPath})
+			out.files = append(out.files, f)
+			delete(existing, fc.Path)
+			if fc.OldPath != "" {
+				out.renames = append(out.renames, pathRename{from: fc.OldPath, to: fc.Path})
+				delete(existing, fc.OldPath)
+			}
+			continue
+		}
+		// #917: reuse the pre-rename entry so in-memory comments follow.
+		if fc.OldPath != "" {
+			if old, ok := existing[fc.OldPath]; ok {
+				out.updates = append(out.updates, fileListUpdate{
+					entry:   old,
+					status:  fc.Status,
+					oldPath: fc.OldPath,
+					newPath: fc.Path,
+					absPath: absPath,
+				})
+				out.files = append(out.files, old)
+				delete(existing, fc.OldPath)
+				out.renames = append(out.renames, pathRename{from: fc.OldPath, to: fc.Path})
+				continue
+			}
+			out.renames = append(out.renames, pathRename{from: fc.OldPath, to: fc.Path})
+		}
+
+		fe := &FileEntry{
+			Path:     fc.Path,
+			OldPath:  fc.OldPath,
+			AbsPath:  absPath,
+			Status:   fc.Status,
+			FileType: detectFileType(fc.Path),
+			Comments: []Comment{},
+		}
+
+		if len(changes) > lazyFileThreshold && i >= lazyFileThreshold {
+			fe.Lazy = true
+			if ns, ok := numstats[fc.Path]; ok {
+				fe.LazyAdditions = ns.Additions
+				fe.LazyDeletions = ns.Deletions
+			}
+		} else if fc.Status != "deleted" {
+			if data, err := os.ReadFile(absPath); err == nil {
+				fe.Content = string(data)
+				fe.FileHash = fileHash(data)
+			}
+		}
+
+		out.files = append(out.files, fe)
+	}
+	return out
+}
+
+// pathRename is old→new path for a VCS-reported rename.
+type pathRename struct {
+	from, to string
+}
+
+// rewriteReviewJSONRenames moves CritJSON.Files keys from the pre-rename path
+// to the post-rename path (merging comments if both keys exist). Best-effort:
+// failures leave disk unchanged so a later write can still reconcile.
+func rewriteReviewJSONRenames(critPath string, renames []pathRename) {
+	if critPath == "" || len(renames) == 0 {
+		return
+	}
+	reviewPath := ReviewPathsFor(critPath).Review
+	data, err := os.ReadFile(reviewPath)
+	if err != nil {
+		return
+	}
+	var cj CritJSON
+	if err := json.Unmarshal(data, &cj); err != nil || cj.Files == nil {
+		return
+	}
+	changed := false
+	for _, r := range renames {
+		if r.from == "" || r.to == "" || r.from == r.to {
+			continue
+		}
+		oldFile, hasOld := cj.Files[r.from]
+		if !hasOld {
+			continue
+		}
+		if newFile, hasNew := cj.Files[r.to]; hasNew {
+			cj.Files[r.to] = CritJSONFile{
+				Status:   newFile.Status,
+				FileHash: newFile.FileHash,
+				Comments: mergeCommentSlices(newFile.Comments, oldFile.Comments),
+			}
+		} else {
+			oldFile.Status = "renamed"
+			cj.Files[r.to] = oldFile
+		}
+		delete(cj.Files, r.from)
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	out, err := json.MarshalIndent(cj, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = AtomicWriteFile(reviewPath, out, 0o600)
+}
+
+// mergeCommentSlices appends comments from extra whose IDs are not already in base.
+func mergeCommentSlices(base, extra []Comment) []Comment {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base))
+	for _, c := range base {
+		seen[c.ID] = struct{}{}
+	}
+	out := append([]Comment(nil), base...)
+	for _, c := range extra {
+		if _, ok := seen[c.ID]; ok {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // Watch dispatches to the appropriate file-watching strategy based on session mode.
@@ -734,6 +858,12 @@ func (s *Session) loadResolvedComments() {
 	for _, f := range s.Files {
 		if cf, ok := cj.Files[f.Path]; ok {
 			f.PreviousComments = cf.Comments
+		} else if f.OldPath != "" {
+			if cf, ok := cj.Files[f.OldPath]; ok {
+				f.PreviousComments = cf.Comments
+			} else {
+				f.PreviousComments = nil
+			}
 		} else {
 			f.PreviousComments = nil
 		}

--- a/internal/session/watch_refresh_test.go
+++ b/internal/session/watch_refresh_test.go
@@ -122,6 +122,60 @@ func TestRefreshDiffs_SkipsDeletedAndLazyFiles(t *testing.T) {
 	}
 }
 
+// TestRefreshFileList_RenameCarriesComments verifies that when the VCS reports
+// a rename (new path with OldPath pointing at the previous file), comments
+// stored on the old path are migrated to the new FileEntry instead of being
+// dropped or orphaned.
+func TestRefreshFileList_RenameCarriesComments(t *testing.T) {
+	v := &fakeWatchVCS{
+		currentBranch: "feature",
+		defaultBranch: "main",
+		branchChanges: []vcs.FileChange{
+			{Path: "new.go", OldPath: "old.go", Status: "renamed"},
+		},
+	}
+	s := newWatchSession(t, v)
+
+	oldAbs := filepath.Join(s.RepoRoot, "old.go")
+	newAbs := filepath.Join(s.RepoRoot, "new.go")
+	if err := os.WriteFile(oldAbs, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newAbs, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldComment := Comment{ID: "c1", Body: "fix this", StartLine: 1, EndLine: 1, Scope: "line"}
+	s.Files = []*FileEntry{
+		{Path: "old.go", AbsPath: oldAbs, Status: "modified", Comments: []Comment{oldComment}},
+	}
+
+	s.RefreshFileList()
+
+	byPath := make(map[string]*FileEntry, len(s.Files))
+	for _, f := range s.Files {
+		byPath[f.Path] = f
+	}
+
+	newF, ok := byPath["new.go"]
+	if !ok {
+		t.Fatalf("new.go missing from file list; got paths %v", byPath)
+	}
+	if newF.OldPath != "old.go" {
+		t.Errorf("new.go OldPath = %q, want %q", newF.OldPath, "old.go")
+	}
+	if len(newF.Comments) != 1 {
+		t.Fatalf("new.go comments = %d, want 1", len(newF.Comments))
+	}
+	if newF.Comments[0].ID != "c1" {
+		t.Errorf("new.go comment ID = %q, want %q", newF.Comments[0].ID, "c1")
+	}
+
+	if _, ok := byPath["old.go"]; ok {
+		t.Error("old.go should not remain as a separate entry after rename")
+	}
+}
+
 func TestRefreshFileList_AddsAndRemoves(t *testing.T) {
 	v := &fakeWatchVCS{
 		currentBranch: "feature",


### PR DESCRIPTION
## Summary
- `RefreshFileList` now reuses the pre-rename `FileEntry` via `OldPath`, so in-memory comments follow the new path
- Review JSON path keys are rewritten on rename so persisted threads are not resurrected as orphans under the old path
- Orphan restore / comment load also honor `OldPath` as a safety net

Closes #917

## Review
- [x] Code review: local TDD (two RED→GREEN regressions)
- [x] Parity audit: N/A (session file-list / review JSON; CLI git mode)

## Test plan
- [x] `TestRefreshFileList_RenameCarriesComments`
- [x] `TestHandleRoundCompleteGit_RenameFollowsPersistedComments`
- [x] pre-commit (gofmt, lint, tests)
- [ ] CI full suite


Made with [Cursor](https://cursor.com)