### PR TITLE
test: settle lazy bodies after perf scroll

### DIFF
--- a/test/e2e/tests/large-review.perf.spec.ts
+++ b/test/e2e/tests/large-review.perf.spec.ts
@@ -84,6 +84,10 @@ test('scrolling a large review keeps bodies deferred and main thread free', asyn
       await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
     }
     window.scrollTo(0, 0);
+    // The final jump also schedules IntersectionObserver work. Yield two
+    // frames so the top-position mount/defer cycle is complete before the
+    // structural budget is sampled, just like each intermediate scroll step.
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
   });
 
   const wallMs = Date.now() - wallStart;


### PR DESCRIPTION
## Summary
- Fix the large-review Playwright performance test's final scroll synchronization.
- Yield two animation frames after returning to the top so deferred-body IntersectionObserver work has completed before structural budgets are sampled.

## Flaky failure and evidence
The source run [34335437773](https://github.com/tomasz-tomczyk/crit/actions/runs/34335437773) failed only in `e2e-windows` at `large-review.perf.spec.ts:70`, waiting for `mountedBodies(page).count()` to become `<= 40`. The same commit's earlier run [34333863699](https://github.com/tomasz-tomczyk/crit/actions/runs/34333863699) passed all jobs, including `e2e-windows`, without a code change. Linux E2E also passed in the failing run.

## Root cause
The test yielded two frames after each intermediate scroll but not after the final `window.scrollTo(0, 0)`. That final jump schedules the same IntersectionObserver mount/defer work used by the application. On slower Windows runners, the budget could be sampled before that cycle had settled.

## Tests run
- `mise exec -- npx playwright test tests/large-review.perf.spec.ts --project=perf`
- `mise exec -- go test ./...`
- `mise exec -- npm run test:frontend`
- `mise exec -- npm run test:perf`
- Pre-commit hooks (gofmt, golangci-lint, tests, ESLint, confusable check, Stylelint)
