### PR TITLE
fix: refresh story chapter mark button when files are viewed

### DIFF
--- a/test/e2e/tests/story.spec.ts
+++ b/test/e2e/tests/story.spec.ts
@@ -304,6 +304,33 @@ test.describe('Story mode', () => {
     await expect(storyView(page, 'ch1').locator('.crit-story-file-group[data-story-file="routes.go"]')).toHaveClass(/viewed/);
   });
 
+  test('marking every file in a chapter viewed updates the chapter mark button in place', async ({ page }) => {
+    await ingestStory(critBin, fixtureDir, fakeHome);
+    await loadPage(page);
+
+    await tocItem(page, 'ch1').scrollIntoViewIfNeeded();
+    await tocItem(page, 'ch1').click();
+    await expect(storyView(page, 'ch1')).toBeVisible();
+
+    // ch1 owns a single file group (routes.go), so one checkbox flips the
+    // whole chapter to all-viewed.
+    const markBtn = storyView(page, 'ch1').locator('.crit-story-chapter__mark-row .crit-story-chapter__mark');
+    await expect(markBtn).toHaveText('Mark chapter viewed');
+
+    const group = storyView(page, 'ch1').locator('.crit-story-file-group[data-story-file="routes.go"]');
+    await group.locator('.file-header-viewed').scrollIntoViewIfNeeded();
+    await group.locator('.file-header-viewed').click();
+
+    await expect(group).toHaveClass(/viewed/);
+    await expect(markBtn).toHaveText('Chapter viewed');
+
+    // Click polarity flips too: clicking the viewed-state button unmarks.
+    await markBtn.scrollIntoViewIfNeeded();
+    await markBtn.click();
+    await expect(markBtn).toHaveText('Mark chapter viewed');
+    await expect(group).not.toHaveClass(/viewed/);
+  });
+
   test('chapter file headers reuse collapse and selected-text comment affordances', async ({ page }) => {
     await ingestStory(critBin, fixtureDir, fakeHome);
     await loadPage(page);

--- a/web/__tests__/story-chapter-mark.test.js
+++ b/web/__tests__/story-chapter-mark.test.js
@@ -1,0 +1,48 @@
+'use strict';
+// Source-contract tests for the story chapter mark button (#fix/story-chapter-mark-button).
+// Bug: per-file Viewed checkboxes only called toggleViewed + renderStoryRail,
+// leaving `.crit-story-chapter__mark` stale (wrong label + stale click polarity).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appSrc = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+function sliceFunction(src, name, nextName) {
+  const start = src.indexOf('function ' + name);
+  assert.notEqual(start, -1, name + ' must exist');
+  const end = nextName ? src.indexOf('function ' + nextName, start + 1) : start + 8000;
+  assert.notEqual(end, -1, nextName + ' must follow ' + name);
+  return src.slice(start, end);
+}
+
+test('updateStoryMarkButton helper exists and syncs label from storyPageProgress', () => {
+  const body = sliceFunction(appSrc, 'updateStoryMarkButton', 'storyStatusClass');
+  assert.match(body, /storyPageProgress\s*\(\s*page\s*\)/);
+  assert.match(body, /crit-story-chapter__mark/);
+  assert.match(body, /Chapter viewed/);
+  assert.match(body, /Mark chapter viewed/);
+});
+
+test('chapter mark click reads live progress instead of closing over render-time allViewed', () => {
+  const body = sliceFunction(appSrc, 'renderStoryPage', 'renderStoryFileGroup');
+  assert.match(body, /crit-story-chapter__mark/);
+  // No stale closure: handler must recompute allViewed at click time.
+  assert.doesNotMatch(body, /markPageViewed\s*\(\s*page\s*,\s*!allViewed\s*\)/);
+  assert.match(body, /storyPageProgress\s*\(\s*page\s*\)[\s\S]{0,200}markPageViewed\s*\(\s*page\s*,/s);
+});
+
+test('per-file Viewed toggle refreshes the chapter mark button in place', () => {
+  const body = sliceFunction(appSrc, 'renderStoryFileGroup', 'storySupportReasonForFile');
+  assert.match(body, /toggleViewed\s*\(\s*filePath\s*\)/);
+  assert.match(body, /renderStoryRail\s*\(\s*\)/);
+  assert.match(body, /updateStoryMarkButton\s*\(\s*page\s*\)/);
+});
+
+test('renderStoryFileByPath refreshes the chapter mark button after partial re-render', () => {
+  const body = sliceFunction(appSrc, 'renderStoryFileByPath', 'markPageViewed');
+  assert.match(body, /renderStoryRail\s*\(\s*\)/);
+  assert.match(body, /updateStoryMarkButton\s*\(\s*page\s*\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10911,6 +10911,23 @@
     return { done: done, total: groupFiles.length };
   }
 
+  // Keep the chapter mark button in sync when per-file Viewed state changes.
+  // Updates the existing button in place (preserves scroll/open state) — the
+  // click handler itself reads storyPageProgress live, so only the label needs
+  // syncing here.
+  function updateStoryMarkButton(page) {
+    if (!page || !storyState) return;
+    if (typeof storyView !== 'undefined' && storyView !== storyPageId(page)) return;
+    const view = document.getElementById('crit-story-view-' + storyPageId(page));
+    if (!view) return;
+    const markBtn = view.querySelector('.crit-story-chapter__mark');
+    if (!markBtn) return;
+    const prog = storyPageProgress(page);
+    const allViewed = prog.total > 0 && prog.done >= prog.total;
+    const label = allViewed ? 'Chapter viewed' : 'Mark chapter viewed';
+    if (markBtn.textContent !== label) markBtn.textContent = label;
+  }
+
   function storyStatusClass(page) {
     const p = storyPageProgress(page);
     if (p.total === 0) return '';
@@ -11340,7 +11357,11 @@
     markBtn.type = 'button';
     markBtn.className = 'crit-story-chapter__mark';
     markBtn.textContent = allViewed ? 'Chapter viewed' : 'Mark chapter viewed';
-    markBtn.addEventListener('click', function () { markPageViewed(page, !allViewed); });
+    markBtn.addEventListener('click', function () {
+      const cur = storyPageProgress(page);
+      const curAll = cur.total > 0 && cur.done >= cur.total;
+      markPageViewed(page, !curAll);
+    });
     markRow.appendChild(markBtn);
     view.appendChild(markRow);
 
@@ -11502,6 +11523,7 @@
       if (file && file.viewed && section.open) section.open = false;
       section.classList.toggle('viewed', !!(file && file.viewed));
       renderStoryRail();
+      updateStoryMarkButton(page);
     });
     header.appendChild(viewedLabel);
     section.appendChild(header);
@@ -11546,6 +11568,7 @@
         rebuildNavList();
         applyHideResolved();
         renderStoryRail();
+        updateStoryMarkButton(page);
       }).catch(function () {
         const emptyEl = section.querySelector('.crit-story-file-group__empty');
         if (emptyEl) emptyEl.textContent = 'Failed to load diff.';
@@ -11582,6 +11605,7 @@
     rebuildNavList();
     applyHideResolved();
     renderStoryRail();
+    updateStoryMarkButton(page);
     return true;
   }
 


### PR DESCRIPTION
## Summary
- When every file in a story chapter is marked viewed individually, update the chapter mark button in place (`Chapter viewed` / live click polarity) instead of leaving a stale `Mark chapter viewed` label.
- Add source-contract unit tests and an E2E covering view-all → unmark.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (story mode is local CLI only)

## Test plan
- [x] `node --test web/__tests__/story-chapter-mark.test.js` (+ related story unit tests)
- [x] `go test ./...` (pre-commit equivalent)
- [ ] CI e2e story.spec.ts

Made with [Cursor](https://cursor.com)